### PR TITLE
fix: suggestion for issue #1636

### DIFF
--- a/packages/core/src/Input/Input.d.ts
+++ b/packages/core/src/Input/Input.d.ts
@@ -126,13 +126,13 @@ export interface HvInputProps extends StandardProps<InputProps, HvInputClassKey,
 
   /**
    * Called back when the value is changed.
-   * Must return the new value to be accepted.
+   * Return the new value to be accepted, or undefined/void to accept as it is.
    * The event can be undefined when the clear button is clicked.
    */
   onChange?: (
     event: React.ChangeEvent<HTMLTextAreaElement | HTMLInputElement> | undefined,
     value: string
-  ) => string;
+  ) => string | undefined | void;
 }
 
 export type HvInputClassKey =

--- a/packages/core/src/Input/Input.js
+++ b/packages/core/src/Input/Input.js
@@ -152,7 +152,7 @@ class HvInput extends React.Component {
   onChangeHandler = event => {
     const { onChange } = this.props;
     const { value } = event.target;
-    const newValue = onChange(event, value);
+    const newValue = onChange(event, value) ?? value;
     this.suggestionHandler(value);
     this.manageInputValueState(newValue, null);
   };

--- a/packages/core/src/SearchBox/SearchBox.d.ts
+++ b/packages/core/src/SearchBox/SearchBox.d.ts
@@ -8,11 +8,6 @@ export interface HvSearchBoxProps
    * it receives the value or event+value.
    */
   onSubmit?: (event: Event, value: string) => void;
-  /**
-   * The function that will be executed when the searchbox changes,
-   * it receives the searchbox value
-   */
-  onChange?: (event: Event, value: string) => void;
 }
 
 export type HvSearchBoxClassKey = "root";


### PR DESCRIPTION
The purpose of this PR is to explain the suggested fix for #1636. I am not 100% sure if this makes sense to you, but it feels to me the below is the reasonable assumption.
(1) HvInput and HvSearchBox should expect the consistent onChange handler type
(2) HvInput and HvSearchBox should accept void/undefined from onChange handler and accept the value as it is (rather than behaving wildly)

Thanks for taking a look!