### PR TITLE
feat(lab-navigationanchors): ability to have custom keys for listitems

### DIFF
--- a/packages/lab/src/NavigationAnchors/NavigationAnchors.js
+++ b/packages/lab/src/NavigationAnchors/NavigationAnchors.js
@@ -72,7 +72,7 @@ class NavigationAnchors extends React.Component {
                   root: classes.listItemRoot,
                   gutters: classes.listItemGutters
                 }}
-                key={option.label}
+                key={option.key || option.label}
                 onClick={event => this.handleListItemClick(event, index)}
                 selected={selectedIndex === index}
               >
@@ -90,7 +90,7 @@ class NavigationAnchors extends React.Component {
 
             if (href) {
               return (
-                <HvLink route={`#${options[index].value}`} key={option.label}>
+                <HvLink route={`#${options[index].value}`} key={option.key || option.label}>
                   {listItem}
                 </HvLink>
               );


### PR DESCRIPTION
For the lab NavigationAnchors: giving the ability to have a `key` field for the options passed in allow for custom keys on list items.  If the field exists when passed in the options prop, it will use that for the component's key instead of label.