### PR TITLE
fix(checkboxgroup): type definition of onChange and orientation

### DIFF
--- a/packages/core/src/CheckBoxGroup/CheckBoxGroup.d.ts
+++ b/packages/core/src/CheckBoxGroup/CheckBoxGroup.d.ts
@@ -88,14 +88,14 @@ export interface HvCheckBoxGroupProps
   /**
    * The callback fired when the value changes.
    */
-  onChange: (event: Event, value: any) => void;
+  onChange?: (event: Event, value: any) => void;
 
   /**
    * Indicates whether the checkbox group's orientation is horizontal or vertical.
    *
    * Defaults to vertical.
    */
-  orientation: "vertical" | "horizontal";
+  orientation?: "vertical" | "horizontal";
   /**
    * Indicates if an aditional select all checkbox should be shown.
    */


### PR DESCRIPTION
Greetings, we started to use HvCheckBoxGroup and found a couple of type definition issues. This PR is aiming to fix it.
- `onChange` should be optional as documented;  actually it is not necessary when the individual checkboxes handle the value changes.
- `orientation` should be optional and default to vertical as documented.

Thanks!