### PR TITLE
fix(dialogcontent): indentContent type definition

### DIFF
--- a/packages/core/src/Dialog/DialogContent/DialogContent.d.ts
+++ b/packages/core/src/Dialog/DialogContent/DialogContent.d.ts
@@ -7,7 +7,7 @@ export interface HvDialogContentProps
   /**
    * Content should be indented in relationship to the Dialog title.
    */
-  indentContent: boolean;
+  indentContent?: boolean;
 }
 
 export default function HvDialogContent(props: HvDialogContentProps): JSX.Element | null;


### PR DESCRIPTION
Greetings, we tried core 3.8.2 and it broke our build. It was because the newly added type definition was not marked as optional, and here is the fix. Thanks!