### PR TITLE
test(input): disable clear test in ie #HVUIKIT-5427

### DIFF
--- a/automation/robot/storybook/core/forms/adornments/clear_button.robot
+++ b/automation/robot/storybook/core/forms/adornments/clear_button.robot
@@ -12,7 +12,7 @@ show clean button when input is not empty and is focused
     wait Until Element Is Visible    ${clean_button}
 
 show clean button when input is not empty and mouse is hover it
-    [Tags]    bug-ie
+    [Tags]    bug-ie-webdriver
     [Documentation]    to avoid firefox errors must be used input text and then keyboard kw
     Input Text                           ${input}    Joao
     Press Keys                           NONE    TAB


### PR DESCRIPTION
on .../forms/adornments/clear_button.robot the problem are on IE Webdriver who's have a know issue on hover actions.
On the other hand
on .../input/clean_button.robot the error is on component running on IE (that is why is opened HVUIKIT-5409 )