### PR TITLE
refactor(dropdown/list): disabled resetList on props update

### DIFF
--- a/packages/core/src/Dropdown/List/List.js
+++ b/packages/core/src/Dropdown/List/List.js
@@ -17,7 +17,6 @@
 import React from "react";
 import PropTypes from "prop-types";
 import classNames from "classnames";
-import isEqual from "lodash/isEqual";
 import HvCheckBox from "../../Selectors/CheckBox";
 import Search from "../Search";
 import Actions from "../Actions";
@@ -44,13 +43,6 @@ class List extends React.Component {
   componentWillMount() {
     const { values, notifyChangesOnFirstRender } = this.props;
     if (values) this.resetLists(notifyChangesOnFirstRender);
-  }
-
-  componentWillReceiveProps(nextProps) {
-    const { values } = this.props;
-    if (!isEqual(nextProps.values, values)) {
-      this.setState({ list: values }, () => this.resetLists());
-    }
   }
 
   /**

--- a/packages/core/src/Dropdown/List/tests/list.test.js
+++ b/packages/core/src/Dropdown/List/tests/list.test.js
@@ -87,37 +87,4 @@ describe("<List />", () => {
     expect(instance.state.prevList).toEqual(instance.state.list);
     expect(instance.setSelection).toBeCalledWith(true, true, true);
   });
-
-  it("should only reset when values change", () => {
-    instance = wrapper.find(List).instance();
-    instance.resetLists = jest.fn();
-    instance.componentWillReceiveProps({
-      values: [...mockData],
-      multiSelect: true,
-      showSearch: true,
-      onChange: onChangeMock(),
-      labels: mockLabels,
-    });
-    expect(instance.resetLists.mock.calls.length).toEqual(0);
-
-    const newMockData = [
-     {
-       label: "Value 4"
-     },
-     {
-       label: "Value 5"
-     },
-     {
-       label: "Value 6"
-     }
-    ];
-    instance.componentWillReceiveProps({
-      values: newMockData,
-      multiSelect: true,
-      showSearch: true,
-      onChange: onChangeMock(),
-      labels: mockLabels,
-    });
-    expect(instance.resetLists.mock.calls.length).toEqual(1);
-  })
 });


### PR DESCRIPTION
componentWillReceiveProps is not working properly - https://github.com/pentaho/hv-uikit-react/blob/alpha/packages/core/src/Dropdown/List/List.js#L49.

Since this will be replaced by the new list, I would remove this for now. 