### PR TITLE
docs(table): alignment prop. HVUIKIT-5651 HVUIKIT-5650

### DIFF
--- a/packages/lab/src/Table/stories/utils.js
+++ b/packages/lab/src/Table/stories/utils.js
@@ -1,17 +1,23 @@
 import { useState } from "react";
+import range from "lodash/range";
+import { Random } from "@hv/uikit-react-core";
 
-const getRand = (id) => (Math.abs(Math.sin(id)) * 10 ** 4) % 1;
+const rand = new Random();
+
+const formatDate = (date) => date.toISOString().split("T")[0];
+
 const newEntry = (value, i) => {
-  const r = getRand(i);
+  const [r1, r2] = range(2).map(() => rand.next());
+  const [dateMax, dateMin] = [1640995200000, 1514764800000];
   return {
     id: `${i}`,
     name: `Event ${i}`,
-    createdDate: "10/14/2018",
+    createdDate: formatDate(new Date(rand.next(dateMax, dateMin))),
     eventType: "Anomaly detection",
     status: i % 2 === 0 ? "Closed" : "Open",
-    riskScore: `${100 - i}%`,
-    severity: (r > 0.66 && "Critical") || (r > 0.33 && "Major") || "Minor",
-    priority: (r > 0.66 && "High") || (r > 0.33 && "Medium") || "Low",
+    riskScore: rand.next(100, 10),
+    severity: (r1 > 0.66 && "Critical") || (r1 > 0.33 && "Major") || "Minor",
+    priority: (r2 > 0.66 && "High") || (r2 > 0.33 && "Medium") || "Low",
   };
 };
 
@@ -19,11 +25,17 @@ export const makeData = (len = 10) => Array.from(Array(len), newEntry);
 
 // https://react-table.tanstack.com/docs/api/useTable#column-options
 export const getColumns = () => [
-  { Header: "Title", accessor: "name" },
+  { Header: "Title", accessor: "name", width: 260 },
   { Header: "Time", accessor: "createdDate" },
-  { Header: "Event Type", accessor: "eventType" },
-  { Header: "Status", accessor: "status" },
-  { Header: "Probability", accessor: "riskScore", align: "right" },
+  { Header: "Event Type", accessor: "eventType", width: 200 },
+  { Header: "Status", accessor: "status", width: 120 },
+  // numeric values should be right-aligned
+  {
+    Header: "Probability",
+    accessor: "riskScore",
+    align: "right",
+    Cell: ({ value }) => `${value}%`,
+  },
   { Header: "Severity", accessor: "severity" },
   { Header: "Priority", accessor: "priority" },
 ];

--- a/packages/lab/src/Table/tests/__snapshots__/Table.test.js.snap
+++ b/packages/lab/src/Table/tests/__snapshots__/Table.test.js.snap
@@ -65,7 +65,7 @@ exports[`Table Main Story should match snapshot 1`] = `
           <td
             class="HvTableCell-root HvTableCell-body"
           >
-            10/14/2018
+            2021-11-24
           </td>
           <td
             class="HvTableCell-root HvTableCell-body"
@@ -80,7 +80,7 @@ exports[`Table Main Story should match snapshot 1`] = `
           <td
             class="HvTableCell-root HvTableCell-body"
           >
-            100%
+            28
           </td>
           <td
             class="HvTableCell-root HvTableCell-body"
@@ -90,7 +90,7 @@ exports[`Table Main Story should match snapshot 1`] = `
           <td
             class="HvTableCell-root HvTableCell-body"
           >
-            Low
+            High
           </td>
         </tr>
         <tr
@@ -104,7 +104,7 @@ exports[`Table Main Story should match snapshot 1`] = `
           <td
             class="HvTableCell-root HvTableCell-body"
           >
-            10/14/2018
+            2018-08-15
           </td>
           <td
             class="HvTableCell-root HvTableCell-body"
@@ -119,17 +119,17 @@ exports[`Table Main Story should match snapshot 1`] = `
           <td
             class="HvTableCell-root HvTableCell-body"
           >
-            99%
+            88
           </td>
           <td
             class="HvTableCell-root HvTableCell-body"
           >
-            Critical
+            Minor
           </td>
           <td
             class="HvTableCell-root HvTableCell-body"
           >
-            High
+            Low
           </td>
         </tr>
         <tr
@@ -143,7 +143,7 @@ exports[`Table Main Story should match snapshot 1`] = `
           <td
             class="HvTableCell-root HvTableCell-body"
           >
-            10/14/2018
+            2018-11-05
           </td>
           <td
             class="HvTableCell-root HvTableCell-body"
