### PR TITLE
test(automation): pa11y as npm package

### DIFF
--- a/automation/robot/package-lock.json
+++ b/automation/robot/package-lock.json
@@ -1,0 +1,505 @@
+{
+  "name": "robot",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "agent-base": {
+      "version": "4.3.0",
+      "resolved": "https://nexus.pentaho.org/repository/group-npm/agent-base/-/agent-base-4.3.0.tgz",
+      "integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
+      "requires": {
+        "es6-promisify": "^5.0.0"
+      }
+    },
+    "ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://nexus.pentaho.org/repository/group-npm/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "requires": {
+        "color-convert": "^1.9.0"
+      }
+    },
+    "async-limiter": {
+      "version": "1.0.1",
+      "resolved": "https://nexus.pentaho.org/repository/group-npm/async-limiter/-/async-limiter-1.0.1.tgz",
+      "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ=="
+    },
+    "axe-core": {
+      "version": "3.5.1",
+      "resolved": "https://nexus.pentaho.org/repository/group-npm/axe-core/-/axe-core-3.5.1.tgz",
+      "integrity": "sha512-mwpDgPwWB+5kMHyLjlxh4w25ClJfqSxi+c6LQ4ix349TdCUctMwJNPTkhPD1qP9SYIjFgjeVpVZWCvK9oBGwCg=="
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://nexus.pentaho.org/repository/group-npm/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+    },
+    "bfj": {
+      "version": "4.2.4",
+      "resolved": "https://nexus.pentaho.org/repository/group-npm/bfj/-/bfj-4.2.4.tgz",
+      "integrity": "sha1-hfeyNoPCr9wVhgOEotHD+sgO0zo=",
+      "requires": {
+        "check-types": "^7.3.0",
+        "hoopy": "^0.1.2",
+        "tryer": "^1.0.0"
+      }
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://nexus.pentaho.org/repository/group-npm/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "buffer-from": {
+      "version": "1.1.1",
+      "resolved": "https://nexus.pentaho.org/repository/group-npm/buffer-from/-/buffer-from-1.1.1.tgz",
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
+    },
+    "chalk": {
+      "version": "2.4.2",
+      "resolved": "https://nexus.pentaho.org/repository/group-npm/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "requires": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      }
+    },
+    "check-types": {
+      "version": "7.4.0",
+      "resolved": "https://nexus.pentaho.org/repository/group-npm/check-types/-/check-types-7.4.0.tgz",
+      "integrity": "sha512-YbulWHdfP99UfZ73NcUDlNJhEIDgm9Doq9GhpyXbF+7Aegi3CVV7qqMCKTTqJxlvEvnQBp9IA+dxsGN6xK/nSg=="
+    },
+    "color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://nexus.pentaho.org/repository/group-npm/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "resolved": "https://nexus.pentaho.org/repository/group-npm/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+    },
+    "commander": {
+      "version": "3.0.2",
+      "resolved": "https://nexus.pentaho.org/repository/group-npm/commander/-/commander-3.0.2.tgz",
+      "integrity": "sha512-Gar0ASD4BDyKC4hl4DwHqDrmvjoxWKZigVnAbn5H1owvm4CxCPdb0HQDehwNYMJpla5+M2tPmPARzhtYuwpHow=="
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://nexus.pentaho.org/repository/group-npm/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+    },
+    "concat-stream": {
+      "version": "1.6.2",
+      "resolved": "https://nexus.pentaho.org/repository/group-npm/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
+      }
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://nexus.pentaho.org/repository/group-npm/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
+    "debug": {
+      "version": "4.1.1",
+      "resolved": "https://nexus.pentaho.org/repository/group-npm/debug/-/debug-4.1.1.tgz",
+      "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+      "requires": {
+        "ms": "^2.1.1"
+      }
+    },
+    "es6-promise": {
+      "version": "4.2.8",
+      "resolved": "https://nexus.pentaho.org/repository/group-npm/es6-promise/-/es6-promise-4.2.8.tgz",
+      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
+    },
+    "es6-promisify": {
+      "version": "5.0.0",
+      "resolved": "https://nexus.pentaho.org/repository/group-npm/es6-promisify/-/es6-promisify-5.0.0.tgz",
+      "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
+      "requires": {
+        "es6-promise": "^4.0.3"
+      }
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://nexus.pentaho.org/repository/group-npm/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+    },
+    "extract-zip": {
+      "version": "1.6.7",
+      "resolved": "https://nexus.pentaho.org/repository/group-npm/extract-zip/-/extract-zip-1.6.7.tgz",
+      "integrity": "sha1-qEC0uK9kAyZMjbV/Txp0Mz74H+k=",
+      "requires": {
+        "concat-stream": "1.6.2",
+        "debug": "2.6.9",
+        "mkdirp": "0.5.1",
+        "yauzl": "2.4.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://nexus.pentaho.org/repository/group-npm/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://nexus.pentaho.org/repository/group-npm/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        }
+      }
+    },
+    "fd-slicer": {
+      "version": "1.0.1",
+      "resolved": "https://nexus.pentaho.org/repository/group-npm/fd-slicer/-/fd-slicer-1.0.1.tgz",
+      "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
+      "requires": {
+        "pend": "~1.2.0"
+      }
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://nexus.pentaho.org/repository/group-npm/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+    },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://nexus.pentaho.org/repository/group-npm/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+    },
+    "glob": {
+      "version": "7.1.6",
+      "resolved": "https://nexus.pentaho.org/repository/group-npm/glob/-/glob-7.1.6.tgz",
+      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "has": {
+      "version": "1.0.3",
+      "resolved": "https://nexus.pentaho.org/repository/group-npm/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "requires": {
+        "function-bind": "^1.1.1"
+      }
+    },
+    "has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://nexus.pentaho.org/repository/group-npm/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+    },
+    "hoopy": {
+      "version": "0.1.4",
+      "resolved": "https://nexus.pentaho.org/repository/group-npm/hoopy/-/hoopy-0.1.4.tgz",
+      "integrity": "sha512-HRcs+2mr52W0K+x8RzcLzuPPmVIKMSv97RGHy0Ea9y/mpcaK+xTrjICA04KAHi4GRzxliNqNJEFYWHghy3rSfQ=="
+    },
+    "html_codesniffer": {
+      "version": "2.4.1",
+      "resolved": "https://nexus.pentaho.org/repository/group-npm/html_codesniffer/-/html_codesniffer-2.4.1.tgz",
+      "integrity": "sha512-7g4Z8+7agJFi7XJGu2r0onIqA7ig9b26vFEvUE6DgtFJlJzy1ELYEKzzd5Xwam4xjHiHQ/w8yHO7KTGNcXnwzg=="
+    },
+    "https-proxy-agent": {
+      "version": "2.2.4",
+      "resolved": "https://nexus.pentaho.org/repository/group-npm/https-proxy-agent/-/https-proxy-agent-2.2.4.tgz",
+      "integrity": "sha512-OmvfoQ53WLjtA9HeYP9RNrWMJzzAz1JGaSFr1nijg0PVR1JaD/xbJq1mdEIIlxGpXp9eSe/O2LgU9DJmTPd0Eg==",
+      "requires": {
+        "agent-base": "^4.3.0",
+        "debug": "^3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://nexus.pentaho.org/repository/group-npm/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        }
+      }
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://nexus.pentaho.org/repository/group-npm/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.4",
+      "resolved": "https://nexus.pentaho.org/repository/group-npm/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "is": {
+      "version": "3.3.0",
+      "resolved": "https://nexus.pentaho.org/repository/group-npm/is/-/is-3.3.0.tgz",
+      "integrity": "sha512-nW24QBoPcFGGHJGUwnfpI7Yc5CdqWNdsyHQszVE/z2pKHXzh7FZ5GWhJqSyaQ9wMkQnsTx+kAI8bHlCX4tKdbg=="
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://nexus.pentaho.org/repository/group-npm/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+    },
+    "mime": {
+      "version": "2.4.4",
+      "resolved": "https://nexus.pentaho.org/repository/group-npm/mime/-/mime-2.4.4.tgz",
+      "integrity": "sha512-LRxmNwziLPT828z+4YkNzloCFC2YM4wrB99k+AV5ZbEyfGNWfG8SO1FUXLmLDBSo89NrJZ4DIWeLjy1CHGhMGA=="
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://nexus.pentaho.org/repository/group-npm/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "minimist": {
+      "version": "0.0.8",
+      "resolved": "https://nexus.pentaho.org/repository/group-npm/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://nexus.pentaho.org/repository/group-npm/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "requires": {
+        "minimist": "0.0.8"
+      }
+    },
+    "ms": {
+      "version": "2.1.2",
+      "resolved": "https://nexus.pentaho.org/repository/group-npm/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+    },
+    "node.extend": {
+      "version": "2.0.2",
+      "resolved": "https://nexus.pentaho.org/repository/group-npm/node.extend/-/node.extend-2.0.2.tgz",
+      "integrity": "sha512-pDT4Dchl94/+kkgdwyS2PauDFjZG0Hk0IcHIB+LkW27HLDtdoeMxHTxZh39DYbPP8UflWXWj9JcdDozF+YDOpQ==",
+      "requires": {
+        "has": "^1.0.3",
+        "is": "^3.2.1"
+      }
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://nexus.pentaho.org/repository/group-npm/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "p-finally": {
+      "version": "1.0.0",
+      "resolved": "https://nexus.pentaho.org/repository/group-npm/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
+    },
+    "p-timeout": {
+      "version": "2.0.1",
+      "resolved": "https://nexus.pentaho.org/repository/group-npm/p-timeout/-/p-timeout-2.0.1.tgz",
+      "integrity": "sha512-88em58dDVB/KzPEx1X0N3LwFfYZPyDc4B6eF38M1rk9VTZMbxXXgjugz8mmwpS9Ox4BDZ+t6t3QP5+/gazweIA==",
+      "requires": {
+        "p-finally": "^1.0.0"
+      }
+    },
+    "pa11y": {
+      "version": "5.3.0",
+      "resolved": "https://nexus.pentaho.org/repository/group-npm/pa11y/-/pa11y-5.3.0.tgz",
+      "integrity": "sha512-g1cVpmRQQXClTZYbx4JC+FqCu6AfM9K3px2TPb2NY9JrorxYiInOKQCa9eF6URjY//bDkQmkn65rTWmbwTC07A==",
+      "requires": {
+        "commander": "^3.0.2",
+        "node.extend": "^2.0.2",
+        "p-timeout": "^2.0.1",
+        "pa11y-reporter-cli": "^1.0.1",
+        "pa11y-reporter-csv": "^1.0.0",
+        "pa11y-reporter-json": "^1.0.0",
+        "pa11y-runner-axe": "^1.0.1",
+        "pa11y-runner-htmlcs": "^1.2.0",
+        "puppeteer": "^1.13.0",
+        "semver": "^5.6.0"
+      }
+    },
+    "pa11y-reporter-cli": {
+      "version": "1.0.1",
+      "resolved": "https://nexus.pentaho.org/repository/group-npm/pa11y-reporter-cli/-/pa11y-reporter-cli-1.0.1.tgz",
+      "integrity": "sha512-k+XPl5pBU2R1J6iagGv/GpN/dP7z2cX9WXqO0ALpBwHlHN3ZSukcHCOhuLMmkOZNvufwsvobaF5mnaZxT70YyA==",
+      "requires": {
+        "chalk": "^2.1.0"
+      }
+    },
+    "pa11y-reporter-csv": {
+      "version": "1.0.0",
+      "resolved": "https://nexus.pentaho.org/repository/group-npm/pa11y-reporter-csv/-/pa11y-reporter-csv-1.0.0.tgz",
+      "integrity": "sha512-S2gFgbAvONBzAVsVbF8zsYabszrzj7SKhQxrEbw19zF0OFI8wCWn8dFywujYYkg674rmyjweSxSdD+kHTcx4qA=="
+    },
+    "pa11y-reporter-json": {
+      "version": "1.0.0",
+      "resolved": "https://nexus.pentaho.org/repository/group-npm/pa11y-reporter-json/-/pa11y-reporter-json-1.0.0.tgz",
+      "integrity": "sha512-EdLrzh1hyZ8DudCSSrcakgtsHDiSsYNsWLSoEAo1JnFTIK8hYpD7vL+xgd0u+LXDxz9wLLFnckdubpklaRpl/w==",
+      "requires": {
+        "bfj": "^4.2.3"
+      }
+    },
+    "pa11y-runner-axe": {
+      "version": "1.0.1",
+      "resolved": "https://nexus.pentaho.org/repository/group-npm/pa11y-runner-axe/-/pa11y-runner-axe-1.0.1.tgz",
+      "integrity": "sha512-TZls/tSpiQfCbgRg7t+5O0R6/PrOHBCZXX+/dT4QemarTef0TzQqHz8az8sbC9IpDFAY+X2pGJW5becaXiIuWw==",
+      "requires": {
+        "axe-core": "^3.1.2"
+      }
+    },
+    "pa11y-runner-htmlcs": {
+      "version": "1.2.0",
+      "resolved": "https://nexus.pentaho.org/repository/group-npm/pa11y-runner-htmlcs/-/pa11y-runner-htmlcs-1.2.0.tgz",
+      "integrity": "sha512-uf0wEsoeRfyALXVcZeDadV7ot7pE6JZ3EZwbspwmyXW30ahjCClAfE/FtaNo1y2Mlxx5J9ui1sW2YzhHXocV5g==",
+      "requires": {
+        "html_codesniffer": "^2.4.1"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://nexus.pentaho.org/repository/group-npm/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+    },
+    "pend": {
+      "version": "1.2.0",
+      "resolved": "https://nexus.pentaho.org/repository/group-npm/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA="
+    },
+    "process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://nexus.pentaho.org/repository/group-npm/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+    },
+    "progress": {
+      "version": "2.0.3",
+      "resolved": "https://nexus.pentaho.org/repository/group-npm/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA=="
+    },
+    "proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://nexus.pentaho.org/repository/group-npm/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+    },
+    "puppeteer": {
+      "version": "1.20.0",
+      "resolved": "https://nexus.pentaho.org/repository/group-npm/puppeteer/-/puppeteer-1.20.0.tgz",
+      "integrity": "sha512-bt48RDBy2eIwZPrkgbcwHtb51mj2nKvHOPMaSH2IsWiv7lOG9k9zhaRzpDZafrk05ajMc3cu+lSQYYOfH2DkVQ==",
+      "requires": {
+        "debug": "^4.1.0",
+        "extract-zip": "^1.6.6",
+        "https-proxy-agent": "^2.2.1",
+        "mime": "^2.0.3",
+        "progress": "^2.0.1",
+        "proxy-from-env": "^1.0.0",
+        "rimraf": "^2.6.1",
+        "ws": "^6.1.0"
+      }
+    },
+    "readable-stream": {
+      "version": "2.3.7",
+      "resolved": "https://nexus.pentaho.org/repository/group-npm/readable-stream/-/readable-stream-2.3.7.tgz",
+      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+      "requires": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "rimraf": {
+      "version": "2.7.1",
+      "resolved": "https://nexus.pentaho.org/repository/group-npm/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "requires": {
+        "glob": "^7.1.3"
+      }
+    },
+    "safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://nexus.pentaho.org/repository/group-npm/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
+    "semver": {
+      "version": "5.7.1",
+      "resolved": "https://nexus.pentaho.org/repository/group-npm/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+    },
+    "string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://nexus.pentaho.org/repository/group-npm/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "requires": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://nexus.pentaho.org/repository/group-npm/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "requires": {
+        "has-flag": "^3.0.0"
+      }
+    },
+    "tryer": {
+      "version": "1.0.1",
+      "resolved": "https://nexus.pentaho.org/repository/group-npm/tryer/-/tryer-1.0.1.tgz",
+      "integrity": "sha512-c3zayb8/kWWpycWYg87P71E1S1ZL6b6IJxfb5fvsUgsf0S2MVGaDhDXXjDMpdCpfWXqptc+4mXwmiy1ypXqRAA=="
+    },
+    "typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://nexus.pentaho.org/repository/group-npm/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://nexus.pentaho.org/repository/group-npm/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://nexus.pentaho.org/repository/group-npm/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    },
+    "ws": {
+      "version": "6.2.1",
+      "resolved": "https://nexus.pentaho.org/repository/group-npm/ws/-/ws-6.2.1.tgz",
+      "integrity": "sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==",
+      "requires": {
+        "async-limiter": "~1.0.0"
+      }
+    },
+    "yauzl": {
+      "version": "2.4.1",
+      "resolved": "https://nexus.pentaho.org/repository/group-npm/yauzl/-/yauzl-2.4.1.tgz",
+      "integrity": "sha1-lSj0QtqxsihOWLQ3m7GU4i4MQAU=",
+      "requires": {
+        "fd-slicer": "~1.0.1"
+      }
+    }
+  }
+}

--- a/automation/robot/package.json
+++ b/automation/robot/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@hv/uikit-react-automation-robot",
+  "version": "1.0.0",
+  "description": "Environment for test UI components running pa11y tool.",
+  "homepage": "https://github.com/pentaho/hv-uikit-react",
+  "license": "Apache-2.0",
+  "private": true,
+  "author": {
+    "name": "Hitachi Vantara UI Kit Team"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/pentaho/hv-uikit-react.git"
+  },
+  "scripts": {
+  },
+  "dependencies": {
+    "pa11y": "^5.3.0"
+  }
+}

--- a/automation/robot/storybook/_resources/accessibility.robot
+++ b/automation/robot/storybook/_resources/accessibility.robot
@@ -1,34 +1,21 @@
 *** Setting ***
-Library    Process
-Library    OperatingSystem
-Library    customLibrary.py    
-Library    String    
-
-
-*** Variables ***
-@{pa11y_options}    node              %{pa11y_home}/pa11y.js
-...                 --runner          htmlcs                             --runner    axe
-...                 --standard        WCAG2AA
-...                 --root-element    div[class|='Component-content']
-# pa11y options based on https://github.com/pa11y/pa11y
+Library      Process
+Library      OperatingSystem
+Library      String
+Library      customLibrary.py
+Variables    accessibility_variables.py
 
 
 *** Keywords ***
-get story file name from url
-    [Arguments]    ${url}       
-    ${story}    Fetch From Right    ${url}    id=
-    [Return]    ${OUTPUT_DIR}${/}${story}
-
 get pa11y errors
     [Arguments]    ${url}
     [Documentation]    
     ...    run pa11y script against ${url} and return path of saved errors results 
     ...
-    ${story}                       get story file name from url    ${url}
-    ${pa11yResult}=                Run Process                     @{pa11y_options}
-    ...                            --reporter                      json                ${url}
-    ...                            stdout=${story}                 stderr=STDOUT       timeout=60s
-    Should Be Equal As Integers    ${pa11yResult.rc}               2                   ${pa11yResult.stdout}
+    ${story}                       Fetch From Right                    ${url}           id=
+    ${pa11yResult}=                Run Process                         @{PA11Y_JSON}    ${url}
+    ...                            stdout=${OUTPUT_DIR}${/}${story}    stderr=STDOUT    timeout=60s
+    Should Be Equal As Integers    ${pa11yResult.rc}                   2                ${pa11yResult.stdout}
     [Return]                       ${pa11yResult.stdout_path}
     
 pa11y should not find errors
@@ -37,11 +24,11 @@ pa11y should not find errors
      ...   run pa11y script against ${url}
      ...   fails if pa11y return errors and in this case is saved a related error file on outputdir
      ...
-    ${story}                       get story file name from url    ${url}
-    ${pa11yResult}=                Run Process                     @{pa11y_options}    ${url}
-    ...                            stdout=${story}                 stderr=STDOUT       timeout=60s
-    Should Be Equal As Integers    ${pa11yResult.rc}               0                   please look errors file: \n ${pa11yResult.stdout_path} \n
-    Remove File                    ${story}
+    ${story}                       Fetch From Right                    ${url}              id=
+    ${pa11yResult}=                Run Process                         @{PA11Y_CONSOLE}    ${url}
+    ...                            stdout=${OUTPUT_DIR}${/}${story}    stderr=STDOUT       timeout=60s
+    Should Be Equal As Integers    ${pa11yResult.rc}                   0                   errors file: ${pa11yResult.stdout_path}
+    Remove File                    ${pa11yResult.stdout_path}
 
 pa11y result should be equal as file
     [Arguments]    ${url}    ${expectedFile}

--- a/automation/robot/storybook/_resources/accessibility_variables.py
+++ b/automation/robot/storybook/_resources/accessibility_variables.py
@@ -1,0 +1,13 @@
+import os
+
+path_dir = os.path.abspath(__file__).split("robot")[0]
+pa11y_path = os.path.normpath(path_dir + "robot/node_modules/pa11y/bin/pa11y.js")
+
+# pa11y options based on https://github.com/pa11y/pa11y
+PA11Y_CONSOLE = ["node", pa11y_path,\
+                       "--runner", "htmlcs",\
+                       "--runner", "axe",\
+                       "--standard", "WCAG2AA",\
+                       "--root-element", "div[class|='Component-content']"]
+
+PA11Y_JSON = PA11Y_CONSOLE + ["--reporter","json"]

--- a/automation/robot/storybook/_resources/storybook_variables.yaml
+++ b/automation/robot/storybook/_resources/storybook_variables.yaml
@@ -1,3 +1,2 @@
 STORYBOOK_URL:    http://localhost:9002
 BROWSER:    ff
-PA11Y_STANDARD:    WCAG2AA


### PR DESCRIPTION
- run accessibility tests with pa11y as npm dependency
- keep same version (axe-runner) of sub-dependencies
- split variables from keywords