### PR TITLE
bug(input): Update inputRef propTypes

### DIFF
--- a/packages/core/src/Input/Input.js
+++ b/packages/core/src/Input/Input.js
@@ -613,7 +613,7 @@ HvInput.propTypes = {
   /**
    * Allows passing a ref to the underlying input
    */
-  inputRef: PropTypes.shape({ current: PropTypes.instanceOf(Element) }),
+  inputRef: PropTypes.shape({ current: PropTypes.any }),
   /**
    * If ´true´ the input is disabled.
    */


### PR DESCRIPTION
Changing the `PropTypes` of `inputRef` from `inputRef: PropTypes.shape({ current: PropTypes.instanceOf(Element) }),` to `inputRef: PropTypes.shape({ current: PropTypes.any) }),`,
so it also can be used for server-side rendering.