### PR TITLE
feat(tags-input): change selected element scroll position

### DIFF
--- a/packages/core/src/TagsInput/TagsInput.js
+++ b/packages/core/src/TagsInput/TagsInput.js
@@ -102,7 +102,11 @@ const HvTagsInput = (props) => {
       // this setTimeout is a workaround for Firefox not properly dealing
       // with setting the scrollLeft value.
       setTimeout(() => {
-        containerRef.current.scrollLeft = element?.offsetLeft || 0;
+        containerRef.current.scrollLeft = element
+          ? element.offsetLeft -
+            containerRef.current.getBoundingClientRect().width / 2 +
+            element.getBoundingClientRect().width / 2
+          : 0;
       }, 50);
 
       element?.focus();


### PR DESCRIPTION
This PR changes the behavior when navigating with the arrow keys on a single line tags input. The current behavior sets the container scroll position to that of the selected element which means that the selected element is always on the first position of the container. 

With this change the selected element will be centered in the container (except when near the edges), which I think is more appropriate and provides better visual feedback and context to the user since both the previous and next elements are now visible.

This is an unrequested update, so take a look and merge if you agree and discard otherwise.