### PR TITLE
feat(typescript): support new component and restructure files

### DIFF
--- a/packages/core/src/@types/HvProvider.d.ts
+++ b/packages/core/src/@types/HvProvider.d.ts
@@ -1,4 +1,0 @@
-declare module '@hv/uikit-react-core/dist' {
-  export class HvProvider extends React.Component<HvProviderProps, any> {}
-  export interface HvProviderProps extends React.HTMLAttributes<HvProvider> {}
-}

--- a/packages/core/src/Badge/index.d.ts
+++ b/packages/core/src/Badge/index.d.ts
@@ -1,0 +1,69 @@
+declare module '@hv/uikit-react-core/dist/Badge' {
+  import React from 'react'
+
+  class HvBadge extends React.Component<HvBadgeProps> {}
+
+  export default HvBadge
+
+  export interface HvBadgeProps extends React.HTMLAttributes<HvBadge> {
+    /**
+     *   A Jss Object used to override or extend the styles applied to the badge.
+     */
+    classes?: {
+      /**
+       * Styles applied to the component root class.
+       */
+      root?: string
+
+      /**
+       * Styles applied to the component badge position.
+       */
+      badgePosition?: string
+
+      /**
+       * Styles applied to the component badge.
+       */
+      badge?: string
+
+      /**
+       * Styles applied to the component badge count.
+       */
+      count?: string
+
+      /**
+       * Styles applied to the component badge when count greater than 9.
+       */
+      badgeTwoDigits?: string
+    }
+
+    /**
+     * Count is the number of unread notifications
+     */
+    count?: number
+
+    /**
+     * True if count should be displayed.
+     */
+    showCount?: boolean
+
+    /**
+     * The maximum number of unread notifications to be displayed
+     */
+    maxCount?: number
+
+    /**
+     * Icon which the notification will be attached.
+     */
+    icon?: React.ReactNode
+
+    /**
+     * Text which the notification will be attached.
+     */
+    text?: string
+
+    /**
+     * Text variant.
+     */
+    textVariant?: string
+  }
+}

