### PR TITLE
fix: change [Event] to React.[Event]

### DIFF
--- a/packages/core/src/DropDownMenu/DropDownMenu.d.ts
+++ b/packages/core/src/DropDownMenu/DropDownMenu.d.ts
@@ -46,7 +46,7 @@ export interface HvDropDownMenuProps
   /**
    * Function executed in each onClick. Should received the clicked element.
    */
-  onClick?: (event: MouseEvent, item: ListValueProp) => void;
+  onClick?: (event: React.MouseEvent, item: ListValueProp) => void;
   /**
    * Keep the Dropdown Menu opened after clicking one option
    */

--- a/packages/core/src/Forms/Suggestions/Suggestions.d.ts
+++ b/packages/core/src/Forms/Suggestions/Suggestions.d.ts
@@ -25,7 +25,7 @@ export interface HvSuggestionsProps
   /**
    * Function called when a suggestion is selected
    */
-  onSuggestionSelected?: (event: MouseEvent, item: ListValueProp) => void;
+  onSuggestionSelected?: (event: React.MouseEvent, item: ListValueProp) => void;
 }
 
 export default function HvSuggestions(props: HvSuggestionsProps): JSX.Element | null;


### PR DESCRIPTION
React uses React.[Events] (e.g. `React.MouseEvent` instead of `MouseEvent`) for its elements
Most of UI-Kit's typings use React.[Event], but these few are missing.

This makes it not possible to share an onClick handle for both these events, or any native one:
```jsx
<HvDropDownMenu onClick={handleClick} />
<div onClick={handleClick} /> ❌
```

```
TS2345: Argument of type 'MouseEvent' is not assignable to parameter of type 'MouseEvent<Element, MouseEvent>'.
  Type 'MouseEvent' is missing the following properties from type 'MouseEvent<Element, MouseEvent>': nativeEvent, isDefaultPrevented, isPropagationStopped, persist
  ```