### PR TITLE
feat(typescript): Semantic and IconSize types

### DIFF
--- a/packages/icons/src/typeGen/IconBase.d.ts
+++ b/packages/icons/src/typeGen/IconBase.d.ts
@@ -1,5 +1,29 @@
 declare module '@hv/uikit-react-icons/dist' {
   class IconBase extends React.Component<IconBaseProps> { }
+
+  export type Semantic =
+    | 'sema1'
+    | 'sema2'
+    | 'sema3'
+    | 'sema4'
+    | 'sema5'
+    | 'sema6'
+    | 'sema7'
+    | 'sema8'
+    | 'sema9'
+    | 'sema10'
+    | 'sema11'
+    | 'sema12'
+    | 'sema13'
+    | 'sema14'
+    | 'sema15'
+    | 'sema16'
+    | 'sema17'
+    | 'sema18'
+    | 'sema19'
+
+  export type IconSize = 'XS' | 'S' | 'M' | 'L' | 'XL'
+
   interface IconBaseProps extends React.HTMLAttributes<IconBase> {
     /**
      * A Jss Object used to override or extend the styles applied.
@@ -55,12 +79,12 @@ declare module '@hv/uikit-react-icons/dist' {
     /**
      * Sets one of the standard sizes of the icons
      */
-    iconSize?: 'XS' | 'S' | 'M' | 'L' | 'XL'
+    iconSize?: IconSize
 
     /**
      * Sets one of the standard semantic palette colors of the icon
      */
-    semantic?: 'sema1' | 'sema2' | 'sema3' | 'sema4' | 'sema5' | 'sema6' | 'sema7' | 'sema8' | 'sema9' | 'sema10' | 'sema11' | 'sema12' | 'sema13' | 'sema14' | 'sema15' | 'sema16' | 'sema17' | 'sema18' | 'sema19'
+    semantic?: Semantic
 
     /**
      * Inverts the background-foreground on semantic icons


### PR DESCRIPTION
Greetings, we are sending another type definition enhancement we have made recently. Hope you will find it a small, clear, and safe change that is helpful for applications.

It is to extract data types `Semantic` and `IconSize` as named types from icon's properties since the applications have many reasons to use those types in their variables/parameters. The example use cases would include:
- the return type of application logic to determine the semantic to show based on their own requirement, such as system status
- the parameter type of application-specific reusable component with customizable icon size

Also we notice UI Kit itself has many places that refer to these concepts, so it would definitely be beneficial to give them clear names and definitions in a long run.

Please let us know if there is anything you need from us, such as rebasing on another specific branch, for example.
Best Regards,