### PR TITLE
fix: add "error" to HvInputClassKey

### DIFF
--- a/packages/core/src/Input/Input.d.ts
+++ b/packages/core/src/Input/Input.d.ts
@@ -45,6 +45,7 @@ export type HvInputClassKey =
   | "labelContainer"
   | "label"
   | "description"
+  | "error"
   | "adornmentsBox"
   | "adornmentButton"
   | "icon"


### PR DESCRIPTION
Greetings, I see `HvInputClassKey` misses several keys that are documented here: https://lumada-design.github.io/uikit/master/?path=/docs/forms-input--main .

This PR adds `error` key which our application needs to use. There are other keys apparently missing as below, but I am not including them because I cannot test them with my application. Please include them as well if needed.
- `hasSuggestions`
- `inputBorderContainer`
- `inputExtension`

Thanks!