### PR TITLE
feat(types): type definitions from Olympus initial version (based on master) #533

### DIFF
--- a/packages/core/src/@types/HvBanner.d.ts
+++ b/packages/core/src/@types/HvBanner.d.ts
@@ -1,0 +1,84 @@
+declare module '@hv/uikit-react-core/dist' {
+  export class HvBanner extends React.Component<HvBannerProps, any> {}
+
+  export interface HvBannerProps extends React.HTMLAttributes<HvBanner> {
+    /**
+     * A Jss Object used to override or extend the styles applied.
+     */
+    classes?: {
+      /**
+       * Styles applied to the component root class.
+       */
+      root?: string
+      /**
+       * Styles applied to the component when define as top.
+       */
+      anchorOriginTopCenter?: string
+      /**
+       * Styles applied to the component when define as bottom.
+       */
+      anchorOriginBottomCenter?: string
+    }
+
+    /**
+     *  If true, Snackbar is open.
+     */
+    open: boolean
+
+    /**
+     * Callback fired when the component requests to be closed. Typically onClose is used to set state in the parent component, which is used to control the Snackbar open prop. The reason parameter can optionally be used to control the response to onClose, for example ignoring clickaway.
+     */
+    onClose: (...args: any[]) => any
+
+    /**
+     * The message to display.
+     */
+    label?: string
+
+    /**
+     * The message to display.
+     * @deprecated. Instead use the label property
+     */
+    message?: string
+
+    /**
+     *  The anchor of the Snackbar.
+     */
+    anchorOrigin?: 'top' | 'bottom'
+
+    /**
+     * Variant of the snackbar.
+     */
+    variant?: 'success' | 'warning' | 'error' | 'info' | 'default'
+
+    /**
+     * Custom icon to replace the variant default.
+     */
+    customIcon?: React.ReactNode
+
+    /**
+     * Controls if the associated icon to the variant should be shown.
+     */
+    showIcon?: boolean
+
+    /**
+     * Actions to display on the right side.
+     */
+    action?: React.ReactNode
+
+    /**
+     * Actions to display on message.
+     */
+    actionsOnMessage?: React.ReactNode
+
+    /**
+     * How much the transition animation last in milliseconds, if 0 no animation is played.
+     */
+    transitionDuration?: number
+
+    /**
+     * Direction of slide transition.
+     */
+    transitionDirection?: 'up' | 'down' | 'left' | 'right'
+  }
+}

--- a/packages/core/src/@types/HvButton.d.ts
+++ b/packages/core/src/@types/HvButton.d.ts
@@ -1,0 +1,121 @@
+declare module '@hv/uikit-react-core/dist' {
+  export class HvButton extends React.Component<HvButtonProps, any> {}
+
+  export interface HvButtonProps extends React.HTMLAttributes<HvButton> {
+    /**
+     * Type of button to use.
+     *  - Accepted values:
+     *    --"submit",
+     *    --"reset",
+     *    --"button"
+     * @deprecated
+     */
+    type?: 'submit' | 'reset' | 'button'
+
+    /**
+     * Type of color of HvButton to use.
+     *  - Accepted values:
+     *    --"primary",
+     *    --"secondary",
+     *    --"link"
+     *  - note: the buttonType object should be used to set this value.
+     * @deprecated
+     */
+    colorType?: 'primary' | 'secondary' | 'link'
+
+    /**
+     * Category of button to use.
+     *  - Accepted values:
+     *    --"primary",
+     *    --"secondary",
+     *    --"ghost"
+     *    --"ghostSecondary"
+     *  - note: the buttonType object should be used to set this value.
+     */
+    category?: 'primary' | 'secondary' | 'ghost' | 'ghostSecondary'
+
+    /**
+     * A Jss Object used to override or extend the styles applied.
+     */
+    classes?: {
+      /**
+       * Styles applied to the component root class.
+       */
+      root?: string
+      /**
+       * Styles applied to the primary primary button.
+       */
+      primary?: string
+      /**
+       * Styles applied to the primary primary button when it is disabled.
+       */
+      primaryDisabled?: string
+      /**
+       * Styles applied to the primary secondary button.
+       */
+      secondary?: string
+      /**
+       * Styles applied to the primary secondary button when it is disabled.
+       */
+      secondaryDisabled?: string
+      /**
+       * Styles applied to the primary ghost button.
+       */
+      ghost?: string
+      /**
+       * Styles applied to the primary ghost button when it is disabled.
+       */
+      ghostDisabled?: string
+      /**
+       * Styles applied to the primary secondary ghost  button.
+       */
+      ghostSecondary?: string
+      /**
+       * Styles applied to the primary secondary ghost button when it is disabled.
+       */
+      ghostSecondaryDisabled?: string
+      /**
+       * Styles applied to the inspireRed primary button.
+       */
+      inspireRedPrimary?: string
+      /**
+       * Styles applied to the inspireRed primary button when it is disabled.
+       */
+      inspireRedPrimaryDisabled?: string
+      /**
+       * Styles applied to the inspireRed secondary button.
+       */
+      inspireRedSecondary?: string
+      /**
+       * Styles applied to the inspireRed secondary button when it is disabled.
+       */
+      inspireRedSecondaryDisabled?: string
+      /**
+       * Styles applied to the inspireRed ghost button.
+       */
+      inspireRedGhost?: string
+      /**
+       * Styles applied to the inspireRed ghost button when it is disabled.
+       */
+      inspireRedGhostDisabled?: string
+      /**
+       * Styles applied to the inspireRed secondary ghost  button.
+       */
+      inspireRedGhostSecondary?: string
+      /**
+       * Styles applied to the inspireRed secondary ghost button when it is disabled.
+       */
+      inspireRedGhostSecondaryDisabled?: string
+    }
+
+    /**
+     * If `true` the button is disabled and the onClick function will not be called.
+     */
+    disabled?: boolean
+
+    /**
+     * The function executed when the button is pressed.
+     */
+    onClick?: (...args: any[]) => any
+  }
+}

