### PR TITLE
fix(button): icon category background and startIcon prop

### DIFF
--- a/packages/core/src/Button/Button.js
+++ b/packages/core/src/Button/Button.js
@@ -21,46 +21,6 @@ import { Button, withStyles } from "@material-ui/core";
 import getMaterialConfiguration from "./materialConfigurarion";
 import styles from "./styles";
 
-/**
- * Hitachi Vantara Design System compliant Button allows 4 categories
- * md expects a path to the md file relative to the location of doc/.storybook/layout-addon/Layout/Accessibility
- * @md
- * ../../../../../core/src/Button/ButtonAccessibility.md
- * @mde
- * @a
- *  -1.1.1 Non-text Content:
- *  -1.3.1 Info and Relationships:
- *  -1.3.1 Sensory Characteristics:
- *    - In case of button without(Ex: just an icon) text an alternative description must be provided for instance:
- *      - aria-labelledby or aria-label.
- *      - aria-describedby that points to the id of an element containing the description.
- *   -2.1.1 Keyboard:
- *    - Make all functionality available from a keyboard.
- *      - Following button activation, focus is set depending on the type of action the button performs. For example:
- *        - If the button onClick opens a dialog, the focus moves inside the dialog.
- *        - If the button onClick closes a dialog, focus typically returns to the button that opened the dialog unless
- *          the function performed in the dialog context logically leads to a different element.
- *          For example, activating a cancel button in a dialog returns focus to the button that opened the dialog.
- *          However, if the dialog were confirming the action of deleting the page from which it was opened,
- *          the focus would logically move to a new context.
- *        - If the button onClick does not dismiss the current context,
- *          then focus typically remains on the button after activation, e.g., an Apply or Recalculate button.
- *        - If the button action indicates a context change, such as move to next step in a wizard or add another
- *          search criteria, then it is often appropriate to move focus to the starting point for that action.
- *        - If the button is activated with a shortcut key, the focus usually remains in the context from which the shortcut key was activated.
- *          For example, if Alt + U were assigned to an "Up" button that moves the currently focused item in a list one position higher in the list,
- *          pressing Alt + U when the focus is in the list would not move the focus from the list.
- *  -2.1.2 No Keyboard Trap:
- *    - If keyboard focus can be moved to a button using a keyboard interface,
- *      then focus can be moved away from the button using only a keyboard interface.
- *  -2.4.3 Focus Order
- *    - If a Web page can be navigated sequentially and the navigation sequences affect meaning or operation,
- *      focusable buttons receive focus in an order that preserves meaning and operability.
- *  -2.5.3 Label in Name:
- *     -For buttons with labels that include text or images of text, the name contains the text that is presented visually.
- *        - When using aria-labelledby, aria-label or aria-describedby these values must contain the text that is visible.
- * @ea
- */
 const HvButton = props => {
   const {
     classes,
@@ -91,9 +51,9 @@ const HvButton = props => {
       disabled={disabled}
       disableRipple
       onClick={onClickHandler}
+      startIcon={startIcon}
       {...other}
     >
-      {startIcon && <div className={classes.startIcon}>{startIcon}</div>}
       {children}
     </Button>
   );
@@ -200,7 +160,7 @@ HvButton.defaultProps = {
   category: "primary",
   disabled: false,
   onClick: () => {},
-  startIcon: null
+  startIcon: undefined
 };
 
 export default withStyles(styles, { name: "HvButton" })(HvButton);

--- a/packages/core/src/Button/materialConfigurarion.js
+++ b/packages/core/src/Button/materialConfigurarion.js
@@ -53,7 +53,8 @@ const getMaterialConfiguration = (classes, category) => {
     containedPrimary: classes.primary,
     outlinedPrimary: classes.secondary,
     textPrimary: classes.ghost,
-    disabled: classes.primaryDisabled
+    disabled: classes.primaryDisabled,
+    startIcon: classes.startIcon
   };
 
   switch (category) {
@@ -61,7 +62,9 @@ const getMaterialConfiguration = (classes, category) => {
     case categoryValues.primary:
       return {
         ...materialContained,
-        classes: styling
+        classes: {
+          ...styling
+        }
       };
     case categoryValues.secondary:
       return {
@@ -95,6 +98,14 @@ const getMaterialConfiguration = (classes, category) => {
           ...styling,
           textPrimary: classes.semantic,
           disabled: classes.semanticDisabled
+        }
+      };
+    case categoryValues.icon:
+      return {
+        ...materialText,
+        classes: {
+          ...styling,
+          disabled: classes.ghostDisabled
         }
       };
   }

--- a/packages/core/src/Button/styles.js
+++ b/packages/core/src/Button/styles.js
@@ -46,15 +46,10 @@ const styles = theme => {
     },
     rootIcon: {
       padding: 0,
-      textTransform: "none",
-      "&:hover,&:focus": {},
-      "&:active": {},
-      "&:focus": {
-        ...outlineStyles
-      },
-      cursor: "pointer",
-      minHeight: "32px",
-      minWidth: "32px",
+      height: "unset",
+      width: "unset",
+      minHeight: "unset",
+      minWidth: "unset",
       ...theme.hv.typography.highlightText
     },
     primary: {
@@ -204,7 +199,8 @@ const styles = theme => {
       cursor: "not-allowed"
     },
     startIcon: {
-      marginLeft: "-8px"
+      marginLeft: -8,
+      marginRight: 0
     }
   };
 };

--- a/packages/core/src/Button/tests/__snapshots__/button.test.js.snap
+++ b/packages/core/src/Button/tests/__snapshots__/button.test.js.snap
@@ -782,7 +782,6 @@ exports[`Button should render correctly 1`] = `
       className=""
       disabled={false}
       onClick={[Function]}
-      startIcon={null}
     >
       <HvButton
         category="primary"
@@ -806,7 +805,6 @@ exports[`Button should render correctly 1`] = `
         }
         disabled={false}
         onClick={[Function]}
-        startIcon={null}
       >
         <WithStyles(ForwardRef(Button))
           className=""
@@ -816,6 +814,7 @@ exports[`Button should render correctly 1`] = `
               "disabled": "HvButton-primaryDisabled-49",
               "outlinedPrimary": "HvButton-secondary-50",
               "root": "HvButton-root-46",
+              "startIcon": "HvButton-startIcon-58",
               "textPrimary": "HvButton-ghost-52",
             }
           }
@@ -852,7 +851,7 @@ exports[`Button should render correctly 1`] = `
                 "root": "MuiButton-root HvButton-root-46",
                 "sizeLarge": "MuiButton-sizeLarge",
                 "sizeSmall": "MuiButton-sizeSmall",
-                "startIcon": "MuiButton-startIcon",
+                "startIcon": "MuiButton-startIcon HvButton-startIcon-58",
                 "text": "MuiButton-text",
                 "textPrimary": "MuiButton-textPrimary HvButton-ghost-52",
                 "textSecondary": "MuiButton-textSecondary",

--- a/packages/core/src/Card/Footer/tests/__snapshots__/Footer.test.js.snap
+++ b/packages/core/src/Card/Footer/tests/__snapshots__/Footer.test.js.snap
@@ -65,7 +65,6 @@ exports[`Footer should render the actions and the dropdown accordingly 1`] = `
         id="-0-action-view"
         key="-0-action-view"
         onClick={[Function]}
-        startIcon={null}
       >
         <HvButton
           category="ghost"
@@ -90,7 +89,6 @@ exports[`Footer should render the actions and the dropdown accordingly 1`] = `
           disabled={false}
           id="-0-action-view"
           onClick={[Function]}
-          startIcon={null}
         >
           <WithStyles(ForwardRef(Button))
             className="HvActions-button-6"
@@ -100,6 +98,7 @@ exports[`Footer should render the actions and the dropdown accordingly 1`] = `
                 "disabled": "HvButton-ghostDisabled-17",
                 "outlinedPrimary": "HvButton-secondary-14",
                 "root": "HvButton-root-10",
+                "startIcon": "HvButton-startIcon-22",
                 "textPrimary": "HvButton-ghost-16",
               }
             }
@@ -137,7 +136,7 @@ exports[`Footer should render the actions and the dropdown accordingly 1`] = `
                   "root": "MuiButton-root HvButton-root-10",
                   "sizeLarge": "MuiButton-sizeLarge",
                   "sizeSmall": "MuiButton-sizeSmall",
-                  "startIcon": "MuiButton-startIcon",
+                  "startIcon": "MuiButton-startIcon HvButton-startIcon-22",
                   "text": "MuiButton-text",
                   "textPrimary": "MuiButton-textPrimary HvButton-ghost-16",
                   "textSecondary": "MuiButton-textSecondary",
@@ -1045,7 +1044,6 @@ exports[`Footer should render the actions and the dropdown accordingly 3`] = `
         id="-0-action-view"
         key="-0-action-view"
         onClick={[Function]}
-        startIcon={null}
       >
         <HvButton
           category="ghost"
@@ -1070,7 +1068,6 @@ exports[`Footer should render the actions and the dropdown accordingly 3`] = `
           disabled={false}
           id="-0-action-view"
           onClick={[Function]}
-          startIcon={null}
         >
           <WithStyles(ForwardRef(Button))
             className="HvActions-button-108"
@@ -1080,6 +1077,7 @@ exports[`Footer should render the actions and the dropdown accordingly 3`] = `
                 "disabled": "HvButton-ghostDisabled-119",
                 "outlinedPrimary": "HvButton-secondary-116",
                 "root": "HvButton-root-112",
+                "startIcon": "HvButton-startIcon-124",
                 "textPrimary": "HvButton-ghost-118",
               }
             }
@@ -1117,7 +1115,7 @@ exports[`Footer should render the actions and the dropdown accordingly 3`] = `
                   "root": "MuiButton-root HvButton-root-112",
                   "sizeLarge": "MuiButton-sizeLarge",
                   "sizeSmall": "MuiButton-sizeSmall",
-                  "startIcon": "MuiButton-startIcon",
+                  "startIcon": "MuiButton-startIcon HvButton-startIcon-124",
                   "text": "MuiButton-text",
                   "textPrimary": "MuiButton-textPrimary HvButton-ghost-118",
                   "textSecondary": "MuiButton-textSecondary",
@@ -1199,7 +1197,6 @@ exports[`Footer should render the actions and the dropdown accordingly 3`] = `
         id="-1-action-delete"
         key="-1-action-delete"
         onClick={[Function]}
-        startIcon={null}
       >
         <HvButton
           category="ghost"
@@ -1224,7 +1221,6 @@ exports[`Footer should render the actions and the dropdown accordingly 3`] = `
           disabled={false}
           id="-1-action-delete"
           onClick={[Function]}
-          startIcon={null}
         >
           <WithStyles(ForwardRef(Button))
             className="HvActions-button-108"
@@ -1234,6 +1230,7 @@ exports[`Footer should render the actions and the dropdown accordingly 3`] = `
                 "disabled": "HvButton-ghostDisabled-119",
                 "outlinedPrimary": "HvButton-secondary-116",
                 "root": "HvButton-root-112",
+                "startIcon": "HvButton-startIcon-124",
                 "textPrimary": "HvButton-ghost-118",
               }
             }
@@ -1271,7 +1268,7 @@ exports[`Footer should render the actions and the dropdown accordingly 3`] = `
                   "root": "MuiButton-root HvButton-root-112",
                   "sizeLarge": "MuiButton-sizeLarge",
                   "sizeSmall": "MuiButton-sizeSmall",
-                  "startIcon": "MuiButton-startIcon",
+                  "startIcon": "MuiButton-startIcon HvButton-startIcon-124",
                   "text": "MuiButton-text",
                   "textPrimary": "MuiButton-textPrimary HvButton-ghost-118",
                   "textSecondary": "MuiButton-textSecondary",

--- a/packages/core/src/DatePicker/Actions/tests/__snapshots__/actions.test.js.snap
+++ b/packages/core/src/DatePicker/Actions/tests/__snapshots__/actions.test.js.snap
@@ -811,7 +811,6 @@ exports[`<Actions /> should render correctly 1`] = `
             disabled={false}
             id="id-apply"
             onClick={[Function]}
-            startIcon={null}
           >
             <HvButton
               category="ghost"
@@ -836,7 +835,6 @@ exports[`<Actions /> should render correctly 1`] = `
               disabled={false}
               id="id-apply"
               onClick={[Function]}
-              startIcon={null}
             >
               <WithStyles(ForwardRef(Button))
                 className="HvDatePickerActions-button-1"
@@ -846,6 +844,7 @@ exports[`<Actions /> should render correctly 1`] = `
                     "disabled": "HvButton-ghostDisabled-9",
                     "outlinedPrimary": "HvButton-secondary-6",
                     "root": "HvButton-root-2",
+                    "startIcon": "HvButton-startIcon-14",
                     "textPrimary": "HvButton-ghost-8",
                   }
                 }
@@ -883,7 +882,7 @@ exports[`<Actions /> should render correctly 1`] = `
                       "root": "MuiButton-root HvButton-root-2",
                       "sizeLarge": "MuiButton-sizeLarge",
                       "sizeSmall": "MuiButton-sizeSmall",
-                      "startIcon": "MuiButton-startIcon",
+                      "startIcon": "MuiButton-startIcon HvButton-startIcon-14",
                       "text": "MuiButton-text",
                       "textPrimary": "MuiButton-textPrimary HvButton-ghost-8",
                       "textSecondary": "MuiButton-textSecondary",
@@ -964,7 +963,6 @@ exports[`<Actions /> should render correctly 1`] = `
             disabled={false}
             id="id-cancel"
             onClick={[Function]}
-            startIcon={null}
           >
             <HvButton
               category="ghost"
@@ -989,7 +987,6 @@ exports[`<Actions /> should render correctly 1`] = `
               disabled={false}
               id="id-cancel"
               onClick={[Function]}
-              startIcon={null}
             >
               <WithStyles(ForwardRef(Button))
                 className="HvDatePickerActions-button-1"
@@ -999,6 +996,7 @@ exports[`<Actions /> should render correctly 1`] = `
                     "disabled": "HvButton-ghostDisabled-9",
                     "outlinedPrimary": "HvButton-secondary-6",
                     "root": "HvButton-root-2",
+                    "startIcon": "HvButton-startIcon-14",
                     "textPrimary": "HvButton-ghost-8",
                   }
                 }
@@ -1036,7 +1034,7 @@ exports[`<Actions /> should render correctly 1`] = `
                       "root": "MuiButton-root HvButton-root-2",
                       "sizeLarge": "MuiButton-sizeLarge",
                       "sizeSmall": "MuiButton-sizeSmall",
-                      "startIcon": "MuiButton-startIcon",
+                      "startIcon": "MuiButton-startIcon HvButton-startIcon-14",
                       "text": "MuiButton-text",
                       "textPrimary": "MuiButton-textPrimary HvButton-ghost-8",
                       "textSecondary": "MuiButton-textSecondary",

--- a/packages/core/src/Dropdown/Actions/tests/__snapshots__/actions.test.js.snap
+++ b/packages/core/src/Dropdown/Actions/tests/__snapshots__/actions.test.js.snap
@@ -805,7 +805,6 @@ exports[`<Actions /> should render correctly 1`] = `
             disabled={false}
             id="acts-apply"
             onClick={[Function]}
-            startIcon={null}
           >
             <HvButton
               category="ghost"
@@ -830,7 +829,6 @@ exports[`<Actions /> should render correctly 1`] = `
               disabled={false}
               id="acts-apply"
               onClick={[Function]}
-              startIcon={null}
             >
               <WithStyles(ForwardRef(Button))
                 className="HvDropdownActions-button-1"
@@ -840,6 +838,7 @@ exports[`<Actions /> should render correctly 1`] = `
                     "disabled": "HvButton-ghostDisabled-9",
                     "outlinedPrimary": "HvButton-secondary-6",
                     "root": "HvButton-root-2",
+                    "startIcon": "HvButton-startIcon-14",
                     "textPrimary": "HvButton-ghost-8",
                   }
                 }
@@ -877,7 +876,7 @@ exports[`<Actions /> should render correctly 1`] = `
                       "root": "MuiButton-root HvButton-root-2",
                       "sizeLarge": "MuiButton-sizeLarge",
                       "sizeSmall": "MuiButton-sizeSmall",
-                      "startIcon": "MuiButton-startIcon",
+                      "startIcon": "MuiButton-startIcon HvButton-startIcon-14",
                       "text": "MuiButton-text",
                       "textPrimary": "MuiButton-textPrimary HvButton-ghost-8",
                       "textSecondary": "MuiButton-textSecondary",
@@ -958,7 +957,6 @@ exports[`<Actions /> should render correctly 1`] = `
             disabled={false}
             id="acts-cancel"
             onClick={[Function]}
-            startIcon={null}
           >
             <HvButton
               category="ghost"
@@ -983,7 +981,6 @@ exports[`<Actions /> should render correctly 1`] = `
               disabled={false}
               id="acts-cancel"
               onClick={[Function]}
-              startIcon={null}
             >
               <WithStyles(ForwardRef(Button))
                 className="HvDropdownActions-button-1"
@@ -993,6 +990,7 @@ exports[`<Actions /> should render correctly 1`] = `
                     "disabled": "HvButton-ghostDisabled-9",
                     "outlinedPrimary": "HvButton-secondary-6",
                     "root": "HvButton-root-2",
+                    "startIcon": "HvButton-startIcon-14",
                     "textPrimary": "HvButton-ghost-8",
                   }
                 }
@@ -1030,7 +1028,7 @@ exports[`<Actions /> should render correctly 1`] = `
                       "root": "MuiButton-root HvButton-root-2",
                       "sizeLarge": "MuiButton-sizeLarge",
                       "sizeSmall": "MuiButton-sizeSmall",
-                      "startIcon": "MuiButton-startIcon",
+                      "startIcon": "MuiButton-startIcon HvButton-startIcon-14",
                       "text": "MuiButton-text",
                       "textPrimary": "MuiButton-textPrimary HvButton-ghost-8",
                       "textSecondary": "MuiButton-textSecondary",

--- a/packages/core/src/Dropdown/tests/__snapshots__/dropdown.test.js.snap
+++ b/packages/core/src/Dropdown/tests/__snapshots__/dropdown.test.js.snap
@@ -6427,7 +6427,6 @@ exports[`<Dropdown /> <Dropdown /> with multiselect and search should render cor
                                         disabled={false}
                                         id="test-dropdown-values-actions-apply"
                                         onClick={[Function]}
-                                        startIcon={null}
                                       >
                                         <HvButton
                                           category="ghost"
@@ -6452,7 +6451,6 @@ exports[`<Dropdown /> <Dropdown /> with multiselect and search should render cor
                                           disabled={false}
                                           id="test-dropdown-values-actions-apply"
                                           onClick={[Function]}
-                                          startIcon={null}
                                         >
                                           <WithStyles(ForwardRef(Button))
                                             className="HvDropdownActions-button-1158"
@@ -6462,6 +6460,7 @@ exports[`<Dropdown /> <Dropdown /> with multiselect and search should render cor
                                                 "disabled": "HvButton-ghostDisabled-1166",
                                                 "outlinedPrimary": "HvButton-secondary-1163",
                                                 "root": "HvButton-root-1159",
+                                                "startIcon": "HvButton-startIcon-1171",
                                                 "textPrimary": "HvButton-ghost-1165",
                                               }
                                             }
@@ -6499,7 +6498,7 @@ exports[`<Dropdown /> <Dropdown /> with multiselect and search should render cor
                                                   "root": "MuiButton-root HvButton-root-1159",
                                                   "sizeLarge": "MuiButton-sizeLarge",
                                                   "sizeSmall": "MuiButton-sizeSmall",
-                                                  "startIcon": "MuiButton-startIcon",
+                                                  "startIcon": "MuiButton-startIcon HvButton-startIcon-1171",
                                                   "text": "MuiButton-text",
                                                   "textPrimary": "MuiButton-textPrimary HvButton-ghost-1165",
                                                   "textSecondary": "MuiButton-textSecondary",
@@ -6580,7 +6579,6 @@ exports[`<Dropdown /> <Dropdown /> with multiselect and search should render cor
                                         disabled={false}
                                         id="test-dropdown-values-actions-cancel"
                                         onClick={[Function]}
-                                        startIcon={null}
                                       >
                                         <HvButton
                                           category="ghost"
@@ -6605,7 +6603,6 @@ exports[`<Dropdown /> <Dropdown /> with multiselect and search should render cor
                                           disabled={false}
                                           id="test-dropdown-values-actions-cancel"
                                           onClick={[Function]}
-                                          startIcon={null}
                                         >
                                           <WithStyles(ForwardRef(Button))
                                             className="HvDropdownActions-button-1158"
@@ -6615,6 +6612,7 @@ exports[`<Dropdown /> <Dropdown /> with multiselect and search should render cor
                                                 "disabled": "HvButton-ghostDisabled-1166",
                                                 "outlinedPrimary": "HvButton-secondary-1163",
                                                 "root": "HvButton-root-1159",
+                                                "startIcon": "HvButton-startIcon-1171",
                                                 "textPrimary": "HvButton-ghost-1165",
                                               }
                                             }
@@ -6652,7 +6650,7 @@ exports[`<Dropdown /> <Dropdown /> with multiselect and search should render cor
                                                   "root": "MuiButton-root HvButton-root-1159",
                                                   "sizeLarge": "MuiButton-sizeLarge",
                                                   "sizeSmall": "MuiButton-sizeSmall",
-                                                  "startIcon": "MuiButton-startIcon",
+                                                  "startIcon": "MuiButton-startIcon HvButton-startIcon-1171",
                                                   "text": "MuiButton-text",
                                                   "textPrimary": "MuiButton-textPrimary HvButton-ghost-1165",
                                                   "textSecondary": "MuiButton-textSecondary",

--- a/packages/core/src/VerticalNavigation/test/__snapshots__/verticalnavigation.test.js.snap
+++ b/packages/core/src/VerticalNavigation/test/__snapshots__/verticalnavigation.test.js.snap
@@ -849,7 +849,7 @@ exports[`<VerticalNavigation /> collapsable closed vertical navigation should re
                         Object {
                           "current": <button
                             aria-label="open"
-                            class="MuiButtonBase-root MuiButton-root HvButton-root-13 MuiButton-contained HvVerticalNavigationVerticalContainer-button-10 HvButton-rootIcon-14 MuiButton-containedPrimary HvButton-primary-15"
+                            class="MuiButtonBase-root MuiButton-root HvButton-root-13 MuiButton-text HvVerticalNavigationVerticalContainer-button-10 HvButton-rootIcon-14 MuiButton-textPrimary HvButton-ghost-19"
                             id="hv-verticalnavigation1-container-hamburger-button"
                             tabindex="0"
                             type="button"
@@ -883,7 +883,6 @@ exports[`<VerticalNavigation /> collapsable closed vertical navigation should re
                       disabled={false}
                       id="hv-verticalnavigation1-container-hamburger-button"
                       onClick={[Function]}
-                      startIcon={null}
                     >
                       <HvButton
                         aria-label="open"
@@ -891,7 +890,7 @@ exports[`<VerticalNavigation /> collapsable closed vertical navigation should re
                           Object {
                             "current": <button
                               aria-label="open"
-                              class="MuiButtonBase-root MuiButton-root HvButton-root-13 MuiButton-contained HvVerticalNavigationVerticalContainer-button-10 HvButton-rootIcon-14 MuiButton-containedPrimary HvButton-primary-15"
+                              class="MuiButtonBase-root MuiButton-root HvButton-root-13 MuiButton-text HvVerticalNavigationVerticalContainer-button-10 HvButton-rootIcon-14 MuiButton-textPrimary HvButton-ghost-19"
                               id="hv-verticalnavigation1-container-hamburger-button"
                               tabindex="0"
                               type="button"
@@ -942,7 +941,6 @@ exports[`<VerticalNavigation /> collapsable closed vertical navigation should re
                         disabled={false}
                         id="hv-verticalnavigation1-container-hamburger-button"
                         onClick={[Function]}
-                        startIcon={null}
                       >
                         <WithStyles(ForwardRef(Button))
                           aria-label="open"
@@ -950,7 +948,7 @@ exports[`<VerticalNavigation /> collapsable closed vertical navigation should re
                             Object {
                               "current": <button
                                 aria-label="open"
-                                class="MuiButtonBase-root MuiButton-root HvButton-root-13 MuiButton-contained HvVerticalNavigationVerticalContainer-button-10 HvButton-rootIcon-14 MuiButton-containedPrimary HvButton-primary-15"
+                                class="MuiButtonBase-root MuiButton-root HvButton-root-13 MuiButton-text HvVerticalNavigationVerticalContainer-button-10 HvButton-rootIcon-14 MuiButton-textPrimary HvButton-ghost-19"
                                 id="hv-verticalnavigation1-container-hamburger-button"
                                 tabindex="0"
                                 type="button"
@@ -983,9 +981,10 @@ exports[`<VerticalNavigation /> collapsable closed vertical navigation should re
                           classes={
                             Object {
                               "containedPrimary": "HvButton-primary-15",
-                              "disabled": "HvButton-primaryDisabled-16",
+                              "disabled": "HvButton-ghostDisabled-20",
                               "outlinedPrimary": "HvButton-secondary-17",
                               "root": "HvButton-root-13",
+                              "startIcon": "HvButton-startIcon-25",
                               "textPrimary": "HvButton-ghost-19",
                             }
                           }
@@ -994,7 +993,7 @@ exports[`<VerticalNavigation /> collapsable closed vertical navigation should re
                           disabled={false}
                           id="hv-verticalnavigation1-container-hamburger-button"
                           onClick={[Function]}
-                          variant="contained"
+                          variant="text"
                         >
                           <ForwardRef(Button)
                             aria-label="open"
@@ -1002,7 +1001,7 @@ exports[`<VerticalNavigation /> collapsable closed vertical navigation should re
                               Object {
                                 "current": <button
                                   aria-label="open"
-                                  class="MuiButtonBase-root MuiButton-root HvButton-root-13 MuiButton-contained HvVerticalNavigationVerticalContainer-button-10 HvButton-rootIcon-14 MuiButton-containedPrimary HvButton-primary-15"
+                                  class="MuiButtonBase-root MuiButton-root HvButton-root-13 MuiButton-text HvVerticalNavigationVerticalContainer-button-10 HvButton-rootIcon-14 MuiButton-textPrimary HvButton-ghost-19"
                                   id="hv-verticalnavigation1-container-hamburger-button"
                                   tabindex="0"
                                   type="button"
@@ -1041,7 +1040,7 @@ exports[`<VerticalNavigation /> collapsable closed vertical navigation should re
                                 "containedSizeLarge": "MuiButton-containedSizeLarge",
                                 "containedSizeSmall": "MuiButton-containedSizeSmall",
                                 "disableElevation": "MuiButton-disableElevation",
-                                "disabled": "Mui-disabled HvButton-primaryDisabled-16",
+                                "disabled": "Mui-disabled HvButton-ghostDisabled-20",
                                 "endIcon": "MuiButton-endIcon",
                                 "focusVisible": "Mui-focusVisible",
                                 "fullWidth": "MuiButton-fullWidth",
@@ -1057,7 +1056,7 @@ exports[`<VerticalNavigation /> collapsable closed vertical navigation should re
                                 "root": "MuiButton-root HvButton-root-13",
                                 "sizeLarge": "MuiButton-sizeLarge",
                                 "sizeSmall": "MuiButton-sizeSmall",
-                                "startIcon": "MuiButton-startIcon",
+                                "startIcon": "MuiButton-startIcon HvButton-startIcon-25",
                                 "text": "MuiButton-text",
                                 "textPrimary": "MuiButton-textPrimary HvButton-ghost-19",
                                 "textSecondary": "MuiButton-textSecondary",
@@ -1070,7 +1069,7 @@ exports[`<VerticalNavigation /> collapsable closed vertical navigation should re
                             disabled={false}
                             id="hv-verticalnavigation1-container-hamburger-button"
                             onClick={[Function]}
-                            variant="contained"
+                            variant="text"
                           >
                             <WithStyles(ForwardRef(ButtonBase))
                               aria-label="open"
@@ -1078,7 +1077,7 @@ exports[`<VerticalNavigation /> collapsable closed vertical navigation should re
                                 Object {
                                   "current": <button
                                     aria-label="open"
-                                    class="MuiButtonBase-root MuiButton-root HvButton-root-13 MuiButton-contained HvVerticalNavigationVerticalContainer-button-10 HvButton-rootIcon-14 MuiButton-containedPrimary HvButton-primary-15"
+                                    class="MuiButtonBase-root MuiButton-root HvButton-root-13 MuiButton-text HvVerticalNavigationVerticalContainer-button-10 HvButton-rootIcon-14 MuiButton-textPrimary HvButton-ghost-19"
                                     id="hv-verticalnavigation1-container-hamburger-button"
                                     tabindex="0"
                                     type="button"
@@ -1107,7 +1106,7 @@ exports[`<VerticalNavigation /> collapsable closed vertical navigation should re
                                   </button>,
                                 }
                               }
-                              className="MuiButton-root HvButton-root-13 MuiButton-contained HvVerticalNavigationVerticalContainer-button-10 HvButton-rootIcon-14 MuiButton-containedPrimary HvButton-primary-15"
+                              className="MuiButton-root HvButton-root-13 MuiButton-text HvVerticalNavigationVerticalContainer-button-10 HvButton-rootIcon-14 MuiButton-textPrimary HvButton-ghost-19"
                               component="button"
                               disableRipple={true}
                               disabled={false}
@@ -1123,7 +1122,7 @@ exports[`<VerticalNavigation /> collapsable closed vertical navigation should re
                                   Object {
                                     "current": <button
                                       aria-label="open"
-                                      class="MuiButtonBase-root MuiButton-root HvButton-root-13 MuiButton-contained HvVerticalNavigationVerticalContainer-button-10 HvButton-rootIcon-14 MuiButton-containedPrimary HvButton-primary-15"
+                                      class="MuiButtonBase-root MuiButton-root HvButton-root-13 MuiButton-text HvVerticalNavigationVerticalContainer-button-10 HvButton-rootIcon-14 MuiButton-textPrimary HvButton-ghost-19"
                                       id="hv-verticalnavigation1-container-hamburger-button"
                                       tabindex="0"
                                       type="button"
@@ -1152,7 +1151,7 @@ exports[`<VerticalNavigation /> collapsable closed vertical navigation should re
                                     </button>,
                                   }
                                 }
-                                className="MuiButton-root HvButton-root-13 MuiButton-contained HvVerticalNavigationVerticalContainer-button-10 HvButton-rootIcon-14 MuiButton-containedPrimary HvButton-primary-15"
+                                className="MuiButton-root HvButton-root-13 MuiButton-text HvVerticalNavigationVerticalContainer-button-10 HvButton-rootIcon-14 MuiButton-textPrimary HvButton-ghost-19"
                                 classes={
                                   Object {
                                     "disabled": "Mui-disabled",
@@ -1171,7 +1170,7 @@ exports[`<VerticalNavigation /> collapsable closed vertical navigation should re
                               >
                                 <button
                                   aria-label="open"
-                                  className="MuiButtonBase-root MuiButton-root HvButton-root-13 MuiButton-contained HvVerticalNavigationVerticalContainer-button-10 HvButton-rootIcon-14 MuiButton-containedPrimary HvButton-primary-15"
+                                  className="MuiButtonBase-root MuiButton-root HvButton-root-13 MuiButton-text HvVerticalNavigationVerticalContainer-button-10 HvButton-rootIcon-14 MuiButton-textPrimary HvButton-ghost-19"
                                   disabled={false}
                                   id="hv-verticalnavigation1-container-hamburger-button"
                                   onBlur={[Function]}
@@ -2092,7 +2091,7 @@ exports[`<VerticalNavigation /> collapsable open vertical navigation should rend
                         Object {
                           "current": <button
                             aria-label="close"
-                            class="MuiButtonBase-root MuiButton-root HvButton-root-75 MuiButton-contained HvVerticalNavigationVerticalContainer-button-72 HvButton-rootIcon-76 MuiButton-containedPrimary HvButton-primary-77"
+                            class="MuiButtonBase-root MuiButton-root HvButton-root-75 MuiButton-text HvVerticalNavigationVerticalContainer-button-72 HvButton-rootIcon-76 MuiButton-textPrimary HvButton-ghost-81"
                             id="hv-verticalnavigation2-container-hamburger-button"
                             tabindex="0"
                             type="button"
@@ -2126,7 +2125,6 @@ exports[`<VerticalNavigation /> collapsable open vertical navigation should rend
                       disabled={false}
                       id="hv-verticalnavigation2-container-hamburger-button"
                       onClick={[Function]}
-                      startIcon={null}
                     >
                       <HvButton
                         aria-label="close"
@@ -2134,7 +2132,7 @@ exports[`<VerticalNavigation /> collapsable open vertical navigation should rend
                           Object {
                             "current": <button
                               aria-label="close"
-                              class="MuiButtonBase-root MuiButton-root HvButton-root-75 MuiButton-contained HvVerticalNavigationVerticalContainer-button-72 HvButton-rootIcon-76 MuiButton-containedPrimary HvButton-primary-77"
+                              class="MuiButtonBase-root MuiButton-root HvButton-root-75 MuiButton-text HvVerticalNavigationVerticalContainer-button-72 HvButton-rootIcon-76 MuiButton-textPrimary HvButton-ghost-81"
                               id="hv-verticalnavigation2-container-hamburger-button"
                               tabindex="0"
                               type="button"
@@ -2185,7 +2183,6 @@ exports[`<VerticalNavigation /> collapsable open vertical navigation should rend
                         disabled={false}
                         id="hv-verticalnavigation2-container-hamburger-button"
                         onClick={[Function]}
-                        startIcon={null}
                       >
                         <WithStyles(ForwardRef(Button))
                           aria-label="close"
@@ -2193,7 +2190,7 @@ exports[`<VerticalNavigation /> collapsable open vertical navigation should rend
                             Object {
                               "current": <button
                                 aria-label="close"
-                                class="MuiButtonBase-root MuiButton-root HvButton-root-75 MuiButton-contained HvVerticalNavigationVerticalContainer-button-72 HvButton-rootIcon-76 MuiButton-containedPrimary HvButton-primary-77"
+                                class="MuiButtonBase-root MuiButton-root HvButton-root-75 MuiButton-text HvVerticalNavigationVerticalContainer-button-72 HvButton-rootIcon-76 MuiButton-textPrimary HvButton-ghost-81"
                                 id="hv-verticalnavigation2-container-hamburger-button"
                                 tabindex="0"
                                 type="button"
@@ -2226,9 +2223,10 @@ exports[`<VerticalNavigation /> collapsable open vertical navigation should rend
                           classes={
                             Object {
                               "containedPrimary": "HvButton-primary-77",
-                              "disabled": "HvButton-primaryDisabled-78",
+                              "disabled": "HvButton-ghostDisabled-82",
                               "outlinedPrimary": "HvButton-secondary-79",
                               "root": "HvButton-root-75",
+                              "startIcon": "HvButton-startIcon-87",
                               "textPrimary": "HvButton-ghost-81",
                             }
                           }
@@ -2237,7 +2235,7 @@ exports[`<VerticalNavigation /> collapsable open vertical navigation should rend
                           disabled={false}
                           id="hv-verticalnavigation2-container-hamburger-button"
                           onClick={[Function]}
-                          variant="contained"
+                          variant="text"
                         >
                           <ForwardRef(Button)
                             aria-label="close"
@@ -2245,7 +2243,7 @@ exports[`<VerticalNavigation /> collapsable open vertical navigation should rend
                               Object {
                                 "current": <button
                                   aria-label="close"
-                                  class="MuiButtonBase-root MuiButton-root HvButton-root-75 MuiButton-contained HvVerticalNavigationVerticalContainer-button-72 HvButton-rootIcon-76 MuiButton-containedPrimary HvButton-primary-77"
+                                  class="MuiButtonBase-root MuiButton-root HvButton-root-75 MuiButton-text HvVerticalNavigationVerticalContainer-button-72 HvButton-rootIcon-76 MuiButton-textPrimary HvButton-ghost-81"
                                   id="hv-verticalnavigation2-container-hamburger-button"
                                   tabindex="0"
                                   type="button"
@@ -2284,7 +2282,7 @@ exports[`<VerticalNavigation /> collapsable open vertical navigation should rend
                                 "containedSizeLarge": "MuiButton-containedSizeLarge",
                                 "containedSizeSmall": "MuiButton-containedSizeSmall",
                                 "disableElevation": "MuiButton-disableElevation",
-                                "disabled": "Mui-disabled HvButton-primaryDisabled-78",
+                                "disabled": "Mui-disabled HvButton-ghostDisabled-82",
                                 "endIcon": "MuiButton-endIcon",
                                 "focusVisible": "Mui-focusVisible",
                                 "fullWidth": "MuiButton-fullWidth",
@@ -2300,7 +2298,7 @@ exports[`<VerticalNavigation /> collapsable open vertical navigation should rend
                                 "root": "MuiButton-root HvButton-root-75",
                                 "sizeLarge": "MuiButton-sizeLarge",
                                 "sizeSmall": "MuiButton-sizeSmall",
-                                "startIcon": "MuiButton-startIcon",
+                                "startIcon": "MuiButton-startIcon HvButton-startIcon-87",
                                 "text": "MuiButton-text",
                                 "textPrimary": "MuiButton-textPrimary HvButton-ghost-81",
                                 "textSecondary": "MuiButton-textSecondary",
@@ -2313,7 +2311,7 @@ exports[`<VerticalNavigation /> collapsable open vertical navigation should rend
                             disabled={false}
                             id="hv-verticalnavigation2-container-hamburger-button"
                             onClick={[Function]}
-                            variant="contained"
+                            variant="text"
                           >
                             <WithStyles(ForwardRef(ButtonBase))
                               aria-label="close"
@@ -2321,7 +2319,7 @@ exports[`<VerticalNavigation /> collapsable open vertical navigation should rend
                                 Object {
                                   "current": <button
                                     aria-label="close"
-                                    class="MuiButtonBase-root MuiButton-root HvButton-root-75 MuiButton-contained HvVerticalNavigationVerticalContainer-button-72 HvButton-rootIcon-76 MuiButton-containedPrimary HvButton-primary-77"
+                                    class="MuiButtonBase-root MuiButton-root HvButton-root-75 MuiButton-text HvVerticalNavigationVerticalContainer-button-72 HvButton-rootIcon-76 MuiButton-textPrimary HvButton-ghost-81"
                                     id="hv-verticalnavigation2-container-hamburger-button"
                                     tabindex="0"
                                     type="button"
@@ -2350,7 +2348,7 @@ exports[`<VerticalNavigation /> collapsable open vertical navigation should rend
                                   </button>,
                                 }
                               }
-                              className="MuiButton-root HvButton-root-75 MuiButton-contained HvVerticalNavigationVerticalContainer-button-72 HvButton-rootIcon-76 MuiButton-containedPrimary HvButton-primary-77"
+                              className="MuiButton-root HvButton-root-75 MuiButton-text HvVerticalNavigationVerticalContainer-button-72 HvButton-rootIcon-76 MuiButton-textPrimary HvButton-ghost-81"
                               component="button"
                               disableRipple={true}
                               disabled={false}
@@ -2366,7 +2364,7 @@ exports[`<VerticalNavigation /> collapsable open vertical navigation should rend
                                   Object {
                                     "current": <button
                                       aria-label="close"
-                                      class="MuiButtonBase-root MuiButton-root HvButton-root-75 MuiButton-contained HvVerticalNavigationVerticalContainer-button-72 HvButton-rootIcon-76 MuiButton-containedPrimary HvButton-primary-77"
+                                      class="MuiButtonBase-root MuiButton-root HvButton-root-75 MuiButton-text HvVerticalNavigationVerticalContainer-button-72 HvButton-rootIcon-76 MuiButton-textPrimary HvButton-ghost-81"
                                       id="hv-verticalnavigation2-container-hamburger-button"
                                       tabindex="0"
                                       type="button"
@@ -2395,7 +2393,7 @@ exports[`<VerticalNavigation /> collapsable open vertical navigation should rend
                                     </button>,
                                   }
                                 }
-                                className="MuiButton-root HvButton-root-75 MuiButton-contained HvVerticalNavigationVerticalContainer-button-72 HvButton-rootIcon-76 MuiButton-containedPrimary HvButton-primary-77"
+                                className="MuiButton-root HvButton-root-75 MuiButton-text HvVerticalNavigationVerticalContainer-button-72 HvButton-rootIcon-76 MuiButton-textPrimary HvButton-ghost-81"
                                 classes={
                                   Object {
                                     "disabled": "Mui-disabled",
@@ -2414,7 +2412,7 @@ exports[`<VerticalNavigation /> collapsable open vertical navigation should rend
                               >
                                 <button
                                   aria-label="close"
-                                  className="MuiButtonBase-root MuiButton-root HvButton-root-75 MuiButton-contained HvVerticalNavigationVerticalContainer-button-72 HvButton-rootIcon-76 MuiButton-containedPrimary HvButton-primary-77"
+                                  className="MuiButtonBase-root MuiButton-root HvButton-root-75 MuiButton-text HvVerticalNavigationVerticalContainer-button-72 HvButton-rootIcon-76 MuiButton-textPrimary HvButton-ghost-81"
                                   disabled={false}
                                   id="hv-verticalnavigation2-container-hamburger-button"
                                   onBlur={[Function]}


### PR DESCRIPTION
Our `<Button category="icon">` has some issues, because it's inheriting the default `primary` class. This PR fixes it. Addresses #819

![image](https://user-images.githubusercontent.com/638946/75465849-2256f980-5981-11ea-8585-504753d21843.png)
