### PR TITLE
fix(tabs): onChange callback type definition

### DIFF
--- a/packages/core/src/Tabs/Tabs.d.ts
+++ b/packages/core/src/Tabs/Tabs.d.ts
@@ -2,6 +2,12 @@ import { StandardProps, TabsProps } from "@material-ui/core";
 
 export type HvTabsClassKey = "root" | "flexContainer" | "indicator" | "scroller";
 
-export type HvTabsProps = StandardProps<TabsProps, HvTabsClassKey>;
+export interface HvTabsProps extends StandardProps<TabsProps, HvTabsClassKey, "onChange"> {
+  /**
+   * Explicit re-declaration to workaround MUI typing issue
+   * https://github.com/mui-org/material-ui/issues/17454
+   */
+  onChange?: (event: React.SyntheticEvent, value: any) => void;
+}
 
 export default function HvTabs(props: HvTabsProps): JSX.Element | null;


### PR DESCRIPTION
Hi all, this is a minor type definition fix of `HvTabsProps.onChange`.

## Issue

You get this error when passing `onChange` handler to `HvTabs`.
![image](https://user-images.githubusercontent.com/57977241/102415923-df1c5480-3fad-11eb-9986-870300029356.png)

## Analysis

It appears an issue of MUI 4, which they admit but will not fix as they are now focusing on MUI 5.
https://github.com/mui-org/material-ui/issues/17454

## Solution

Based on the discussion in the thread above, explicitly declaring `onChange` handler with the event type `React.SyntheticEvent` (parent class of ChangeEvent, FormEvent, etc.) can workaround the issue.