### PR TITLE
fix(filtergroup): enable typings

### DIFF
--- a/packages/core/src/FilterGroup/FilterGroup.js
+++ b/packages/core/src/FilterGroup/FilterGroup.js
@@ -25,6 +25,11 @@ const DEFAULT_LABELS = {
   multiSelectionConjunction: "/",
 };
 
+/**
+ * This component implements one potential use-case of the Filter Group pattern Design System Specifies.
+ * Due to the enormous variety of capabilities required for this, we strongly recommend checking the code of the component and extend it yourself,
+ * while we do not provide a better approach for building this component with smaller and more composable parts.
+ */
 const HvFilterGroup = ({
   className,
 

--- a/packages/core/src/FilterGroup/index.d.ts
+++ b/packages/core/src/FilterGroup/index.d.ts
@@ -1,0 +1,2 @@
+export { default } from "./FilterGroup";
+export * from "./FilterGroup";

--- a/packages/core/src/FilterGroup/stories/FilterGroup.stories.js
+++ b/packages/core/src/FilterGroup/stories/FilterGroup.stories.js
@@ -4,8 +4,8 @@ import HvFilterGroup from "../FilterGroup";
 export default {
   title: "Widgets/Filter Group",
   parameters: {
-    componentSubtitle:
-      "This component implements one potential use-case of the Filter Group pattern Design System Specifies. Due to the enormous variety of capabilities required for this, we strongly recommend checking the code of the component and extend it yourself, while we do not provide a better approach for building this component with smaller and more composable parts.",
+    componentSubtitle: null,
+    usage: 'import { HvFilterGroup } from "@hitachivantara/uikit-react-core"',
     dsVersion: "3.6.0",
   },
   component: HvFilterGroup,

--- a/packages/core/src/index.d.ts
+++ b/packages/core/src/index.d.ts
@@ -61,6 +61,7 @@ export { default as HvFileUploader } from "./FileUploader";
 export * from "./FileUploader";
 
 export { default as HvFilterGroup } from "./FilterGroup";
+export * from "./FilterGroup";
 
 export { default as HvFooter } from "./Footer";
 export * from "./Footer";


### PR DESCRIPTION
`FilterGroup`'s TS declarations aren't being exposed.

Also, docs in Wicked aren't visible:
![image](https://user-images.githubusercontent.com/638946/163838387-9dedc86f-eec2-468e-9db5-3eb45797b31c.png)
