### PR TITLE
docs: accessibility for checkbox/radio

### DIFF
--- a/packages/doc/.storybook/layout-addon/Layout/Accessibility/Accessibility.js
+++ b/packages/doc/.storybook/layout-addon/Layout/Accessibility/Accessibility.js
@@ -18,28 +18,10 @@ import React from "react";
 import ReactMarkdown from "react-markdown";
 import HvTypography from "@hv/uikit-react-core/dist/Typography";
 
-class Accessibility extends React.Component {
-  state = {
-    content: ""
-  }
-
-  async componentDidMount() {
-    const { componentName } = this.props;
-
-    let documentPage = await require(`../../../../pages/components/${ componentName }/accessibility.md`);
-    this.setState({
-      content: documentPage.default
-    })
-  }
-
-  render() {
-    return   (
-      <>
-        <ReactMarkdown source={ this.state.content } />
-    
-      </>
-    ); 
-  }
-}
+const Accessibility = ({ pageData }) => (
+  <HvTypography component="div">
+    <ReactMarkdown source={pageData} />
+  </HvTypography>
+);
 
 export default Accessibility;

--- a/packages/doc/.storybook/layout-addon/Layout/Tabs/Tabs.js
+++ b/packages/doc/.storybook/layout-addon/Layout/Tabs/Tabs.js
@@ -15,6 +15,7 @@
  */
 
 import React from "react";
+import { basename } from "path";
 import PropTypes from "prop-types";
 import MUITabs from "@material-ui/core/Tabs";
 import MUITab from "@material-ui/core/Tab";
@@ -62,25 +63,17 @@ class Tabs extends React.Component {
   };
 
   render() {
-    const {
-      classes,
-      parameters,
-      propsMetaData,
-      descriptionMetadata,
-      theme
-    } = this.props;
+    const { classes, parameters, propsMetaData, theme } = this.props;
     const { value } = this.state;
 
-    let showAccessibility;
-    const showCssTab = !isNil(propsMetaData) && !isNil(propsMetaData.classes);
-
+    let accessPage = null;
     try {
-      showAccessibility = require(`../../../../pages/components/${
-        parameters.title
-      }/accessibility.md`);
-    } catch (error) {
-      showAccessibility = false;
-    }
+      const folder = basename(parameters.fileName, ".js").toLowerCase();
+      accessPage = require(`../../../../pages/components/${folder}/accessibility.md`);
+    } catch (error) {}
+
+    const showCssTab = !isNil(propsMetaData) && !isNil(propsMetaData.classes);
+    const showAccessibilityTab = !isNil(accessPage);
 
     return (
       <div className={classes.root}>
@@ -106,7 +99,7 @@ class Tabs extends React.Component {
               label="CSS"
             />
           )}