--- a/packages/core/src/@types/HvCheckBox.d.ts
+++ b/packages/core/src/@types/HvCheckBox.d.ts
@@ -1,0 +1,120 @@
+declare module '@hv/uikit-react-core/dist' {
+  export class HvCheckBox extends React.Component<HvCheckBoxProps, any> {}
+
+  export interface HvCheckBoxProps extends React.HTMLAttributes<HvCheckBox> {
+    /**
+     * A Jss Object used to override or extend the styles applied to the checkbox.
+     */
+    classes?: {
+      /**
+       * Styles applied to the component.
+       */
+      container?: string
+      /**
+       * Styles applied to the label typography.
+       */
+      labelTypography?: string
+      /**
+       * Styles applied to the component when the label is disable.
+       */
+      labelDisabled?: string
+      /**
+       *  Styles applied to the label when the position is end.
+       */
+      labelEnd?: string
+      /**
+       * Styles applied to the label when the position is start.
+       */
+      labelStart?: string
+      /**
+       * Styles applied to the checkbox core element (material-ui).
+       */
+      checkBox?: string
+      /**
+       * Styles applied to the icon.
+       */
+      icon?: string
+      /**
+       * Styles applied to the icon when not selected.
+       */
+      iconEmpty?: string
+      /**
+       * Styles applied to the icon when selected.
+       */
+      iconFull?: string
+      /**
+       * Styles applied to the icon when disable.
+       */
+      iconDisable?: string
+      /**
+       * Styles applied to the icon when indeterminate.
+       */
+      iconIndeterminate?: string
+    }
+
+    /**
+     * If `true` the checkbox is disabled and the onClick function will not be called.
+     */
+    disabled?: boolean
+
+    /**
+     * The function executed when the checkbox is pressed.
+     */
+    onChange?: (...args: any[]) => any
+
+    /**
+     * If `true` the checkbox is selected, if set to `false` the checkbox is not selected.
+     * note: if this value is specified the state of the checkbox must be managed
+     */
+    checked?: boolean
+
+    /**
+     * If `true` the checkbox uses the intermediate state, if set to `false` the checkbox will not use the intermediate state.
+     */
+    indeterminate?: boolean
+
+    /**
+     * The value of the checkbox. This value will be returned in the event object generated for the onChange callback
+     */
+    value?: string
+
+    /**
+     * The label to be added to the checkbox.
+     */
+    label?: string
+
+    /**
+     * The position of the checkbox label.
+     *  - Accepted values:
+     *    --"start",
+     *    --"end"
+     *  - note: the labelPositions object should be used to set this value.
+     */
+    labelPlacement?: 'start' | 'end'
+
+    /**
+     * Extra properties passed to the MUI FormControlLabel component.
+     */
+    formControlLabelProps?: any
+
+    /**
+     * @deprecated Instead use the formControlLabelProps property
+     */
+    propsIcon?: string
+
+    /**
+     * Extra properties passed to the MUI Checkbox component.
+     */
+    checkboxProps?: any
+
+    /**
+     * @deprecated Instead use the checkboxProps property
+     */
+    propsLabel?: string
+
+    /**
+     * The theme passed by the provider.
+     */
+    theme?: any
+  }
+}

--- a/packages/core/src/@types/HvHeader.d.ts
+++ b/packages/core/src/@types/HvHeader.d.ts
@@ -1,0 +1,192 @@
+declare module '@hv/uikit-react-core/dist' {
+  export class HvHeader extends React.Component<HvHeaderProps, any> {}
+
+  export interface NavigationStructure {
+    showSearch?: boolean
+    data?: NavigationStructureData[]
+  }
+
+  export interface NavigationStructureData {
+    id?: string
+    label: string
+    selected?: boolean
+    isHidden?: boolean
+    leftIcon?: (...args: any[]) => any
+    iconCallback?: (arg: { isSelected: boolean }) => any
+    showNavIcon?: boolean
+    path?: string
+    params?: any
+    subData?: {
+      data: {
+        label?: string
+        path?: string
+      }[]
+    }
+  }
+
+  export interface NavigationData {
+    label?: string
+    path?: string
+    subData?: {
+      label?: string
+      path?: string
+    }[]
+  }
+
+  export interface UserData {
+    name?: string
+    role?: string
+  }
+
+  export interface HeaderLabel {
+    productName?: string
+    tenantName?: string
+  }
+
+  export interface ResponsivenessConfig {
+    showHbMenus?: 'xs' | 'sm' | 'md' | 'lg' | 'xl'
+    showNavigation?: 'xs' | 'sm' | 'md' | 'lg' | 'xl'
+    showUser?: 'xs' | 'sm' | 'md' | 'lg' | 'xl'
+    showActions?: 'xs' | 'sm' | 'md' | 'lg' | 'xl'
+    centerAlignElement?: 'xs' | 'sm' | 'md' | 'lg' | 'xl'
+  }
+
+  export interface ActionValue {
+    id?: string
+    label: string
+    selected?: boolean
+    isHidden?: boolean
+    leftIcon?: (...args: any[]) => any
+    iconCallback?: (...args: any[]) => any
+    showNavIcon?: boolean
+    subData?: any
+    path?: string
+    onVerticalClick?: (...args: any[]) => any
+    params?: any
+    horizontalItemAction?: React.ReactNode
+  }
+
+  export interface HvHeaderProps extends React.HTMLAttributes<HvHeader> {
+    /**
+     * The theme passed by the provider.
+     */
+    theme?: any
+
+    /**
+     * A Jss Object used to override or extend the styles applied.
+     */
+    classes?: {
+      shadowPadding?: string
+      root?: string
+      navButton?: string
+      verticalNavigationContainer?: string
+      verticalNavigationSeparation?: string
+    }
+
+    /**
+     * The position property of the header.
+     */
+    position?: 'fixed' | 'absolute' | 'sticky' | 'static' | 'relative'
+
+    /**
+     * Company logo. Can be a path for a image or a component.
+     */
+    companyLogo?: React.ReactNode
+
+    /**
+     * Product logo. Can be a path for a image or a component.
+     */
+    productLogo?: React.ReactNode
+
+    /**
+     * Product text.
+     * @deprecated Instead use the label property
+     */
+    productText?: string
+
+    /**
+     * Product text.
+     */
+    label?: string
+
+    /**
+     * Props passed to the navigation component
+     */
+    navigationStructure?: NavigationStructure
+
+    /**
+     * The index of the selected navigation item.
+     */
+    selected?: number | number[]
+
+    /**
+     * The data used for creating the navigation item.
+     * @deprecated
+     */
+    navigationData?: NavigationData[]
+
+    /**
+     * Path to be as base to be concatenated with the pat of the navigation data.
+     */
+    basePath?: string
+
+    /**
+     * Indicates if the router should be used.
+     */
+    useRouter?: boolean
+
+    /**
+     * Function when the navigation item detects a keydown. It returns the index.
+     */
+    onNavigationKeyDown?: (...args: any) => any
+
+    /**
+     * Function when the navigation item is click. It returns the selected index.
+     */
+    onNavigationClick?: (...args: any) => any
+
+    /**
+     * Object containing the text to be present
+     */
+    userData?: UserData
+
+    /**
+     * Object containing the labels to be present
+     */
+    labels?: HeaderLabel
+
+    /**
+     * Image to be render. If a path is passed an image is render, otherwise the component itself.
+     */
+    userIcon?: React.ReactNode
+
+    /**
+     * Function to be triggered by clicking in any point of container.
+     */
+    userClick?: (...args: any[]) => any
+
+    /**
+     * Array with the components to be render.
+     * @deprecated
+     */
+    itemActions?: React.ReactElement[]
+
+    /**
+     * Array with responsiveness breakpoints for components.
+     * *  - Accepted values:
+     *    --"xs",
+     *    --"sm",
+     *    --"md",
+     *    --"lg",
+     *    --"xl",
+     */
+    responsivenessConfig?: ResponsivenessConfig
+
+    /**
+     * Property set for actions to be displayed in the Vertical Navigation.
+     */
+    actionValues?: ActionValue[]
+
+    fixVerticalNavigation?: boolean
+  }
+}

