### PR TITLE
fix: uniformize React.Ref propTypes

### DIFF
--- a/packages/core/src/BaseDropdown/BaseDropdown.d.ts
+++ b/packages/core/src/BaseDropdown/BaseDropdown.d.ts
@@ -92,7 +92,7 @@ export interface HvBaseDropdownProps
    * Callback called when the dropdown is opened and ready,
    * commonly used to set focus to the content.
    */
-  onContainerCreation: (containerRef: React.ReactNode) => void;
+  onContainerCreation: (containerRef: React.Ref<HTMLDivElement>) => void;
   /**
    * When expanded dropdown changes position.
    */

--- a/packages/core/src/BaseDropdown/BaseDropdown.js
+++ b/packages/core/src/BaseDropdown/BaseDropdown.js
@@ -12,6 +12,7 @@ import {
   isKeypress,
   KeyboardCodes,
   setId,
+  refType,
   useControlled,
   useForkRef,
 } from "../utils";
@@ -444,7 +445,7 @@ HvBaseDropdown.propTypes = {
   /**
    * Pass a ref to the dropdown header element.
    */
-  dropdownHeaderRef: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
+  dropdownHeaderRef: refType,
 };
 
 export default withStyles(styles, { name: "HvBaseDropdown" })(HvBaseDropdown);

--- a/packages/core/src/BaseInput/BaseInput.js
+++ b/packages/core/src/BaseInput/BaseInput.js
@@ -2,6 +2,7 @@ import React, { useContext } from "react";
 import PropTypes from "prop-types";
 import clsx from "clsx";
 import { Input, withStyles } from "@material-ui/core";
+import { refType } from "../utils";
 import styles from "./styles";
 
 import {
@@ -238,7 +239,7 @@ HvBaseInput.propTypes = {
   /**
    * Allows passing a ref to the underlying input
    */
-  inputRef: PropTypes.shape({ current: PropTypes.any }),
+  inputRef: refType,
 };
 
 export default withStyles(styles, { name: "HvBaseInput" })(HvBaseInput);

--- a/packages/core/src/Focus/Focus.d.ts
+++ b/packages/core/src/Focus/Focus.d.ts
@@ -19,7 +19,7 @@ export interface HvFocusProps
   /**
    * The reference to the root element to hold all Focus' context.
    */
-  rootRef: React.RefObject<HTMLInputElement>;
+  rootRef: React.Ref<HTMLInputElement>;
   /**
    * Extra configuration for the child element.
    */

--- a/packages/core/src/Focus/Focus.js
+++ b/packages/core/src/Focus/Focus.js
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 import clsx from "clsx";
 import isNil from "lodash/isNil";
 import { withStyles } from "@material-ui/core";
-import { KeyboardCodes, isBrowser } from "../utils";
+import { KeyboardCodes, isBrowser, refType } from "../utils";
 import ConditionalWrapper from "../utils/ConditionalWrapper";
 import { isKey, isOneOfKeys, setFocusTo, getFocusableChildren } from "./utils";
 import styles from "./styles";
@@ -387,7 +387,7 @@ Focus.propTypes = {
   /**
    * The reference to the root element to hold all Focus' context.
    */
-  rootRef: PropTypes.oneOfType([PropTypes.func, PropTypes.shape({ current: PropTypes.any })]),
+  rootRef: refType,
   /**
    * Extra configuration for the child element.
    */

--- a/packages/core/src/Input/Input.js
+++ b/packages/core/src/Input/Input.js
@@ -20,7 +20,15 @@ import {
   useIsMounted,
 } from "..";
 
-import { isBrowser, isKeypress, KeyboardCodes, setId, useControlled, useLabels } from "../utils";
+import {
+  isBrowser,
+  isKeypress,
+  KeyboardCodes,
+  refType,
+  setId,
+  useControlled,
+  useLabels,
+} from "../utils";
 
 import validationStates, { isValid, isInvalid } from "../Forms/FormElement/validationStates";
 import {
@@ -948,7 +956,7 @@ HvInput.propTypes = {
   /**
    * Allows passing a ref to the underlying input
    */
-  inputRef: PropTypes.shape({ current: PropTypes.any }),
+  inputRef: refType,
 
   /**
    * The function that will be executed onBlur, allows checking the validation state,

--- a/packages/core/src/TextArea/TextArea.js
+++ b/packages/core/src/TextArea/TextArea.js
@@ -6,7 +6,7 @@ import isNil from "lodash/isNil";
 import clsx from "clsx";
 import { withStyles } from "@material-ui/core";
 
-import { setId, useControlled } from "../utils";
+import { refType, setId, useControlled } from "../utils";
 
 import {
   HvFormElement,
@@ -558,7 +558,7 @@ HvTextArea.propTypes = {
   /**
    * Allows passing a ref to the underlying input
    */
-  inputRef: PropTypes.shape({ current: PropTypes.any }),
+  inputRef: refType,
 
   /**
    * The function that will be executed onBlur, allows checking the validation state,

--- a/packages/core/src/utils/index.js
+++ b/packages/core/src/utils/index.js
@@ -8,6 +8,8 @@ export * from "./focusableElementFinder";
 
 export * from "./sizes";
 
+export { default as refType } from "./refType";
+
 export { default as Random } from "./Random";
 
 export { default as hexToRgbA } from "./hexToRgbA";

--- a/packages/core/src/utils/refType.js
+++ b/packages/core/src/utils/refType.js
@@ -1,0 +1,5 @@
+import PropTypes from "prop-types";
+
+const refType = PropTypes.oneOfType([PropTypes.func, PropTypes.object]);
+
+export default refType;


### PR DESCRIPTION
Fixes some inconsistencies between TS declarations and propTypes.
React.Ref can be function or object

This issue arose as I tried passing a function ref to `HvInput` - PropTypes wrongly complained.

I created a `refType` util type, same as [MUI does](https://github.com/mui-org/material-ui/blob/next/packages/material-ui/src/TextField/TextField.js#L314)