### PR TITLE
fix(dropdownmenu): fix dropdownmenu opening on Tab. #602

### DIFF
--- a/packages/core/src/DropDownMenu/DropDownMenu.js
+++ b/packages/core/src/DropDownMenu/DropDownMenu.js
@@ -59,6 +59,18 @@ const DropDownMenu = ({
   };
 
   /**
+   * Open the dropdown on Enter or Space.
+   *
+   * @param event
+   */
+  const handleKeyDown = event => {
+    const { currentTarget, key } = event;
+    const openingKeys = ["Enter", " "];
+    if (openingKeys.includes(key)) setOpen(!open);
+    setAnchorEl(currentTarget);
+  };
+
+  /**
    * Close the dropdown.
    */
   const handleClickAway = () => {
@@ -70,7 +82,7 @@ const DropDownMenu = ({
       <div {...id && { id }} className={classes.root}>
         <div
           role="button"
-          onKeyDown={handleClick}
+          onKeyDown={handleKeyDown}
           tabIndex={0}
           className={classNames(classes.icon, {
             [classes.iconSelected]: open

--- a/packages/core/src/DropDownMenu/tests/dropDownMenu.test.js
+++ b/packages/core/src/DropDownMenu/tests/dropDownMenu.test.js
@@ -20,6 +20,7 @@ import toJson from "enzyme-to-json";
 
 import DropDownMenu from "../index";
 import HvProvider from "../../Provider";
+import Popper from "../../utils/Popper";
 
 jest.mock(
   "popper.js",
@@ -37,6 +38,8 @@ jest.mock(
 
 describe("DropDownMenu", () => {
   let wrapper;
+  const SPACE = " ";
+  const ENTER = "Enter";
 
   const menuOptions = [
     {
@@ -75,6 +78,56 @@ describe("DropDownMenu", () => {
       button.at(0).simulate("click");
       button.at(0).simulate("click");
       expect(toJson(wrapper)).toMatchSnapshot();
+    });
+
+    it("opens on Enter", () => {
+      const button = wrapper.find('div[role="button"]');
+
+      button.simulate("keydown", { key: ENTER });
+      expect(wrapper.find(Popper).props().open).toBe(true);
+    });
+
+    it("closes on double Enter", () => {
+      const button = wrapper.find('div[role="button"]');
+
+      button.simulate("keydown", { key: ENTER });
+      expect(wrapper.find(Popper).props().open).toBe(true);
+
+      button.simulate("keydown", { key: ENTER });
+      expect(wrapper.find(Popper).props().open).toBe(false);
+    });
+
+    it("opens on Space", () => {
+      const button = wrapper.find('div[role="button"]');
+
+      button.simulate("keydown", { key: SPACE });
+      expect(wrapper.find(Popper).props().open).toBe(true);
+    });
+
+    it("closes on double Space", () => {
+      const button = wrapper.find('div[role="button"]');
+
+      button.simulate("keydown", { key: SPACE });
+      expect(wrapper.find(Popper).props().open).toBe(true);
+
+      button.simulate("keydown", { key: SPACE });
+      expect(wrapper.find(Popper).props().open).toBe(false);
+    });
+
+    it("opens and closes mixing mouse click, Enter, and Space", () => {
+      const button = wrapper.find('div[role="button"]');
+
+      button.simulate("click");
+      expect(wrapper.find(Popper).props().open).toBe(true);
+
+      button.simulate("keydown", { key: ENTER });
+      expect(wrapper.find(Popper).props().open).toBe(false);
+
+      button.simulate("keydown", { key: SPACE });
+      expect(wrapper.find(Popper).props().open).toBe(true);
+
+      button.simulate("click");
+      expect(wrapper.find(Popper).props().open).toBe(false);
     });
   });
 });

--- a/packages/doc/.storybook/layout-addon/Layout/Examples/styles.js
+++ b/packages/doc/.storybook/layout-addon/Layout/Examples/styles.js
@@ -40,6 +40,9 @@ const styles = theme => ({
     borderRadius: "0",
     "&:hover": {
       backgroundColor: theme.hv.palette.atmosphere.atmo4,
+    },
+    "&:focus": {
+      outline: "5px auto rgba(0, 150, 255, 1)"
     }
   }
 });


### PR DESCRIPTION
When focused, a DropDownMenu was opening when any key was pressed.
Dropdowns should open when `Enter` key is pressed.

Fixes #602 