### PR TITLE
fix(chart): prevent chart defaults for some falsy values.

### DIFF
--- a/packages/core/src/Barchart/barchartPlotlyOverrides.js
+++ b/packages/core/src/Barchart/barchartPlotlyOverrides.js
@@ -2,7 +2,7 @@ import clone from "lodash/cloneDeep";
 
 const setterIfNil = (object, property, value) => {
   // eslint-disable-next-line no-param-reassign
-  object[property] = object[property] || value;
+  object[property] = object[property] ?? value;
 };
 
 /**

--- a/packages/core/src/Chart/chartPlotlyOverrides.js
+++ b/packages/core/src/Chart/chartPlotlyOverrides.js
@@ -2,7 +2,7 @@ import styles from "./styles";
 
 const setterIfNil = (object, property, value) => {
   // eslint-disable-next-line no-param-reassign
-  object[property] = object[property] || value;
+  object[property] = object[property] ?? value;
 };
 
 /**

--- a/packages/core/src/Donutchart/donutchartPlotlyOverrides.js
+++ b/packages/core/src/Donutchart/donutchartPlotlyOverrides.js
@@ -2,7 +2,7 @@ import clone from "lodash/cloneDeep";
 
 const setterIfNil = (object, property, value) => {
   // eslint-disable-next-line no-param-reassign
-  object[property] = object[property] || value;
+  object[property] = object[property] ?? value;
 };
 
 /**

--- a/packages/core/src/Linechart/lineChartPlotlyOverrides.js
+++ b/packages/core/src/Linechart/lineChartPlotlyOverrides.js
@@ -2,7 +2,7 @@ import clone from "lodash/cloneDeep";
 
 const setterIfNil = (object, property, value) => {
   // eslint-disable-next-line no-param-reassign
-  object[property] = object[property] || value;
+  object[property] = object[property] ?? value;
 };
 
 /**


### PR DESCRIPTION
I was trying to use the Linechart of ui-kit and came upon a problem. I want to force a showline: false , however the function setterIfNil  inside lineChartPlotlyOverrides and chartPlotlyOverrides is only checking for truthy values, since false  is not, it always defaults to true when applying the defaults.
I think you could swap the ||  with ??  to allow false and 0 in some cases.