### PR TITLE
Fix/dropdownmenu classes menulist

### DIFF
--- a/packages/core/src/DropDownMenu/DropDownMenu.d.ts
+++ b/packages/core/src/DropDownMenu/DropDownMenu.d.ts
@@ -2,7 +2,7 @@ import * as React from "react";
 import { IconButtonProps, StandardProps } from "@material-ui/core";
 import { ListValueProp } from "../List";
 
-export type HvDropDownMenuClassKey = "root" | "icon" | "iconSelected";
+export type HvDropDownMenuClassKey = "root" | "icon" | "iconSelected" | "menuList";
 
 export interface HvDropDownMenuProps
   extends StandardProps<IconButtonProps, HvDropDownMenuClassKey, "onClick"> {

--- a/packages/core/src/DropDownMenu/DropDownMenu.js
+++ b/packages/core/src/DropDownMenu/DropDownMenu.js
@@ -100,6 +100,7 @@ const DropDownMenu = ({
             onClick?.(event, item);
           }}
           onKeyDown={handleKeyDown}
+          classes={{ root: classes.menuList }}
         />
       </HvPanel>
     </HvBaseDropdown>
@@ -131,6 +132,10 @@ DropDownMenu.propTypes = {
      * Styles applied to the icon when selected.
      */
     iconSelected: PropTypes.string,
+    /**
+     * Styles applied to the list.
+     */
+    menuList: PropTypes.string,
   }).isRequired,
   /**
    * Icon.

--- a/packages/core/src/DropDownMenu/tests/__snapshots__/dropDownMenu.test.js.snap
+++ b/packages/core/src/DropDownMenu/tests/__snapshots__/dropDownMenu.test.js.snap
@@ -1370,6 +1370,11 @@ exports[`DropDownMenu component with portal opens on click 1`] = `
                                 className="MuiBox-root MuiBox-root-9 HvPanel-root"
                               >
                                 <WithStyles(HvList)
+                                  classes={
+                                    Object {
+                                      "root": undefined,
+                                    }
+                                  }
                                   condensed={true}
                                   id="drop-down-menu-10-list"
                                   onClick={[Function]}
@@ -3175,6 +3180,11 @@ exports[`DropDownMenu component without portal opens on click 1`] = `
                                 className="MuiBox-root MuiBox-root-1 HvPanel-root"
                               >
                                 <WithStyles(HvList)
+                                  classes={
+                                    Object {
+                                      "root": undefined,
+                                    }
+                                  }
                                   condensed={true}
                                   id="drop-down-menu-2-list"
                                   onClick={[Function]}


### PR DESCRIPTION
Hi all, this PR is to address the conversation in Slack at https://hitachivantara-eng.slack.com/archives/CFY74GK6G/p1607513629183200?thread_ts=1607511700.182900&cid=CFY74GK6G . I tested and confirmed this fix would allow us to achieve our goal.

369b515: As per the conversation, `menuList` is added to `HvDropDownMenuClassKey` and set to `HvList` inside. I chose `menuList` as the class name because it is compatible with v2.x (https://lumada-design.github.io/uikit/v2.x/?path=/docs/components-dropdown-menu--main ) and clear in its meaning. If you prefer another name for other reasons (such as structural accuracy or compatibility with `HvDropdown`), please suggest and I would be happy to fix accordingly.

72e0173: I also added `root` to `HvDropDownMenuClassKey` that was just missed from the type definition.

