### PR TITLE
fix(tooltip): propTypes and samples

### DIFF
--- a/packages/core/src/Tooltip/Tooltip.js
+++ b/packages/core/src/Tooltip/Tooltip.js
@@ -16,7 +16,6 @@
 
 import React from "react";
 import PropTypes from "prop-types";
-
 import Tooltip from "@material-ui/core/Tooltip";
 import Fade from "@material-ui/core/Fade";
 
@@ -92,7 +91,7 @@ HvTooltip.propTypes = {
   /**
    * Values to display in tooltip.
    */
-  tooltipData: PropTypes.shape({}),
+  tooltipData: PropTypes.node,
   /**
    * If true, the tooltip is shown.
    */
@@ -113,11 +112,13 @@ HvTooltip.propTypes = {
   /**
    * The component used for the transition
    */
-  TransitionComponent: PropTypes.node,
+  // eslint-disable-next-line react/forbid-prop-types
+  TransitionComponent: PropTypes.any,
   /**
    * Properties applied to the Transition element.
    */
-  TransitionProps: PropTypes.shape({}),
+  // eslint-disable-next-line react/forbid-prop-types
+  TransitionProps: PropTypes.object,
   /**
    * Defines if should use a single or multiline tooltip.
    */
@@ -130,9 +131,7 @@ HvTooltip.defaultProps = {
   enterDelay: 300,
   placement: "top",
   useSingle: true,
-  tooltipData: {
-    title: "Some Value"
-  },
+  tooltipData: null,
   tooltipAnchor: null,
   TransitionComponent: Fade,
   TransitionProps: {

--- a/packages/core/src/Tooltip/tests/__snapshots__/tooltip.test.js.snap
+++ b/packages/core/src/Tooltip/tests/__snapshots__/tooltip.test.js.snap
@@ -10556,28 +10556,7 @@ body {
           Hello World
         </button>
       }
-      tooltipData={
-        Object {
-          "elements": Array [
-            Object {
-              "name": "Status",
-              "value": "Open",
-            },
-            Object {
-              "name": "Date",
-              "value": "12/08/2018",
-            },
-            Object {
-              "name": "Assignee",
-              "value": "Management",
-            },
-            Object {
-              "name": "Approval",
-              "value": "Not yet requested",
-            },
-          ],
-        }
-      }
+      tooltipData={<WithStyles(TooltipContent) />}
       useSingle={false}
     >
       <HvTooltip
@@ -11542,28 +11521,7 @@ body {
             Hello World
           </button>
         }
-        tooltipData={
-          Object {
-            "elements": Array [
-              Object {
-                "name": "Status",
-                "value": "Open",
-              },
-              Object {
-                "name": "Date",
-                "value": "12/08/2018",
-              },
-              Object {
-                "name": "Assignee",
-                "value": "Management",
-              },
-              Object {
-                "name": "Approval",
-                "value": "Not yet requested",
-              },
-            ],
-          }
-        }
+        tooltipData={<WithStyles(TooltipContent) />}
         useSingle={false}
       >
         <WithStyles(Tooltip)
@@ -11582,28 +11540,7 @@ body {
           enterDelay={300}
           open={null}
           placement="top"
-          title={
-            Object {
-              "elements": Array [
-                Object {
-                  "name": "Status",
-                  "value": "Open",
-                },
-                Object {
-                  "name": "Date",
-                  "value": "12/08/2018",
-                },
-                Object {
-                  "name": "Assignee",
-                  "value": "Management",
-                },
-                Object {
-                  "name": "Approval",
-                  "value": "Not yet requested",
-                },
-              ],
-            }
-          }
+          title={<WithStyles(TooltipContent) />}
         >
           <Tooltip
             TransitionComponent={[Function]}
@@ -12563,28 +12500,7 @@ body {
                 },
               }
             }
-            title={
-              Object {
-                "elements": Array [
-                  Object {
-                    "name": "Status",
-                    "value": "Open",
-                  },
-                  Object {
-                    "name": "Date",
-                    "value": "12/08/2018",
-                  },
-                  Object {
-                    "name": "Assignee",
-                    "value": "Management",
-                  },
-                  Object {
-                    "name": "Approval",
-                    "value": "Not yet requested",
-                  },
-                ],
-              }
-            }
+            title={<WithStyles(TooltipContent) />}
           >
             <RootRef
               rootRef={[Function]}
@@ -23177,21 +23093,7 @@ body {
           Hello World
         </button>
       }
-      tooltipData={
-        Object {
-          "elements": Array [
-            Object {
-              "name": "Sales",
-              "value": "52,000 units",
-            },
-            Object {
-              "name": "Profit",
-              "value": "50%",
-            },
-          ],
-          "title": "January",
-        }
-      }
+      tooltipData={<WithStyles(TooltipContent) />}
       useSingle={false}
     >
       <HvTooltip
@@ -24156,21 +24058,7 @@ body {
             Hello World
           </button>
         }
-        tooltipData={
-          Object {
-            "elements": Array [
-              Object {
-                "name": "Sales",
-                "value": "52,000 units",
-              },
-              Object {
-                "name": "Profit",
-                "value": "50%",
-              },
-            ],
-            "title": "January",
-          }
-        }
+        tooltipData={<WithStyles(TooltipContent) />}
         useSingle={false}
       >
         <WithStyles(Tooltip)
@@ -24189,21 +24077,7 @@ body {
           enterDelay={300}
           open={null}
           placement="top"
-          title={
-            Object {
-              "elements": Array [
-                Object {
-                  "name": "Sales",
-                  "value": "52,000 units",
-                },
-                Object {
-                  "name": "Profit",
-                  "value": "50%",
-                },
-              ],
-              "title": "January",
-            }
-          }
+          title={<WithStyles(TooltipContent) />}
         >
           <Tooltip
             TransitionComponent={[Function]}
@@ -25163,21 +25037,7 @@ body {
                 },
               }
             }
-            title={
-              Object {
-                "elements": Array [
-                  Object {
-                    "name": "Sales",
-                    "value": "52,000 units",
-                  },
-                  Object {
-                    "name": "Profit",
-                    "value": "50%",
-                  },
-                ],
-                "title": "January",
-              }
-            }
+            title={<WithStyles(TooltipContent) />}
           >
             <RootRef
               rootRef={[Function]}
@@ -25235,9 +25095,11 @@ exports[`Single Line Tooltip should render single line tooltip correctly 1`] = `
     </button>
   }
   tooltipData={
-    Object {
-      "title": "Grid view",
-    }
+    <WithStyles(Typography)
+      variant="labelText"
+    >
+      Grid View
+    </WithStyles(Typography)>
   }
   useSingle={true}
 >
@@ -25258,9 +25120,11 @@ exports[`Single Line Tooltip should render single line tooltip correctly 1`] = `
     open={null}
     placement="top"
     title={
-      Object {
-        "title": "Grid view",
-      }
+      <WithStyles(Typography)
+        variant="labelText"
+      >
+        Grid View
+      </WithStyles(Typography)>
     }
   >
     <Tooltip
@@ -25655,9 +25519,11 @@ exports[`Single Line Tooltip should render single line tooltip correctly 1`] = `
         }
       }
       title={
-        Object {
-          "title": "Grid view",
-        }
+        <WithStyles(Typography)
+          variant="labelText"
+        >
+          Grid View
+        </WithStyles(Typography)>
       }
     >
       <RootRef

--- a/packages/core/src/Tooltip/tests/tooltip.test.js
+++ b/packages/core/src/Tooltip/tests/tooltip.test.js
@@ -18,28 +18,53 @@
 
 import React from "react";
 import { mount } from "enzyme";
+import withStyles from "@material-ui/core/styles/withStyles";
 
 import TooltipWithStyles from "..";
 import Tooltip from "../Tooltip";
 import HvProvider from "../../Provider";
+import HvTypography from "../../Typography";
+import tooltipStyling from "../styles";
+
+const createTooltipData = data => {
+  // eslint-disable-next-line react/prop-types
+  const TooltipContent = ({ classes }) => (
+    <div>
+      <div className={classes.title}>
+        <HvTypography variant="labelText">{data.title || ""}</HvTypography>
+      </div>
+      <div className={classes.valueWrapper}>
+        {data.elements.map(element => (
+          <div key={element.name} className={classes.values}>
+            <HvTypography variant="labelText">{element.name}</HvTypography>
+            <div className={classes.separator} />
+            <HvTypography variant="sText">{element.value}</HvTypography>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+
+  return withStyles(tooltipStyling, {
+    withTheme: true
+  })(TooltipContent);
+};
+
+const Anchor = (
+  <button id="testChild" type="submit">
+    Hello World
+  </button>
+);
 
 describe("Single Line Tooltip", () => {
   let wrapper;
 
-  const data = {
-    title: "Grid view"
-  };
-
-  const defaultProps = {
-    children: (
-      <button id="testChild" type="submit">
-        Hello World
-      </button>
-    )
-  };
   beforeEach(async () => {
     wrapper = mount(
-      <Tooltip tooltipData={data} tooltipAnchor={defaultProps.children} />
+      <Tooltip
+        tooltipData={<HvTypography variant="labelText">Grid View</HvTypography>}
+        tooltipAnchor={Anchor}
+      />
     );
   });
 
@@ -62,38 +87,21 @@ describe("Multi Line Tooltip - No Header", () => {
 
   const data = {
     elements: [
-      {
-        name: "Status",
-        value: "Open"
-      },
-      {
-        name: "Date",
-        value: "12/08/2018"
-      },
-      {
-        name: "Assignee",
-        value: "Management"
-      },
-      {
-        name: "Approval",
-        value: "Not yet requested"
-      }
+      { name: "Status", value: "Open" },
+      { name: "Date", value: "12/08/2018" },
+      { name: "Assignee", value: "Management" },
+      { name: "Approval", value: "Not yet requested" }
     ]
   };
 
-  const defaultProps = {
-    children: (
-      <button id="testChild" type="submit">
-        Hello World
-      </button>
-    )
-  };
+  const TooltipData = createTooltipData(data);
+
   beforeEach(async () => {
     wrapper = mount(
       <HvProvider>
         <TooltipWithStyles
-          tooltipData={data}
-          tooltipAnchor={defaultProps.children}
+          tooltipData={<TooltipData />}
+          tooltipAnchor={Anchor}
           useSingle={false}
         />
       </HvProvider>
@@ -120,30 +128,19 @@ describe("Multi Line Tooltip - With Header", () => {
   const data = {
     title: "January",
     elements: [
-      {
-        name: "Sales",
-        value: "52,000 units"
-      },
-      {
-        name: "Profit",
-        value: "50%"
-      }
+      { name: "Sales", value: "52,000 units" },
+      { name: "Profit", value: "50%" }
     ]
   };
 
-  const defaultProps = {
-    children: (
-      <button id="testChild" type="submit">
-        Hello World
-      </button>
-    )
-  };
+  const TooltipData = createTooltipData(data);
+
   beforeEach(async () => {
     wrapper = mount(
       <HvProvider>
         <TooltipWithStyles
-          tooltipData={data}
-          tooltipAnchor={defaultProps.children}
+          tooltipData={<TooltipData />}
+          tooltipAnchor={Anchor}
           useSingle={false}
         />
       </HvProvider>

--- a/packages/doc/samples/components/tooltip/multilineNoheaderTooltip.js
+++ b/packages/doc/samples/components/tooltip/multilineNoheaderTooltip.js
@@ -3,18 +3,8 @@ import Tooltip from "@hv/uikit-react-core/dist/Tooltip";
 import HvTypography from "@hv/uikit-react-core/dist/Typography";
 import withStyles from "@material-ui/core/styles/withStyles";
 
-
-/* ******************************************************************************
-*  ******************************************************************************
-*  ******************************************************************************
-*
-*
-*  IMPORTANT - To ensure conformity with the design specs for this component, import
-*   the styling provided with the component
-*
-** ******************************************************************************
-* *******************************************************************************
-* ***************************************************************************** */
+// To ensure conformity with the design specs for this component,
+// import the styling provided with the component
 import tooltipStyling from "@hv/uikit-react-core/dist/Tooltip/styles";
 
 const styling = {
@@ -23,74 +13,44 @@ const styling = {
     justifyContent: "center",
     cursor: "pointer",
     paddingTop: 170
-  },
-  container: {
-    width: 100,
-    color: "#414141"
-  },
-  typographyAligner: {
-    textAlign: "center"
   }
 };
 
+const data = [
+  { name: "Status", value: "Open" },
+  { name: "Date", value: "12/08/2018" },
+  { name: "Assignee", value: "Management" },
+  { name: "Approval", value: "Not yet requested" }
+];
+
 const TooltipContent = ({ classes }) => (
-  <>
-    <div className={classes.valueWrapper}>
-      {tooltipData.elements.map(element => (
-        <div key={element.name} className={classes.values}>
-          <HvTypography variant="labelText">{element.name}</HvTypography>
-          <div className={classes.separator} />
-          <HvTypography variant="sText">{element.value}</HvTypography>
-        </div>
-      ))}
-    </div>
-  </>
+  <div className={classes.valueWrapper}>
+    {data.map(element => (
+      <div key={element.name} className={classes.values}>
+        <HvTypography variant="labelText">{element.name}</HvTypography>
+        <div className={classes.separator} />
+        <HvTypography variant="sText">{element.value}</HvTypography>
+      </div>
+    ))}
+  </div>
 );
 
 const TooltipContentWithStyles = withStyles(tooltipStyling, {
   withTheme: true
 })(TooltipContent);
 
-
-const TooltipControl = (() => {
-  return (
-    <div tabIndex="0" style={styling.cotainer}>
-      <div style={styling.typographyAligner}>
-        <HvTypography variant="normalText">Hover here</HvTypography>
-      </div>
-    </div>
-  );
-})();
-
-const tooltipData = {
-  elements: [
-    {
-      name: "Status",
-      value: "Open"
-    },
-    {
-      name: "Date",
-      value: "12/08/2018"
-    },
-    {
-      name: "Assignee",
-      value: "Management"
-    },
-    {
-      name: "Approval",
-      value: "Not yet requested"
-    }
-  ]
-};
+const TooltipControl = (
+  <HvTypography tabIndex="0" variant="normalText">
+    Hover here
+  </HvTypography>
+);
 
 export default (
   <div style={styling.placeholder}>
-    <>
-      <Tooltip
-        tooltipData={<TooltipContentWithStyles />}
-        useSingle={false}
-        tooltipAnchor={TooltipControl}
-      />
-    </>
+    <Tooltip
+      tooltipData={<TooltipContentWithStyles />}
+      useSingle={false}
+      tooltipAnchor={TooltipControl}
+    />
   </div>
 );

--- a/packages/doc/samples/components/tooltip/multilineNoheaderTooltipOpen.js
+++ b/packages/doc/samples/components/tooltip/multilineNoheaderTooltipOpen.js
@@ -3,18 +3,8 @@ import Tooltip from "@hv/uikit-react-core/dist/Tooltip";
 import HvTypography from "@hv/uikit-react-core/dist/Typography";
 import withStyles from "@material-ui/core/styles/withStyles";
 
-
-/* ******************************************************************************
-*  ******************************************************************************
-*  ******************************************************************************
-*
-*
-*  IMPORTANT - To ensure conformity with the design specs for this component, import
-*   the styling provided with the component
-*
-** ******************************************************************************
-* *******************************************************************************
-* ***************************************************************************** */
+// To ensure conformity with the design specs for this component,
+// import the styling provided with the component
 import tooltipStyling from "@hv/uikit-react-core/dist/Tooltip/styles";
 
 const styling = {
@@ -23,74 +13,45 @@ const styling = {
     cursor: "pointer",
     justifyContent: "center",
     paddingTop: 170
-  },
-  container: {
-    width: 100,
-    color: "#414141"
-  },
-  typographyAligner: {
-    textAlign: "center"
   }
 };
 
+const data = [
+  { name: "Status", value: "Open" },
+  { name: "Date", value: "12/08/2018" },
+  { name: "Assignee", value: "Management" },
+  { name: "Approval", value: "Not yet requested" }
+];
+
 const TooltipContent = ({ classes }) => (
-  <>
-    <div className={classes.valueWrapper}>
-      {tooltipData.elements.map(element => (
-        <div key={element.name} className={classes.values}>
-          <HvTypography variant="labelText">{element.name}</HvTypography>
-          <div className={classes.separator} />
-          <HvTypography variant="sText">{element.value}</HvTypography>
-        </div>
-      ))}
-    </div>
-  </>
+  <div className={classes.valueWrapper}>
+    {data.map(element => (
+      <div key={element.name} className={classes.values}>
+        <HvTypography variant="labelText">{element.name}</HvTypography>
+        <div className={classes.separator} />
+        <HvTypography variant="sText">{element.value}</HvTypography>
+      </div>
+    ))}
+  </div>
 );
 
 const TooltipContentWithStyles = withStyles(tooltipStyling, {
   withTheme: true
 })(TooltipContent);
 
-const TooltipControl = (() => {
-  return (
-    <div tabIndex="0" style={styling.cotainer}>
-      <div style={styling.typographyAligner}>
-        <HvTypography variant="normalText">Tooltip open</HvTypography>
-      </div>
-    </div>
-  );
-})();
-
-const tooltipData = {
-  elements: [
-    {
-      name: "Status",
-      value: "Open"
-    },
-    {
-      name: "Date",
-      value: "12/08/2018"
-    },
-    {
-      name: "Assignee",
-      value: "Management"
-    },
-    {
-      name: "Approval",
-      value: "Not yet requested"
-    }
-  ]
-};
+const TooltipControl = (
+  <HvTypography tabIndex="0" variant="normalText">
+    Tooltip open
+  </HvTypography>
+);
 
 export default (
   <div style={styling.placeholder}>
-    <>
-      <Tooltip
-        tooltipData={<TooltipContentWithStyles />}
-        useSingle={false}
-        tooltipAnchor={TooltipControl}
-        open={true}
-      />
-    </>
+    <Tooltip
+      tooltipData={<TooltipContentWithStyles />}
+      useSingle={false}
+      tooltipAnchor={TooltipControl}
+      open
+    />
   </div>
 );

--- a/packages/doc/samples/components/tooltip/multilineWithHeaderTooltip.js
+++ b/packages/doc/samples/components/tooltip/multilineWithHeaderTooltip.js
@@ -3,102 +3,62 @@ import Tooltip from "@hv/uikit-react-core/dist/Tooltip";
 import HvTypography from "@hv/uikit-react-core/dist/Typography";
 import withStyles from "@material-ui/core/styles/withStyles";
 
-
-/* ******************************************************************************
-*  ******************************************************************************
-*  ******************************************************************************
-*
-*
-*  IMPORTANT - To ensure conformity with the design specs for this component, import
-*   the styling provided with the component
-*
-** ******************************************************************************
-* *******************************************************************************
-* ***************************************************************************** */
+// To ensure conformity with the design specs for this component,
+// import the styling provided with the component
 import tooltipStyling from "@hv/uikit-react-core/dist/Tooltip/styles";
 
 const styling = {
-  wrapper: {
-    height: 170
-  },
-
   placeholder: {
     display: "flex",
-    justifyContent: "center",
-    paddingTop: 150
-  },
-
-  container: {
-    width: 100,
     cursor: "pointer",
-    color: "#414141"
-  },
-
-  typographyAligner: {
-    textAlign: "center"
+    justifyContent: "center",
+    paddingTop: 170
   }
 };
 
+const tooltipData = {
+  title: "January",
+  elements: [
+    { name: "Sales", value: "52,000 units" },
+    { name: "Profit", value: "50%" }
+  ]
+};
+
 const TooltipContent = ({ classes }) => (
-  <>
-    <div>
-      <div className={classes.title}>
-        <div>
-          <HvTypography variant="labelText">{tooltipData.title}</HvTypography>
-        </div>
-      </div>
-      <div className={classes.valueWrapper}>
-        {tooltipData.elements.map(element => (
-          <div key={element.name} className={classes.values}>
-            <HvTypography variant="labelText">{element.name}</HvTypography>
-            <div className={classes.separator} />
-            <HvTypography variant="sText">{element.value}</HvTypography>
-          </div>
-        ))}
+  <div>
+    <div className={classes.title}>
+      <div>
+        <HvTypography variant="labelText">{tooltipData.title}</HvTypography>
       </div>
     </div>
-  </>
+    <div className={classes.valueWrapper}>
+      {tooltipData.elements.map(element => (
+        <div key={element.name} className={classes.values}>
+          <HvTypography variant="labelText">{element.name}</HvTypography>
+          <div className={classes.separator} />
+          <HvTypography variant="sText">{element.value}</HvTypography>
+        </div>
+      ))}
+    </div>
+  </div>
 );
 
 const TooltipContentWithStyles = withStyles(tooltipStyling, {
   withTheme: true
 })(TooltipContent);
 
-
-const TooltipControl = (() => {
-  return (
-    <div tabIndex="0" style={styling.container}>
-      <div style={styling.typographyAligner}>
-        <HvTypography variant="normalText">Hover here</HvTypography>
-      </div>
-    </div>
-  );
-})();
-
-const tooltipData = {
-  title: "January",
-  elements: [
-    {
-      name: "Sales",
-      value: "52,000 units"
-    },
-    {
-      name: "Profit",
-      value: "50%"
-    }
-  ]
-};
+const TooltipControl = (
+  <HvTypography tabIndex="0" variant="normalText">
+    Hover here
+  </HvTypography>
+);
 
 export default (
-  <div style={styling.wrapper}>
-    <div style={styling.placeholder}>
-      <>
-        <Tooltip
-          tooltipData={<TooltipContentWithStyles />}
-          useSingle={false}
-          tooltipAnchor={TooltipControl}
-        />
-      </>
-    </div>
+  <div style={styling.placeholder}>
+    <Tooltip
+      tooltipData={<TooltipContentWithStyles />}
+      useSingle={false}
+      tooltipAnchor={TooltipControl}
+    />
   </div>
 );

--- a/packages/doc/samples/components/tooltip/multilineWithHeaderTooltipOpen.js
+++ b/packages/doc/samples/components/tooltip/multilineWithHeaderTooltipOpen.js
@@ -3,102 +3,63 @@ import Tooltip from "@hv/uikit-react-core/dist/Tooltip";
 import HvTypography from "@hv/uikit-react-core/dist/Typography";
 import withStyles from "@material-ui/core/styles/withStyles";
 
-
-/* ******************************************************************************
-*  ******************************************************************************
-*  ******************************************************************************
-*
-*
-*  IMPORTANT - To ensure conformity with the design specs for this component, import
-*   the styling provided with the component
-*
-** ******************************************************************************
-* *******************************************************************************
-* ***************************************************************************** */
+// To ensure conformity with the design specs for this component,
+// import the styling provided with the component
 import tooltipStyling from "@hv/uikit-react-core/dist/Tooltip/styles";
 
 const styling = {
-  wrapper: {
-    height: 170
-  },
-
   placeholder: {
     display: "flex",
-    justifyContent: "center",
-    paddingTop: 150
-  },
-
-  container: {
-    width: 100,
     cursor: "pointer",
-    color: "#414141"
-  },
-
-  typographyAligner: {
-    textAlign: "center"
+    justifyContent: "center",
+    paddingTop: 170
   }
 };
 
+const tooltipData = {
+  title: "January",
+  elements: [
+    { name: "Sales", value: "52,000 units" },
+    { name: "Profit", value: "50%" }
+  ]
+};
+
 const TooltipContent = ({ classes }) => (
-  <>
-    <div>
-      <div className={classes.title}>
-        <div>
-          <HvTypography variant="labelText">{tooltipData.title}</HvTypography>
-        </div>
-      </div>
-      <div className={classes.valueWrapper}>
-        {tooltipData.elements.map(element => (
-          <div key={element.name} className={classes.values}>
-            <HvTypography variant="labelText">{element.name}</HvTypography>
-            <div className={classes.separator} />
-            <HvTypography variant="sText">{element.value}</HvTypography>
-          </div>
-        ))}
+  <div>
+    <div className={classes.title}>
+      <div>
+        <HvTypography variant="labelText">{tooltipData.title}</HvTypography>
       </div>
     </div>
-  </>
+    <div className={classes.valueWrapper}>
+      {tooltipData.elements.map(element => (
+        <div key={element.name} className={classes.values}>
+          <HvTypography variant="labelText">{element.name}</HvTypography>
+          <div className={classes.separator} />
+          <HvTypography variant="sText">{element.value}</HvTypography>
+        </div>
+      ))}
+    </div>
+  </div>
 );
 
 const TooltipContentWithStyles = withStyles(tooltipStyling, {
   withTheme: true
 })(TooltipContent);
 
-const TooltipControl = (() => {
-  return (
-    <div tabIndex="0" style={styling.container}>
-      <div style={styling.typographyAligner}>
-        <HvTypography variant="normalText">Tooltip open</HvTypography>
-      </div>
-    </div>
-  );
-})();
-
-const tooltipData = {
-  title: "January",
-  elements: [
-    {
-      name: "Sales",
-      value: "52,000 units"
-    },
-    {
-      name: "Profit",
-      value: "50%"
-    }
-  ]
-};
+const TooltipControl = (
+  <HvTypography tabIndex="0" variant="normalText">
+    Tooltip open
+  </HvTypography>
+);
 
 export default (
-  <div style={styling.wrapper}>
-    <div style={styling.placeholder}>
-      <>
-        <Tooltip
-          tooltipData={<TooltipContentWithStyles />}
-          useSingle={false}
-          tooltipAnchor={TooltipControl}
-          open={true}
-        />
-      </>
-    </div>
+  <div style={styling.placeholder}>
+    <Tooltip
+      tooltipData={<TooltipContentWithStyles />}
+      useSingle={false}
+      tooltipAnchor={TooltipControl}
+      open
+    />
   </div>
 );

--- a/packages/doc/samples/components/tooltip/simpleTooltip.js
+++ b/packages/doc/samples/components/tooltip/simpleTooltip.js
@@ -3,52 +3,37 @@ import Tooltip from "@hv/uikit-react-core/dist/Tooltip";
 import HvTypography from "@hv/uikit-react-core/dist/Typography";
 
 const styling = {
-  outerDiv:{
+  outerDiv: {
     width: 100,
-    cursor: "pointer",
-    color: "#414141"
+    cursor: "pointer"
   },
   placeholder: {
     display: "flex",
+    textAlign: "center",
     justifyContent: "space-between",
     width: 600,
     marginLeft: "18%",
     paddingTop: 80
-  },
-  typographyAligner:{
-    textAlign: "center"
   }
 };
 
-const TooltipHover = (() => {
-  return (
-    <div tabIndex="0" style={styling.outerDiv}>
-      <div style={styling.typographyAligner}>
-        <HvTypography variant="normalText">Hover here</HvTypography>
-      </div>
-    </div>
-  );
-})();
+const TooltipHover = (
+  <div tabIndex="0" style={styling.outerDiv}>
+    <HvTypography variant="normalText">Hover here</HvTypography>
+  </div>
+);
 
-const TooltipOpen = (() => {
-  return (
-    <div tabIndex="0" style={styling.outerDiv}>
-      <div style={styling.typographyAligner}>
-        <HvTypography variant="normalText">Tooltip open</HvTypography>
-      </div>
-    </div>
-  );
-})();
+const TooltipOpen = (
+  <div tabIndex="0" style={styling.outerDiv}>
+    <HvTypography variant="normalText">Tooltip open</HvTypography>
+  </div>
+);
 
-const data = (() => {
-  return <HvTypography variant="infoText">Grid View</HvTypography>;
-})();
+const data = <HvTypography variant="infoText">Grid View</HvTypography>;
 
 export default (
   <div style={styling.placeholder}>
-    <>
-      <Tooltip tooltipData={data} tooltipAnchor={TooltipHover} />
-      <Tooltip tooltipData={data} tooltipAnchor={TooltipOpen} open={true} />
-    </>
+    <Tooltip tooltipData={data} tooltipAnchor={TooltipHover} />
+    <Tooltip tooltipData={data} tooltipAnchor={TooltipOpen} open />
   </div>
 );

--- a/packages/doc/samples/components/tooltip/simpleTooltipLong.js
+++ b/packages/doc/samples/components/tooltip/simpleTooltipLong.js
@@ -3,40 +3,33 @@ import Tooltip from "@hv/uikit-react-core/dist/Tooltip";
 import HvTypography from "@hv/uikit-react-core/dist/Typography";
 
 const styling = {
-  outerDiv:{
+  outerDiv: {
     width: 100,
-    cursor: "pointer",
+    cursor: "pointer"
   },
   placeholder: {
     display: "flex",
+    textAlign: "center",
     justifyContent: "center",
     paddingTop: 90
-  },
-  typographyAligner:{
-    textAlign: "center"
   }
 };
 
-const TooltipControl = (() => {
-  return (
-    <div tabIndex="0" style={styling.outerDiv}>
-      <div style={styling.typographyAligner}>
-        <HvTypography variant="normalText">Hover here</HvTypography>
-      </div>
-    </div>
-  );
-})();
+const TooltipControl = (
+  <div tabIndex="0" style={styling.outerDiv}>
+    <HvTypography variant="normalText">Hover here</HvTypography>
+  </div>
+);
 
-const data = (() => {
-  return (
-    <HvTypography variant="infoText">Tooltips can showcase truncated text. The text should be concise and not redundant.</HvTypography>
-  );
-})()
+const data = (
+  <HvTypography variant="infoText">
+    Tooltips can showcase truncated text. The text should be concise and not
+    redundant.
+  </HvTypography>
+);
 
 export default (
   <div style={styling.placeholder}>
-    <>
-      <Tooltip tooltipData={data} tooltipAnchor={TooltipControl} />
-    </>
+    <Tooltip tooltipData={data} tooltipAnchor={TooltipControl} />
   </div>
 );

--- a/packages/doc/samples/components/tooltip/simpleTooltipLongOpen.js
+++ b/packages/doc/samples/components/tooltip/simpleTooltipLongOpen.js
@@ -3,40 +3,33 @@ import Tooltip from "@hv/uikit-react-core/dist/Tooltip";
 import HvTypography from "@hv/uikit-react-core/dist/Typography";
 
 const styling = {
-  outerDiv:{
+  outerDiv: {
     width: 100,
-    cursor: "pointer",
+    cursor: "pointer"
   },
   placeholder: {
     display: "flex",
+    textAlign: "center",
     justifyContent: "center",
     paddingTop: 90
-  },
-  typographyAligner:{
-    textAlign: "center"
   }
 };
 
-const TooltipControl = (() => {
-  return (
-    <div tabIndex="0" style={styling.outerDiv}>
-      <div style={styling.typographyAligner}>
-        <HvTypography variant="normalText">Tooltip open</HvTypography>
-      </div>
-    </div>
-  );
-})();
+const TooltipControl = (
+  <div tabIndex="0" style={styling.outerDiv}>
+    <HvTypography variant="normalText">Tooltip open</HvTypography>
+  </div>
+);
 
-const data = (() => {
-  return (
-    <HvTypography variant="infoText">Tooltips can showcase truncated text. The text should be concise and not redundant.</HvTypography>
-  );
-})()
+const data = (
+  <HvTypography variant="infoText">
+    Tooltips can showcase truncated text. The text should be concise and not
+    redundant.
+  </HvTypography>
+);
 
 export default (
   <div style={styling.placeholder}>
-    <>
-      <Tooltip tooltipData={data} tooltipAnchor={TooltipControl} open={true} />
-    </>
+    <Tooltip tooltipData={data} tooltipAnchor={TooltipControl} open />
   </div>
 );


### PR DESCRIPTION
addresses #930 

Aligns Tooltip's `propTypes` with `material-ui`'s, and updates tests and samples accordingly. Also simplifies samples. 