### PR TITLE
docs(typescript): colSpan types

### DIFF
--- a/packages/lab/src/Table/stories/KitchenSink.js
+++ b/packages/lab/src/Table/stories/KitchenSink.js
@@ -22,7 +22,7 @@ import { makeData, getColumns } from "./utils";
 
 const EmptyRow = () => (
   <HvTableRow>
-    <HvTableCell colSpan="100%" style={{ height: 100 }}>
+    <HvTableCell colSpan={100} style={{ height: 100 }}>
       <HvEmptyState message="No data to display" icon={<Ban role="presentation" />} />
     </HvTableCell>
   </HvTableRow>

--- a/packages/lab/src/Table/stories/Table.stories.js
+++ b/packages/lab/src/Table/stories/Table.stories.js
@@ -82,7 +82,7 @@ export const NoData = () => (
       </HvTableHead>
       <HvTableBody>
         <HvTableRow>
-          <HvTableCell colSpan="100%" style={{ height: 96 }}>
+          <HvTableCell colSpan={100} style={{ height: 96 }}>
             <HvEmptyState message="No data to display." icon={<Ban role="presentation" />} />
           </HvTableCell>
         </HvTableRow>

--- a/packages/lab/src/Table/stories/TableHooks.stories.js
+++ b/packages/lab/src/Table/stories/TableHooks.stories.js
@@ -128,7 +128,7 @@ export const Pagination = () => {
 
   const EmptyRow = () => (
     <HvTableRow>
-      <HvTableCell colSpan="100%" />
+      <HvTableCell colSpan={100} />
     </HvTableRow>
   );
 
@@ -297,7 +297,7 @@ export const BulkActions = () => {
   const EmptyStateRow = useCallback(
     () => (
       <HvTableRow>
-        <HvTableCell colSpan="100%" style={{ height: 96 }}>
+        <HvTableCell colSpan={100} style={{ height: 96 }}>
           <HvEmptyState message="No data to display." icon={<Ban role="presentation" />} />
         </HvTableCell>
       </HvTableRow>
@@ -894,7 +894,7 @@ export const ServerSide = () => {
 
   const EmptyRow = () => (
     <HvTableRow>
-      <HvTableCell colSpan="100%" />
+      <HvTableCell colSpan={100} />
     </HvTableRow>
   );
 
@@ -1017,7 +1017,7 @@ export const KitchenSink = () => {
 
   const EmptyRow = () => (
     <HvTableRow>
-      <HvTableCell colSpan="100%" style={{ height: 100 }}>
+      <HvTableCell colSpan={100} style={{ height: 100 }}>
         <HvEmptyState message="No data to display" icon={<Ban role="presentation" />} />
       </HvTableCell>
     </HvTableRow>

--- a/packages/lab/src/Table/stories/TableHooks.stories.test.js
+++ b/packages/lab/src/Table/stories/TableHooks.stories.test.js
@@ -172,7 +172,7 @@ const getRowId = (v) => v.id.toString();
 
 const EmptyStateRow = () => (
   <HvTableRow>
-    <HvTableCell colSpan="100%" style={{ height: 96 }}>
+    <HvTableCell colSpan={100} style={{ height: 96 }}>
       <HvEmptyState message="No data to display." icon={<Ban role="presentation" />} />
     </HvTableCell>
   </HvTableRow>


### PR DESCRIPTION
[`colSpan` is a `number`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/td#attr-colspan), and TypeScript will complain when using the samples.
Also, `"100%"` is already internally converted to `100`.