### PR TITLE
chore(querybuilder): export extra types

### DIFF
--- a/packages/lab/src/QueryBuilder/index.d.ts
+++ b/packages/lab/src/QueryBuilder/index.d.ts
@@ -1,3 +1,4 @@
 export { default } from "./QueryBuilder";
 
 export * from "./QueryBuilder";
+export * from "./types";


### PR DESCRIPTION
`QueryBuilder` is not exporting all types. I would like to leverage them on my app for safety and IntelliSense