--- a/packages/core/src/@types/HvInput.d.ts
+++ b/packages/core/src/@types/HvInput.d.ts
@@ -1,0 +1,291 @@
+declare module '@hv/uikit-react-core/dist' {
+  export class HvInput extends React.Component<HvInputProps, any> {}
+
+  export interface InputTextConfiguration {
+    inputLabel?: string
+    placeholder?: string
+    infoText?: string
+    warningText?: string
+    maxCharQuantityWarningText?: string
+    minCharQuantityWarningText?: string
+    requiredWarningText?: string
+  }
+
+  export interface InputLabels {
+    inputLabel?: string
+    placeholder?: string
+    infoText?: string
+    warningText?: string
+    maxCharQuantityWarningText?: string
+    minCharQuantityWarningText?: string
+    requiredWarningText?: string
+  }
+
+  export interface HvInputProps extends React.HTMLAttributes<HvInput> {
+    /**
+     * A Jss Object used to override or extend the component styles applied.
+     */
+    classes?: {
+      /**
+       * Styles applied to the container of the input.
+       */
+      container?: string
+      /**
+       * Styles applied to input root which is comprising of everything but the labels and descriptions.
+       */
+      inputRoot?: string
+      /**
+       * Styles applied to input root when it is disabled.
+       */
+      inputRootDisabled?: string
+      /**
+       * Styles applied to input root when it is focused.
+       */
+      inputRootFocused?: string
+      /**
+       * Styles applied to input html element.
+       */
+      input?: string
+      /**
+       * Styles applied to input html element when it is disabled.
+       */
+      inputDisabled?: string
+      /**
+       * Styles applied to input html element when it is multiline mode.
+       */
+      multiLine?: string
+      /**
+       * Styles applied to the label element.
+       */
+      label?: string
+      /**
+       * Styles applied to the container of the labels elements.
+       */
+      labelContainer?: string
+      /**
+       * Styles applied to the icon information container.
+       */
+      infoIconContainer?: string
+      /**
+       * Styles applied to the description.
+       */
+      text?: string
+      /**
+       * Styles applied to the description when it is showing an information.
+       */
+      textInfo?: string
+      /**
+       * Styles applied to the description when it is showing a warning.
+       */
+      textWarning?: string
+      /**
+       * Styles applied to the icon.
+       */
+      icon?: string
+      /**
+       * Styles applied to the container of the icon.
+       */
+      iconContainer?: string
+      /**
+       * Styles applied to the icon used to clean the input.
+       */
+      iconClear?: string
+      /**
+       * IE11 specific styling.
+       */
+      '@global'?: string
+    }
+
+    /**
+     * An Object containing the various text associated with the input.
+     *
+     * - inputLabel: the label on top of the input.
+     * - placeholder: the placeholder value of the input.
+     * - infoText: the default value of the info text below the input.
+     * - warningText: the value when a validation fails.
+     * - maxCharQuantityWarningText: the message that appears when there are too many characters.
+     * - minCharQuantityWarningText: the message that appears when there are too few characters.
+     * - requiredWarningText: the message that appears when the input is empty and required.
+     * @deprecated Instead use the labels property
+     */
+    inputTextConfiguration?: InputTextConfiguration
+
+    /**
+     * An Object containing the various text associated with the input.
+     *
+     * - inputLabel: the label on top of the input.
+     * - placeholder: the placeholder value of the input.
+     * - infoText: the default value of the info text below the input.
+     * - warningText: the value when a validation fails.
+     * - maxCharQuantityWarningText: the message that appears when there are too many characters.
+     * - minCharQuantityWarningText: the message that appears when there are too few characters.
+     * - requiredWarningText: the message that appears when the input is empty and required.
+     */
+    labels?: InputLabels
+
+    /**
+     * Attributes applied to the input element.
+     */
+    inputProps?: any
+
+    /**
+     * If ´true´ the input is disabled.
+     */
+    disabled?: boolean
+
+    /**
+     * If ´true´ the input value must be filled on blur or else the validation fails.
+     */
+    isRequired?: boolean
+
+    /**
+     * If ´true´ the input is of type password hiding the value.
+     */
+    password?: boolean
+
+    /**
+     * The function that will be executed onChange, allows modification of the input,
+     * it receives the value. If a new value should be presented it must returned it.
+     */
+    onChange?: (...args: any[]) => any
+
+    /**
+     * The function that will be executed onBlur, allows checking the validation state,
+     * it receives the value and the validation state (´empty´, ´filled´, ´invalid´, ´valid´).
+     */
+    onBlur?: (...args: any[]) => any
+
+    /**
+     * The function that will be executed onBlur, allows checking the value state,
+     * it receives the value.
+     */
+    onFocus?: (...args: any[]) => any
+
+    /**
+     * The function that will be executed onKeyDown, allows checking the value state,
+     * it receives the event and value.
+     */
+    onKeyDown?: (...args: any[]) => any
+
+    /**
+     * The function that will be executed to received an array of objects that has a label and id to create list of suggestion
+     */
+    suggestionListCallback?: (...args: any[]) => any
+
+    /**
+     * The function that will be executed after selecting a value in the suggestion list
+     */
+    suggestionSelectedCallback?: (...args: any[]) => any
+
+    /**
+     * If `true` validation is shown, `false` otherwise.
+     *  * @deprecated Instead use the showInfo property
+     */
+    validate?: boolean
+
+    /**
+     * If `true` information label is shown, `false` otherwise.
+     */
+    showInfo?: boolean
+
+    /**
+     * The custom validation function, it receives the value and must return
+     * either ´true´ for valid or ´false´ for invalid, default validations would only
+     * occur if this function is null or undefined
+     */
+    validation?: (...args: any[]) => any
+
+    /**
+     * The initial value of the input.
+     * @deprecated Instead use the initialValue property
+     */
+    value?: string
+
+    /**
+     * The initial value of the input.
+     */
+    initialValue?: string
+
+    /**
+     * The input value to be set. If used it is the responsibility of the caller to maintain the state.
+     * @deprecated will be replaced by value
+     */
+    inputValue?: string
+
+    /**
+     * If `true` it should autofocus.
+     */
+    autoFocus?: boolean
+
+    /**
+     * The initial state of the input.
+     *
+     * note: Is recommended you use the provided validationStates object to set this value.
+     */
+    validationState?: 'empty' | 'filled' | 'invalid' | 'valid'
+
+    /**
+     * Show info icon with info label.infoText.
+     */
+    infoIcon?: boolean
+
+    /**
+     * If `true` the icon is visible, `false` otherwise
+     * @deprecated Instead use the validationIconVisible property
+     */
+    iconVisible?: boolean
+
+    /**
+     * If `true` the validation icon is visible, `false` otherwise
+     */
+    validationIconVisible?: boolean
+
+    /**
+     * If `true` the clear button is disabled if `false` is enable
+     */
+    disableClear?: boolean
+
+    /**
+     * The icon position of the input. It is recommended to use the provided iconPositions object to set this value.
+     * @deprecated Instead use the validationIconPosition property
+     */
+    iconPosition?: 'left' | 'right'
+
+    /**
+     * The icon position of the input. It is recommended to use the provided validationIconPosition object to set this value.
+     */
+    validationIconPosition?: 'left' | 'right'
+
+    /**
+     * a custom icon to be added into the input.
+     */
+    customFixedIcon?: React.ReactNode
+
+    /**
+     * The maximum allowed length of the characters, if this value is null no check
+     * will be performed.
+     */
+    maxCharQuantity?: number
+
+    /**
+     * The minimum allowed length of the characters, if this value is null no check
+     * will be perform.
+     */
+    minCharQuantity?: number
+
+    /**
+     * Which type of default validation should the input perform. It is recommended to use the provided ValidationTypes object to set this value.
+     */
+    validationType?: 'none' | 'number' | 'email'
+
+    /**
+     * Overrides any validation with a specific error/warning message to set in the infoText slot.
+     */
+    externalWarningTextOverride?: string
+
+    /**
+     * The theme passed by the provider.
+     */
+    theme?: any
+  }
+}

