### PR TITLE
fix(TagsInput): add status validation and other fixes

### DIFF
--- a/packages/core/src/TagsInput/TagsInput.d.ts
+++ b/packages/core/src/TagsInput/TagsInput.d.ts
@@ -1,8 +1,9 @@
 import { StandardProps } from "@material-ui/core";
 import { HvTagProps } from "../Tag/Tag";
 import { HvCharCounterProps } from "../Forms/CharCounter";
+import { HvFormStatus } from "../Forms/FormElement";
 
-import { HvBaseInputProps } from "../BaseInput";
+import { HvInputProps } from "..";
 
 export type HvTagsInputClassKey =
   | "root"
@@ -12,10 +13,11 @@ export type HvTagsInputClassKey =
   | "labelContainer"
   | "label"
   | "characterCounter"
-  | "description";
+  | "description"
+  | "error";
 
 export interface HvTagsInputProps
-  extends StandardProps<HvBaseInputProps, HvTagsInputClassKey, "onChange" | "onBlur"> {
+  extends StandardProps<HvInputProps, HvTagsInputClassKey, "onChange" | "onBlur"> {
   /**
    * The label of the form element.
    *
@@ -95,7 +97,24 @@ export interface HvTagsInputProps
   /**
    * Called back when the value is changed.
    */
-  onChange?: (event: React.ChangeEvent<HTMLInputElement>, value: string) => void;
+  onChange?: (
+    event:
+      | React.ChangeEvent<HTMLInputElement>
+      | React.KeyboardEvent<HTMLInputElement>
+      | React.MouseEvent<HTMLButtonElement>
+      | React.MouseEvent<HTMLElement, MouseEvent>
+      | React.KeyboardEventHandler<HTMLElement>,
+    value: HvTagProps[]
+  ) => void;
+
+  /**
+   * The status of the form element.
+   */
+  status?: HvFormStatus;
+  /**
+   * The error message to show when `status` is "invalid".
+   */
+  statusMessage?: React.ReactNode;
 }
 
 export default function HvTagsInput(props: HvTagsInputProps): JSX.Element | null;

--- a/packages/core/src/TagsInput/TagsInput.d.ts
+++ b/packages/core/src/TagsInput/TagsInput.d.ts
@@ -50,6 +50,10 @@ export interface HvTagsInputProps
    * Indicates that the form element is not editable.
    */
   readOnly?: boolean;
+  /**
+   * Indicates that the form element is required.
+   */
+  required?: boolean;
 
   /**
    * If `true` it should autofocus.

--- a/packages/core/src/TagsInput/TagsInput.js
+++ b/packages/core/src/TagsInput/TagsInput.js
@@ -34,6 +34,7 @@ const HvTagsInput = (props) => {
 
     readOnly = false,
     disabled = false,
+    required = false,
 
     label: textAreaLabel,
     "aria-label": ariaLabel,
@@ -217,6 +218,7 @@ const HvTagsInput = (props) => {
       disabled={disabled}
       readOnly={readOnly}
       status={validationState}
+      required={required}
       className={clsx(classes.root, className, {
         [classes.disabled]: disabled,
       })}
@@ -490,6 +492,10 @@ HvTagsInput.propTypes = {
    * Indicates that the form element is not editable.
    */
   readOnly: PropTypes.bool,
+  /**
+   * Indicates that the form element is required.
+   */
+  required: PropTypes.bool,
   /**
    * The function that will be executed onChange.
    */

--- a/packages/core/src/TagsInput/TagsInput.js
+++ b/packages/core/src/TagsInput/TagsInput.js
@@ -12,8 +12,10 @@ import {
   HvLabel,
   HvInfoMessage,
   HvCharCounter,
+  HvWarningText,
   useUniqueId,
 } from "..";
+import validationStates from "../Forms/FormElement/validationStates";
 import styles from "./styles";
 
 /**
@@ -55,9 +57,11 @@ const HvTagsInput = (props) => {
 
     multiline = false,
 
+    status,
+    statusMessage,
+
     ...others
   } = props;
-
   const elementId = useUniqueId(id, "hvTagsInput");
 
   const hasLabel = textAreaLabel != null;
@@ -67,6 +71,8 @@ const HvTagsInput = (props) => {
 
   const [tagInput, setTagInput] = useState("");
   const [tagCursorPos, setTagCursorPos] = useState(value.length);
+
+  const [validationState, setValidationState] = useControlled(status, validationStates.standBy);
 
   const isTagSelected = tagCursorPos >= 0 && tagCursorPos < value.length;
 
@@ -78,6 +84,8 @@ const HvTagsInput = (props) => {
 
   const inputRef = useRef();
   const containerRef = useRef();
+
+  const canShowError = status !== undefined && status === "invalid" && statusMessage !== undefined;
 
   /**
    * Handler for the `onChange` event on the tag input
@@ -119,13 +127,14 @@ const HvTagsInput = (props) => {
    */
   const onEnterHandler = useCallback(
     (event, tag) => {
+      event.preventDefault();
       if (tag !== "") {
         const newTagsArr = [...value, { label: tag, type: "semantic" }];
         setValue(newTagsArr);
         setTagInput("");
         setTagCursorPos(newTagsArr.length);
 
-        onChange?.(newTagsArr);
+        onChange?.(event, newTagsArr);
       }
     },
     [onChange, setValue, value]
@@ -153,7 +162,7 @@ const HvTagsInput = (props) => {
               setValue(newTagsArr);
               setTagCursorPos(tagCursorPos > 0 ? tagCursorPos - 1 : 0);
               inputRef.current?.focus();
-              onChange?.(newTagsArr);
+              onChange?.(event, newTagsArr);
             } else {
               setTagCursorPos(value.length - 1);
             }
@@ -167,7 +176,7 @@ const HvTagsInput = (props) => {
               setValue(newTagsArr);
               setTagCursorPos(tagCursorPos > 0 ? tagCursorPos - 1 : 0);
               inputRef.current?.focus();
-              onChange?.(newTagsArr);
+              onChange?.(event, newTagsArr);
             }
             break;
           default:
@@ -182,14 +191,15 @@ const HvTagsInput = (props) => {
    * Handler for the `onDelete` event on the tag component
    */
   const onDeleteTagHandler = useCallback(
-    (i) => {
+    (event, i) => {
       const newTagsArr = [...value.slice(0, i), ...value.slice(i + 1)];
+      setValidationState(validationStates.standBy);
       setValue(newTagsArr);
       setTagCursorPos(newTagsArr.length);
       inputRef.current?.focus();
-      onChange?.(newTagsArr);
+      onChange?.(event, newTagsArr);
     },
-    [value, setValue, onChange]
+    [value, setValidationState, setValue, onChange]
   );
 
   /**
@@ -206,6 +216,7 @@ const HvTagsInput = (props) => {
       name={name}
       disabled={disabled}
       readOnly={readOnly}
+      status={validationState}
       className={clsx(classes.root, className, {
         [classes.disabled]: disabled,
       })}
@@ -243,6 +254,7 @@ const HvTagsInput = (props) => {
       <HvListContainer
         className={clsx(
           classes.tagsList,
+          canShowError && classes.error,
           resizable && multiline && classes.resizable,
           isStateInvalid && classes.invalid,
           !multiline && classes.singleLine
@@ -276,9 +288,12 @@ const HvTagsInput = (props) => {
                 <HvTag
                   label={label}
                   className={clsx(i === tagCursorPos && classes.tagSelected)}
+                  classes={{
+                    chipRoot: classes.chipRoot,
+                  }}
                   type={type}
                   {...(!(readOnly || disabled || type === "categorical") && {
-                    onDelete: () => onDeleteTagHandler(i),
+                    onDelete: (event) => onDeleteTagHandler(event, i),
                   })}
                   deleteButtonProps={{
                     tabIndex: -1,
@@ -329,6 +344,11 @@ const HvTagsInput = (props) => {
           </HvListItem>
         )}
       </HvListContainer>
+      {canShowError && (
+        <HvWarningText id={setId(elementId, "error")} disableBorder className={classes.error}>
+          {statusMessage}
+        </HvWarningText>
+      )}
     </HvFormElement>
   );
 };
@@ -358,6 +378,10 @@ HvTagsInput.propTypes = {
      * Styles applied to the root container of the textarea.
      */
     root: PropTypes.string,
+    /**
+     *
+     */
+    chipRoot: PropTypes.string,
     /**
      * Style applied to the root when resizable is `true`.
      */
@@ -411,9 +435,13 @@ HvTagsInput.propTypes = {
      */
     tagInputRootFocused: PropTypes.string,
     /**
-     * Styles applied to the container when in single line mode§.
+     * Styles applied to the container when in single line mode.
      */
     singleLine: PropTypes.string,
+    /**
+     * Styles applied to the tags list when an error occurred.
+     */
+    error: PropTypes.string,
   }).isRequired,
   /**
    * Id to be applied to the form element root node.
@@ -503,6 +531,14 @@ HvTagsInput.propTypes = {
    * If `true` the component is in multiline mode.
    */
   multiline: PropTypes.bool,
+  /**
+   * The status of the form element.
+   */
+  status: PropTypes.string,
+  /**
+   * The error message to show when `status` is "invalid".
+   */
+  statusMessage: PropTypes.string,
 };
 
 export default withStyles(styles, { name: "HvTagsInput" })(HvTagsInput);

--- a/packages/core/src/TagsInput/stories/TagsInput.stories.js
+++ b/packages/core/src/TagsInput/stories/TagsInput.stories.js
@@ -257,14 +257,14 @@ export const InAForm = () => {
 
   const validationSchema = yup.object({
     name: yup.string().required("Name is required"),
-    tags: yup.array().min(3),
+    tags: yup.array().required("Tags is required").min(3),
   });
 
   return (
     <Formik
       initialValues={{
         name: "",
-        tags: [],
+        tags: undefined,
       }}
       validationSchema={validationSchema}
       onSubmit={onSubmit}
@@ -288,6 +288,7 @@ export const InAForm = () => {
                 label="Name"
                 aria-label="Name"
                 value={values.name}
+                required
                 description="Required"
                 status={parseStatus("name")}
                 statusMessage={parseStatusMessage("name")}
@@ -304,6 +305,7 @@ export const InAForm = () => {
                 aria-label="Tags"
                 placeholder="Enter value"
                 description="Should have at least 3 tags"
+                required
                 classes={{
                   root: classes.root,
                 }}

--- a/packages/core/src/TagsInput/stories/TagsInput.stories.js
+++ b/packages/core/src/TagsInput/stories/TagsInput.stories.js
@@ -1,6 +1,8 @@
 import React, { useState } from "react";
 import { makeStyles } from "@material-ui/core";
-import { HvTagsInput, HvTypography } from "../..";
+import { Formik } from "formik";
+import * as yup from "yup";
+import { HvTagsInput, HvTypography, HvInput, HvButton } from "../..";
 
 export default {
   title: "Forms/Tags Input",
@@ -236,5 +238,98 @@ export const TagsCounterValidation = () => {
 TagsCounterValidation.parameters = {
   docs: {
     description: { story: "Tags Input with tags counter." },
+  },
+};
+
+export const InAForm = () => {
+  const useStyles = makeStyles(() => ({
+    root: {
+      width: 350,
+      height: 100,
+    },
+  }));
+
+  const classes = useStyles();
+
+  const onSubmit = (value) => {
+    alert(JSON.stringify(value));
+  };
+
+  const validationSchema = yup.object({
+    name: yup.string().required("Name is required"),
+    tags: yup.array().min(3),
+  });
+
+  return (
+    <Formik
+      initialValues={{
+        name: "",
+        tags: [],
+      }}
+      validationSchema={validationSchema}
+      onSubmit={onSubmit}
+      validateOnChange={false}
+      validateOnBlur={false}
+    >
+      {(props) => {
+        const { values, errors, touched, handleSubmit, setFieldValue, setFieldTouched } = props;
+
+        const parseStatus = (name) => {
+          return errors[name] && touched[name] ? "invalid" : "valid";
+        };
+
+        const parseStatusMessage = (name) => {
+          return errors[name] && touched[name] ? errors[name] : "";
+        };
+        return (
+          <div style={{ width: 350 }}>
+            <form data-testid="create-project-form" onSubmit={handleSubmit} noValidate>
+              <HvInput
+                label="Name"
+                aria-label="Name"
+                value={values.name}
+                description="Required"
+                status={parseStatus("name")}
+                statusMessage={parseStatusMessage("name")}
+                placeholder="Enter Value"
+                onChange={(evt, value) => {
+                  setFieldTouched("name");
+                  setFieldValue("name", value);
+                }}
+              />
+              <br />
+              <HvTagsInput
+                id="tags-list-9"
+                label="Tags"
+                aria-label="Tags"
+                placeholder="Enter value"
+                description="Should have at least 3 tags"
+                classes={{
+                  root: classes.root,
+                }}
+                status={parseStatus("tags")}
+                statusMessage={parseStatusMessage("tags")}
+                onChange={(event, tagsValues) => {
+                  event?.preventDefault();
+                  const value = tagsValues;
+                  setFieldTouched("tags");
+                  setFieldValue("tags", value);
+                }}
+              />
+              <br />
+              <HvButton type="submit" category="secondary">
+                Submit
+              </HvButton>
+            </form>
+          </div>
+        );
+      }}
+    </Formik>
+  );
+};
+
+InAForm.parameters = {
+  docs: {
+    description: { story: "Tags Input in a form." },
   },
 };

--- a/packages/core/src/TagsInput/styles.js
+++ b/packages/core/src/TagsInput/styles.js
@@ -4,12 +4,18 @@ const styles = (theme) => {
       display: "inline-block",
       maxWidth: "100%",
     },
+    chipRoot: {
+      maxWidth: "none",
+    },
     resizable: {
       width: "auto",
       resize: "both",
       overflow: "auto",
     },
     disabled: {},
+    error: {
+      float: "left",
+    },
     invalid: {
       border: `1px solid ${theme.hv.palette.semantic.sema4}!important`,
     },
@@ -79,22 +85,15 @@ const styles = (theme) => {
 
       "&:hover": {
         cursor: "text",
+        border: `1px solid ${theme.hv.palette.accent.acce1}`,
       },
 
-      "&:focus": {
-        outline: "none",
-      },
-
-      "&:focus-visible": {
+      "&:focus, &:focus-within, &:focus-visible": {
         outlineColor: "#52A8EC",
         outlineStyle: "solid",
         outlineWidth: "0px",
         outlineOffset: "-1px",
         boxShadow: "0 0 0 1px #52A8EC, 0 0 0 4px rgba(29,155,209,.3)",
-      },
-
-      "&:focus-within, &:hover": {
-        border: `1px solid ${theme.hv.palette.accent.acce1}`,
       },
 
       "&$disabled": {
@@ -113,6 +112,10 @@ const styles = (theme) => {
         display: "table-row",
         paddingTop: 0,
         paddingLeft: 4,
+      },
+
+      "&$error": {
+        border: `1px solid ${theme.hv.palette.semantic.sema4}`,
       },
     },
     tagInputContainerRoot: {


### PR DESCRIPTION
- update `onChange` signature
- update type definition to extend from `HvInputProps` instead of `HvBaseInputProps`
- Remove max-width limit on tags
- Add outline on focus
- Add error message and status validation
- Disable default behavior when enter is pressed to add a tag to prevent submiting a form where the component might be included 
- Added new story to illustrate usage of the component in a form
