### PR TITLE
fix: add minWidth to Table.d.ts

### DIFF
--- a/packages/core/src/Table/Table.d.ts
+++ b/packages/core/src/Table/Table.d.ts
@@ -55,6 +55,10 @@ export interface TableColumn {
    * The max-width of the column
    */
   maxWidth?: string | number
+  /**
+   * The min-width of the column
+   */
+  minWidth?: string | number
 
 }
 


### PR DESCRIPTION
Greetings, as discussed in Slack at https://hitachivantara-eng.slack.com/archives/CFY74GK6G/p1588252511052600?thread_ts=1588183220.050600&cid=CFY74GK6G , Diogo suggested `minWidth` is missing from `Table.d.ts`. So here is the fix. Thanks for your work as usual.