--- a/packages/core/src/@types/HvKpi.d.ts
+++ b/packages/core/src/@types/HvKpi.d.ts
@@ -1,0 +1,98 @@
+declare module '@hv/uikit-react-core/dist' {
+  export class HvKpi extends React.Component<HvKpiProps, any> {}
+
+  export interface KpiTextConfiguration {
+    title?: string
+    indicator?: string
+    unit?: string
+    comparisonIndicatorInfo?: string
+  }
+
+  export interface KpiLabels {
+    title?: string
+    indicator?: string
+    unit?: string
+    comparisonIndicatorInfo?: string
+  }
+
+  export interface HvKpiProps extends React.HTMLAttributes<HvKpi> {
+    /**
+     * A Jss Object used to override or extend the component styles applied.
+     */
+    classes?: {
+      /**
+       * Styles applied to the component root class.
+       */
+      kpiContainer?: string
+      /**
+       * Styles applied to the component visual indicator.
+       */
+      visualIndicatorContainer?: string
+      /**
+       * Styles applied to the component comparison.
+       */
+      comparisonContainer?: string
+      /**
+       * Styles applied to the component indicators.
+       */
+      indicatorsContainer?: string
+      /**
+       * Styles applied to the component indicators text.
+       */
+      indicatorText?: string
+      /**
+       * Styles applied to the component indicators unit.
+       */
+      indicatorUnit?: string
+      /**
+       * Styles applied to the component comparison container right spacing.
+       */
+      spacingToTheRight?: string
+      /**
+       * Styles applied to the component visual comparison.
+       */
+      comparisons?: string
+    }
+
+    /**
+     * An Element that will be rendered to the left of the kpi indicator text.
+     */
+    visualIndicator?: React.ReactNode
+
+    /**
+     * An Element that will be rendered below the kpi indicator text.
+     */
+    visualComparison?: React.ReactNode
+
+    /**
+     * The object that contains the different labels inside the kpi.
+     *
+     * - Title: The text at the top of the kpi.
+     * - Indicator: The text in the middle of the kpi.
+     * - Unit: The text to the right of the indicator.
+     * - comparisonIndicatorInfo: the text to the right of the visual comparison.
+     * @deprecated Instead use the labels property
+     */
+    kpiTextConfiguration?: KpiTextConfiguration
+
+    /**
+     * The object that contains the different labels inside the kpi.
+     *
+     * - Title: The text at the top of the kpi.
+     * - Indicator: The text in the middle of the kpi.
+     * - Unit: The text to the right of the indicator.
+     * - comparisonIndicatorInfo: the text to the right of the visual comparison.
+     */
+    labels?: KpiLabels
+
+    /**
+     *  The typography variant used in the main text indicator of the KPI
+     */
+    indicatorTextVariant?: '5xlTitle' | 'xxlTitle' | 'lTitle' | 'sTitle'
+
+    /**
+     *  The typography variant used in the main text indicator of the KPI
+     */
+    indicatorUnitTextVariant?: 'sText' | 'infoText'
+  }
+}

