### PR TITLE
fix(popper): blurred contents on zoom. #1624

### DIFF
--- a/packages/core/src/Dropdown/Dropdown.d.ts
+++ b/packages/core/src/Dropdown/Dropdown.d.ts
@@ -1,6 +1,7 @@
 import * as React from "react";
 import { StandardProps } from "@material-ui/core";
 import { ListLabelsProp, ListValueProp } from "../List";
+import { PopperProps } from "@material-ui/core/Popper";
 
 export interface DropDownLabelsProp extends ListLabelsProp {
   /**
@@ -86,6 +87,10 @@ export interface HvDropdownProps
    * A function to be executed whenever a item is selected in the dropdown, the function receives the selected item(s).
    */
   onChange?: (selected: ListValueProp | ListValueProp[] | undefined) => void;
+  /**
+   * Properties passed to the undelying Popper component
+   */
+  popperProps?: Partial<PopperProps>;
 }
 
 export type HvDropdownClassKey =

--- a/packages/core/src/Dropdown/Dropdown.js
+++ b/packages/core/src/Dropdown/Dropdown.js
@@ -189,7 +189,8 @@ class HvDropdown extends React.Component {
       labels,
       singleSelectionToggle,
       classes,
-      placement
+      placement,
+      popperProps
     } = this.props;
     const { isOpen, values, anchorEl } = this.state;
 
@@ -216,6 +217,7 @@ class HvDropdown extends React.Component {
         singleSelectionToggle={singleSelectionToggle}
         aria-labelledby={labels.title ? setId(id, "label") : undefined}
         placement={placement}
+        popperProps={popperProps}
       />
     );
   }
