### PR TITLE
fix(datepicker): focus on input. HVUIKIT-5680

### DIFF
--- a/packages/core/src/BaseDropdown/BaseDropdown.js
+++ b/packages/core/src/BaseDropdown/BaseDropdown.js
@@ -186,7 +186,7 @@ const HvBaseDropdown = ({
    * @param data
    */
   const handleContainerCreate = (data) => {
-    onContainerCreation(containerRef.current);
+    onContainerCreation?.(containerRef.current);
     if (!created) {
       const position = data.flipped;
       setterPosition(position);

--- a/packages/core/src/DatePicker/DatePicker.js
+++ b/packages/core/src/DatePicker/DatePicker.js
@@ -165,19 +165,8 @@ const HvDatePicker = (props) => {
   };
 
   const setFocusToDateInput = (containerRef) => {
-    /**
-     *  TODO: Review this focus function, it should focus the input
-     *  https://insightgroup.atlassian.net/browse/HVUIKIT-5680
-     *  containerRef?.getElementsByTagName("input")[0]?.focus();
-     */
-    const divs = [...containerRef?.getElementsByTagName("div")];
-    divs.every((div) => {
-      if (div.tabIndex >= 0) {
-        div.focus();
-        return false;
-      }
-      return true;
-    });
+    const calendarInput = containerRef?.querySelector(".HvCalendarHeader-input");
+    calendarInput?.focus();
   };
 
   const handleDateChange = (event, newDate) => {
@@ -313,11 +302,6 @@ const HvDatePicker = (props) => {
           undefined
         }
       >
-        {
-          /* eslint-disable jsx-a11y/no-noninteractive-tabindex */
-          // necessary because `HvBaseDropdown` re-render auto-focus
-        }
-        <div tabIndex={0} />
         <HvCalendar
           id={setId(id, "calendar")}
           startAdornment={startAdornment}


### PR DESCRIPTION
As mentioned [in the issue](https://insightgroup.atlassian.net/browse/HVUIKIT-5680?focusedCommentId=220707) I don't think this is an accessibility issue.

I opened this PR to show the implications of focusing this input on mount, where the `div` in question is removed and the Input is focused on enter.

Looking [at a sample](https://lumada-design.github.io/uikit/pr-2288/iframe.html?id=forms-date-picker--range-mode&viewMode=story), there are some issues:

Opening the DatePicker, we see the input on the left in edit mode with a different format to the right one, which is a bit odd.
![image](https://user-images.githubusercontent.com/638946/110007647-d3217280-7d12-11eb-9cdb-87324049b63c.png)

There's a blatant issue with the date selection with this simple change, due to the re-rendering of the `HvBaseDropdown` and the way the input events are handled. I believe this is the main reason why we have this `div`.