--- a/packages/core/src/Banner/index.d.ts
+++ b/packages/core/src/Banner/index.d.ts
@@ -1,5 +1,14 @@
-declare module '@hv/uikit-react-core/dist' {
-  export class HvBanner extends React.Component<HvBannerProps, any> {}
+declare module '@hv/uikit-react-core/dist/Banner' {
+  class HvBanner extends React.Component<HvBannerProps, any> {}
+
+  export default HvBanner
+
+  export interface BannerAction {
+    id: string
+    label: string
+    icon?: (...args: any[]) => any
+    disabled?: boolean
+  }
 
   export interface HvBannerProps extends React.HTMLAttributes<HvBanner> {
     /**
@@ -23,23 +32,17 @@ declare module '@hv/uikit-react-core/dist' {
     /**
      *  If true, Snackbar is open.
      */
-    open: boolean
+    open?: boolean
 
     /**
      * Callback fired when the component requests to be closed. Typically onClose is used to set state in the parent component, which is used to control the Snackbar open prop. The reason parameter can optionally be used to control the response to onClose, for example ignoring clickaway.
      */
-    onClose: (...args: any[]) => any
+    onClose?: (...args: any[]) => any
 
     /**
      * The message to display.
      */
     label?: string
-
-    /**
-     * The message to display.
-     * @deprecated. Instead use the label property
-     */
-    message?: string
 
     /**
      *  The anchor of the Snackbar.
@@ -64,12 +67,17 @@ declare module '@hv/uikit-react-core/dist' {
     /**
      * Actions to display on the right side.
      */
-    action?: React.ReactNode
+    actions?: React.ReactNode | BannerAction[]
 
     /**
-     * Actions to display on message.
+     *  The callback function ran when an action is triggered, receiving ´action´ as param
      */
-    actionsOnMessage?: React.ReactNode
+    actionsCallback?: (...args: any[]) => any
+
+    /**
+     * The position property of the header.
+     */
+    actionsPosition?: 'auto' | 'inline' | 'bottom-right'
 
     /**
      * How much the transition animation last in milliseconds, if 0 no animation is played.
@@ -80,5 +88,29 @@ declare module '@hv/uikit-react-core/dist' {
      * Direction of slide transition.
      */
     transitionDirection?: 'up' | 'down' | 'left' | 'right'
+
+    /**
+     * Offset from top/bottom of the page, in px. Defaults to 60px.
+     */
+    offset?: number
+
+    // deprecated:
+    /**
+     * The message to display.
+     * @deprecated. Instead use the label property
+     */
+    message?: string
+
+    /**
+     * Actions to display on the right side.
+     * @deprecated. Instead use the actions property
+     */
+    action?: React.ReactNode
+
+    /**
+     * Actions to display on message.
+     * @deprecated. Instead use the actions property together with actionsPosition="inline"
+     */
+    actionsOnMessage?: React.ReactNode
   }
 }

--- a/packages/core/src/BreadCrumb/index.d.ts
+++ b/packages/core/src/BreadCrumb/index.d.ts
@@ -1,12 +1,16 @@
-declare module '@hv/uikit-react-core/dist' {
-  export class HvBreadcrumb extends React.Component<HvBreadCrumbProps, any> {}
+declare module '@hv/uikit-react-core/dist/BreadCrumb' {
+  import React from 'react'
+
+  class HvBreadCrumb extends React.Component<HvBreadCrumbProps, any> {}
+
+  export default HvBreadCrumb
 
   export interface BreadCrumbPathElement {
     label: string
     path: string
   }
 
-  export interface HvBreadCrumbProps extends React.HTMLAttributes<HvInput> {
+  export interface HvBreadCrumbProps extends React.HTMLAttributes<HvBreadCrumb> {
     /**
      * Class names to be applied.
      */
@@ -40,7 +44,7 @@ declare module '@hv/uikit-react-core/dist' {
     /**
      * Should use the router.
      */
-    useRouter?: bool
+    useRouter?: boolean
 
     /**
      * List of breadcrumb.

--- a/packages/core/src/Button/index.d.ts
+++ b/packages/core/src/Button/index.d.ts
@@ -1,5 +1,9 @@
-declare module '@hv/uikit-react-core/dist' {
-  export class HvButton extends React.Component<HvButtonProps, any> {}
+declare module '@hv/uikit-react-core/dist/Button' {
+  import React from 'react'
+
+  class HvButton extends React.Component<HvButtonProps, any> {}
+
+  export default HvButton
 
   export interface HvButtonProps extends React.HTMLAttributes<HvButton> {
     /**
@@ -32,80 +36,117 @@ declare module '@hv/uikit-react-core/dist' {
      *    --"ghostSecondary"
      *  - note: the buttonType object should be used to set this value.
      */
-    category?: 'primary' | 'secondary' | 'ghost' | 'ghostSecondary'
+    category?: 'primary' | 'secondary' | 'ghost' | 'ghostSecondary' | 'semantic' | 'icon'
 
     /**
      * A Jss Object used to override or extend the styles applied.
      */
     classes?: {
+      
       /**
        * Styles applied to the component root class.
        */
       root?: string
+
       /**
-       * Styles applied to the primary primary button.
+       * Styles applied to the component root when category is icon.
+       */
+      rootIcon?: string
+
+      /**
+       * Styles applied to the primary button.
        */
       primary?: string
+
       /**
-       * Styles applied to the primary primary button when it is disabled.
+       * Styles applied to the primary button when it is disabled.
        */
       primaryDisabled?: string
+
       /**
-       * Styles applied to the primary secondary button.
+       * Styles applied to the secondary button.
        */
       secondary?: string
+
       /**
-       * Styles applied to the primary secondary button when it is disabled.
+       * Styles applied to the secondary button when it is disabled.
        */
       secondaryDisabled?: string
+
       /**
-       * Styles applied to the primary ghost button.
+       * Styles applied to the ghost button.
        */
       ghost?: string
+
       /**
-       * Styles applied to the primary ghost button when it is disabled.
+       * Styles applied to the ghost button when it is disabled.
        */
       ghostDisabled?: string
+
       /**
-       * Styles applied to the primary secondary ghost  button.
+       * Styles applied to the secondary ghost button.
        */
       ghostSecondary?: string
+
       /**
-       * Styles applied to the primary secondary ghost button when it is disabled.
+       * Styles applied to the secondary ghost button when it is disabled.
        */
       ghostSecondaryDisabled?: string
+
+      /**
+       * Styles applied to the semantic button.
+       */
+      semantic?: string
+
+      /**
+       * Styles applied to the semantic button when it is disabled.
+       */
+      semanticDisabled?: string
+
       /**
        * Styles applied to the inspireRed primary button.
        */
       inspireRedPrimary?: string
+
       /**
        * Styles applied to the inspireRed primary button when it is disabled.
        */
       inspireRedPrimaryDisabled?: string
+
       /**
        * Styles applied to the inspireRed secondary button.
        */
       inspireRedSecondary?: string
+
       /**
        * Styles applied to the inspireRed secondary button when it is disabled.
        */
       inspireRedSecondaryDisabled?: string
+
       /**
        * Styles applied to the inspireRed ghost button.
        */
       inspireRedGhost?: string
+
       /**
        * Styles applied to the inspireRed ghost button when it is disabled.
        */
       inspireRedGhostDisabled?: string
+
       /**
        * Styles applied to the inspireRed secondary ghost  button.
        */
       inspireRedGhostSecondary?: string
+
       /**
        * Styles applied to the inspireRed secondary ghost button when it is disabled.
        */
       inspireRedGhostSecondaryDisabled?: string
+
+      /**
+       * Styles applied to the icon on the left.
+       */
+      startIcon?: string
     }
 
     /**
@@ -117,5 +158,10 @@ declare module '@hv/uikit-react-core/dist' {
      * The function executed when the button is pressed.
      */
     onClick?: (...args: any[]) => any
+
+    /**
+     * The icon to be rendered before the children.
+     */
+    startIcon?: React.ReactNode
   }
 }

--- a/packages/core/src/Card/index.d.ts
+++ b/packages/core/src/Card/index.d.ts
@@ -1,0 +1,197 @@
+declare module '@hv/uikit-react-core/dist/Card' {
+  import React from 'react'
+  import { Semantic } from '@hv/uikit-react-icons/dist'
+
+  class HvCard extends React.Component<HvCardProps, any> {}
+
+  export default HvCard
+
+  export interface CardAction {
+    id: string
+    label: string
+    icon: (...args: any[]) => any
+  }
+
+  export interface HvCardProps extends React.HTMLAttributes<HvCard> {
+    /**
+     *  Used to define a string that labels the current element.
+     */
+    defaultCardAriaLabel?: string
+
+    /**
+     *  Establishes relationships between objects and their label(s), and its value should be one or more element IDs.
+     */
+    defaultCardAriaLabelledBy?: string
+
+    /**
+     *  Used to indicate the IDs of the elements that describe the object.
+     */
+    defaultCardAriaDescribedBy?: string
+
+    /**
+     * A Jss Object used to override or extend the styles applied.
+     */
+    classes?: {
+      /**
+       * Style applied to the border top.
+       */
+      borderTop?: string
+    }
+
+    /**
+     *  The renderable content inside the title slot of the header.
+     */
+    headerTitle?: React.ReactNode
+
+    /**
+     *  The renderable content inside the subheader slot of the header.
+     */
+    subheader?: React.ReactNode
+
+    /**
+     *  The renderable content inside the icon slot of the header.
+     */
+    icon?: React.ReactNode
+
+    /**
+     * The renderable content inside the actions slot of the footer,
+     * or an Array of actions ´{id, label, icon}´
+     */
+    actions?: React.ReactNode | CardAction[]
+
+    /**
+     *  The callback function ran when an action is triggered, receiving ´action´ as param
+     */
+    actionsCallback?: (...args: any[]) => any
+
+    /**
+     * The alignment applied to the action elements
+     */
+    actionsAlignment?: 'left' | 'right'
+
+    /**
+     *  The renderable content inside the body of the card.
+     */
+    innerCardContent?: React.ReactNode
+
+    /**
+     *  The path to the image to show in the media slot.
+     */
+    mediaPath?: string
+
+    /**
+     *  The title of the media.
+     */
+    mediaTitle?: string
+
+    /**
+     *  The height necessary to adjust the media container to the image.
+     */
+    mediaHeight?: number
+
+    /**
+     *  Used to define a string that labels the media element.
+     */
+    mediaAriaLabel?: string
+
+    /**
+     *  Establishes relationships between the media and it's label(s), its value should be one or more element IDs.
+     */
+    mediaAriaLabelledBy?: string
+
+    /**
+     *  Used to indicate the IDs of the elements that describe the media element.
+     */
+    mediaAriaDescribedBy?: string
+
+    /**
+     *  The border color at the top of the card. Must be one of palette semantic colors. To set another color, the borderTop should be override.
+     */
+    semantic?: Semantic
+
+    /**
+     *  The function that will be executed when the upper part of the card is clicked.
+     *  only works for the default card.
+     */
+    onClickAction?: (...args: any[]) => any
+
+    /**
+     *  Removes the header for the default card.
+     */
+    noHeader?: boolean
+
+    /**
+     *  Removes the footer for the default card.
+     */
+    noFooter?: boolean
+
+    /**
+     *  allows selecting on click action.
+     *  only works for the default card.
+     */
+    selectOnClickAction?: boolean
+
+    /**
+     *  The function that will be executed when the card is selected.
+     */
+    onChange?: (...args: any[]) => any
+
+    /**
+     * ´true´ if the card should have a checkbox in the footer to be selectable ´false´ if it is not required.
+     */
+    isSelectable?: boolean
+
+    /**
+     *  The value the checkbox in the footer will return when selected.
+     */
+    checkboxValue?: string
+
+    /**
+     *  The label for the checkbox in the footer of the card.
+     */
+    checkboxLabel?: string
+
+    /**
+     *  ´true´ if the checkbox is selected or ´false´ if not selected.
+     *
+     *  Note: if this value is specified the checkbox becomes a controlled component and it's state should be set from outside.
+     */
+    checkboxSelected?: boolean
+
+    /**
+     *  ´true´ if the checkbox should use the intermediate state when selected ´false´ if not.
+     */
+    checkboxIndeterminate?: boolean
+
+    /**
+     *  Used to define a string that labels the checkbox element.
+     */
+    checkboxAriaLabel?: string
+
+    /**
+     *  Establishes relationships between checkbox and it's label(s), its value should be one or more element IDs.
+     */
+    checkboxAriaLabelledBy?: string
+
+    /**
+     *  Used to indicate the IDs of the elements that describe the checkbox.
+     */
+    checkboxAriaDescribedBy?: string
+
+    /**
+     * The theme passed by the provider.
+     */
+    theme?: any
+
+    /**
+     *  The number of maximum visible actions before they're collapsed into a ´DropDownMenu´.
+     */
+    maxVisibleActions?: number
+
+    /**
+     *  Width applicable to the action container, to handle an issue Safari has when using css flex:
+     *  It resizes descendant divs, unless a width is forced
+     **/
+    actionItemWidth?: number
+  }
+}

--- a/packages/core/src/Header/index.d.ts
+++ b/packages/core/src/Header/index.d.ts
@@ -1,5 +1,9 @@
-declare module '@hv/uikit-react-core/dist' {
-  export class HvHeader extends React.Component<HvHeaderProps, any> {}
+declare module '@hv/uikit-react-core/dist/Header' {
+  import React from 'react'
+  
+  class HvHeader extends React.Component<HvHeaderProps, any> {}
+
+  export default HvHeader
 
   export interface NavigationStructure {
     showSearch?: boolean

--- a/packages/core/src/Input/input.d.ts
+++ b/packages/core/src/Input/input.d.ts
@@ -1,5 +1,9 @@
-declare module '@hv/uikit-react-core/dist' {
-  export class HvInput extends React.Component<HvInputProps, any> {}
+declare module '@hv/uikit-react-core/dist/Input' {
+  import React from 'react'
+  
+  class HvInput extends React.Component<HvInputProps, any> {}
+
+  export default HvInput
 
   export interface InputTextConfiguration {
     inputLabel?: string

--- a/packages/core/src/Kpi/index.d.ts
+++ b/packages/core/src/Kpi/index.d.ts
@@ -1,5 +1,9 @@
-declare module '@hv/uikit-react-core/dist' {
-  export class HvKpi extends React.Component<HvKpiProps, any> {}
+declare module '@hv/uikit-react-core/dist/Kpi' {
+  import React from 'react'
+  
+  class HvKpi extends React.Component<HvKpiProps, any> {}
+
+  export default HvKpi
 
   export interface KpiTextConfiguration {
     title?: string

--- a/packages/core/src/Login/index.d.ts
+++ b/packages/core/src/Login/index.d.ts
@@ -1,5 +1,9 @@
-declare module '@hv/uikit-react-core/dist' {
-  export class HvLogin extends React.Component<HvLoginProps, any> {}
+declare module '@hv/uikit-react-core/dist/Login' {
+  import React from 'react'
+
+  class HvLogin extends React.Component<HvLoginProps, any> {}
+
+  export default HvLogin
 
   export interface LoginInfo {
     username: string
@@ -22,11 +26,11 @@ declare module '@hv/uikit-react-core/dist' {
     loginButtonMessage?: string
     loginButtonLabel?: string
     forgotYourCredentialMessage?: string
-    emailLabel: string
-    emailPlaceholder: string
-    cancelButton: string
-    recoverButton: string
-    recoveringMessage: string
+    emailLabel?: string
+    emailPlaceholder?: string
+    cancelButton?: string
+    recoverButton?: string
+    recoveringMessage?: string
     incorrectCredentialsMessage?: string
   }
 

--- a/packages/core/src/Modal/ModalActions/index.d.ts
+++ b/packages/core/src/Modal/ModalActions/index.d.ts
@@ -1,8 +1,12 @@
-declare module '@hv/uikit-react-core/dist' {
-  export class HvModalActions extends React.Component<
+declare module '@hv/uikit-react-core/dist/Modal/ModalActions' {
+  import React from 'react'
+
+  class HvModalActions extends React.Component<
     HvModalActionsProps,
     any
   > {}
+
+  export default HvModalActions
 
   export interface HvModalActionsProps
     extends React.HTMLAttributes<HvModalActions> {

--- a/packages/core/src/Modal/ModalContent/index.d.ts
+++ b/packages/core/src/Modal/ModalContent/index.d.ts
@@ -1,8 +1,12 @@
-declare module '@hv/uikit-react-core/dist' {
-  export class HvModalContent extends React.Component<
+declare module '@hv/uikit-react-core/dist/Modal/ModalContent' {
+  import React from 'react'
+  
+  class HvModalContent extends React.Component<
     HvModalContentProps,
     any
   > {}
+
+  export default HvModalContent
 
   export interface HvModalContentProps
     extends React.HTMLAttributes<HvModalContent> {

--- a/packages/core/src/Modal/ModalTitle/index.d.ts
+++ b/packages/core/src/Modal/ModalTitle/index.d.ts
@@ -1,5 +1,9 @@
-declare module '@hv/uikit-react-core/dist' {
-  export class HvModalTitle extends React.Component<HvModalTitleProps, any> {}
+declare module '@hv/uikit-react-core/dist/Modal/ModalTitle' {
+  import React from 'react'
+  
+  class HvModalTitle extends React.Component<HvModalTitleProps, any> {}
+
+  export default HvModalTitle
 
   export interface HvModalTitleProps
     extends React.HTMLAttributes<HvModalTitle> {

--- a/packages/core/src/Modal/index.d.ts
+++ b/packages/core/src/Modal/index.d.ts
@@ -1,5 +1,9 @@
-declare module '@hv/uikit-react-core/dist' {
-  export class HvModal extends React.Component<HvModalProps, any> {}
+declare module '@hv/uikit-react-core/dist/Modal' {
+  import React from 'react'
+
+  class HvModal extends React.Component<HvModalProps, any> {}
+
+  export default HvModal
 
   export interface HvModalProps extends React.HTMLAttributes<HvModal> {
     /**

--- a/packages/core/src/NewHeader/index.d.ts
+++ b/packages/core/src/NewHeader/index.d.ts
@@ -1,0 +1,119 @@
+declare module '@hv/uikit-react-core/dist/NewHeader' {
+  import React from 'react'
+  
+  class HvHeader extends React.Component<HvHeaderProps, any> {}
+
+  export default HvHeader
+
+  export interface HvHeaderProps extends React.HTMLAttributes<HvHeader> {
+    /**
+     * A Jss Object used to override or extend the styles applied.
+     */
+    classes?: {
+      /**
+       * Styles applied to the component root class.
+       */
+      root?: string
+
+      /**
+       * Styles applied to the component header class.
+       */
+      header?: string
+    }
+
+    /**
+     * Position of the component.
+     */
+    position?: 'static' | 'relative' | 'fixed' | 'absolute' | 'sticky'
+  }
+
+  export class HvHeaderBrand extends React.Component<HvHeaderBrandProps, any> {}
+
+  export interface HvHeaderBrandProps
+    extends React.HTMLAttributes<HvHeaderBrand> {
+    /**
+     * A Jss Object used to override or extend the styles applied.
+     */
+    classes?: {
+      /**
+       * Styles applied to the component root class.
+       */
+      root?: string
+
+      /**
+       * Styles applied to the separator component class.
+       */
+      separator?: string
+    }
+
+    /**
+     * The brand image node.
+     */
+    logo?: React.ReactNode
+
+    /**
+     * The brand name string.
+     */
+    name?: string
+  }
+
+  export class HvHeaderActions extends React.Component<
+    HvHeaderActionsProps,
+    any
+  > {}
+
+  export interface HvHeaderActionsProps
+    extends React.HTMLAttributes<HvHeaderActions> {
+    /**
+     * A Jss Object used to override or extend the styles applied.
+     */
+    classes?: {
+      /**
+       * Styles applied to the component root class.
+       */
+      root?: string
+    }
+  }
+
+  export interface HeaderNavigationData {
+    id: string
+    label: string
+    data?: HeaderNavigationData[]
+  }
+
+  export class HvHeaderNavigation extends React.Component<
+    HvHeaderNavigationProps,
+    any
+  > {}
+
+  export interface HvHeaderNavigationProps
+    extends React.HTMLAttributes<HvHeaderNavigation> {
+    /**
+     * A Jss Object used to override or extend the styles applied.
+     */
+    classes?: {
+      /**
+       * Styles applied to the component root class.
+       */
+      root?: string
+    }
+
+    /**
+     * An array containing the data for each menu item.
+     *
+     * id - the id to be applied to the root element.
+     * label - the label to be rendered on the menu item.
+     */
+    data?: HeaderNavigationData[]
+
+    /**
+     * Menu item id selected.
+     */
+    selected?: string
+
+    /**
+     * Callback triggered when any item is clicked.
+     */
+    onClick?: (e: MouseEvent, selectedItem: HeaderNavigationData) => void
+  }
+}

--- a/packages/core/src/NewVerticalNavigation/index.d.ts
+++ b/packages/core/src/NewVerticalNavigation/index.d.ts
@@ -1,0 +1,97 @@
+declare module '@hv/uikit-react-core/dist/NewVerticalNavigation' {
+  import React from 'react'
+  
+  class HvVerticalNavigation extends React.Component<
+    HvVerticalNavigationProps,
+    any
+  > {}
+
+  export default HvVerticalNavigation
+
+  export interface HvVerticalNavigationProps
+    extends React.HTMLAttributes<HvVerticalNavigation> {
+    /**
+     * A Jss Object used to override or extend the styles applied to the component.
+     */
+    classes?: {
+      /**
+       * Style applied to the root of the component.
+       */
+      root?: string
+    }
+
+    /**
+     * Sets if the navigation should have a button to hide itself.
+     */
+    isCollapsable?: boolean
+
+    /**
+     * Is the navigation open.
+     */
+    isOpen?: boolean
+
+    /**
+     * Callback when the navigation toggles between open and close.
+     */
+    toggleOpenCallback?: (any) => any // TODO
+
+    /**
+     * Position of the component.
+     */
+    position?: 'static' | 'relative' | 'fixed' | 'absolute'
+
+    /**
+     * Defines if the navigation should close when losing focus / clicking outside.
+     */
+    closeOnExit?: boolean
+  }
+
+  export class Navigation extends React.Component<NavigationProps, any> {}
+
+  export interface NavigationData {
+    id: string
+    label: string
+    icon?: ReactNode
+    data?: NavigationData[]
+  }
+
+  export interface NavigationProps extends React.HTMLAttributes<Navigation> {
+    /**
+     * The theme passed by the provider.
+     */
+    theme?: any
+
+    /**
+     * A Jss Object used to override or extend the styles applied.
+     */
+    classes?: {
+      /**
+       * Style applied to the component.
+       */
+      root?: string
+    }
+
+    /**
+     * Label.
+     */
+    label?: string
+
+    /**
+     * An array containing the data for each menu item.
+     *
+     * id - the id to be applied to the root element.
+     * label - the label to be rendered on the menu item.
+     */
+    data?: NavigationData[]
+
+    /**
+     * Menu item id selected.
+     */
+    selected?: string
+
+    /**
+     * Callback triggered when any item is clicked.
+     */
+    onClick?: (e: MouseEvent, selectedItem: NavigationData) => void
+  }
+}

--- a/packages/core/src/Provider/index.d.ts
+++ b/packages/core/src/Provider/index.d.ts
@@ -1,0 +1,9 @@
+declare module '@hv/uikit-react-core/dist/Provider' {
+  import React from 'react'
+
+  class HvProvider extends React.Component<HvProviderProps, any> {}
+
+  export default HvProvider
+
+  export interface HvProviderProps extends React.HTMLAttributes<HvProvider> {}
+}

--- a/packages/core/src/SearchBox/index.d.ts
+++ b/packages/core/src/SearchBox/index.d.ts
@@ -1,5 +1,9 @@
-declare module '@hv/uikit-react-core/dist' {
-  export class HvSearchBox extends React.Component<HvSearchBoxProps, any> {}
+declare module '@hv/uikit-react-core/dist/SearchBox' {
+  import React from 'react'
+  
+  class HvSearchBox extends React.Component<HvSearchBoxProps, any> {}
+
+  export default HvSearchBox
 
   export interface SearchBoxLabel {
     inputLabel?: string
@@ -19,7 +23,7 @@ declare module '@hv/uikit-react-core/dist' {
       /**
        * Styles applied to searchbox root.
        */
-      root: string
+      root?: string
     }
 
     /**

--- a/packages/core/src/Selectors/index.d.ts
+++ b/packages/core/src/Selectors/index.d.ts
@@ -1,4 +1,6 @@
-declare module '@hv/uikit-react-core/dist' {
+declare module '@hv/uikit-react-core/dist/Selectors' {
+  import React from 'react'
+
   export class HvCheckBox extends React.Component<HvCheckBoxProps, any> {}
 
   export interface HvCheckBoxProps extends React.HTMLAttributes<HvCheckBox> {

--- a/packages/core/src/Tab/index.d.ts
+++ b/packages/core/src/Tab/index.d.ts
@@ -1,5 +1,9 @@
-declare module "@hv/uikit-react-core/dist" {
-  export class HvTab extends React.Component<HvTabProps, any> {}
+declare module "@hv/uikit-react-core/dist/Tab" {
+  import React from 'react'
+  
+  class HvTab extends React.Component<HvTabProps, any> {}
+
+  export default HvTab
 
   export interface HvTabProps extends React.HTMLAttributes<HvTab> {
     /**

--- a/packages/core/src/Table/index.d.ts
+++ b/packages/core/src/Table/index.d.ts
@@ -1,5 +1,9 @@
-declare module '@hv/uikit-react-core/dist' {
-  export class HvTable extends React.Component<HvTableProps, any> {}
+declare module '@hv/uikit-react-core/dist/Table' {
+  import React from 'react'
+  
+  class HvTable extends React.Component<HvTableProps, any> {}
+
+  export default HvTable
 
   export interface TableLabel {
     titleText?: string

--- a/packages/core/src/Tabs/index.d.ts
+++ b/packages/core/src/Tabs/index.d.ts
@@ -1,5 +1,9 @@
-declare module "@hv/uikit-react-core/dist" {
-  export class HvTabs extends React.Component<HvTabsProps, any> {}
+declare module "@hv/uikit-react-core/dist/Tabs" {
+  import React from 'react'
+  
+  class HvTabs extends React.Component<HvTabsProps, any> {}
+
+  export default HvTabs
 
   export interface HvTabsProps extends React.Component<HvTabs> {
     /**

--- a/packages/core/src/Typography/index.d.ts
+++ b/packages/core/src/Typography/index.d.ts
@@ -1,0 +1,55 @@
+declare module '@hv/uikit-react-core/dist/Typography' {
+  import React from 'react'
+
+  class HvTypography extends React.Component<HvTypographyProps, any> {}
+
+  export default HvTypography
+
+  export interface HvTypographyProps
+    extends React.HTMLAttributes<HvTypography> {
+    /**
+     * Styles applied to the Drawer Paper element.
+     */
+    classes?: Object
+
+    /**
+     * The component used for the root node.
+     * Either a string to use a DOM element or a component.
+     * By default, it maps the variant to a good default headline component.
+     */
+    component?: React.ReactElement
+
+    /**
+     * If `true`, the text will have a bottom margin.
+     */
+    paragraph?: boolean
+
+    /**
+     * The selected Typography.
+     */
+    variant?:
+      | '5xlTitle'
+      | '4xlTitle'
+      | '3xlTitle'
+      | 'xxlTitle'
+      | 'xlTitle'
+      | 'lTitle'
+      | 'mTitle'
+      | 'sTitle'
+      | 'xsTitle'
+      | 'xxsTitle'
+      | 'highlightText'
+      | 'normalText'
+      | 'selectedText'
+      | 'disabledButtonText'
+      | 'placeholderText'
+      | 'inlineLink'
+      | 'selectedNavText'
+      | 'labelText'
+      | 'infoText'
+      | 'sLink'
+      | 'sText'
+      | 'vizText'
+      | 'disabledText'
+  }
+}

--- a/packages/core/src/index.d.ts
+++ b/packages/core/src/index.d.ts
@@ -1,17 +1,45 @@
-import "./@types/HvBanner"
-import "./@types/HvBreadCrumb"
-import "./@types/HvButton"
-import "./@types/HvCheckBox"
-import "./@types/HvHeader"
-import "./@types/HvInput"
-import "./@types/HvKpi"
-import "./@types/HvLogin"
-import "./@types/HvModalActions"
-import "./@types/HvModalContent"
-import "./@types/HvModal"
-import "./@types/HvModalTitle"
-import "./@types/HvProvider"
-import "./@types/HvSearchBox"
-import "./@types/HvTable"
-import "./@types/HvTab"
-import "./@types/HvTabs"
+import './Badge'
+import './Banner'
+import './BreadCrumb'
+import './Button'
+import './Card'
+import './Header'
+import './Input'
+import './Kpi'
+import './Login'
+import './Modal'
+import './Modal/ModalActions'
+import './Modal/ModalContent'
+import './Modal/ModalTitle'
+import './Provider'
+import './SearchBox'
+import './Selectors'
+import './Table'
+import './Tab'
+import './Tabs'
+import './Typography'
+import './NewHeader'
+import './NewVerticalNavigation'
+
+declare module '@hv/uikit-react-core/dist' {
+  export { default as HvBadge, HvBadgeProps } from '@hv/uikit-react-core/dist/Badge'
+  export { default as HvBanner, HvBannerProps, BannerAction } from '@hv/uikit-react-core/dist/Banner'
+  export { default as HvBreadcrumb, HvBreadCrumbProps, BreadCrumbPathElement } from '@hv/uikit-react-core/dist/BreadCrumb'
+  export { default as HvButton, HvButtonProps } from '@hv/uikit-react-core/dist/Button'
+  export { default as HvCard, HvCardProps, CardAction } from '@hv/uikit-react-core/dist/Card'
+  export { HvCheckBox, HvCheckBoxProps } from '@hv/uikit-react-core/dist/Selectors'
+  export { default as HvHeader, HvHeaderProps, HeaderLabel} from '@hv/uikit-react-core/dist/Header'
+  export { default as HvInput, HvInputProps, InputLabels, InputTextConfiguration } from '@hv/uikit-react-core/dist/Input'
+  export { default as HvKpi, HvKpiProps, KpiLabels, KpiTextConfiguration } from '@hv/uikit-react-core/dist/Kpi'
+  export { default as HvLogin, HvLoginProps, LoginInfo, LoginLabel } from '@hv/uikit-react-core/dist/Login'
+  export { default as HvModal, HvModalProps } from '@hv/uikit-react-core/dist/Modal'
+  export { default as HvModalActions, HvModalActionsProps } from '@hv/uikit-react-core/dist/Modal/ModalActions'
+  export { default as HvModalContent, HvModalContentProps } from '@hv/uikit-react-core/dist/Modal/ModalContent'
+  export { default as HvModalTitle, HvModalTitleProps } from '@hv/uikit-react-core/dist/Modal/ModalTitle'
+  export { default as HvProvider, HvProviderProps } from '@hv/uikit-react-core/dist/Provider'
+  export { default as HvSearchBox, HvSearchBoxProps, SearchBoxLabel } from '@hv/uikit-react-core/dist/SearchBox'
+  export { default as HvTab, HvTabProps } from '@hv/uikit-react-core/dist/Tab'
+  export { default as HvTable, HvTableProps, SecondaryAction, TableColumn, TableLabel } from '@hv/uikit-react-core/dist/Table'
+  export { default as HvTabs, HvTabsProps } from '@hv/uikit-react-core/dist/Tabs'
+  export { default as HvTypography, HvTypographyProps } from '@hv/uikit-react-core/dist/Typography'
+}

--- a/packages/lab/src/Footer/index.d.ts
+++ b/packages/lab/src/Footer/index.d.ts
@@ -1,5 +1,9 @@
-declare module '@hv/uikit-react-lab/dist' {
-  export class HvFooter extends React.Component<HvFooterProps, any> {}
+declare module '@hv/uikit-react-lab/dist/Footer' {
+  import React from 'react'
+  
+  class HvFooter extends React.Component<HvFooterProps, any> {}
+
+  export default HvFooter
 
   export interface HvFooterProps extends React.HTMLAttributes<HvFooter> {
     classes?: {

--- a/packages/lab/src/Loading/index.d.ts
+++ b/packages/lab/src/Loading/index.d.ts
@@ -1,0 +1,65 @@
+declare module '@hv/uikit-react-lab/dist/Loading' {
+  import React from 'react'
+  
+  class HvLoading extends React.Component<HvLoadingProps, any> {}
+
+  export default HvLoading
+
+  export interface HvLoadingProps extends React.HTMLAttributes<HvLoading> {
+    /**
+     *  Styles applied to the Drawer Paper element.
+     */
+    classes?: {
+      /**
+       * The class applied on the text area input box.
+       */
+      input?: string
+
+      /**
+       * The class applied on the character counter.
+       */
+      characterCounter?: string
+
+      /**
+       * The class controlling the layout of the counter.
+       */
+      inline?: string
+
+      /**
+       * The class applied to the separator element of the character counter.
+       */
+      separator?: string
+
+      /**
+       * The class applied to the max counter element of the character counter.
+       */
+      maxCharacter?: string
+
+      /**
+       * The class applied to the current counter element of the character counter.
+       */
+      currentCounter?: string
+
+      /**
+       * The class applied to the character counter when it is disabled.
+       */
+      disabled?: string
+    }
+
+    /**
+     * The size of the loading indicator.
+     */
+    size?: 'regular' | 'small'
+
+    /**
+     * The position where the loading indicator is to be positioned in,
+     * center of the page or inline in the container where its inserted.
+     */
+    position?: 'center' | 'inline'
+
+    /**
+     * The text to be displayed.
+     */
+    text?: string
+  }
+}

--- a/packages/lab/src/Slider/index.d.ts
+++ b/packages/lab/src/Slider/index.d.ts
@@ -1,11 +1,15 @@
-declare module '@hv/uikit-react-lab/dist' {
-  export class HvSlider extends React.Component<HvSliderProps, any> {}
+declare module '@hv/uikit-react-lab/dist/Slider' {
+  import React from 'react'
+
+  class HvSlider extends React.Component<HvSliderProps, any> {}
+
+  export default HvSlider
 
   export interface KnobProperty {
     color?: string
     defaultValue?: number
-    hidden?: bool
-    fixed?: bool
+    hidden?: boolean
+    fixed?: boolean
     hoverColor?: string
     trackColor?: string
     dragColor?: string
@@ -16,6 +20,7 @@ declare module '@hv/uikit-react-lab/dist' {
     label?: string
   }
 
+  // @ts-ignore
   export interface HvSliderProps extends React.HTMLAttributes<HvSlider> {
     /**
      * The object created by material to apply to the component.

--- a/packages/lab/src/index.d.ts
+++ b/packages/lab/src/index.d.ts
@@ -1,2 +1,9 @@
-import "./@types/HvFooter"
-import "./@types/HvSlider"
+import './Footer'
+import './Loading'
+import './Slider'
+
+declare module '@hv/uikit-react-lab/dist' {
+  export { default as HvFooter, HvFooterProps } from '@hv/uikit-react-lab/dist/Footer'
+  export { default as HvLoading, HvLoadingProps } from '@hv/uikit-react-lab/dist/Loading'
+  export { default as HvSlider, HvSliderProps } from '@hv/uikit-react-lab/dist/Slider'
+}


### PR DESCRIPTION
Hello, thank you for the recent release of the new header component. We are very excited with that, and glad to contribute additional type definitions to cover them. This time, we also moved the type definition files to each component's individual directories (i.e. `./@types/Xxx.d.ts` is now moved to `./Xxx/index.d.ts`) so that the application can import them by `.../dist/Xxx` (instead of `.../dist`) as the official Storybook examples do.

- Type definition files are moved as just explained above, and the root `index.d.ts` is also fixed accordingly.
- Newly supported components: HvCard, HvTypography, HvBadge, NewHeader, NewVerticalNavigation, HvLoading
- Updated definitions: HvButton, HvBanner
- Minor bug fixes

Confirmed that `npm run boostrap` runs successfully, the type definition files are deployed under `dist`, and they work with our application as intended. 

As usual, please let us know if there are any problems or anything we can do. Thank you very much.