### PR TITLE
fix(table): currentPage of onPageSizeChange callback

### DIFF
--- a/packages/core/src/Table/Table.js
+++ b/packages/core/src/Table/Table.js
@@ -105,8 +105,9 @@ const HvTable = (props) => {
   }, []);
 
   useEffect(() => {
-    // don't nullify current page when page is not specified
-    setCurrentPage(page || 0);
+    if (page) {
+      setCurrentPage(page);
+    }
   }, [page]);
 
   useEffect(() => {
@@ -129,6 +130,10 @@ const HvTable = (props) => {
 
   useEffect(() => {
     const newPageSize = !pageSize && !showPagination ? data.length : pageSize;
+
+    if (pages && currentPage === pages) {
+      setCurrentPage((previousValue) => previousValue - 1);
+    }
 
     if (newPageSize && currentPageSize !== newPageSize) {
       const newPage = Math.floor((currentPageSize * currentPage) / newPageSize);


### PR DESCRIPTION
This is the draft PR to explain the suggested fix regarding this issue: https://github.com/lumada-design/hv-uikit-react/issues/2190#issuecomment-757060872

(1) Line 133-140: The current page needs to be passed to the second parameter of `onPageSizeChange` after being updated in terms of the new page size.

(2) Line 108-109: Pass zero to `setCurrentPage` instead of `undefined` when `page` is unspecified. Otherwise, `currentPage` is set to `undefined` and the calculation in (1) may fail.

(3) Line 228-230: The page number shown on the pagination bar should be bound to `currentPage`, not `page`. Otherwise, the pagination shows a wrong number when `currentPage` is updated in (1).

I tested this code with both our application and your storybook (with additional "set pageSize to 5" button), in both client-side and server-side pagination modes. When `pageSize` is changed from the application, the current page is recalculated (just like `pageSize` is changed by the dropdown on the pagination bar) and the recalculated page number is passed to the second argument of `onPageSizeChange` callback.

Hope I am not missing anything. Please let me know if you have any questions. I will keep this PR as "Draft" for discussion purpose until it is proven to be a valid approach. Thank you very much.