### PR TITLE
fix(table): bulkActions class key definition

### DIFF
--- a/packages/core/src/Table/Table.d.ts
+++ b/packages/core/src/Table/Table.d.ts
@@ -114,7 +114,8 @@ export type HvTableClassKey =
   | "checkBoxText"
   | "menuItem"
   | "expand"
-  | "separatorContainer";
+  | "separatorContainer"
+  | "bulkActions";
 
 export interface HvTableProps
   extends StandardProps<React.HTMLAttributes<HTMLDivElement>, HvTableClassKey>,


### PR DESCRIPTION
Hi Team, I noticed class key `bulkActions` of `HvTable` is missing in the type definition that we want to use. Here is the small fix. Thank you very much!