### PR TITLE
fix: correctly inherit onChange (to amend #1637)

### DIFF
--- a/packages/core/src/SearchBox/SearchBox.d.ts
+++ b/packages/core/src/SearchBox/SearchBox.d.ts
@@ -2,7 +2,7 @@ import { StandardProps } from "@material-ui/core";
 import { HvInputProps } from "../Input";
 
 export interface HvSearchBoxProps
-  extends StandardProps<HvInputProps, HvSearchBoxClassKey, "onSubmit" | "onChange"> {
+  extends StandardProps<HvInputProps, HvSearchBoxClassKey, "onSubmit"> {
   /**
    * The function that will be executed on Enter, allows checking the value state,
    * it receives the value or event+value.


### PR DESCRIPTION
**THIS IS A FIX OF A BREAKING CHANGE**

Thanks for taking care of https://github.com/lumada-design/hv-uikit-react/pull/1637. I incidentally noticed that this fix was incomplete and gave me a compilation error that says `HvSearchBox` does not have `onChange`. It was because `onChange` was still in the "don't inherit from the parent" list in the type definition of `HvSearchBox`. This PR will fix this issue. I tested it locally with my application and confirmed it is working as expected. Thank you very much.