--- a/packages/core/src/@types/HvLogin.d.ts
+++ b/packages/core/src/@types/HvLogin.d.ts
@@ -1,0 +1,198 @@
+declare module '@hv/uikit-react-core/dist' {
+  export class HvLogin extends React.Component<HvLoginProps, any> {}
+
+  export interface LoginInfo {
+    username: string
+    password: string
+  }
+
+  export interface LoginLabel {
+    titleText?: string
+    recoveryTitle?: string
+    messageToRecover?: string
+    messageAfterRecover?: string
+    recoveryInputLabel?: string
+    recoveryPlaceholder?: string
+    recoveryErrorMessage?: string
+    userNameInputLabel?: string
+    userNamePlaceHolder?: string
+    passwordInputLabel?: string
+    passwordPlaceHolder?: string
+    rememberMeLabel?: string
+    loginButtonMessage?: string
+    loginButtonLabel?: string
+    forgotYourCredentialMessage?: string
+    emailLabel: string
+    emailPlaceholder: string
+    cancelButton: string
+    recoverButton: string
+    recoveringMessage: string
+    incorrectCredentialsMessage?: string
+  }
+
+  export interface HvLoginProps extends React.HTMLAttributes<HvLogin> {
+    /**
+     * the classes object to be applied into the root object.
+     */
+    classes?: {
+      /**
+       * Styles applied to the component root class.
+       */
+      root?: string
+      /**
+       * Styles applied to the right container.
+       */
+      rightContainer?: string
+      /**
+       * Styles applied to the form, inside the right container.
+       */
+      formContainer?: string
+    }
+
+    /**
+     * the function invoked for the log in
+     */
+    login: (info: LoginInfo) => any
+
+    /**
+     * the function invoked for the recovery
+     */
+    recovery?: (...args: any[]) => any
+
+    /**
+     * the url for the background image
+     */
+    backgroundImage?: string
+
+    /**
+     * Sizing for background image
+     */
+    backgroundImageSize?: string
+
+    /**
+     * the welcome message.
+     * @deprecated Instead use the labels property
+     */
+    titleText?: string
+
+    /**
+     * the url for the logo in the welcome message.
+     */
+    logo?: string
+
+    /**
+     * a component to replace the welcome message
+     */
+    titleComponent?: React.ReactElement
+
+    /**
+     * the component should have the recovery capability
+     */
+    allowRecover?: boolean
+
+    /**
+     * the component should have the remember me capability
+     */
+    allowRememberMe?: boolean
+
+    /**
+     * Icon to be presented when the recovery occurs successfully.
+     */
+    okRecoveryIcon?: React.ReactElement
+
+    /**
+     * Icon to be presented when an error occurs in the login.
+     */
+    errorLoginIcon?: React.ReactElement
+
+    /**
+     *  Incorrect Credentials Message.
+     */
+    incorrectCredentialsMessage?: string
+
+    /**
+     * The object that contains the different labels inside the kpi.
+     *
+     * - titleText: The welcome message.
+     * - recoveryTitle: Recovery title.
+     * - messageToRecover: Message to recover
+     * - messageAfterRecover: Message shown after recover.
+     * - recoveryInputLabel: Recovery input label.
+     * - recoveryPlaceholder: Recovery placeholder.
+     * - recoveryErrorMessage: Message shown when an error occurs.
+     * - userNameInputLabel: Input user name label.
+     * - userNamePlaceHolder: Input user name placeholder.
+     * - passwordInputLabel: Password label.
+     * - passwordPlaceHolder: Password placeholder.
+     * - rememberMeLabel: Remember me label.
+     * - incorrectCredentialsMessage: Incorrect Credentials Message
+     */
+    labels?: LoginLabel
+
+    /**
+     * Recovery title.
+     * @deprecated Instead use the labels property
+     */
+    recoveryTitle?: string
+
+    /**
+     * Message to recover.
+     * @deprecated Instead use the labels property
+     */
+    messageToRecover?: string
+
+    /**
+     * Message shown after recover.
+     * @deprecated Instead use the labels property
+     */
+    messageAfterRecover?: string
+
+    /**
+     * Recovery input label.
+     * @deprecated Instead use the labels property
+     */
+    recoveryInputLabel?: string
+
+    /**
+     * Recovery placeholder.
+     * @deprecated Instead use the labels property
+     */
+    recoveryPlaceholder?: string
+
+    /**
+     * Message shown when an error occurs.
+     * @deprecated Instead use the labels property
+     */
+    recoveryErrorMessage?: string
+
+    /**
+     * Input user name label.
+     * @deprecated Instead use the labels property
+     */
+    userNameInputLabel?: string
+
+    /**
+     * Input user name placeholder.
+     * @deprecated Instead use the labels property
+     */
+    userNamePlaceHolder?: string
+
+    /**
+     * Password label.
+     * @deprecated Instead use the labels property
+     */
+    passwordInputLabel?: string
+
+    /**
+     * Password placeholder.
+     * @deprecated Instead use the labels property
+     */
+    passwordPlaceHolder?: string
+
+    /**
+     * Remember me label.
+     * @deprecated Instead use the labels property
+     */
+    rememberMeLabel?: string
+  }
+}

--- a/packages/core/src/@types/HvModal.d.ts
+++ b/packages/core/src/@types/HvModal.d.ts
@@ -1,0 +1,33 @@
+declare module '@hv/uikit-react-core/dist' {
+  export class HvModal extends React.Component<HvModalProps, any> {}
+
+  export interface HvModalProps extends React.HTMLAttributes<HvModal> {
+    /**
+     * A Jss Object used to override or extend the styles applied.
+     */
+    classes?: {
+      /**
+       * Style applied to the background (outside) of the component.
+       */
+      background?: string
+      /**
+       * Style applied to the component (root).
+       */
+      paper?: string
+      /**
+       * Style applied to the close button.
+       */
+      closeButton?: string
+    }
+
+    /**
+     * Current state of the modal.
+     */
+    open: boolean
+
+    /**
+     * Function executed on close.
+     */
+    onClose: (...args: any[]) => any
+  }
+}

--- a/packages/core/src/@types/HvModalActions.d.ts
+++ b/packages/core/src/@types/HvModalActions.d.ts
@@ -1,0 +1,23 @@
+declare module '@hv/uikit-react-core/dist' {
+  export class HvModalActions extends React.Component<
+    HvModalActionsProps,
+    any
+  > {}
+
+  export interface HvModalActionsProps
+    extends React.HTMLAttributes<HvModalActions> {
+    /**
+     * A Jss Object used to override or extend the styles applied.
+     */
+    classes?: {
+      /**
+       * Style applied to the root of the component (container for the actions).
+       */
+      root?: string
+      /**
+       * Style applied to each child action.
+       */
+      action?: string
+    }
+  }
+}

--- a/packages/core/src/@types/HvModalContent.d.ts
+++ b/packages/core/src/@types/HvModalContent.d.ts
@@ -1,0 +1,23 @@
+declare module '@hv/uikit-react-core/dist' {
+  export class HvModalContent extends React.Component<
+    HvModalContentProps,
+    any
+  > {}
+
+  export interface HvModalContentProps
+    extends React.HTMLAttributes<HvModalContent> {
+    /**
+     * A Jss Object used to override or extend the styles applied.
+     */
+    classes?: {
+      /**
+       * Style applied to the root of the component (container for the content).
+       */
+      root?: string
+      /**
+       * Style applied when the content is a string.
+       */
+      textContent?: string
+    }
+  }
+}

