### PR TITLE
fix(table): page type definition

### DIFF
--- a/packages/core/src/Table/Table.d.ts
+++ b/packages/core/src/Table/Table.d.ts
@@ -174,6 +174,11 @@ export interface HvTableProps
   pages?: number;
 
   /**
+   * Specify the current page number when using a server side pagination
+   */
+  page?: number;
+
+  /**
    * Callback with receives the page info and should fetch the data to show on the table
    */
   onFetchData?: (...args: any[]) => any;


### PR DESCRIPTION
Greetings, we found that `page` property is missing from the type definition of `HvTableProps` when we tried using it. This PR is to add this type definition.

This is not necessarily an urgent request because we are OK to workaround with `@ts-ignore` till the next release. Please take your time. Thank you very much.