### PR TITLE
fix(dropdown): make onToggle optional in type definition

### DIFF
--- a/packages/core/src/Dropdown/Dropdown.d.ts
+++ b/packages/core/src/Dropdown/Dropdown.d.ts
@@ -120,7 +120,7 @@ export interface HvDropdownProps
    * @param {object} event The event source of the callback.
    * @param {boolean} open If the dropdown new state is open (`true`) or closed (`false`).
    */
-  onToggle: (event: Event, open: boolean) => void;
+  onToggle?: (event: Event, open: boolean) => void;
   /**
    * Callback called when the user clicks outside the open container.
    *


### PR DESCRIPTION
Greetings, I noticed a newly introduced property (`onToggle` in `Dropdown`) was not marked as optional so the application build fails. Here is the suggested fix. Thanks!