--- a/packages/core/src/@types/HvModalTitle.d.ts
+++ b/packages/core/src/@types/HvModalTitle.d.ts
@@ -1,0 +1,48 @@
+declare module '@hv/uikit-react-core/dist' {
+  export class HvModalTitle extends React.Component<HvModalTitleProps, any> {}
+
+  export interface HvModalTitleProps
+    extends React.HTMLAttributes<HvModalTitle> {
+    /**
+     * A Jss Object used to override or extend the styles applied.
+     */
+    classes?: {
+      /**
+       * Style applied to the root of the component (container for the title).
+       */
+      root?: string
+      /**
+       * Style applied to the container of the title
+       */
+      messageContainer?: string
+      /**
+       * Style applied to the text when the icon is present.
+       */
+      textWithIcon?: string
+      /**
+       * Style applied to the icon.
+       */
+      icon?: string
+    }
+
+    /**
+     * Variant of the modal.
+     */
+    variant?: 'success' | 'warning' | 'error' | 'info' | 'default'
+
+    /**
+     * Controls if the associated icon to the variant should be shown.
+     */
+    showIcon?: boolean
+
+    /**
+     * Custom icon to replace the variant default.
+     */
+    customIcon?: React.ReactNode
+
+    /**
+     * The theme passed by the provider.
+     */
+    theme?: any
+  }
+}

--- a/packages/core/src/@types/HvProvider.d.ts
+++ b/packages/core/src/@types/HvProvider.d.ts
@@ -1,0 +1,4 @@
+declare module '@hv/uikit-react-core/dist' {
+  export class HvProvider extends React.Component<HvProviderProps, any> {}
+  export interface HvProviderProps extends React.HTMLAttributes<HvProvider> {}
+}

--- a/packages/core/src/@types/HvSearchBox.d.ts
+++ b/packages/core/src/@types/HvSearchBox.d.ts
@@ -1,0 +1,93 @@
+declare module '@hv/uikit-react-core/dist' {
+  export class HvSearchBox extends React.Component<HvSearchBoxProps, any> {}
+
+  export interface SearchBoxLabel {
+    inputLabel?: string
+    placeholder?: string
+  }
+
+  export interface HvSearchBoxProps extends React.HTMLAttributes<HvSearchBox> {
+    /**
+     * The theme passed by the provider.
+     */
+    theme?: any
+
+    /**
+     * A Jss Object used to override or extend the styles applied to the search box.
+     */
+    classes?: {
+      /**
+       * Styles applied to searchbox root.
+       */
+      root: string
+    }
+
+    /**
+     * An Object containing the various text associated with the searchbox.
+     *
+     * - inputLabel: the label on top of the searchbox.
+     * - placeholder: the placeholder value of the searchbox.
+     */
+    labels?: SearchBoxLabel
+
+    /**
+     * The initial value of the searchbox
+     */
+    value?: string
+
+    /**
+     * The function that will be executed when the searchbox changes,
+     * it receives the searchbox value
+     */
+    onChange?: (...args: any[]) => any
+
+    /**
+     * The function that will be executed to received an array of objects that has a label and id to create list of suggestion
+     */
+    suggestionListCallback?: (...ags: any[]) => any
+
+    /**
+     * The function that will be executed after selecting a value in the suggestion list
+     */
+    suggestionSelectedCallback?: (...args: any[]) => any
+
+    /**
+     * The function that will be executed onBlur, allows checking the validation state,
+     * it receives the value and the validation state (´empty´, ´filled´, ´invalid´, ´valid´).
+     */
+    onBlur?: (...args: any[]) => any
+
+    /**
+     * The function that will be executed onFocus, allows checking the value state,
+     * it receives the value.
+     */
+    onFocus?: (...args: any[]) => any
+
+    /**
+     * The function that will be executed onKeyDown, allows checking the value state,
+     * it receives the value.
+     */
+    onKeyDown?: (...args: any[]) => any
+
+    /**
+     * The function that will be executed on Enter, allows checking the value state,
+     * it receives the value.
+     */
+    onSubmit?: (...args: any[]) => any
+
+    /**
+     * If `true` it should autofocus.
+     */
+    autoFocus?: boolean
+
+    /**
+     * If ´true´ the searchBox is disabled.
+     */
+    disabled?: boolean
+
+    /**
+     * The initial value of the searchBox.
+     */
+    initialValue?: string
+  }
+}

