### PR TITLE
fix: export HvAppSwitcherPanelAction in root

### DIFF
--- a/packages/lab/src/AppSwitcherPanel/index.d.ts
+++ b/packages/lab/src/AppSwitcherPanel/index.d.ts
@@ -1,2 +1,5 @@
 export { default } from "./AppSwitcherPanel";
 export * from "./AppSwitcherPanel";
+
+export { default as HvAppSwitcherPanelAction } from "./Action";
+export * from "./Action";

--- a/packages/lab/src/AppSwitcherPanel/index.js
+++ b/packages/lab/src/AppSwitcherPanel/index.js
@@ -1,3 +1,2 @@
-import AppSwitcherPanel from "./AppSwitcherPanel";
-
-export default AppSwitcherPanel;
+export { default } from "./AppSwitcherPanel";
+export { default as HvAppSwitcherPanelAction } from "./Action";

--- a/packages/lab/src/index.js
+++ b/packages/lab/src/index.js
@@ -1,5 +1,6 @@
 // components
 export { default as HvAppSwitcherPanel } from "./AppSwitcherPanel";
+export * from "./AppSwitcherPanel";
 export { default as HvFormComposer } from "./FormComposer";
 export { default as HvNavigationAnchors } from "./NavigationAnchors";
 export { default as HvNotificationPanel } from "./NotificationPanel";


### PR DESCRIPTION
Hello team!

I'm trying to reduce my bundle size by tree shaking. The missing `HvAppSwitcherPanelAction` export in the root level package is preventing me from tree-shaking the uikit library.