### PR TITLE
test(visual): chart waitBeforeScreenshot #1792

### DIFF
--- a/automation/applitools/applitools.config.js
+++ b/automation/applitools/applitools.config.js
@@ -1,5 +1,6 @@
 module.exports = {
   // showLogs: true,
+  matchLevel: 'Strict',
   puppeteerOptions: { args: ['--no-sandbox', "--disable-setuid-sandbox"], ignoreHTTPSErrors: true},
   runInDocker: true,
   variations: () => ["theme:wicked"],

--- a/packages/core/src/Kpi/stories/Kpi.stories.js
+++ b/packages/core/src/Kpi/stories/Kpi.stories.js
@@ -171,8 +171,9 @@ Iops.story = {
       storyDescription: "A Kpi sample showcasing the total IOPS."
     },
     eyes: {
-      // excluded due to the trendline chart rendering issues #1792
-      include: false
+      // waiting until external charts are rendered (issue #1792)
+      waitBeforeScreenshot: "[id|=reactgooglegraph]",
+      include: true
     }
   }
 };
@@ -377,8 +378,9 @@ Selectable.story = {
       storyDescription: "A selectable kpi with the total numbers of event."
     },
     eyes: {
-      // excluded due to the trendline chart rendering issues #1792
-      include: false
+      // waiting until external charts are rendered (issue #1792)
+      waitBeforeScreenshot: "[id|=reactgooglegraph]",
+      include: true
     }
   }
 };
@@ -486,8 +488,9 @@ SelectableNoSemantic.story = {
       storyDescription: "A selectable kpi with the total numbers of event."
     },
     eyes: {
-      // excluded due to the trendline chart rendering issues #1792
-      include: false
+      // waiting until external charts are rendered (issue #1792)
+      waitBeforeScreenshot: "[id|=reactgooglegraph]",
+      include: true
     }
   }
 };
@@ -594,8 +597,9 @@ SelectableNoTrendIcon.story = {
       storyDescription: "A selectable kpi with the total numbers of event."
     },
     eyes: {
-      // excluded due to the trendline chart rendering issues #1792
-      include: false
+      // waiting until external charts are rendered (issue #1792)
+      waitBeforeScreenshot: "[id|=reactgooglegraph]",
+      include: true
     }
   }
 };

--- a/packages/core/src/Table/stories/Table.stories.js
+++ b/packages/core/src/Table/stories/Table.stories.js
@@ -1033,8 +1033,9 @@ WithExpanderAndCustomContent.story = {
         "Table sample that shows the ability to add a complex expander and custom cell."
     },
     eyes: {
-      // excluded due to the custom chart rendering issues #1792
-      include: false
+      // waiting until external charts are rendered (issue #1792)
+      waitBeforeScreenshot: "[id|=reactgooglegraph]",
+      include: true
     }
   }
 };
@@ -1450,8 +1451,9 @@ WithCheckboxCustomContent.story = {
       storyDescription: "Table sample that shows the ability to add use a checkbox."
     },
     eyes: {
-      // excluded due to the custom chart rendering issues #1792
-      include: false
+      // waiting until external charts are rendered (issue #1792)
+      waitBeforeScreenshot: "[id|=reactgooglegraph]",
+      include: true
     }
   }
 };


### PR DESCRIPTION
- explicit define matchLevel ( default is managed by third parties )
- waitBeforeScreenshot until external charts are rendered