### PR TITLE
test: split actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: CI
+on: [push, pull_request]
+
+env:
+  RESOLVE_REGISTRY: https://nexus.pentaho.org/repository/group-npm/
+
+jobs:
+  Build:
+    runs-on: [self-hosted, Linux]
+    container:
+      image: node:12.14.1-buster
+      options: -u 1000 # buildguy
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Install
+        run: |
+          npm config set @hv:registry ${RESOLVE_REGISTRY}
+          npm ci
+
+      - name: Bootstrap
+        run: npm run bootstrap
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Test
+        run: npm run test

--- a/.github/workflows/robot.yml
+++ b/.github/workflows/robot.yml
@@ -1,5 +1,10 @@
-name: Continuous Integration
-on: [push, pull_request]
+name: Robot
+on:
+  schedule:
+    - cron: "0 3 * * *" # daily at 03:00
+  pull_request:
+    branches:
+      - master
 
 env:
   RESOLVE_REGISTRY: https://nexus.pentaho.org/repository/group-npm/
@@ -17,7 +22,7 @@ jobs:
 
       - name: Install
         run: |
-          npm config set registry ${RESOLVE_REGISTRY}
+          npm config set @hv:registry ${RESOLVE_REGISTRY}
           npm ci
 
       - name: Bootstrap
@@ -39,7 +44,6 @@ jobs:
           path: automation/storybook/dist
 
   Robot:
-    if: github.event_name == 'pull_request' && github.base_ref == 'master'
     needs: Build
     runs-on: [self-hosted, Windows]
     strategy:
@@ -75,7 +79,7 @@ jobs:
 
       - name: Save Reports
         uses: actions/upload-artifact@v1
-        if: always()
+        if: failure()
         with:
           name: ${{ matrix.browser }}-reports
           path: reports

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 ![alt text](https://img.shields.io/badge/plataforms-chrome%20%7C%20firefox%20%7C%20safari%20%7C%20edge%20%7C%20ie%2011-blue.svg)
 ![alt text](https://img.shields.io/badge/core--coverage-80%25-green.svg)
 ![alt text](https://img.shields.io/badge/lab--coverage-68%25-orange.svg)
-![alt text](https://github.com/pentaho/hv-uikit-react/workflows/Continuous%20Integration/badge.svg?branch=alpha)
+![CI](https://github.com/pentaho/hv-uikit-react/workflows/CI/badge.svg?branch=next)
 
 </div>
 


### PR DESCRIPTION
Split GitHub actions into
- CI: running bootstrap/test/lint (branches + PRs)
- Robot: CI + storybook archiving + robot tests (3am daily + `master` PR)