-          {showAccessibility && (
+          {showAccessibilityTab && (
             <MUITab
               disableRipple
               classes={{ root: classes.tabRoot, selected: classes.tabSelected }}
@@ -118,12 +111,7 @@ class Tabs extends React.Component {
           {value === 0 && <TabUsage parameters={parameters} theme={theme.hv} />}
           {value === 1 && <TabAPI propsMetaData={propsMetaData} />}
           {value === 2 && <TabCSS propsMetaData={propsMetaData} />}
-          {value === 3 && (
-            <Accessibility
-              descriptionMetadata={descriptionMetadata}
-              componentName={parameters.title}
-            />
-          )}
+          {value === 3 && <Accessibility pageData={accessPage.default} />}
         </div>
       </div>
     );

--- a/packages/doc/pages/components/Button/accessibility.md
+++ b/packages/doc/pages/components/Button/accessibility.md
@@ -1,24 +1,23 @@
+#### In case of button without text an alternative description must be provided using:
 
-### In case of button without text an alternative description must be provided using:
 - aria-labelledby or aria-label
 - aria-describedby that points to the id of an element containing the description
 
-### All functionality should be available from a keyboard
- 
-- Following button activation, focus is set depending on the type of action the button performs. 
+#### All functionality should be available from a keyboard
 
+- Following button activation, focus is set depending on the type of action the button performs.
 
-### No Keyboard Trap
+#### No Keyboard Trap
+
 - If keyboard focus can be moved to a button using a keyboard interface, then focus can be moved away from the button using only a keyboard interface.
 
-### Focus Order
+#### Focus Order
+
 - If a Web page can be navigated sequentially and the navigation sequences affect meaning or operation, focusable buttons receive focus in an order that preserves meaning and operability.
 
-### Label in Name
+#### Label in Name
+
 - For buttons with labels that include text or images of text, the name contains the text that is presented visually.
 - When using aria-labelledby, aria-label or aria-describedby these values must contain the text that is visible.
 
-### Want to know more? 
-Please visit [WAI Button Reference](https://www.w3.org/WAI/WCAG21/quickref/?currentsidebar=%23col_customize&tags=buttons&levels=aa%2Caaa&technologies=smil%2Cpdf%2Cflash%2Csl#labels-or-instructions)
-
-
+Want to know more? Please visit [WAI Button Reference](https://www.w3.org/WAI/WCAG21/quickref/?currentsidebar=%23col_customize&tags=buttons&levels=aaa)

--- a/packages/doc/pages/components/checkbox/accessibility.md
+++ b/packages/doc/pages/components/checkbox/accessibility.md
@@ -1,0 +1,3 @@
+As a form control, a Checkbox should have a label. Whenever a checkbox can't have a label, you should apply an additional attribute, like `title`, `aria-label`, or `aria-labelledby` to the checkbox input, via `inputProps`, as shown in the first Example.
+
+[WAI Checkbox Reference](https://www.w3.org/TR/wai-aria-practices/#checkbox)

--- a/packages/doc/pages/components/radiobutton/accessibility.md
+++ b/packages/doc/pages/components/radiobutton/accessibility.md
@@ -1,0 +1,3 @@
+As a form control, a Radio button should have a label. Whenever it can't have a label, you should apply an additional attribute, like `title`, `aria-label`, or `aria-labelledby` to the checkbox input, via `inputProps`, as shown in the first Example.
+
+[WAI Radio Button Reference](https://www.w3.org/TR/wai-aria-practices/#radiobutton)

--- a/packages/doc/pages/components/searchbox/accessibility.md
+++ b/packages/doc/pages/components/searchbox/accessibility.md
@@ -1,23 +1,27 @@
+#### In case of search without labels an alternative description must be provided using:
 
-### In case of search without labels an alternative description must be provided using:
 - aria-labelledby or aria-label
 - aria-describedby that points to the id of an element containing the description
 
-### No Keyboard Trap
+#### No Keyboard Trap
+
 - If keyboard focus can be moved to the searchbox using a keyboard interface, then focus can be moved away from the searchbox using only a keyboard interface.
 
-### On Focus
+#### On Focus
+
 - When the searchbox receives focus, it does not initiate a change of context.
 
-### On Input
+#### On Input
+
 - Changing the setting of any searchbox does not automatically cause a change of context unless the user has been advised of the behavior before using the searchbox
 
-### Focus Order
+#### Focus Order
+
 - If a Web page can be navigated sequentially and the navigation sequences affect meaning or operation, focusable searchbox receive focus in an order that preserves meaning and operability.
 
-### Label in Name
+#### Label in Name
+
 - For buttons with labels that include text or images of text, the name contains the text that is presented visually.
 - When using aria-labelledby, aria-label or aria-describedby these values must contain the text that is visible.
 
-### Want to know more? 
-Please visit [WAI Button Reference](https://www.w3.org/WAI/WCAG21/quickref/?currentsidebar=%23col_overview&levels=aa%2Caaa&technologies=smil%2Cpdf%2Cflash%2Csl#labels-or-instructions)
+Want to know more? Please visit [WAI Button Reference](https://www.w3.org/WAI/WCAG21/quickref/?currentsidebar=%23col_customize&levels=aaa)


### PR DESCRIPTION
addresses #622.

Fixes a bug in `Tab` attempting to load from the wrong pathname.
Adds Checkbox/Radio Button Accessibility Tab guidelines