### PR TITLE
 docs: fix props not showing on the Properties table

### DIFF
--- a/.storybook/props/extractArgTypes.js
+++ b/.storybook/props/extractArgTypes.js
@@ -23,7 +23,7 @@ export const extractArgTypes = (component) => {
             // eslint-disable-next-line no-empty
           } catch {}
 
-          acc[row.name] = {
+          acc[`${section}_${row.name}`] = {
             ...row,
             defaultValue,
             type: { required, ...sbType },


### PR DESCRIPTION
- Fixed missing props on the Properties table when a class with the same name exists. This was happening because we were creating an array with the prop or class name as id. This meant that when a CSS class with the same name as a property existed it would replace the property on the array therefore effectivelly eliminating the property from the array.