### PR TITLE
fix(typescript): HvTableProps.onPageSizeChange args

### DIFF
--- a/packages/core/src/Table/Table.d.ts
+++ b/packages/core/src/Table/Table.d.ts
@@ -161,7 +161,7 @@ export interface HvTableProps
   /**
    * Callback to notify when the page size changes
    */
-  onPageSizeChange?: (pageSize: number) => void;
+  onPageSizeChange?: (pageSize: number, currentPage: number) => void;
 
   /**
    * Boolean to enable or disable the server side pagination mechanism


### PR DESCRIPTION
Hello, this is the proposed change regarding my question on Slack, https://hitachivantara-eng.slack.com/archives/CFY74GK6G/p1607339743175100 .

We expect `HvTableProps.onPageSizeChange` to have two callback arguments, `pageSize` and `currentPage`, but the second argument was missing in the type definition of UI-Kit 3. We have been relying on this second argument in UI-Kit 2, and have confirmed it is still passed from `Table.js` as below. Hence this proposal is to recover the second argument in the type definition.

https://github.com/lumada-design/hv-uikit-react/blob/1c806703ce84f3ea84d314a315cccdb61e49323f/packages/core/src/Table/Table.js#L132-L135

Hope our assumption is correct and this fix is aligned with your intention. Thanks!