@@ -158,7 +158,46 @@ exports[`Table Main Story should match snapshot 1`] = `
           <td
             class="HvTableCell-root HvTableCell-body"
           >
-            98%
+            92
+          </td>
+          <td
+            class="HvTableCell-root HvTableCell-body"
+          >
+            Critical
+          </td>
+          <td
+            class="HvTableCell-root HvTableCell-body"
+          >
+            Low
+          </td>
+        </tr>
+        <tr
+          class="HvTableRow-root HvTableRow-hover HvTableRow-body"
+        >
+          <td
+            class="HvTableCell-root HvTableCell-body"
+          >
+            Event 3
+          </td>
+          <td
+            class="HvTableCell-root HvTableCell-body"
+          >
+            2018-04-18
+          </td>
+          <td
+            class="HvTableCell-root HvTableCell-body"
+          >
+            Anomaly detection
+          </td>
+          <td
+            class="HvTableCell-root HvTableCell-body"
+          >
+            Open
+          </td>
+          <td
+            class="HvTableCell-root HvTableCell-body"
+          >
+            89
           </td>
           <td
             class="HvTableCell-root HvTableCell-body"
@@ -177,51 +216,12 @@ exports[`Table Main Story should match snapshot 1`] = `
           <td
             class="HvTableCell-root HvTableCell-body"
           >
-            Event 3
-          </td>
-          <td
-            class="HvTableCell-root HvTableCell-body"
-          >
-            10/14/2018
-          </td>
-          <td
-            class="HvTableCell-root HvTableCell-body"
-          >
-            Anomaly detection
-          </td>
-          <td
-            class="HvTableCell-root HvTableCell-body"
-          >
-            Open
-          </td>
-          <td
-            class="HvTableCell-root HvTableCell-body"
-          >
-            97%
-          </td>
-          <td
-            class="HvTableCell-root HvTableCell-body"
-          >
-            Minor
-          </td>
-          <td
-            class="HvTableCell-root HvTableCell-body"
-          >
-            Low
-          </td>
-        </tr>
-        <tr
-          class="HvTableRow-root HvTableRow-hover HvTableRow-body"
-        >
-          <td
-            class="HvTableCell-root HvTableCell-body"
-          >
             Event 4
           </td>
           <td
             class="HvTableCell-root HvTableCell-body"
           >
-            10/14/2018
+            2021-06-28
           </td>
           <td
             class="HvTableCell-root HvTableCell-body"
@@ -236,7 +236,7 @@ exports[`Table Main Story should match snapshot 1`] = `
           <td
             class="HvTableCell-root HvTableCell-body"
           >
-            96%
+            80
           </td>
           <td
             class="HvTableCell-root HvTableCell-body"
@@ -246,7 +246,7 @@ exports[`Table Main Story should match snapshot 1`] = `
           <td
             class="HvTableCell-root HvTableCell-body"
           >
-            Low
+            High
           </td>
         </tr>
         <tr
@@ -260,7 +260,7 @@ exports[`Table Main Story should match snapshot 1`] = `
           <td
             class="HvTableCell-root HvTableCell-body"
           >
-            10/14/2018
+            2020-01-20
           </td>
           <td
             class="HvTableCell-root HvTableCell-body"
@@ -275,7 +275,7 @@ exports[`Table Main Story should match snapshot 1`] = `
           <td
             class="HvTableCell-root HvTableCell-body"
           >
-            95%
+            28
           </td>
           <td
             class="HvTableCell-root HvTableCell-body"
@@ -285,7 +285,7 @@ exports[`Table Main Story should match snapshot 1`] = `
           <td
             class="HvTableCell-root HvTableCell-body"
           >
-            Low
+            High
           </td>
         </tr>
       </tbody>


### PR DESCRIPTION
Regarding leveraging the current `cellType`:

`cellType` is not part of `react-table@6` (I couldn't find it in the [docs](https://github.com/tannerlinsley/react-table/tree/v6#props)), it's actually something that we maintained on our side. In `react-table@7` there's the similar `sortType`, which is a mix between our `cellType` and `react-table@6`'s `sortMethod`.

By adding `cellType`, a user trying to leverage `react-table@7`'s `sortType`, would have to add both `cellType` and `sortType`; unless we added support for both `cellType` and `sortType` - but doing so we'd be adding extra complexity to both sides, unnecessary.
That would mean we'd be maintaining 3 configurations to handle alignment: `align`, `sortType`, `cellType`.
Therefore I ended up just using `align`, since it's the most "standard" and powerful (there's `"center", "inherit", "justify", "left", "right"` alignments)