### PR TITLE
fix(BarChart): fix tooltip displaying when hovering outside of the chart bars

### DIFF
--- a/packages/core/src/Barchart/barchartPlotlyOverrides.js
+++ b/packages/core/src/Barchart/barchartPlotlyOverrides.js
@@ -12,6 +12,7 @@ export const applyLayoutDefaults = (inputLayout, stack, isHorizontal) => {
   const layout = inputLayout === undefined ? {} : clone(inputLayout);
   setterIfNil(layout, "bargap", 0.25);
   setterIfNil(layout, "bargroupgap", 0.25);
+  setterIfNil(layout, "hovermode", "closest");
   if (stack) setterIfNil(layout, "barmode", "stack");
 
   setterIfNil(layout, "yaxis", {});

--- a/packages/core/src/Barchart/stories/Barchart.stories.js
+++ b/packages/core/src/Barchart/stories/Barchart.stories.js
@@ -52,8 +52,11 @@ export const GroupedVerticalBarchart = () => {
     { x: ["Group 1", "Group 2", "Group 3"], y: [2100, 8500, 3000], name: "Target" },
     { x: ["Group 1", "Group 2", "Group 3"], y: [500, 8000, 8400], name: "Cash" },
   ];
+  const layout = {
+    hovermode: "x",
+  };
 
-  return <HvBarchart data={data} />;
+  return <HvBarchart data={data} layout={layout} />;
 };
 
 GroupedVerticalBarchart.parameters = {
@@ -215,8 +218,11 @@ export const GroupedHorizontalBarchart = () => {
     { y: ["Group 1", "Group 2", "Group 3"], x: [2100, 8500, 3000], name: "Target" },
     { y: ["Group 1", "Group 2", "Group 3"], x: [500, 8000, 8400], name: "Cash" },
   ];
+  const layout = {
+    hovermode: "y",
+  };
 
-  return <HvBarchart horizontal data={data} />;
+  return <HvBarchart horizontal data={data} layout={layout} />;
 };
 
 GroupedHorizontalBarchart.parameters = {


### PR DESCRIPTION
This is the proposed fix for:
https://hv-eng.atlassian.net/browse/HVUIKIT-6312

The problem was that the tooltip would display even outside the chart bars. I added a default value for the `hovermode` property on plotly to set it to `closest`. This value can still be overridden by the user to keep grouping functionality like I did in the two updated stories.