### PR TITLE
Table improvements [Secondary Actions & Expander]

### DIFF
--- a/packages/core/src/Table/expander/expander.js
+++ b/packages/core/src/Table/expander/expander.js
@@ -20,9 +20,9 @@ import React from "react";
  * Add the expander element to the first column. This way the expander element doesn't create
  * a single column for itself but is introduced along side the data in the first column.
  *
- * @param {Array} columns - The array that contains the columns in the tabble.
+ * @param {Array} columns - The array that contains the columns in the table.
  * @param {JSX} subElementTemplate - the expander template provided by the user.
- * @param {Object} classes - the clases to be applied to the expander container.
+ * @param {Object} classes - the classes to be applied to the expander container.
  * @returns {JSX|Array} - The expander
  */
 const expander = (subElementTemplate, classes) => {
@@ -36,4 +36,4 @@ const expander = (subElementTemplate, classes) => {
   return newSubComponent;
 };
 
-export default expander
+export default expander;

--- a/packages/core/src/Table/selectTable.js
+++ b/packages/core/src/Table/selectTable.js
@@ -10,17 +10,23 @@
 import React from "react";
 import HvCheckBox from "../Selectors/CheckBox";
 
-const defaultSelectInputComponent = props => {
+const defaultSelectInputComponent = ({
+  internalId,
+  id,
+  checked,
+  row,
+  onClick
+}) => {
   return (
     <HvCheckBox
-      inputProps={{ "aria-label": `${props.internalId}-select-${props.id}` }}
-      id={props.id}
-      checked={props.checked}
+      inputProps={{ "aria-label": `${internalId}-select-${id}` }}
+      id={id}
+      checked={checked}
       onChange={() => {}}
       onClick={e => {
         const { shiftKey } = e;
         e.stopPropagation();
-        props.onClick(props.id, shiftKey, props.row);
+        onClick(id, shiftKey, row);
       }}
     />
   );

--- a/packages/core/src/Table/styles.js
+++ b/packages/core/src/Table/styles.js
@@ -283,7 +283,14 @@ const styles = theme => ({
   },
   iconContainer: {
     width: "30px",
-    height: "30px"
+    height: "30px",
+    cursor: "pointer"
+  },
+  iconContainerDisabled: {
+    width: "30px",
+    height: "30px",
+    cursor: "not-allowed",
+    opacity: "0.5"
   },
   firstWithNumeric: {
     width: "calc(100% - 32px)"


### PR DESCRIPTION
# 1 - Secondary Actions 
The goal is to add more control on the actions available with the secondaryActions field in the HvTable, namely adding the possibility of having actions disabled per row.

## requirements:
**1.** When creating the secondaryActions for the HvTable, add a '_id_' property to latter use for disable it.
![image](https://user-images.githubusercontent.com/26247266/77351784-2be04100-6d36-11ea-9316-e0f85f188d30.png)
**2.** When creating the data object to supply to the table, add a new property "_actions_", whish will be the available actions that row will have available. 
![image](https://user-images.githubusercontent.com/26247266/77352254-d0fb1980-6d36-11ea-8fb1-661b205270e2.png)
**3.** The final result will me something like this: 
![image](https://user-images.githubusercontent.com/26247266/77352790-a6f62700-6d37-11ea-86c8-5caa0c7ac69c.png)

# 2 - Expander
The focus on this feature is to add trigger actions over the expander icon, and add the control to disable specific rows

## requirements:
**1.**  create "_expanderOptions_" configuration:
![image](https://user-images.githubusercontent.com/26247266/77353091-3f8ca700-6d38-11ea-904e-39ade1bd4e66.png)
**2.** add it to the HvTable as prop:
![image](https://user-images.githubusercontent.com/26247266/77353224-81b5e880-6d38-11ea-8fc5-0491109340d8.png)
**3.** The final result will me something like this:
![image](https://user-images.githubusercontent.com/26247266/77353552-13bdf100-6d39-11ea-81f0-6df538ebba1f.png)


 