--- a/packages/core/src/@types/HvTable.d.ts
+++ b/packages/core/src/@types/HvTable.d.ts
@@ -1,0 +1,202 @@
+declare module '@hv/uikit-react-core/dist' {
+  export class HvTable extends React.Component<HvTableProps, any> {}
+
+  export interface TableLabel {
+    titleText?: string
+    subtitleText?: string
+  }
+
+  export interface TableColumn {
+    headerText?: string
+    accessor?: string | ((...args: any[]) => any)
+    format?: (...args: any[]) => any
+    cellType?: string
+    style?: any
+    fixed?: string
+    Cell?: any
+    sortable?: boolean
+  }
+
+  export interface SecondaryAction {
+    label?: string
+    action?: (...args: any[]) => any
+  }
+
+  export interface HvTableProps extends React.HTMLAttributes<HvTable> {
+    /**
+     * Unique class name used to identify the fixed table
+     */
+    uniqClassName?: string
+
+    /**
+     * the classes object to be applied into the root object.
+     */
+    classes?: {
+      /**
+       * Styles applied to the component root.
+       */
+      root?: string
+      /**
+       * Styles applied to the component thead.
+       */
+      thead?: string
+      /**
+       * Styles applied to the component tr.
+       */
+      tr?: string
+      /**
+       * Styles applied to the component sort icon.
+       */
+      rtSortIcon?: string
+      /**
+       * Styles applied to the component when the sort icon is shown.
+       */
+      sortedIconShown?: string
+      /**
+       * Styles applied to the component when the sort icon is hidden.
+       */
+      sortedIconHidden?: string
+      /**
+       * Styles applied to the component pointer.
+       */
+      pointer?: string
+      /**
+       * Styles applied to the component subtitle.
+       */
+      subtitle?: string
+      /**
+       * Styles applied to the component title.
+       */
+      title?: string
+      /**
+       * Styles applied to the component when type is link.
+       */
+      link?: string
+      /**
+       * Styles applied to the component expander.
+       */
+      subComponentContainer?: string
+      /**
+       * Styles applied to the component icon in the columns.
+       */
+      iconContainer?: string
+      /**
+       * Styles applied to the component columns.
+       */
+      firstWithNumeric?: string
+    }
+    /**
+     * The labels inside the table.
+     */
+    labels?: TableLabel
+
+    /**
+     * Title of the table.
+     * @deprecated Instead use the labels property
+     */
+    titleText?: string
+
+    /**
+     * Subtitle of the table.
+     * @deprecated Instead use the labels property
+     */
+    subtitleText?: string
+
+    /**
+         * The column definition to apply to the table. Please check https://react-table.js.org/#/story/readme for more info
+         Use the property "cellType" to define the different types of cell. Available values: "number" , "alpha-numeric" and "link.
+         If the type is "link", in data use the structure {displayText: {text to display} ,url: {url} }.
+         */
+    columns: TableColumn[]
+
+    /**
+     * Array with the data elements to show
+     */
+    data: any[]
+
+    /**
+     * Boolean to show or hide the pagination controls
+     */
+    showPagination?: boolean
+
+    /**
+     * Callback to notify when the page changes
+     */
+    onPageChange?: (...args: any[]) => any
+
+    /**
+     * Boolean to show or hide the page size control
+     */
+    showPageSize?: boolean
+
+    /**
+     * Numeric value to control the page size selected
+     */
+    pageSize?: number
+
+    /**
+     * Callback to notify when the page size changes
+     */
+    onPageSizeChange?: (...args: any[]) => any
+
+    /**
+     * Boolean to enable or disable the server side pagination mechanism
+     */
+    paginationServerSide?: boolean
+
+    /**
+     * Numeric value to control the number of pages. Useful when Server side pagination data is enabled
+     */
+    pages?: number
+
+    /**
+     * Callback with receives the page info and should fetch the data to show on the table
+     */
+    onFetchData?: (...args: any[]) => any
+
+    /**
+     * Boolean to enable or disable the sort mechanism
+     */
+    sortable?: boolean
+
+    /**
+     * An object describing what column is sorted by default on the table
+     */
+    defaultSorted?: any[]
+
+    /**
+     * Element to be shown in the expander.
+     */
+    subElementTemplate?: (...args: any[]) => any
+
+    /**
+     * Property to be uses as unique row identifier. One of the fields of the data.
+     */
+    idForCheckbox?: string
+
+    /**
+     * Function to overwrite the existed getTrProps
+     */
+    getTrProps?: (...args: any[]) => any
+
+    /**
+     * Boolean to bind config back to function or not
+     */
+    useRouter?: boolean
+
+    /**
+     * Callback which receives the checked state of all items in the list
+     */
+    onSelection?: (...args: any[]) => any
+
+    /**
+     * Ids of preselected items in the list
+     */
+    selections?: any[]
+
+    /**
+     *  Secondary actions listed in menu dropdown. Label is displayed and action is executed on click.
+     */
+    secondaryActions?: SecondaryAction[]
+  }
+}

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -15,6 +15,7 @@
     "build": "npm-run-all clean build:*",
     "build:convert": "node ./src/svgToReact.js dir --input node_modules/@hv/uikit-common-icons/dist --output bin --force",
     "build:babel": "npx babel bin -d dist --source-maps --copy-files",
+    "build:types": "node ./src/typeGen/main.js --input dist --output dist/@types",
     "clean": "npx del-cli dist bin",
     "prepublish": "npm run build",
     "postpublish": "npm run clean",

--- a/packages/icons/src/typeGen/IconBase.d.ts
+++ b/packages/icons/src/typeGen/IconBase.d.ts
@@ -1,0 +1,76 @@
+declare module '@hv/uikit-react-icons/dist' {
+  class IconBase extends React.Component<IconBaseProps> { }
+  interface IconBaseProps extends React.HTMLAttributes<IconBase> {
+    /**
+     * A Jss Object used to override or extend the styles applied.
+     */
+    classes?: {
+      /**
+       * Styles applied to the component root when it is extra small.
+       */
+      rootXs?: string
+
+      /**
+       * Styles applied to the component root when it is small.
+       */
+      rootS?: string
+
+      /**
+       * Styles applied to the component root when it is medium.
+       */
+      rootM?: string
+
+      /**
+       * Styles applied to the component root when it is large.
+       */
+      rootL?: string
+
+      /**
+       * Styles applied to the component root when it is extra large.
+       */
+      rootXL?: string
+    }
+
+    /**
+     * An array of strings representing the colors to override in the icon.
+     * Each element inside the array will override a diferent color.
+     */
+    color?: string[]
+
+    /**
+     * A string that will override the viewbox of the svg
+     */
+    viewbox?: string
+
+    /**
+     * A string that will override the height of the svg
+     */
+    height?: string
+
+    /**
+     * A string that will override the width of the svg
+     */
+    width?: string
+
+    /**
+     * Sets one of the standard sizes of the icons
+     */
+    iconSize?: 'XS' | 'S' | 'M' | 'L' | 'XL'
+
+    /**
+     * Sets one of the standard semantic palette colors of the icon
+     */
+    semantic?: 'sema1' | 'sema2' | 'sema3' | 'sema4' | 'sema5' | 'sema6' | 'sema7' | 'sema8' | 'sema9' | 'sema10' | 'sema11' | 'sema12' | 'sema13' | 'sema14' | 'sema15' | 'sema16' | 'sema17' | 'sema18' | 'sema19'
+
+    /**
+     * Inverts the background-foreground on semantic icons
+     */
+    inverted?: boolean
+
+    /**
+     * Styles applied to the box around the svg.
+     */
+    boxStyles?: any
+
+  }
+}

--- a/packages/icons/src/typeGen/main.js
+++ b/packages/icons/src/typeGen/main.js
@@ -1,0 +1,65 @@
+
+const fs = require('fs');
+const path = require('path');
+const yargs = require("yargs"); // argumen reader
+
+const moduleRoot = '@hv/uikit-react-icons/dist';
+const iconBasePath = `${__dirname}/IconBase.d.ts`;
+const jsRe = /\.js$/;
+
+function main() {
+  const args = yargs // reading arguments from the command line
+    .option("output", { alias: "o" })
+    .option("input", { alias: "i" })
+    .argv;
+
+  if (!fs.existsSync(args.input)) {
+    error(`${args.input} does not exists`);
+    return;
+  }
+  if (!fs.existsSync(args.output)) {
+    fs.mkdirSync(args.output, {recursive: true});
+  }
+  generate(moduleRoot, args.input, args.output);
+}
+
+function generate(module, input, output, fileSuffix = '') {
+  var text = !fileSuffix ? fs.readFileSync(iconBasePath, 'utf-8') + '\n' : '';
+  fs.readdirSync(input).forEach(f => {
+    var fpath = path.join(input, f);
+    if (isDirectory(fpath)) {
+      generate(module + `/${f}`, fpath, output, f);
+    } else if (f.match(jsRe)) {
+      const className = f.replace(jsRe, '').replace(/[^a-zA-Z0-9]/g, '_');
+      if (className == 'index') {
+        return;
+      }
+      text += `declare module '${module}/${f.replace(jsRe, '')}' {\n`;
+      text += "  import { IconBase } from '@hv/uikit-react-icons/dist'\n"
+      text += `  export default class ${className} extends IconBase {}\n`
+      text += '}\n'
+    }
+  });
+  if (text) {
+    fs.writeFileSync(
+      path.join(output, `Icons${fileSuffix ? `_${fileSuffix}` : ''}.d.ts`),
+      text
+    );
+  }
+}
+
+function error(s) {
+  console.error(s);
+  throw new Error(s)
+}
+
+function isDirectory(p) {
+  try {
+    return fs.statSync(p).isDirectory();
+  } catch (e) {
+    console.error(`cannot access ${p}.`);
+    process.exit(-1);
+  }
+}
+
+main();

