### PR TITLE
fix: resolve type definition problems

### DIFF
--- a/packages/core/src/BaseRadio/BaseRadio.d.ts
+++ b/packages/core/src/BaseRadio/BaseRadio.d.ts
@@ -47,7 +47,7 @@ export interface HvBaseRadioProps
   /**
    * The callback fired when the radio button is pressed.
    */
-  onChange: (event: Event, checked: boolean, value: any) => void;
+  onChange?: (event: Event, checked: boolean, value: any) => void;
 
   /**
    * Whether the selector should use semantic colors.
@@ -57,7 +57,7 @@ export interface HvBaseRadioProps
   /**
    * Properties passed on to the input element.
    */
-  inputProps: object;
+  inputProps?: object;
 }
 
 export default function HvBaseRadio(props: HvBaseRadioProps): JSX.Element | null;

--- a/packages/core/src/Card/Card.d.ts
+++ b/packages/core/src/Card/Card.d.ts
@@ -24,7 +24,7 @@ export interface HvCardProps extends StandardProps<BoxProps, HvCardClassKey> {
   /**
    * Whether the card is selectable.
    */
-  selectable: boolean;
+  selectable?: boolean;
   /**
    * Whether the card is currently selected.
    */

--- a/packages/core/src/Forms/FormElement/FormElement.d.ts
+++ b/packages/core/src/Forms/FormElement/FormElement.d.ts
@@ -10,7 +10,7 @@ export interface HvFormElementProps
   /**
    * Components that will receive the form context values.
    */
-  children: React.ReactNode;
+  children?: React.ReactNode;
 
   /**
    * Name of the form element.

--- a/packages/core/src/Input/Input.d.ts
+++ b/packages/core/src/Input/Input.d.ts
@@ -142,6 +142,14 @@ export interface HvInputProps extends StandardProps<HvBaseInputProps, HvInputCla
    * will be perform.
    */
   minCharQuantity?: number;
+
+  /**
+   * Called back when the value is changed.
+   */
+  onChange?: (
+    event: React.ChangeEvent<HTMLInputElement>,
+    value: string
+  ) => void;
 }
 
 export default function HvInput(props: HvInputProps): JSX.Element | null;


### PR DESCRIPTION
Hello, good job for releasing UI-Kit 3!

We have started to evaluate UI-Kit 3 for adoption to our project, and found some issues in TypeScript type definitions that gave us build errors. This PR is the minimal fix for them.

- `HvInput.d.ts` misses the definition of `onChange`, which is different from the parent interface.
- Several properties fail to be marked as optional.

Thanks!