### PR TITLE
fix: form selectors state with lazy initialization and ts fixes

### DIFF
--- a/packages/core/src/CheckBoxGroup/CheckBoxGroup.d.ts
+++ b/packages/core/src/CheckBoxGroup/CheckBoxGroup.d.ts
@@ -30,7 +30,11 @@ export interface HvCheckBoxGroupProps
    *
    * When defined the checkbox group state becomes controlled.
    */
-  value: any[];
+  value?: any[];
+  /**
+   * When uncontrolled, defines the initial value.
+   */
+  defaultValue?: any[];
 
   /**
    * The label of the form element.

--- a/packages/core/src/CheckBoxGroup/CheckBoxGroup.js
+++ b/packages/core/src/CheckBoxGroup/CheckBoxGroup.js
@@ -23,6 +23,19 @@ const computeSelectAllState = (selected, total) => {
   return "some";
 };
 
+const getValueFromSelectedChildren = (children) => {
+  const selectedValues = React.Children.toArray(children)
+    .map((child) => {
+      const childIsControlled = child.props.checked !== undefined;
+      const childIsSelected = childIsControlled ? child.props.checked : child.props.defaultChecked;
+
+      return childIsSelected ? child.props.value : undefined;
+    })
+    .filter((v) => v !== undefined);
+
+  return selectedValues;
+};
+
 /**
  * A group of checkboxes.
  *
@@ -36,6 +49,8 @@ const HvCheckBoxGroup = (props) => {
     id,
     name,
     value: valueProp,
+    defaultValue,
+
     required = false,
     readOnly = false,
     disabled = false,
@@ -63,26 +78,11 @@ const HvCheckBoxGroup = (props) => {
 
   const [value, setValue] = useControlled(
     valueProp,
-    (() => {
-      // when uncontrolled, extract the initial selected values from the children own state
-      const selectedValues = [];
-
-      React.Children.toArray(children).forEach((child, i) => {
-        const childIsControlled = child.props.checked !== undefined;
-        const childValue = child.props.value;
-
-        let childIsSelected = false;
-        if (childIsControlled) {
-          childIsSelected = child.props.checked;
-        } else {
-          childIsSelected = child.props.defaultChecked;
-        }
-
-        selectedValues[i] = childIsSelected ? childValue : null;
-      });
-
-      return selectedValues.filter((v) => v != null);
-    })()
+    defaultValue !== undefined
+      ? defaultValue
+      : // when uncontrolled and no default value is given,
+        // extract the initial selected values from the children own state
+        () => getValueFromSelectedChildren(children)
   );
 
   const [validationState, setValidationState] = useControlled(status, "standBy");
@@ -295,6 +295,10 @@ HvCheckBoxGroup.propTypes = {
    * When defined the checkbox group state becomes controlled.
    */
   value: PropTypes.arrayOf(PropTypes.any),
+  /**
+   * When uncontrolled, defines the initial value.
+   */
+  defaultValue: PropTypes.arrayOf(PropTypes.any),
 
   /**
    * The label of the form element.

--- a/packages/core/src/Input/Input.d.ts
+++ b/packages/core/src/Input/Input.d.ts
@@ -37,7 +37,9 @@ export interface InputLabelsProp {
 
 export type HvInputClassKey =
   | "root"
+  | "hasSuggestions"
   | "inputRoot"
+  | "inputBorderContainer"
   | "inputRootFocused"
   | "inputRootDisabled"
   | "inputRootMultiline"
@@ -50,6 +52,7 @@ export type HvInputClassKey =
   | "adornmentButton"
   | "icon"
   | "iconClear"
+  | "inputExtension"
   | "suggestionsContainer"
   | "suggestionList";
 

--- a/packages/core/src/ListContainer/ListItem/ListItem.js
+++ b/packages/core/src/ListContainer/ListItem/ListItem.js
@@ -100,70 +100,37 @@ const HvListItem = (props) => {
     [classes.endAdornment, endAdornment]
   );
 
-  const listItemContent = useMemo(
-    () => (
-      <>
-        {clonedStartAdornment}
-        {children}
-        {clonedEndAdornment}
-      </>
-    ),
-    [children, clonedEndAdornment, clonedStartAdornment]
+  const roleOptionAriaProps =
+    role === "option" || role === "menuitem"
+      ? {
+          "aria-disabled": disabled || undefined,
+          "aria-selected": selected,
+        }
+      : {};
+
+  const listItem = (
+    <li
+      id={id}
+      role={role}
+      onClick={handleOnClick}
+      onKeyDown={() => {}}
+      className={clsx(className, classes.root, {
+        [classes.gutters]: !disableGutters,
+        [classes.condensed]: condensed,
+        [classes.interactive]: interactive,
+        [classes.selected]: selected,
+        [classes.disabled]: disabled,
+        [classes.withStartAdornment]: startAdornment != null,
+        [classes.withEndAdornment]: endAdornment != null,
+      })}
+      {...roleOptionAriaProps}
+      {...others}
+    >
+      {clonedStartAdornment}
+      {children}
+      {clonedEndAdornment}
+    </li>
   );
-
-  const listItem = useMemo(() => {
-    const roleOptionAriaProps =
-      role === "option" || role === "menuitem"
-        ? {
-            "aria-disabled": disabled || undefined,
-            "aria-selected": selected,
-          }
-        : {};
-
-    return (
-      <li
-        id={id}
-        role={role}
-        onClick={handleOnClick}
-        onKeyDown={() => {}}
-        className={clsx(className, classes.root, {
-          [classes.gutters]: !disableGutters,
-          [classes.condensed]: condensed,
-          [classes.interactive]: interactive,
-          [classes.selected]: selected,
-          [classes.disabled]: disabled,
-          [classes.withStartAdornment]: startAdornment != null,
-          [classes.withEndAdornment]: endAdornment != null,
-        })}
-        {...roleOptionAriaProps}
-        {...others}
-      >
-        {listItemContent}
-      </li>
-    );
-  }, [
-    role,
-    disabled,
-    selected,
-    id,
-    handleOnClick,
-    className,
-    classes.root,
-    classes.gutters,
-    classes.condensed,
-    classes.interactive,
-    classes.selected,
-    classes.disabled,
-    classes.withStartAdornment,
-    classes.withEndAdornment,
-    disableGutters,
-    condensed,
-    interactive,
-    startAdornment,
-    endAdornment,
-    others,
-    listItemContent,
-  ]);
 
   return interactive ? (
     <Focus

--- a/packages/core/src/RadioGroup/RadioGroup.d.ts
+++ b/packages/core/src/RadioGroup/RadioGroup.d.ts
@@ -23,7 +23,11 @@ export interface HvRadioGroupProps
    *
    * When defined the radio button group state becomes controlled.
    */
