### PR TITLE
feat(icons): implement icon semantic colors and sizes. #425

### DIFF
--- a/packages/doc/package-lock.json
+++ b/packages/doc/package-lock.json
@@ -5237,6 +5237,58 @@
 				"gud": "^1.0.0"
 			}
 		},
+		"cross-env": {
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/cross-env/-/cross-env-6.0.3.tgz",
+			"integrity": "sha512-+KqxF6LCvfhWvADcDPqo64yVIB31gv/jQulX2NGzKS/g3GEVz6/pt4wjHFtFWsHMddebWD/sDthJemzM4MaAag==",
+			"dev": true,
+			"requires": {
+				"cross-spawn": "^7.0.0"
+			},
+			"dependencies": {
+				"cross-spawn": {
+					"version": "7.0.1",
+					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.1.tgz",
+					"integrity": "sha512-u7v4o84SwFpD32Z8IIcPZ6z1/ie24O6RU3RbtL5Y316l3KuHVPx9ItBgWQ6VlfAFnRnTtMUrsQ9MUUTuEZjogg==",
+					"dev": true,
+					"requires": {
+						"path-key": "^3.1.0",
+						"shebang-command": "^2.0.0",
+						"which": "^2.0.1"
+					}
+				},
+				"path-key": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.0.tgz",
+					"integrity": "sha512-8cChqz0RP6SHJkMt48FW0A7+qUOn+OsnOsVtzI59tZ8m+5bCSk7hzwET0pulwOM2YMn9J1efb07KB9l9f30SGg==",
+					"dev": true
+				},
+				"shebang-command": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+					"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+					"dev": true,
+					"requires": {
+						"shebang-regex": "^3.0.0"
+					}
+				},
+				"shebang-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+					"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+					"dev": true
+				},
+				"which": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/which/-/which-2.0.1.tgz",
+					"integrity": "sha512-N7GBZOTswtB9lkQBZA4+zAXrjEIWAUOB93AvzUiudRzRxhUdLURQ7D/gAIMY1gatT/LTbmbcv8SiYazy3eYB7w==",
+					"dev": true,
+					"requires": {
+						"isexe": "^2.0.0"
+					}
+				}
+			}
+		},
 		"cross-spawn": {
 			"version": "6.0.5",
 			"resolved": "https://nexus.pentaho.org/repository/group-npm/cross-spawn/-/cross-spawn-6.0.5.tgz",
@@ -11554,6 +11606,7 @@
 			"version": "16.8.6",
 			"resolved": "https://nexus.pentaho.org/repository/group-npm/react/-/react-16.8.6.tgz",
 			"integrity": "sha512-pC0uMkhLaHm11ZSJULfOBqV4tIZkx87ZLvbbQYunNixAAvjnC+snJCg0XQXn9VIsttVsbZP/H/ewzgsd5fxKXw==",
+			"dev": true,
 			"requires": {
 				"loose-envify": "^1.1.0",
 				"object-assign": "^4.1.1",
@@ -11735,6 +11788,7 @@
 			"version": "16.8.6",
 			"resolved": "https://nexus.pentaho.org/repository/group-npm/react-dom/-/react-dom-16.8.6.tgz",
 			"integrity": "sha512-1nL7PIq9LTL3fthPqwkvr2zY7phIPjYrT0jp4HjyEQrEROnw4dG41VVwi/wfoCneoleqrNX7iAD+pXebJZwrwA==",
+			"dev": true,
 			"requires": {
 				"loose-envify": "^1.1.0",
 				"object-assign": "^4.1.1",
@@ -12562,6 +12616,7 @@
 			"version": "0.13.6",
 			"resolved": "https://nexus.pentaho.org/repository/group-npm/scheduler/-/scheduler-0.13.6.tgz",
 			"integrity": "sha512-IWnObHt413ucAYKsD9J1QShUKkbKLQQHdxRyw73sw4FN26iWr3DY/H34xGPe4nmL1DwXyWmSWmMrA9TfQbE/XQ==",
+			"dev": true,
 			"requires": {
 				"loose-envify": "^1.1.0",
 				"object-assign": "^4.1.1"

--- a/packages/doc/package.json
+++ b/packages/doc/package.json
@@ -14,7 +14,7 @@
   },
   "scripts": {
     "dev": "start-storybook -p 9001",
-    "build": "build-storybook -o dist --quiet",
+    "build": "npx cross-env NODE_OPTIONS=--max-old-space-size=4096 build-storybook -o dist --quiet",
     "prepublish": "npm run build",
     "postpublish": "npm run clean",
     "deploy": "storybook-to-ghpages --ci",
@@ -42,8 +42,6 @@
     "react-syntax-highlighter": "10.2.1"
   },
   "devDependencies": {
-    "react": "^16.8.6",
-    "react-dom": "^16.8.6",
     "@babel/core": "7.4.0",
     "@babel/plugin-proposal-class-properties": "7.4.0",
     "@babel/plugin-transform-regenerator": "7.4.0",
@@ -62,9 +60,12 @@
     "babel-loader": "8.0.5",
     "babel-plugin-module-resolver": "3.2.0",
     "babel-plugin-react-docgen": "3.0.0",
+    "cross-env": "^6.0.3",
     "del-cli": "1.1.0",
     "raw-loader": "1.0.0",
-    "react-docgen": "4.1.0"
+    "react": "^16.8.6",
+    "react-docgen": "4.1.0",
+    "react-dom": "^16.8.6"
   },
   "files": [
     "dist"

--- a/packages/doc/samples/components/genericIcon/semanticColors.js
+++ b/packages/doc/samples/components/genericIcon/semanticColors.js
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2019 Hitachi Vantara Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from "react";
+import Level3 from "@hv/uikit-react-icons/dist/Generic/Level3.Bad";
+
+export default <Level3 iconSize="L" semantic="sema3" />;

--- a/packages/doc/samples/components/genericIcon/semanticInverted.js
+++ b/packages/doc/samples/components/genericIcon/semanticInverted.js
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2019 Hitachi Vantara Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from "react";
+import Level5 from "@hv/uikit-react-icons/dist/Generic/Level5";
+
+export default <Level5 iconSize="L" inverted />;

--- a/packages/doc/samples/foundation/icons.js
+++ b/packages/doc/samples/foundation/icons.js
@@ -23,7 +23,7 @@ const styles = theme => ({
   iconContainer: {
     margin: "5px",
     padding: "5px",
-    minWidth: "200px",
+    width: "140px",
     display: "inherit",
     flexDirection: "column",
     alignItems: "center"
@@ -37,12 +37,12 @@ const dropdownSizes = [
   },
   {
     id: "1",
-    label: "S"
+    label: "S",
+    selected: true
   },
   {
     id: "2",
-    label: "M",
-    selected: true
+    label: "M"
   },
   {
     id: "3",
@@ -138,7 +138,7 @@ const Group = ({ groupLabel, classes, iconSize, colorArray = [], theme }) => {
 const Icon = ({ name, Component, classes, iconSize, colorArray = [] }) => (
   <div className={classes.iconContainer}>
     {Component != null ? (
-      <Component iconSize={iconSize.label} color={colorArray}/>
+      <Component iconSize={iconSize && iconSize.label} color={colorArray} />
     ) : (
       <span
         style={{
@@ -152,11 +152,9 @@ const Icon = ({ name, Component, classes, iconSize, colorArray = [] }) => (
       </span>
     )}
     <div>
-      <HvTypography 
-        style={{
-          margin: "5px 0"
-        }} 
-      variant={"disabledText"}>{name}</HvTypography>
+      <HvTypography style={{ margin: "6px 0" }} variant={"infoText"}>
+        {name}
+      </HvTypography>
     </div>
   </div>
 );
@@ -166,7 +164,7 @@ const Icons = ({ classes, theme }) => {
   const [iconSize, setIconSize] = useState(
     {
       id: 2,
-      label: "XL",
+      label: "M",
       selected: true
     }
   );
@@ -199,10 +197,6 @@ const Icons = ({ classes, theme }) => {
             setIconSize(item);
           }}
           notifyChangesOnFirstRender
-        />
-        <ColorPicker 
-          applyCallback={applyCallback}
-          clearCallback={clearCallback}
         />
       </div>
       <Group groupLabel={GenericLabel} classes={classes} theme={theme} iconSize={iconSize} colorArray={colorArray}/>

--- a/packages/doc/stories/3-components/genericicon.js
+++ b/packages/doc/stories/3-components/genericicon.js
@@ -20,7 +20,7 @@ import CheckboxCheck from '@hv/uikit-react-icons/dist/Generic/CheckboxCheck';
 
 storiesOf("Components", module).add("Generic Icon", () => <CheckboxCheck />, {
   title: "Generic Icons",
-  description: "Usage of The generic icons as any icon works the same the sample will be done using the CheckboxCheck icon",
+  description: "Usage of Generic Icons that can be altered to standard or custom sizes and colors",
   usage: "import CheckboxCheck from '@hv/uikit-react-icons/dist/Generic/CheckboxCheck'",
   examples: [
     {
@@ -42,6 +42,16 @@ storiesOf("Components", module).add("Generic Icon", () => <CheckboxCheck />, {
       title: "Icon with custom size",
       description: "Overrides Generic Icon size using non standard sizes",
       src: "components/genericIcon/nonStandardSizes.js"
+    },
+    {
+      title: "Icon with color from semantic palette",
+      description: "Overrides Generic Icon colors with semantic palette colors",
+      src: "components/genericIcon/semanticColors.js"
+    },
+    {
+      title: "Icon with inverted semantic colors",
+      description: "Inverts Generic Icon colors",
+      src: "components/genericIcon/semanticInverted.js"
     }
   ]
 });

--- a/packages/icons/package-lock.json
+++ b/packages/icons/package-lock.json
@@ -958,9 +958,9 @@
       "integrity": "sha512-RMtr1i6E8MXaBWwhXL3yeOU8JXRnz8GNxHvaUfVvwxokvayUY0zoBeWbKw1S9XkufmGEEdQd228pSZXFkAln8Q=="
     },
     "@hv/uikit-common-icons": {
-      "version": "1.5.0",
-      "resolved": "https://nexus.pentaho.org/repository/group-npm/@hv/uikit-common-icons/-/uikit-common-icons-1.5.0.tgz",
-      "integrity": "sha512-5q2+q9Cdw4FGy2qTAvvPwUGAHbMWS56+p0tsIGp+9s78eclPcGDnSEdrh0OPmTJZ6raaVl2/+Z8U2a/mXLSAjQ=="
+      "version": "1.7.0",
+      "resolved": "https://nexus.pentaho.org/repository/group-npm/@hv/uikit-common-icons/-/uikit-common-icons-1.7.0.tgz",
+      "integrity": "sha512-kyvVGlApURHPVwjRurL3oBJgwHFHWSV/uZBI/OEFLtq+uxVNtT6V7vulLZfjtJCDdbE46Rbd+zdD+aAYNLp0KA=="
     },
     "@hv/uikit-common-themes": {
       "version": "1.3.1",

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -22,7 +22,7 @@
     "update-uikit-common": "npm update @hv/uikit-common-icons"
   },
   "dependencies": {
-    "@hv/uikit-common-icons": "^1.5.0",
+    "@hv/uikit-common-icons": "^1.7.0",
     "@hv/uikit-common-themes": "^1.2.0",
     "@material-ui/core": "^3.9.3",
     "@material-ui/styles": "3.0.0-alpha.10",


### PR DESCRIPTION
Addresses #425

Added semantic coloring and different sizes (according to DS) to Semantic Icons via `generateComponent.js`, using the `colorArray` logic.