### PR TITLE
fix(badge): number rendering in safari

### DIFF
--- a/packages/core/src/Badge/Badge.js
+++ b/packages/core/src/Badge/Badge.js
@@ -22,34 +22,21 @@ import Typography from "../Typography";
 const Badge = props => {
   const { classes, showCount, count, maxCount, icon, text, textVariant } = props;
   const renderedCount = count > maxCount ? `${maxCount}+` : count;
-  let Component;
+  const Component = icon || text && <Typography variant={textVariant}>{text}</Typography>;
 
-  let badgeClasses = classNames(classes.badgePosition, {
+  const badgeClasses = classNames(classes.badgePosition, {
     [classes.badge]: count > 0,
     [classes.showCount]: showCount,
-    [classes.badgeTwoDigits]: showCount && count > 9
+    [classes.badgeIcon]: icon,
+    [classes.badgeOneDigit]: showCount && count <= 9
   });
-
-  if (icon) {
-    Component = icon;
-    badgeClasses = classNames(badgeClasses, {
-      [classes.badgeIcon]: count > 0,
-      [classes.showCountIcon]: showCount,
-      [classes.badgeTwoDigitsIcon]: showCount && count > 9
-    });
-  } else if (text) {
-    Component = <Typography variant={textVariant}>{text}</Typography>;
-    badgeClasses = classNames(badgeClasses, {
-      [classes.badgeText]: count > 0,
-      [classes.showCountText]: showCount,
-      [classes.badgeTwoDigitsText]: showCount && count > 9
-    });
-  }
 
   return (
     <div className={classes.root}>
       {Component}
-      <div className={badgeClasses}>{showCount && renderedCount}</div>
+      <div className={Component ? classes.badgeContainer : null}>
+        <div className={badgeClasses}>{showCount && renderedCount}</div>
+      </div>
     </div>
   );
 };

--- a/packages/core/src/Badge/styles.js
+++ b/packages/core/src/Badge/styles.js
@@ -17,52 +17,35 @@
 const styles = theme => ({
   root: {
     position: "relative",
-    height:30
+    height: `${theme.hv.spacing.md}px`,
+    "&>*": { float: "left" }
   },
-  badgePosition: {
-    display: "flex",
-    alignItems: "center"
+  badgeContainer: {
+    width: 0
   },
   badge: {
     borderRadius: `${theme.hv.spacing.xs}px`,
     backgroundColor: theme.hv.palette.accent.acce1,
+    float: "left",
     minHeight: "6px",
     minWidth: "6px"
   },
   badgeIcon: {
-    position: "absolute",
+    position: "relative",
     top: "2px",
-    right: "2px"
-  },
-  badgeText: {
-    position: "absolute",
-    top: "0px",
-    right: "-6px"
+    left: "-7px"
   },
   showCount: {
     ...theme.hv.typography.labelText,
     fontFamily: theme.hv.typography.fontFamily,
-    justifyContent: "center",
-    height: "16px",
-    width: "16px",
-    lineHeight: "0",
+    padding: "0 0.5em",
     color: theme.hv.palette.atmosphere.atmo1
   },
-  showCountIcon: {
-    right: "-9px"
+  badgeOneDigit: {
+    padding: 0,
+    width: "16px",
+    textAlign: "center"
   },
-  showCountText: {
-    right: "-16px"
-  },
-  badgeTwoDigits: {
-    width: `${theme.hv.spacing.md}px`
-  },
-  badgeTwoDigitsIcon: {
-    right: `-23px`
-  },
-  badgeTwoDigitsText: {
-    right: `-30px`
-  }
 });
 
 export default styles;

--- a/packages/doc/.storybook/layout-addon/Layout/Main/Main.js
+++ b/packages/doc/.storybook/layout-addon/Layout/Main/Main.js
@@ -98,7 +98,6 @@ const Main = ({ classes, children, context, config }) => {
           </Button>
         )}
       </div>
-      )
       <div className={classes.contentWithHeader}>
         {title ? (
           <>

--- a/packages/doc/samples/components/badge/badgeControlled.js
+++ b/packages/doc/samples/components/badge/badgeControlled.js
@@ -1,0 +1,18 @@
+import React, { useState } from "react";
+import HvBadge from "@hv/uikit-react-core/dist/Badge";
+import HvButton from "@hv/uikit-react-core/dist/Button";
+
+const ControlledBadges = () => {
+  const [count, setCount] = useState(1);
+  const addCount = () => setCount(count * 2);
+
+  return (
+    <>
+      <HvButton onClick={addCount}>Double Value</HvButton>
+      <p />
+      <HvBadge showCount count={count} text="Events" textVariant="sTitle" />
+    </>
+  );
+};
+
+export default <ControlledBadges />;

--- a/packages/doc/samples/components/badge/badgeWithIcon.js
+++ b/packages/doc/samples/components/badge/badgeWithIcon.js
@@ -1,5 +1,4 @@
 import React from "react";
-import withStyles from "@material-ui/core/styles/withStyles";
 import HvBadge from "@hv/uikit-react-core/dist/Badge";
 import Alert from "@hv/uikit-react-icons/dist/Generic/Alert";
 

--- a/packages/doc/stories/3-components/badge.js
+++ b/packages/doc/stories/3-components/badge.js
@@ -35,9 +35,13 @@ storiesOf("Components", module).add("Badge", () => <HvBadge />, {
     },
     {
       title: "3. With Text",
-      description:
-        "Badges show when there are unread notifications with text.",
+      description: "Badges show when there are unread notifications with text.",
       src: "components/badge/badgeWithText.js"
+    },
+    {
+      title: "4. With Button controller",
+      description: "Badges update and grow according to their content.",
+      src: "components/badge/badgeControlled.js"
     }
   ]
 });


### PR DESCRIPTION
addresses #391

Safari rendering engine was not updating the count, seemingly because of the styles (badge outside parent component + complex style logic) (see this [SO answer](https://stackoverflow.com/a/55050203)).

I _refactored_(simplified) the Badge's position and sizing logic, and it seemed to solve the issue.
With this, Badge now grows depending on number (instead of being limited to [0-2]), but the 2-digit badge doesn't have exactly the same size.