--- a/packages/lab/src/@types/HvFooter.d.ts
+++ b/packages/lab/src/@types/HvFooter.d.ts
@@ -1,0 +1,12 @@
+declare module '@hv/uikit-react-lab/dist' {
+  export class HvFooter extends React.Component<HvFooterProps, any> {}
+
+  export interface HvFooterProps extends React.HTMLAttributes<HvFooter> {
+    classes?: {
+      root?: string
+      labelRight?: string
+      labelLeft?: string
+    }
+    labelLeftName?: string
+  }
+}

--- a/packages/lab/src/@types/HvSlider.d.ts
+++ b/packages/lab/src/@types/HvSlider.d.ts
@@ -1,0 +1,165 @@
+declare module '@hv/uikit-react-lab/dist' {
+  export class HvSlider extends React.Component<HvSliderProps, any> {}
+
+  export interface KnobProperty {
+    color?: string
+    defaultValue?: number
+    hidden?: bool
+    fixed?: bool
+    hoverColor?: string
+    trackColor?: string
+    dragColor?: string
+  }
+
+  export interface MarkProperty {
+    position?: number
+    label?: string
+  }
+
+  export interface HvSliderProps extends React.HTMLAttributes<HvSlider> {
+    /**
+     * The object created by material to apply to the component.
+     */
+    theme?: any
+
+    /**
+     * The values array to apply to the component
+     */
+    values?: number[]
+
+    /**
+     * The default values array to apply to the component
+     */
+    defaultValues?: number[]
+
+    /**
+     * The object used to set the knob properties,
+     * for every item in the array a new knob will be created.
+     */
+    knobProperties: KnobProperty[]
+
+    /**
+     * The object used to set the mark properties individually.
+     */
+    markProperties?: MarkProperty[]
+
+    /**
+     * the function executed before a change will ocurr in the slider.
+     * it will receive an object like
+     * {
+     *   knobsPosition: [],
+     *   knobsValues: []
+     * }
+     */
+    onBeforeChange?: (args: { knobsPosition: any[]; knobsValues: any[] }) => any
+
+    /**
+     * the function executed while a change is ocurring in the slider.
+     * it will receive an object like
+     * {
+     *   knobsPosition: [],
+     *   knobsValues: []
+     * }
+     */
+    onChange?: (args: { knobsPosition: any[]; knobsValues: any[] }) => any
+
+    /**
+     * the function executed after a change ocurred in the slider.
+     * it will receive an object like
+     * {
+     *   knobsPosition: [],
+     *   knobsValues: []
+     * }
+     */
+    onAfterChange?: (args: { knobsPosition: any[]; knobsValues: any[] }) => any
+
+    /**
+     * the separation in points between marks.
+     * example: if 10 divisions and a markstep of 2 there will be 5 marks.
+     */
+    markStep?: number
+
+    /**
+     * how many subdivisions there are in the slider.
+     */
+    divisionQuantity?: number
+
+    /**
+     * the value of the first point in the slider from left to right.
+     */
+    minPointValue?: number
+
+    /**
+     * the value of the last point in the slider from left to right.
+     */
+    maxPointValue?: number
+
+    /**
+     * the nax number of decimals if no format function is applied
+     */
+    markDigits?: number
+
+    /**
+     * a formatting function used to add format to the marks in the track,
+     * the function receives the mark text
+     */
+    formatMark?: (...args: any[]) => any
+
+    /**
+     * a formatting function used to add format to the tooltip in the track,
+     * the function receives the mark text
+     */
+    formatTooltip?: (...args: any[]) => any
+
+    /**
+     * if `true` the knobs can't have the same value, if `false` knobs can have the same value.
+     */
+    noOverlap?: boolean
+
+    /**
+     * the classes object to be applied into the root object.
+     */
+    classes?: {
+      /**
+       * Style applied to the root of the component.
+       */
+      root?: string
+      /**
+       * Style applied to the dot.
+       */
+      dot?: string
+      /**
+       * Style applied to the rail.
+       */
+      rail?: string
+      /**
+       * Style applied to the inner of the knob.
+       */
+      knobInner?: string
+      /**
+       * Style applied to the outside of the knob.
+       */
+      knobOuter?: string
+      /**
+       * Style applied when the knob is hidden.
+       */
+      knobHidden?: string
+      /**
+       * Style applied  last hidden knob.
+       */
+      knobHiddenLast?: string
+      /**
+       * Style applied to the track.
+       */
+      track?: string
+      /**
+       * Style applied to the mark.
+       */
+      mark?: string
+      /**
+       * Style applied to the tooltip.
+       */
+      sliderTooltip?: string
+    }
+  }
+}


### PR DESCRIPTION
Copied over from https://github.com/pentaho/hv-uikit-react/pull/955, rebased on master from alpha:

Hello, as we discussed last week (on Dec 20), we are contributing the type definitions we wrote in our project, Olympus. We are a strong believer of strongly-typed approach, and it was crucial for us to have the type definitions for UI Kit to use it; hence we wrote these. Hope it helps other projects like us.

* For core and lab packages, the type definitions are stored in src/@types.
* For icons package, `build:types` npm script (run as a part of `npm run build`) will generate the type definitions into dist/@types. See the diff of `packages/icons/package.json`.

Note we wrote these type definitions based on our readings of your code as we require, which means the work is not complete. Your feedback and corrections will be most welcome, and we will update them as well as we get better understandings. Let us work closely together to achieve a better completeness and quality to be helpful for other projects, and we will be happy to arrange con calls to have necessary communications. Thank you very much.