### PR TITLE
fix: appswitcher component #1393

### DIFF
--- a/packages/doc/samples/lab/appSwitcherPanel/appSwitcherPanel1.js
+++ b/packages/doc/samples/lab/appSwitcherPanel/appSwitcherPanel1.js
@@ -16,15 +16,18 @@
 
 import React from "react";
 
+import { Tool } from "@hv/uikit-react-icons/dist/Generic";
+
 import DefaultHeader from "./utils/DefaultHeader";
 import AppSwitcherToggle from "./utils/AppSwitcherToggle";
+import { boxStyles } from "./utils/boxStyles";
 
 const appSwitcherToggleProps = {
   applications: [
     {
       iconUrl: "",
       description: "Application without a name should not appear",
-      url: "https://pentaho.github.io/hv-uikit-react/",
+      url: "https://github.com/pentaho/hv-uikit-react",
       target: "_top",
     },
     {
@@ -37,7 +40,7 @@ const appSwitcherToggleProps = {
       name: "",
       iconUrl: "",
       description: "Application with an empty name should not appear",
-      url: "https://pentaho.github.io/hv-uikit-react/",
+      url: "https://github.com/pentaho/hv-uikit-react",
       target: "_top",
     },
     {
@@ -56,59 +59,30 @@ const appSwitcherToggleProps = {
       target: "_top",
     },
     {
-      name: "UI-KIT Storybook (New Tab)",
-      iconUrl:
-        "https://pbs.twimg.com/profile_images/1100804485616566273/sOct-Txm_400x400.png",
-      description: "This is the Storybook for the UI-KIT project",
-      url: "https://pentaho.github.io/hv-uikit-react/",
-      target: "_blank",
+      name: "UI-KIT GitHub (New Tab)",
+      iconElement: <Tool boxStyles={boxStyles} />,
+      description: "This is the UI-KIT repository on Github",
+      url: "https://github.com/pentaho/hv-uikit-react",
+      target: "_blank"
     },
     {
-      name:
-        "UI-KIT Storybook - This one has a bigger name than the others just so we can see the truncation!!!",
-      iconUrl:
-        "https://pbs.twimg.com/profile_images/1100804485616566273/sOct-Txm_400x400.png",
-      description:
-        "This application has a bigger name than the others so we can see the truncation in action",
-      url: "https://pentaho.github.io/hv-uikit-react/",
-      target: "_top",
-    },
-    {
-      name: "Pentaho GitHub",
-      iconUrl: "https://logodix.com/logo/1960244.png",
-      description: "This is the Pentaho repository on Github",
-      url: "https://github.com/pentaho/",
-    },
-    {
-      name: "Google",
-      iconUrl:
-        "https://p7.hiclipart.com/preview/249/19/631/google-logo-g-suite-google-guava-google-plus.jpg",
-      url: "https://www.google.com/",
-      target: "_top",
+      name: "App with a bigger name than the other just to showcase the truncation on the AppSwitcherPanel",
+      iconElement: <Tool boxStyles={boxStyles} />,
+      description: "App 1 description",
+      url: "https://github.com/pentaho/hv-uikit-react",
+      target: "_top"
     },
     {
       name: "No Icon App",
       description:
         "This is an App without an icon, URL is set to the UI-KIT storybook",
-      url: "https://pentaho.github.io/hv-uikit-react/",
+      url: "https://github.com/pentaho/hv-uikit-react",
     },
     {
       name: "No Description App",
-      url: "https://pentaho.github.io/hv-uikit-react/",
-    },
-    {
-      name: "YouTube",
-      iconUrl: "https://logodix.com/logo/2735.png",
-      description: "YouTube page",
-      url: "https://www.youtube.com/",
-    },
-    {
-      name: "GitHub",
-      iconUrl: "https://logodix.com/logo/64427.png",
-      description: "GitHub page",
-      url: "https://www.github.com/",
-    },
-  ],
+      url: "https://github.com/pentaho/hv-uikit-react",
+    }
+  ]
 };
 
 export default (

--- a/packages/doc/samples/lab/appSwitcherPanel/appSwitcherPanel2.js
+++ b/packages/doc/samples/lab/appSwitcherPanel/appSwitcherPanel2.js
@@ -16,14 +16,17 @@
 
 import React from "react";
 
+import { Tool } from "@hv/uikit-react-icons/dist/Generic";
+
 import DefaultHeader from "./utils/DefaultHeader";
 import AppSwitcherToggle from "./utils/AppSwitcherToggle";
+import { boxStyles } from "./utils/boxStyles";
 
 const appSwitcherToggleProps = {
   title: "Dummy Apps with footer and a really big name to not fit in the container",
   applications: [
     {
-      name: "UI-KIT Storybook",
+      name: "App with a bigger name than the others just to showcase the truncation on the AppSwitcherPanel",
       iconUrl:
         "https://pbs.twimg.com/profile_images/1100804485616566273/sOct-Txm_400x400.png",
       description: "This is the Storybook for the UI-KIT project",
@@ -31,56 +34,21 @@ const appSwitcherToggleProps = {
       target: "_top",
     },
     {
-      name: "UI-KIT Storybook (New Tab)",
-      iconUrl:
-        "https://pbs.twimg.com/profile_images/1100804485616566273/sOct-Txm_400x400.png",
-      description: "This is the Storybook for the UI-KIT project",
-      url: "https://pentaho.github.io/hv-uikit-react/",
-      target: "_blank",
-    },
-    {
-      name: "UI-KIT Storybook - This one has a bigger name than the others just so we can see the truncation!!!",
-      iconUrl:
-        "https://pbs.twimg.com/profile_images/1100804485616566273/sOct-Txm_400x400.png",
-      description: "This application has a bigger name than the others so we can see the truncation in action",
-      url: "https://pentaho.github.io/hv-uikit-react/",
-      target: "_top",
-    },
-    {
-      name: "Pentaho GitHub",
-      iconUrl: "https://logodix.com/logo/1960244.png",
-      description: "This is the Pentaho repository on Github",
-      url: "https://github.com/pentaho/"
-    },
-    {
-      name: "Google",
-      iconUrl:
-        "https://p7.hiclipart.com/preview/249/19/631/google-logo-g-suite-google-guava-google-plus.jpg",
-      url: "https://www.google.com/",
-      target: "_top",
+      name: "UI-KIT GitHub (New Tab)",
+      iconElement: <Tool boxStyles={boxStyles} />,
+      description: "This is the UI-KIT repository on Github",
+      url: "https://github.com/pentaho/hv-uikit-react",
+      target: "_blank"
     },
     {
       name: "No Icon App",
       description:
         "This is an App without an icon, URL is set to the UI-KIT storybook",
-      url: "https://pentaho.github.io/hv-uikit-react/"
+      url: "https://github.com/pentaho/hv-uikit-react",
     },
-
     {
       name: "No Description App",
-      url: "https://pentaho.github.io/hv-uikit-react/"
-    },
-    {
-      name: "YouTube",
-      iconUrl: "https://logodix.com/logo/2735.png",
-      description: "YouTube page",
-      url: "https://www.youtube.com/"
-    },
-    {
-      name: "GitHub",
-      iconUrl: "https://logodix.com/logo/64427.png",
-      description: "GitHub page",
-      url: "https://www.github.com/"
+      url: "https://github.com/pentaho/hv-uikit-react",
     }
   ],
   footer: <div>This is the footer</div>

--- a/packages/doc/samples/lab/appSwitcherPanel/appSwitcherPanel3.js
+++ b/packages/doc/samples/lab/appSwitcherPanel/appSwitcherPanel3.js
@@ -27,7 +27,7 @@ const getDummyApplicationsList = () => {
       name: index % 3 === 0 ? `Application ${index} is an application with a big name` : `Application ${index}`,
       iconUrl: `https://i.picsum.photos/id/${index}/32/32.jpg`,
       description: `This is the auto-generated application number ${index}. Note: All the apps redirect to the UI-KIT storybook`,
-      url: "https://pentaho.github.io/hv-uikit-react/",
+      url: "https://github.com/pentaho/hv-uikit-react",
       target: index % 2 === 0 ? "_top" : "_blank"
     });
   }

--- a/packages/doc/samples/lab/appSwitcherPanel/appSwitcherPanel4.js
+++ b/packages/doc/samples/lab/appSwitcherPanel/appSwitcherPanel4.js
@@ -16,14 +16,17 @@
 
 import React from "react";
 
+import { Tool } from "@hv/uikit-react-icons/dist/Generic";
+
 import DefaultHeader from "./utils/DefaultHeader";
 import AppSwitcherToggle from "./utils/AppSwitcherToggle";
+import { boxStyles } from "./utils/boxStyles";
 
 const appSwitcherToggleProps = {
   title: "Custom header",
   applications: [
     {
-      name: "UI-KIT Storybook",
+      name: "App with a bigger name than the others just to showcase the truncation on the AppSwitcherPanel",
       iconUrl:
         "https://pbs.twimg.com/profile_images/1100804485616566273/sOct-Txm_400x400.png",
       description: "This is the Storybook for the UI-KIT project",
@@ -31,60 +34,24 @@ const appSwitcherToggleProps = {
       target: "_top",
     },
     {
-      name: "UI-KIT Storybook (New Tab)",
-      iconUrl:
-        "https://pbs.twimg.com/profile_images/1100804485616566273/sOct-Txm_400x400.png",
-      description: "This is the Storybook for the UI-KIT project",
-      url: "https://pentaho.github.io/hv-uikit-react/",
-      target: "_blank",
-    },
-    {
-      name: "UI-KIT Storybook - This one has a bigger name than the others just so we can see the truncation!!!",
-      iconUrl:
-        "https://pbs.twimg.com/profile_images/1100804485616566273/sOct-Txm_400x400.png",
-      description: "This application has a bigger name than the others so we can see the truncation in action",
-      url: "https://pentaho.github.io/hv-uikit-react/",
-      target: "_top",
-    },
-    {
-      name: "Pentaho GitHub",
-      iconUrl: "https://logodix.com/logo/1960244.png",
-      description: "This is the Pentaho repository on Github",
-      url: "https://github.com/pentaho/"
-    },
-    {
-      name: "Google",
-      iconUrl:
-        "https://p7.hiclipart.com/preview/249/19/631/google-logo-g-suite-google-guava-google-plus.jpg",
-      url: "https://www.google.com/",
-      target: "_top",
+      name: "UI-KIT GitHub (New Tab)",
+      iconElement: <Tool boxStyles={boxStyles} />,
+      description: "This is the UI-KIT repository on Github",
+      url: "https://github.com/pentaho/hv-uikit-react",
+      target: "_blank"
     },
     {
       name: "No Icon App",
       description:
         "This is an App without an icon, URL is set to the UI-KIT storybook",
-      url: "https://pentaho.github.io/hv-uikit-react/"
+      url: "https://github.com/pentaho/hv-uikit-react",
     },
-
     {
       name: "No Description App",
-      url: "https://pentaho.github.io/hv-uikit-react/"
-    },
-    {
-      name: "YouTube",
-      iconUrl: "https://logodix.com/logo/2735.png",
-      description: "YouTube page",
-      url: "https://www.youtube.com/"
-    },
-    {
-      name: "GitHub",
-      iconUrl: "https://logodix.com/logo/64427.png",
-      description: "GitHub page",
-      url: "https://www.github.com/"
+      url: "https://github.com/pentaho/hv-uikit-react",
     }
   ],
-  header: <div style={{backgroundColor: "lightgreen"}}>This is the custom header</div>,
-  footer: <div>This is the footer</div>
+  header: <div style={{backgroundColor: "lightgreen"}}>This is the custom header</div>
 };
 
 export default (

--- a/packages/doc/samples/lab/appSwitcherPanel/appSwitcherPanel5.js
+++ b/packages/doc/samples/lab/appSwitcherPanel/appSwitcherPanel5.js
@@ -16,13 +16,16 @@
 
 import React from "react";
 
+import { Tool } from "@hv/uikit-react-icons/dist/Generic";
+
 import DefaultHeader from "./utils/DefaultHeader";
 import AppSwitcherToggle from "./utils/AppSwitcherToggle";
+import { boxStyles } from "./utils/boxStyles";
 
 const appSwitcherToggleProps = {
   applications: [
     {
-      name: "UI-KIT Storybook",
+      name: "App with a bigger name than the others just to showcase the truncation on the AppSwitcherPanel",
       iconUrl:
         "https://pbs.twimg.com/profile_images/1100804485616566273/sOct-Txm_400x400.png",
       description: "This is the Storybook for the UI-KIT project",
@@ -30,56 +33,21 @@ const appSwitcherToggleProps = {
       target: "_top",
     },
     {
-      name: "UI-KIT Storybook (New Tab)",
-      iconUrl:
-        "https://pbs.twimg.com/profile_images/1100804485616566273/sOct-Txm_400x400.png",
-      description: "This is the Storybook for the UI-KIT project",
-      url: "https://pentaho.github.io/hv-uikit-react/",
-      target: "_blank",
-    },
-    {
-      name: "UI-KIT Storybook - This one has a bigger name than the others just so we can see the truncation!!!",
-      iconUrl:
-        "https://pbs.twimg.com/profile_images/1100804485616566273/sOct-Txm_400x400.png",
-      description: "This application has a bigger name than the others so we can see the truncation in action",
-      url: "https://pentaho.github.io/hv-uikit-react/",
-      target: "_top",
-    },
-    {
-      name: "Pentaho GitHub",
-      iconUrl: "https://logodix.com/logo/1960244.png",
-      description: "This is the Pentaho repository on Github",
-      url: "https://github.com/pentaho/"
-    },
-    {
-      name: "Google",
-      iconUrl:
-        "https://p7.hiclipart.com/preview/249/19/631/google-logo-g-suite-google-guava-google-plus.jpg",
-      url: "https://www.google.com/",
-      target: "_top",
+      name: "UI-KIT GitHub (New Tab)",
+      iconElement: <Tool boxStyles={boxStyles} />,
+      description: "This is the UI-KIT repository on Github",
+      url: "https://github.com/pentaho/hv-uikit-react",
+      target: "_blank"
     },
     {
       name: "No Icon App",
       description:
         "This is an App without an icon, URL is set to the UI-KIT storybook",
-      url: "https://pentaho.github.io/hv-uikit-react/"
+      url: "https://github.com/pentaho/hv-uikit-react",
     },
-
     {
       name: "No Description App",
-      url: "https://pentaho.github.io/hv-uikit-react/"
-    },
-    {
-      name: "YouTube",
-      iconUrl: "https://logodix.com/logo/2735.png",
-      description: "YouTube page",
-      url: "https://www.youtube.com/"
-    },
-    {
-      name: "GitHub",
-      iconUrl: "https://logodix.com/logo/64427.png",
-      description: "GitHub page",
-      url: "https://www.github.com/"
+      url: "https://github.com/pentaho/hv-uikit-react",
     }
   ],
   panelRightSide: true

--- a/packages/doc/samples/lab/appSwitcherPanel/appSwitcherPanel6.js
+++ b/packages/doc/samples/lab/appSwitcherPanel/appSwitcherPanel6.js
@@ -20,11 +20,7 @@ import { Tool, PingPong, GameController, Champion } from "@hv/uikit-react-icons/
 
 import DefaultHeader from "./utils/DefaultHeader";
 import AppSwitcherToggle from "./utils/AppSwitcherToggle";
-
-const boxStyles = {
-  width: 32,
-  height: 32
-};
+import { boxStyles } from "./utils/boxStyles";
 
 const appSwitcherToggleProps = {
   applications: [
@@ -32,7 +28,7 @@ const appSwitcherToggleProps = {
       name: "App 1 - Icon Tool",
       iconElement: <Tool boxStyles={boxStyles} />,
       description: "App 1 description",
-      url: "https://pentaho.github.io/hv-uikit-react/",
+      url: "https://github.com/pentaho/hv-uikit-react",
       target: "_top"
     },
     {
@@ -40,27 +36,27 @@ const appSwitcherToggleProps = {
       iconUrl:
         "https://pbs.twimg.com/profile_images/1100804485616566273/sOct-Txm_400x400.png",
       description: "App 2 description",
-      url: "https://pentaho.github.io/hv-uikit-react/",
+      url: "https://github.com/pentaho/hv-uikit-react",
       target: "_top"
     },
     {
       name: "App 3 - Icon PingPong",
       iconElement: <PingPong boxStyles={boxStyles} />,
       description: "App 3 description",
-      url: "https://pentaho.github.io/hv-uikit-react/",
+      url: "https://github.com/pentaho/hv-uikit-react",
       target: "_top"
     },
     {
       name: "App 4 - No icon",
       description: "App 4 description",
-      url: "https://pentaho.github.io/hv-uikit-react/",
+      url: "https://github.com/pentaho/hv-uikit-react",
       target: "_top"
     },
     {
       name: "App 5 - Icon GameController",
       iconElement: <GameController boxStyles={boxStyles} />,
       description: "App 5 description",
-      url: "https://pentaho.github.io/hv-uikit-react/",
+      url: "https://github.com/pentaho/hv-uikit-react",
       target: "_top"
     },
     {
@@ -68,14 +64,14 @@ const appSwitcherToggleProps = {
       iconUrl:
         "https://pbs.twimg.com/profile_images/1100804485616566273/sOct-Txm_400x400.pn",
       description: "App 6 description",
-      url: "https://pentaho.github.io/hv-uikit-react/",
+      url: "https://github.com/pentaho/hv-uikit-react",
       target: "_top"
     },
     {
       name: "App 7 - Icon Champion",
       iconElement: <Champion boxStyles={boxStyles} />,
       description: "App 7 description",
-      url: "https://pentaho.github.io/hv-uikit-react/",
+      url: "https://github.com/pentaho/hv-uikit-react",
       target: "_top"
     }
   ],

--- a/packages/doc/samples/lab/appSwitcherPanel/utils/boxStyles.js
+++ b/packages/doc/samples/lab/appSwitcherPanel/utils/boxStyles.js
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2020 Hitachi Vantara Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export const boxStyles = {
+  width: 32,
+  height: 32
+};

--- a/packages/lab/src/AppSwitcherPanel/Action/Action.js
+++ b/packages/lab/src/AppSwitcherPanel/Action/Action.js
@@ -59,7 +59,7 @@ export default class Action extends Component {
         {renderApplicationIcon()}
 
         {isSelected ? (
-          name
+          <span>{name}</span>
         ) : (
           <a href={url} target={target || "_top"} title={name}>
             {name}

--- a/packages/lab/src/AppSwitcherPanel/Action/styles.js
+++ b/packages/lab/src/AppSwitcherPanel/Action/styles.js
@@ -64,7 +64,7 @@ const styles = theme => ({
       cursor: "pointer"
     },
 
-    "& a": {
+    "& a, & span": {
       color: "inherit",
       textDecoration: "inherit",
       overflow: "hidden",


### PR DESCRIPTION
Fixed some issues detected after the publishing to the live storybook:
- On the examples several apps were set with the url of the live storybook, causing the impression that there were several apps active at the same time.
- When the selected app name was too large the truncation wasn't applied as intented.