### PR TITLE
fix(table): fix sticky sorted column transparency

### DIFF
--- a/packages/lab/src/Table/TableCell/styles.js
+++ b/packages/lab/src/Table/TableCell/styles.js
@@ -76,9 +76,15 @@ const styles = (theme) => {
     stickyColumn: {
       position: "sticky",
       zIndex: 2,
+      background: theme.hv.palette.atmosphere.atmo2,
 
       "&$groupColumnMostRight+$stickyColumn": {
         borderLeft: 0,
+      },
+
+      "&$sorted": {
+        backgroundColor: theme.hv.palette.atmosphere.atmo2,
+        backgroundImage: `linear-gradient(to right, ${semiTransparentAtmo1}, ${semiTransparentAtmo1})`,
       },
     },
     stickyColumnMostLeft: {


### PR DESCRIPTION
This css styles already existed in [core Table](https://github.com/lumada-design/hv-uikit-react/blob/master/packages/core/src/Table/styles.js#L152-L160)

#2561