### PR TITLE
fix: prevents user name and role from wrapping

### DIFF
--- a/packages/doc/samples/lab/header/header1.js
+++ b/packages/doc/samples/lab/header/header1.js
@@ -102,6 +102,10 @@ export default (
       selected={0}
       useRouter
       // User
+      userData={{
+        name: "Andrew Jennings",
+        role: "maintenance manager"
+      }}
       userIcon={<UserS />}
       userClick={() => alert("clicked")}
       // Actions

--- a/packages/lab/src/Header/User/styles.js
+++ b/packages/lab/src/Header/User/styles.js
@@ -55,7 +55,8 @@ const styles = theme => ({
 
     marginRight: `${theme.hv.spacing.xs}px`,
     "& p": {
-      color: theme.palette.text.main
+      color: theme.palette.text.main,
+      whiteSpace: "nowrap"
     }
   }
 });


### PR DESCRIPTION
https://github.com/pentaho/hv-uikit-react/issues/468

![Screen Shot 2019-08-27 at 1 56 16 PM](https://user-images.githubusercontent.com/42355453/63807996-c4fbc600-c8d3-11e9-82bc-ce61794f4e99.png)
