### PR TITLE
fix(table): remove extra scroll bar in table

### DIFF
--- a/packages/core/src/Table/styles.js
+++ b/packages/core/src/Table/styles.js
@@ -95,17 +95,18 @@ const styles = theme => ({
             minWidth: "32px",
             display: "inline-table"
           },
-          "&.sortable":{
+          "&.sortable": {
             "&:hover > div > div > div ": {
               visibility: "visible"
             },
             "&:hover": {
               background: theme.hv.palette.atmosphere.atmo4
-            },
+            }
           }
         }
       },
       "& $tbody": {
+        overflow: "hidden",
         "& $trGroups": {
           borderBottom: `solid 1px ${theme.hv.palette.atmosphere.atmo6}`,
           "& $tr > div ": {


### PR DESCRIPTION
**Describe the bug**
In IE, there will be two scroll bars in the table when resizing window to a smaller size.