### PR TITLE
feat(TagsInput): allow commiting tags with other characters and on blur

### DIFF
--- a/packages/core/src/TagsInput/TagsInput.d.ts
+++ b/packages/core/src/TagsInput/TagsInput.d.ts
@@ -143,18 +143,12 @@ export interface HvTagsInputProps
   /**
    * The function that will be executed when the input is blurred.
    */
-   onBlur?: (
-    event: React.FocusEvent<HTMLInputElement>,
-    value: string
-  ) => void;
+  onBlur?: (event: React.FocusEvent<HTMLInputElement>, value: string) => void;
 
   /**
    * The function that will be executed when the input is focused.
    */
-   onFocus?: (
-    event: React.FocusEvent<HTMLInputElement>,
-    value: string
-  ) => void;
+  onFocus?: (event: React.FocusEvent<HTMLInputElement>, value: string) => void;
 
   /**
    * The status of the form element.
@@ -169,6 +163,16 @@ export interface HvTagsInputProps
    * An Object containing the various texts associated with the input.
    */
   validationMessages?: HvBaseInputValidationMessagesProps;
+
+  /**
+   * An array of strings that represent the character used to input a tag.
+   * This character is the string representation of the event.code from the input event.
+   */
+  commitTagOn?: string[];
+  /**
+   * If `true` the tag will be commited when the blur event occurs.
+   */
+  comminOnBlur?: boolean;
 }
 
 export default function HvTagsInput(props: HvTagsInputProps): JSX.Element | null;

--- a/packages/core/src/TagsInput/stories/TagsInput.stories.js
+++ b/packages/core/src/TagsInput/stories/TagsInput.stories.js
@@ -460,3 +460,34 @@ InAForm.parameters = {
     description: { story: "Tags Input in a form." },
   },
 };
+
+export const CustomCommitCharacter = () => {
+  const useStyles = makeStyles(() => ({
+    root: {
+      width: 550,
+    },
+  }));
+
+  const classes = useStyles();
+
+  return (
+    <HvTagsInput
+      id="tags-list-11"
+      label="Custom commit character"
+      description="Will only add a tag when a space or comma is entered or when the user clicks outside the input box and there's text that's not been commited"
+      aria-label="Custom commit character"
+      placeholder="Enter value"
+      classes={{
+        root: classes.root,
+      }}
+      commitTagOn={["Space", "Comma"]}
+      commitOnBlur
+    />
+  );
+};
+
+CustomCommitCharacter.parameters = {
+  docs: {
+    story: "Custom commit character",
+  },
+};

--- a/packages/core/src/TagsInput/tests/tagsInput.test.js
+++ b/packages/core/src/TagsInput/tests/tagsInput.test.js
@@ -245,7 +245,7 @@ describe("TagsInput Component", () => {
     fireEvent.change(tagsInput, { target: { value: "tag3" } });
     expect(tagsInput).toHaveValue("tag3");
     expect(clickableButtons.length).toBe(2);
-    fireEvent.keyDown(tagsInput, { key: "Enter", keyCode: 13 });
+    fireEvent.keyDown(tagsInput, { code: "Enter", keyCode: 13 });
     const remainingButton = await findAllByRole("button");
     expect(onChangeSpy).toHaveBeenCalledWith(expect.any(Object), [
       { label: "tag1" },


### PR DESCRIPTION
- new property `commitOnTag` allows passing an array of key codes that can be used to commit a tag
- new property `commitOnBlur` allows commiting a tag when clicking outside of the input box