### PR TITLE
chore: add NODE_ENV=production to apply babel plugins

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -64,6 +64,7 @@ jobs:
 
   Build-Storybook-V2-Store:
     name: Build Storybook (v2 store)
+    if: github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
 
     steps:
@@ -133,6 +134,7 @@ jobs:
 
   Applitools:
     name: Applitools Storybook Visual Testing
+    if: github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]'
     needs: [Build-Storybook-V2-Store]
     runs-on: [self-hosted, Linux]
 
@@ -191,12 +193,12 @@ jobs:
           rm -rf ${{ github.workspace }}/dist
 
   Applitools-Complete:
+    name: Applitools complete API call
+    if: github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]' && always()
     needs: [Applitools]
-    if: always()
     runs-on: ubuntu-latest
     steps:
       - name: Notify Applitools Finish
-        # repo scope personal token is required to generate a dispatch event
         run: |
           curl -X POST \
             https://eyesapi.applitools.com/api/externals/github/servers/github.com/commit/${{env.APPLITOOLS_BATCH_ID}}/complete?apiKey=${{env.APPLITOOLS_API_KEY}} \
@@ -204,6 +206,7 @@ jobs:
 
   Github-Deployment:
     name: Github Deployment
+    if: github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]'
     needs: [Build-Storybook-V3-Store]
     runs-on: ubuntu-latest
 
@@ -363,10 +366,10 @@ jobs:
           rm -rf ${{ github.workspace }}/dist
           rm -rf ${{ github.workspace }}/reports
 
-  Notify-End:
-    name: Notify End
-    needs: [Static-Checks, Github-Deployment, Applitools, A11Y-Tests, Robot]
+  Cleanup:
+    name: Cleanup test artifacts
     if: always()
+    needs: [Github-Deployment, Applitools, A11Y-Tests, Robot]
     runs-on: ubuntu-latest
 
     steps:
@@ -377,6 +380,13 @@ jobs:
             storybook-v2
             storybook-v3
 
+  Notify-End:
+    name: Notify End
+    if: github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]' && always()
+    needs: [Static-Checks, Github-Deployment, Applitools, A11Y-Tests, Robot]
+    runs-on: ubuntu-latest
+
+    steps:
       - uses: technote-space/workflow-conclusion-action@v1
 
       - name: generate conclusion color

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,7 @@ jobs:
   Release:
     runs-on: [self-hosted, Linux]
     env:
+      NODE_ENV: production
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       PUBLISH_REGISTRY: ${{ github.event.client_payload.registry }}
       CHECKOUT_REF: ${{ github.event.client_payload.ref }}

--- a/.github/workflows/v1x-release.yml
+++ b/.github/workflows/v1x-release.yml
@@ -32,6 +32,7 @@ jobs:
   Release:
     runs-on: [self-hosted, Linux]
     env:
+      NODE_ENV: production
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       PUBLISH_REGISTRY: ${{ github.event.client_payload.registry }}
       CHECKOUT_REF: ${{ github.event.client_payload.ref }}
@@ -135,7 +136,7 @@ jobs:
         if: always()
         run: |
           rm -rf ${{ github.workspace }}/gh-docs
-  
+
       - name: Update Deployment Status
         uses: bobheadxi/deployments@v0.4.3
         if: always()

--- a/.github/workflows/v2x-release.yml
+++ b/.github/workflows/v2x-release.yml
@@ -32,6 +32,7 @@ jobs:
   Release:
     runs-on: [self-hosted, Linux]
     env:
+      NODE_ENV: production
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       PUBLISH_REGISTRY: ${{ github.event.client_payload.registry }}
       CHECKOUT_REF: ${{ github.event.client_payload.ref }}


### PR DESCRIPTION
Currently, `babel-plugin-transform-react-remove-prop-types` isn't being applied, making component `propTypes` always appear in the bundle (the same should be true for other productionPlugins)

This seems to be because these are production-only plugins (`process.env.NODE_ENV === "production"`), but production mode isn't being set anywhere.
This PR adds the `NODE_ENV="production"` to the publish workflows