### PR TITLE
fix(QueryBuilder): don't allow adding groups when maxDepth is 0

### DIFF
--- a/packages/lab/src/QueryBuilder/RuleGroup/RuleGroup.js
+++ b/packages/lab/src/QueryBuilder/RuleGroup/RuleGroup.js
@@ -20,6 +20,7 @@ const RuleGroup = ({ level = 0, id, combinator = "and", rules = [] }) => {
   const context = useContext(Context);
 
   const { dispatchAction, askAction, maxDepth, combinators, labels } = context;
+  const normalizedMaxDepth = maxDepth - 1;
 
   const actionButtons = (
     <>
@@ -34,7 +35,7 @@ const RuleGroup = ({ level = 0, id, combinator = "and", rules = [] }) => {
           ? labels.query?.addRule?.label
           : labels.group.addRule.label}
       </HvButton>
-      {level < maxDepth && (
+      {level <= normalizedMaxDepth && (
         <HvButton
           category="secondary"
           onClick={() => {
@@ -171,7 +172,7 @@ const RuleGroup = ({ level = 0, id, combinator = "and", rules = [] }) => {
               >
                 {`${labels.empty?.createCondition}`}
               </HvTypography>
-              {level === 0 && (
+              {level <= normalizedMaxDepth && (
                 <>
                   {`${labels.empty?.spacer}`}
                   <HvTypography

--- a/packages/lab/src/Slider/tests/slider.test.js
+++ b/packages/lab/src/Slider/tests/slider.test.js
@@ -5,6 +5,9 @@ import { mount } from "enzyme";
 import { HvProvider } from "@hitachivantara/uikit-react-core";
 import HvSlider from "..";
 
+const consoleWarnSpy = jest.fn();
+const originalWarn = console.warn;
+
 describe("Slider ", () => {
   const knobProperties = [
     {
@@ -62,11 +65,16 @@ describe("Slider ", () => {
 
   beforeEach(async () => {
     myMock = jest.fn(() => "mock");
+    console.warn = consoleWarnSpy;
     wrapper = mount(
       <HvProvider>
         <HvSlider knobProperties={knobProperties} defaultValues={knobPropertiesDefaults} />
       </HvProvider>
     );
+  });
+
+  afterEach(() => {
+    console.warn = originalWarn;
   });
 
   it("should be defined", () => {


### PR DESCRIPTION
- Fixed the query builder allowing creating a new group when the `maxDepth` property is set to 0. This was caused by the level using base 0 indexing and the maxDepth using base 1 indexing (ie, when the maxDepth is 0 the current level is 1).
- Also fixed the tests for slider in lab throwing an error for an unexpected `console.warn`.