### PR TITLE
fix(login): disable login form initially for ssr. #502

### DIFF
--- a/packages/core/src/Login/Forms/Login/Login.js
+++ b/packages/core/src/Login/Forms/Login/Login.js
@@ -131,6 +131,7 @@ class Login extends React.Component {
       allowRecover,
       allowRememberMe,
       errorLoginIcon,
+      isLoading,
       userNameInputLabel,
       userNamePlaceHolder,
       passwordInputLabel,
@@ -172,6 +173,7 @@ class Login extends React.Component {
               infoText: ""
             }}
             name="username"
+            disabled={isLoading}
             password={false}
             onChange={this.handleInputChange("username")}
             autoFocus
@@ -185,6 +187,7 @@ class Login extends React.Component {
               infoText: ""
             }}
             name="password"
+            disabled={isLoading}
             password
             onChange={this.handleInputChange("password")}
           />
@@ -207,6 +210,7 @@ class Login extends React.Component {
             type="submit"
             category="primary"
             className={classNames(classes.button, classes.sentenceCase)}
+            disabled={isLoading}
           >
             {isLogging ? loginButtonMessage : loginButtonLabel}
           </HvButton>

--- a/packages/core/src/Login/tests/login.test.js
+++ b/packages/core/src/Login/tests/login.test.js
@@ -64,6 +64,15 @@ describe("Login ", () => {
     expect(loginComponent.length).toBe(1);
   });
 
+  it("should enable the Login form after mount", () => {
+    const loginComponent = wrapper.find(LoginForm);
+
+    expect(loginComponent.length).toBe(1);
+    expect(loginComponent.find('input[name="username"]').prop('disabled')).toBe(false);
+    expect(loginComponent.find('input[name="password"]').prop('disabled')).toBe(false);
+    expect(loginComponent.find('button[type="submit"]').prop('disabled')).toBe(false);
+  });
+
   it("shouldn't render the Recovery form", () => {
     const recoverComponent = wrapper.find(Recovery);
 


### PR DESCRIPTION
When using server-side rendering on slower network, the login form is already rendered before the document is ready. Entering username and password caused the sensitive information to be appended to the url due to default `<form>` submission behavior.

We should disable the form initially and only enable it after the component is mounted. This behavior is only applicable to server-side rendered app.