### PR TITLE
fix: workaround type issue of HvCardHeader.title

### DIFF
--- a/packages/core/src/Card/Header/Header.d.ts
+++ b/packages/core/src/Card/Header/Header.d.ts
@@ -9,11 +9,17 @@ export type HvCardHeaderClassKey =
   | "action"
   | "content";
 
-export interface HvCardHeaderProps extends StandardProps<CardHeaderProps, HvCardHeaderClassKey> {
+export interface HvCardHeaderProps extends StandardProps<CardHeaderProps, HvCardHeaderClassKey, 'title'> {
   /**
    *  The renderable content inside the icon slot of the header.
    */
   icon?: React.ReactNode;
+
+  /**
+   * The renderable content inside the title slot of the header.
+   * (explicitly redeclared here to workaround the type inference issue)
+   */
+  title?: React.ReactNode;
 }
 
 export default function HvCardHeader(props: HvCardHeaderProps): JSX.Element | null;


### PR DESCRIPTION
Greetings, this is the proposed workaround for the issue reported in https://github.com/lumada-design/hv-uikit-react/issues/2162.

`HvCardHeaderProps` gets unexpected type definition of `title` when extending MUI's `CardHeaderProps`. I tried to nail down the root cause, but I gave it up because MUI's type definition is full of generics and too complex. I took the path just to redeclare the type as we exactly expect rather than spending any more time (as much as I am interested in knowing the exact cause). Please feel free to alter the solution if you know a better way. Thank you very much.