### PR TITLE
chore: allow plotly.js@2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28771,9 +28771,9 @@
       }
     },
     "plotly.js-basic-dist": {
-      "version": "1.58.5",
-      "resolved": "https://registry.npmjs.org/plotly.js-basic-dist/-/plotly.js-basic-dist-1.58.5.tgz",
-      "integrity": "sha512-Srbt1ACLknY2r655udWwc8cxEan0FvhQUDkX/VW9NATNs5g38mc+OTLmZIRmUrJu2Sr/jDXqZ4EqFnzN9dOXvQ==",
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/plotly.js-basic-dist/-/plotly.js-basic-dist-2.11.1.tgz",
+      "integrity": "sha512-ZJL/dupVLsNwB1B5IeEQZngZIu3OWDt6BfS5SX031UyjdYa6xbF2wmVVj6amPVsuwENXvvOGrAmhORG08KX8zA==",
       "dev": true
     },
     "pngjs": {

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "monaco-editor": "0.20.0",
     "monaco-editor-webpack-plugin": "1.9.1",
     "npm-run-all": "^4.1.5",
-    "plotly.js-basic-dist": "^1.58.5",
+    "plotly.js-basic-dist": "^2.11.1",
     "prettier": "^2.4.1",
     "react": "^17.0.2",
     "react-beautiful-dnd": "^13.1.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -41,7 +41,7 @@
   },
   "peerDependencies": {
     "@material-ui/core": "^4.12.3",
-    "plotly.js-basic-dist": "^1.55.2",
+    "plotly.js-basic-dist": "^1.55.2 || ^2.11.1",
     "react": "^16.13.1 || ^17.0.0",
     "react-dom": "^16.13.1 || ^17.0.0"
   },


### PR DESCRIPTION
Allows an app to use `plotly.js` v1 or v2, which fixes #2710.

~Testing if internal bump to `plotly.js@2` breaks~. It seems like the [breaking changes](https://github.com/plotly/plotly.js/releases/tag/v2.0.0) ~might~do not affect UI-Kit's charts.

Does it make sense to make this bump in a patch/minor?

Looking forward, given:
- that plotly still relies heavily on `window.document`
- that plotly is a large library
- how often the charts are used
- that in Design System they're in a separate "visualisation" component library
it might be worth it to look into splitting the Visualisation components into a separate library