### PR TITLE
fix(SearchBox): there are two X buttons in input area when using IE

### DIFF
--- a/packages/lab/src/SearchBox/styles.js
+++ b/packages/lab/src/SearchBox/styles.js
@@ -32,11 +32,11 @@ const icon = {
 const styles = theme => ({
   rootWithoutInput: {
     ...root(theme),
-    border: `1px solid ${theme.hv.palette.atmosphere.atmo6}`,
+    border: `1px solid ${theme.hv.palette.atmosphere.atmo6}`
   },
   rootWithInput: {
     ...root(theme),
-    border: `1px solid ${theme.hv.palette.accent.acce1}`,
+    border: `1px solid ${theme.hv.palette.accent.acce1}`
   },
 
   input: {
@@ -51,6 +51,9 @@ const styles = theme => ({
     "&::placeholder": {
       ...theme.hv.typography.normalText,
       color: theme.hv.typography.disabledText.color
+    },
+    "&::-ms-clear": {
+      display: "none"
     }
   },
   icon: {


### PR DESCRIPTION
**Describe the bug**
When using SearchBox on IE11 and input is not empty, there will be two X buttons show up. One of them is automatically generated by IE. 