### PR TITLE
refactor(multibutton): adjust min sizing in btn icon display. #470

### DIFF
--- a/packages/core/src/MultiButton/MultiButton.js
+++ b/packages/core/src/MultiButton/MultiButton.js
@@ -58,21 +58,21 @@ class MultiButton extends React.Component {
     const clickedBtnPositionInState = checkedItems.indexOf(clickedBtnId);
 
     if (btnClickable) {
-      return ;
+      return;
     }
 
     if (
       checkedItems.length === minSelection &&
       checkedItems.indexOf(clickedBtnId) !== -1
     ) {
-      return ;
+      return;
     }
 
     if (
       checkedItems.length === maxSelection &&
       checkedItems.indexOf(clickedBtnId) === -1
     ) {
-      return ;
+      return;
     }
 
     if (multi) {
@@ -90,14 +90,13 @@ class MultiButton extends React.Component {
       // a deselected element mimicking the behavior of the button component
       newState = [clickedBtnId];
     } else {
-      return ;
+      return;
     }
 
     this.setState({
       checkedItems: newState
     });
     onChange(newState);
-    
   }
 
   render() {
@@ -133,8 +132,7 @@ class MultiButton extends React.Component {
       let btnStruct;
       if (btnType === "icon") {
         btnStruct = <>{button.icon}</>;
-      }
-      if (btnType === "text") {
+      } else if (btnType === "text") {
         btnStruct = (
           <>
             <div className={classes.labelText}>{button.value}</div>
@@ -144,7 +142,11 @@ class MultiButton extends React.Component {
         btnStruct = (
           <>
             {button.icon}
-            <div className={classes.labelText}>{button.value}</div>
+            <div
+              className={classNames(classes.labelText, classes.labelPadding)}
+            >
+              {button.value}
+            </div>
           </>
         );
       }
@@ -163,6 +165,7 @@ class MultiButton extends React.Component {
             classes.btnBase,
             classes.btnSecondary,
             {
+              [classes.iconWidth]: type === "icon",
               [classes.isSelected]: checkedItems.indexOf(button.id) !== -1,
               [classes.isUnselected]: !(checkedItems.indexOf(button.id) !== -1)
             },

--- a/packages/core/src/MultiButton/styles.js
+++ b/packages/core/src/MultiButton/styles.js
@@ -21,6 +21,12 @@ const styles = theme => ({
     alignItems: "center",
     transition:"none",
   },
+  iconWidth:{
+    minWidth: "32px !important"
+  },
+  labelPadding:{
+    marginLeft:8
+  },
   btnBase: {
     maxWidth: 200,
     borderLeft: "none",

--- a/packages/doc/samples/components/multiButton/horizontalSamples/iconOnlyHorizontalMultipleSelection.js
+++ b/packages/doc/samples/components/multiButton/horizontalSamples/iconOnlyHorizontalMultipleSelection.js
@@ -26,7 +26,7 @@ const buttonsDefinitions = [
 ];
 
 export default (
-  <div style={{ width: "200px" }}>
+  <div style={{ width: "34px" }}>
     <MultiButton buttons={buttonsDefinitions} type={"icon"} multi />
   </div>
 );

--- a/packages/doc/samples/components/multiButton/horizontalSamples/iconOnlyHorizontalSingleSelection.js
+++ b/packages/doc/samples/components/multiButton/horizontalSamples/iconOnlyHorizontalSingleSelection.js
@@ -26,7 +26,7 @@ const buttonsDefinitions = [
 ];
 
 export default (
-  <div style={{ width: "200px" }}>
+  <div style={{ width: "34px" }}>
     <MultiButton buttons={buttonsDefinitions} type={"icon"} />
   </div>
 );

--- a/packages/doc/samples/components/multiButton/horizontalSamples/inputControlledValue.js
+++ b/packages/doc/samples/components/multiButton/horizontalSamples/inputControlledValue.js
@@ -7,7 +7,7 @@ import Map from "@hv/uikit-react-icons/dist/Generic/Map";
 import LocationPin from "@hv/uikit-react-icons/dist/Generic/LocationPin";
 
 const btnStyle = {
-  width: "50px",
+  width: "110px",
   height: "50px",
   margin: "10px"
 };

--- a/packages/doc/samples/components/multiButton/verticalSamples/iconOnlyVerticalMultipleSelection.js
+++ b/packages/doc/samples/components/multiButton/verticalSamples/iconOnlyVerticalMultipleSelection.js
@@ -26,7 +26,7 @@ const buttonsDefinitions = [
 ];
 
 export default (
-  <div class="testClass" style={{ width: "150px" }}>
+  <div class="testClass" style={{ width: "34px" }}>
     <MultiButton buttons={buttonsDefinitions} type={"icon"} vertical multi />
   </div>
 );

--- a/packages/doc/samples/components/multiButton/verticalSamples/iconOnlyVerticalSingleSelection.js
+++ b/packages/doc/samples/components/multiButton/verticalSamples/iconOnlyVerticalSingleSelection.js
@@ -23,14 +23,14 @@ import LocationPin from "@hv/uikit-react-icons/dist/Generic/LocationPin";
 const buttonsDefinitions = [
   { id: "map", icon: <Map />, selected: true },
   { id: "location", icon: <LocationPin /> },
-{ id: "map1", icon: <Map /> },
-{ id: "location1", icon: <LocationPin /> },
-{ id: "map2", icon: <Map /> },
-{ id: "location2", icon: <LocationPin /> }
+  { id: "map1", icon: <Map /> },
+  { id: "location1", icon: <LocationPin /> },
+  { id: "map2", icon: <Map /> },
+  { id: "location2", icon: <LocationPin /> }
 ];
 
 export default (
-  <div class="testClass" style={{ width: "150px" }}>
+  <div class="testClass" style={{ width: "34px" }}>
     <MultiButton buttons={buttonsDefinitions} type={"icon"} vertical />
   </div>
 );

--- a/packages/doc/stories/3-components/multiButton.js
+++ b/packages/doc/stories/3-components/multiButton.js
@@ -108,6 +108,5 @@ storiesOf("Components", module).add("MultiButton", () => <MultiButton />, {
       description: "Change multibutton properties, triggered by external an agent",
       src: "components/multiButton/horizontalSamples/inputControlledValue.js"
     }
-
   ]
 });


### PR DESCRIPTION
Component was enforcing a min width of 70px, when displaying just an icon, which caused the button to be rendered too wide, even when enforcing a width on the wrapping parent div.