### PR TITLE
feat(table): load styles from columns. HVUIKIT-5659

### DIFF
--- a/packages/lab/src/Table/TableCell/TableCell.js
+++ b/packages/lab/src/Table/TableCell/TableCell.js
@@ -21,6 +21,7 @@ const HvTableCell = forwardRef(function HvTableCell(props, ref) {
     rtCol = {},
 
     align: alignProp,
+    style: styleProp,
     padding: paddingProp,
     sortDirection: sortDirectionProp,
     variant: variantProp,
@@ -31,7 +32,14 @@ const HvTableCell = forwardRef(function HvTableCell(props, ref) {
   } = props;
 
   const tableContext = useContext(TableContext);
-  const { align: rtAlign, padding: rtPadding, isSortable, isSorted, isSortedDesc } = rtCol;
+  const {
+    align: rtAlign,
+    style: rtStyle,
+    padding: rtPadding,
+    isSortable,
+    isSorted,
+    isSortedDesc,
+  } = rtCol;
 
   // prop > RT col > context > fallback
   const align = alignProp ?? rtAlign ?? "inherit";
@@ -50,6 +58,7 @@ const HvTableCell = forwardRef(function HvTableCell(props, ref) {
   return (
     <Component
       ref={ref}
+      style={{ ...(isHeadCell && rtStyle), ...styleProp }}
       className={clsx(className, classes.root, classes[variant], {
         [classes.sortable]: sortable,
         [classes.sorted]: sorted,
@@ -74,6 +83,10 @@ HvTableCell.propTypes = {
    * Content to be rendered
    */
   children: PropTypes.node,
+  /**
+   * Inline styles to be applied to the root element.
+   */
+  style: PropTypes.instanceOf(Object),
   /**
    * React Table column instance. Also contains other props passed as `data`
    * https://react-table.tanstack.com/docs/api/useTable#column-options

--- a/packages/lab/src/Table/stories/Table.stories.js
+++ b/packages/lab/src/Table/stories/Table.stories.js
@@ -218,7 +218,7 @@ export const Sortable = () => {
               <HvTableCell
                 key={col.Header}
                 rtCol={col}
-                {...col.getHeaderProps(col.getSortByToggleProps({ style: { width: col.width } }))}
+                {...col.getHeaderProps(col.getSortByToggleProps())}
               >
                 {col.render("Header")}
               </HvTableCell>
@@ -277,12 +277,7 @@ export const Pagination = () => {
           <HvTableHead>
             <HvTableRow>
               {headers.map((col) => (
-                <HvTableCell
-                  key={col.Header}
-                  rtCol={col}
-                  // adds fixed column sizes
-                  {...col.getHeaderProps({ style: { width: col.width } })}
-                >
+                <HvTableCell key={col.Header} rtCol={col} {...col.getHeaderProps()}>
                   {col.render("Header")}
                 </HvTableCell>
               ))}
@@ -370,7 +365,7 @@ export const ServerSide = () => {
                 <HvTableCell
                   key={col.Header}
                   rtCol={col}
-                  {...col.getHeaderProps(col.getSortByToggleProps({ style: { width: col.width } }))}
+                  {...col.getHeaderProps(col.getSortByToggleProps())}
                 >
                   {col.render("Header")}
                 </HvTableCell>

--- a/packages/lab/src/Table/stories/utils.js
+++ b/packages/lab/src/Table/stories/utils.js
@@ -28,10 +28,10 @@ export const makeData = (len = 10) => range(len).map(newEntry);
 // https://react-table.tanstack.com/docs/api/useTable#column-options
 // width is only used if explicitly passed in column.getHeaderProps
 export const getColumns = () => [
-  { Header: "Title", accessor: "name", width: 260 },
-  { Header: "Time", accessor: "createdDate" },
-  { Header: "Event Type", accessor: "eventType", width: 200 },
-  { Header: "Status", accessor: "status", width: 120 },
+  { Header: "Title", accessor: "name", style: { minWidth: 120 } },
+  { Header: "Time", accessor: "createdDate", style: { minWidth: 100 } },
+  { Header: "Event Type", accessor: "eventType", style: { minWidth: 140 } },
+  { Header: "Status", accessor: "status", style: { width: 120 } },
   // numeric values should be right-aligned
   {
     Header: "Probability",


### PR DESCRIPTION
Handling `style` in `TableCell` instead of passing it every time to `getHeaderProps` RT's prop getter