@@ -413,7 +415,11 @@ HvDropdown.propTypes = {
   /**
    * Placement of the dropdown.
    */
-  placement: PropTypes.oneOf(["left", "right"])
+  placement: PropTypes.oneOf(["left", "right"]),
+  /**
+   * An object containing props to be wired to the popper component.
+   */
+  popperProps: PropTypes.shape()
 };
 
 HvDropdown.defaultProps = {
@@ -431,7 +437,8 @@ HvDropdown.defaultProps = {
   disablePortal: false,
   hasTooltips: false,
   singleSelectionToggle: true,
-  placement: undefined
+  placement: undefined,
+  popperProps: {}
 };
 
 export default withStyles(styles, { name: "HvDropdown" })(

--- a/packages/core/src/Dropdown/List/List.js
+++ b/packages/core/src/Dropdown/List/List.js
@@ -31,6 +31,7 @@ const List = ({
   anchorEl = null,
   singleSelectionToggle,
   placement,
+  popperProps,
   ...others
 }) => {
   const [searchStr, setSearchStr] = useState();
@@ -354,6 +355,7 @@ const List = ({
         onCreate: data => handleListCreate(data)
       }}
       style={{ zIndex: theme.zIndex.tooltip }}
+      {...popperProps}
     >
       <OutsideClickHandler onOutsideClick={e => handleCancel(e)}>
         <ConditionalWrapper condition={showList} wrapper={c => <FocusTrap>{c}</FocusTrap>}>
@@ -428,7 +430,11 @@ List.propTypes = {
   /**
    * Placement of the dropdown.
    */
-  placement: PropTypes.oneOf(["left", "right"])
+  placement: PropTypes.oneOf(["left", "right"]),
+  /**
+   * An object containing props to be wired to the popper component.
+   */
+  popperProps: PropTypes.shape()
 };
 
 export default withStyles(styles, { name: "HvDropdownList" })(List);

--- a/packages/core/src/Dropdown/tests/__snapshots__/dropdown.test.js.snap
+++ b/packages/core/src/Dropdown/tests/__snapshots__/dropdown.test.js.snap
@@ -139,6 +139,7 @@ exports[`<Dropdown /> <Dropdown /> with multiselect and search should render cor
         multiSelect={true}
         notifyChangesOnFirstRender={false}
         onChange={[Function]}
+        popperProps={Object {}}
         selectDefault={true}
         showSearch={true}
         singleSelectionToggle={true}
@@ -169,6 +170,7 @@ exports[`<Dropdown /> <Dropdown /> with multiselect and search should render cor
             id="test-dropdown-header"
             onKeyDown={[Function]}
             onMouseUp={[Function]}
+            popperProps={Object {}}
             role="textbox"
             style={
               Object {
@@ -281,6 +283,7 @@ exports[`<Dropdown /> <Dropdown /> with multiselect and search should render cor
             multiSelect={true}
             notifyChangesOnFirstRender={false}
             onChange={[Function]}
+            popperProps={Object {}}
             selectDefault={true}
             showSearch={true}
             singleSelectionToggle={true}
@@ -339,6 +342,7 @@ exports[`<Dropdown /> <Dropdown /> with multiselect and search should render cor
               multiSelect={true}
               notifyChangesOnFirstRender={false}
               onChange={[Function]}
+              popperProps={Object {}}
               selectDefault={true}
               showSearch={true}
               singleSelectionToggle={true}
@@ -6472,6 +6476,7 @@ exports[`<Dropdown /> <Dropdown /> with selectDefault false should render correc
         multiSelect={false}
         notifyChangesOnFirstRender={false}
         onChange={[Function]}
+        popperProps={Object {}}
         selectDefault={false}
         showSearch={false}
         singleSelectionToggle={true}
@@ -6502,6 +6507,7 @@ exports[`<Dropdown /> <Dropdown /> with selectDefault false should render correc
             id="hv-dropdown-7-header"
             onKeyDown={[Function]}
             onMouseUp={[Function]}
+            popperProps={Object {}}
             role="textbox"
             tabIndex={0}
           >
@@ -6609,6 +6615,7 @@ exports[`<Dropdown /> <Dropdown /> with selectDefault false should render correc
             multiSelect={false}
             notifyChangesOnFirstRender={false}
             onChange={[Function]}
+            popperProps={Object {}}
             selectDefault={false}
             showSearch={false}
             singleSelectionToggle={true}
@@ -6667,6 +6674,7 @@ exports[`<Dropdown /> <Dropdown /> with selectDefault false should render correc
               multiSelect={false}
               notifyChangesOnFirstRender={false}
               onChange={[Function]}
+              popperProps={Object {}}
               selectDefault={false}
               showSearch={false}
               singleSelectionToggle={true}
@@ -8494,6 +8502,7 @@ exports[`<Dropdown /> with defaults should render correctly 1`] = `
         multiSelect={false}
         notifyChangesOnFirstRender={false}
         onChange={[MockFunction]}
+        popperProps={Object {}}
         selectDefault={true}
         showSearch={true}
         singleSelectionToggle={true}
@@ -8524,6 +8533,7 @@ exports[`<Dropdown /> with defaults should render correctly 1`] = `
             id="hv-dropdown-1-header"
             onKeyDown={[Function]}
             onMouseUp={[Function]}
+            popperProps={Object {}}
             role="textbox"
             tabIndex={0}
           >
@@ -8631,6 +8641,7 @@ exports[`<Dropdown /> with defaults should render correctly 1`] = `
             multiSelect={false}
             notifyChangesOnFirstRender={false}
             onChange={[Function]}
+            popperProps={Object {}}
             selectDefault={true}
             showSearch={true}
             singleSelectionToggle={true}
@@ -8689,6 +8700,7 @@ exports[`<Dropdown /> with defaults should render correctly 1`] = `
               multiSelect={false}
               notifyChangesOnFirstRender={false}
               onChange={[Function]}
+              popperProps={Object {}}
               selectDefault={true}
               showSearch={true}
               singleSelectionToggle={true}


### PR DESCRIPTION
This PR aims to resolve the issue pointed out by @tomoto-vantara on the ui-kit channel:

> HvDropdown shows blurry contents when the browser's zoom level is set to other than 100%. You can easily observe it on https://lumada-design.github.io/hv-uikit-react/master/?path=/docs/components-dropdown--main. Apparently this exact issue has been discussed here https://github.com/popperjs/popper-core/issues/682, and "disabling GPU acceleration" (= disabling using translate3d in CSS terminology) would solve the problem.

This allows the user to pass additional props, that will make it to Popper, and disable this prop:
https://popper.js.org/docs/v1/#modifiers..computeStyle.gpuAcceleration
which is responsible for the blurry effect