-  value: any;
+  value?: any;
+  /**
+   * When uncontrolled, defines the initial value.
+   */
+  defaultValue?: any;
 
   /**
    * The label of the form element.

--- a/packages/core/src/RadioGroup/RadioGroup.js
+++ b/packages/core/src/RadioGroup/RadioGroup.js
@@ -11,6 +11,23 @@ import { setId, useControlled } from "../utils";
 
 import styles from "./styles";
 
+const getValueFromSelectedChildren = (children) => {
+  const childrenArray = React.Children.toArray(children);
+  const childrenCount = childrenArray.length;
+  for (let i = 0; i !== childrenCount; i += 1) {
+    const child = childrenArray[i];
+
+    const childIsControlled = child.props.checked !== undefined;
+    const childIsSelected = childIsControlled ? child.props.checked : child.props.defaultChecked;
+
+    if (childIsSelected) {
+      return child.props.value;
+    }
+  }
+
+  return null;
+};
+
 /**
  * A group of radio buttons.
  *
@@ -24,6 +41,8 @@ const HvRadioGroup = (props) => {
     id,
     name,
     value: valueProp,
+    defaultValue,
+
     required = false,
     readOnly = false,
     disabled = false,
@@ -49,33 +68,11 @@ const HvRadioGroup = (props) => {
 
   const [value, setValue] = useControlled(
     valueProp,
-    (() => {
-      // when uncontrolled, extract the initial selected value from the children own state
-      let selectedValue = null;
-
-      const childrenArray = React.Children.toArray(children);
-      const childrenCount = childrenArray.length;
-      for (let i = 0; i !== childrenCount; i += 1) {
-        const child = childrenArray[i];
-
-        const childIsControlled = child.props.checked !== undefined;
-        const childValue = child.props.value;
-
-        let childIsSelected = false;
-        if (childIsControlled) {
-          childIsSelected = child.props.checked;
-        } else {
-          childIsSelected = child.props.defaultChecked;
-        }
-
-        if (childIsSelected) {
-          selectedValue = childValue;
-          break;
-        }
-      }
-
-      return selectedValue;
-    })()
+    defaultValue !== undefined
+      ? defaultValue
+      : // when uncontrolled and no default value is given,
+        // extract the initial selected values from the children own state
+        () => getValueFromSelectedChildren(children)
   );
 
   const onChildChangeInterceptor = useCallback(
@@ -217,6 +214,11 @@ HvRadioGroup.propTypes = {
    */
   // eslint-disable-next-line react/forbid-prop-types
   value: PropTypes.any,
+  /**
+   * When uncontrolled, defines the initial value.
+   */
+  // eslint-disable-next-line react/forbid-prop-types
+  defaultValue: PropTypes.any,
 
   /**
    * The label of the form element.

--- a/packages/core/src/SelectionList/SelectionList.d.ts
+++ b/packages/core/src/SelectionList/SelectionList.d.ts
@@ -14,6 +14,11 @@ export type HvSelectionListClassKey =
 export interface HvSelectionListProps
   extends StandardProps<HvFormElementProps, HvSelectionListClassKey, "onChange"> {
   /**
+   * When uncontrolled, defines the initial value.
+   */
+  defaultValue?: any[] | any;
+
+  /**
    * Indicates that the user may select more than one item from the current selectable list items.
    */
   multiple?: boolean;


### PR DESCRIPTION
The value initial state was being recalculated in every render for no use.

Also addresses @zettca comments on https://github.com/lumada-design/hv-uikit-react/pull/2061#pullrequestreview-517889452 and adds missing keys mentioned in https://github.com/lumada-design/hv-uikit-react/pull/2122#issue-516702628.