### PR TITLE
Allow css baseline to be disabled and to be scoped on children

### DIFF
--- a/.storybook/blocks/DocsContainer.js
+++ b/.storybook/blocks/DocsContainer.js
@@ -5,7 +5,7 @@ import { Global } from "@storybook/theming";
 import { getTheme, UIKIT_THEME } from "../theme";
 import { getDocsStyles } from "../theme/styles/docs";
 
-import { HvProvider } from "@hitachivantara/uikit-react-core";
+import { HvProvider, HvCssBaseline } from "@hitachivantara/uikit-react-core";
 
 export default ({ context, children }) => {
   const theme = getTheme();
@@ -29,7 +29,12 @@ export default ({ context, children }) => {
     <>
       <Global styles={docsStyles} />
       <DocsContainer context={docsContext}>
-        <HvProvider uiKitTheme={themeName} generateClassNameOptions={{ seed: "sb-docs-container" }}>
+        <HvProvider
+          uiKitTheme={themeName}
+          generateClassNameOptions={{ seed: "sb-docs-container" }}
+          disableCssBaseline
+        >
+          <HvCssBaseline />
           {children}
         </HvProvider>
       </DocsContainer>

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -65,7 +65,9 @@ const App = ({ story: Story }) => {
         generateClassNameOptions={
           isIsolatedSample ? undefined : { seed: `sb-preview-${instanceNumber}` }
         }
+        disableCssBaseline
       >
+        <HvCssBaseline />
         <Story />
       </HvProvider>
     </>

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useMemo } from "react";
 import addons from "@storybook/addons";
 import { Global } from "@storybook/theming";
-import { HvProvider } from "@hitachivantara/uikit-react-core";
+import { HvProvider, HvCssBaseline } from "@hitachivantara/uikit-react-core";
 import DocsPage from "./blocks/DocsPage";
 import DocsContainer from "./blocks/DocsContainer";
 import { getTheme, UIKIT_THEME } from "./theme";
@@ -21,7 +21,16 @@ export const parameters = {
         "Get Started",
         ["Introduction", "Installation", "Component List", "Styling"],
         "Foundation",
-        ["Grid", "Container", "Provider", "Theming", "Typography", "Colors", "Icons"],
+        [
+          "Grid",
+          "Container",
+          "Provider",
+          "CSS Baseline",
+          "Theming",
+          "Typography",
+          "Colors",
+          "Icons",
+        ],
         "Components",
         "Forms",
         ["Main", "Form Element", "Form Element Blocks"],

--- a/doc/Foundation/Colors.stories.mdx
+++ b/doc/Foundation/Colors.stories.mdx
@@ -36,7 +36,7 @@ If you require to override the default values of the palette, you will need to c
 the uikit theme is an extension of the Material-UI theme so to create a new theme object you will use Material-UI's
 theme generator
 
-```
+```jsx
 import { createTheme } from "@material-ui/core/styles";
 
 const theme = createTheme({
@@ -51,77 +51,64 @@ const theme = createTheme({
     },
   },
 });
-
 ```
 
 The theme object must override one of the color values of the following object:
 
-```
-"hv": {
-  "palette": {
-    "accent": {
-      "acce1": "#414141",
-      .
-      .
-      .
-      "acce3": "#CC0000"
-    },
-    "atmosphere": {
-      "atmo1": "#FBFCFC",
-      .
-      .
-      .
-      "atmo5": "#999999"
-    },
-    "base": {
-      "base1": "#FBFCFC",
-      "base2": "#414141"
-    },
-    "semantic": {
-      "sema1": "#59941B",
-      .
-      .
-      .
-      "sema20": "#F9E3C5"
-    },
-    "support": {
-      "supp1": "#0F8B8D",
-      .
-      .
-      .
-      "supp5": "#546B6B"
-    },
-    "shadow": {
-      "shad1":"rgba(65,65,65,0.12)"
-    }
-  }
-"viz": {
+```json
+{
+  "hv": {
     "palette": {
-      "categorical": {
-        "cviz1": "#6EAFFF",
-        .
-        .
-        .
-        "cviz20": "#F7B552"
+      "accent": {
+        "acce1": "#414141",
+        ...
+        "acce3": "#CC0000"
       },
-      "undefinedState": {
-        "atmo4": "#CCCED0"
+      "atmosphere": {
+        "atmo1": "#FBFCFC",
+        ...
+        "atmo5": "#999999"
       },
-      "sequential": {
-        "cviz1": "#2DB3E0",
-        .
-        .
-        .
-        "cviz1_100": "#E3F1F6"
+      "base": {
+        "base1": "#FBFCFC",
+        "base2": "#414141"
       },
-      "polarized": {
+      "semantic": {
         "sema1": "#59941B",
-        "cviz21": "#869F1E",
-        .
-        .
-        .
-        "cviz28": "#D8265D",
-        "sema5": "#C51162"
+        ...
+        "sema20": "#F9E3C5"
+      },
+      "support": {
+        "supp1": "#0F8B8D",
+        ...
+        "supp5": "#546B6B"
+      },
+      "shadow": {
+        "shad1":"rgba(65,65,65,0.12)"
+      }
+    }
+  "viz": {
+      "palette": {
+        "categorical": {
+          "cviz1": "#6EAFFF",
+          ...
+          "cviz20": "#F7B552"
+        },
+        "undefinedState": {
+          "atmo4": "#CCCED0"
+        },
+        "sequential": {
+          "cviz1": "#2DB3E0",
+          ...
+          "cviz1_100": "#E3F1F6"
+        },
+        "polarized": {
+          "sema1": "#59941B",
+          "cviz21": "#869F1E",
+          ...
+          "cviz28": "#D8265D",
+          "sema5": "#C51162"
+        }
       }
     }
   }
@@ -136,7 +123,7 @@ Here is an example of a pair of buttons with overridden colors.
 
 ## Code
 
-```
+```jsx
 import React from "react";
 import { createTheme } from "@material-ui/core/styles";
 import { HvProvider, HvButton } from "@hitachivantara/uikit-react-core";

--- a/doc/Foundation/CssBaseline/CssBaseline.stories.mdx
+++ b/doc/Foundation/CssBaseline/CssBaseline.stories.mdx
@@ -1,0 +1,97 @@
+import LinkTo from "@storybook/addon-links/react";
+
+import { HvAvatar } from "@hitachivantara/uikit-react-core";
+import { Caution } from "@hitachivantara/uikit-react-icons";
+
+<Meta title="Foundation/CSS Baseline" />
+
+# CSS Baseline
+
+The UI Kit components require a baseline of CSS styles to function properly.
+
+Namely, [`box-sizing`](https://developer.mozilla.org/en-US/docs/Web/CSS/box-sizing) must be set to `border-box`,
+including on `*::before` and `*::after` pseudo-elements, ensuring that the declared width of the element
+is never exceeded due to padding or border. Without it the layout of UI Kit elements might be broken.
+
+Also, the `font-family` should be set to use the Open Sans font. The font must be loaded by the application.
+See the <LinkTo kind="Foundation/Typography" story="Description" className="sbdocs sbdocs-a">Typography page</LinkTo> for more details.
+
+These base styles can be provided by the application or by using one of components UI Kit provides, described below.
+
+<div style={{ float: "left" }}>
+  <Caution
+    iconSize="M"
+    color="supp4"
+    style={{ display: "inline-block", textAlign: "center", verticalAlign: "top" }}
+  />
+</div>
+
+Currently the `HvProvider` automatically setups the CSS baseline globally, using the
+`HvCssBaseline` component. <strong>This will change in a future major version</strong>.
+You can disable the automatic setup by setting the `disableCssBaseline` prop in the `HvProvider` component.
+
+<span style={{ clear: "both" }}></span>
+
+## Applying the styles globally
+
+This component applies the baseline styles to the whole application, by targeting the `<html>` and `<body>` elements.
+
+```jsx
+import * as React from "react";
+import { HvProvider, HvCssBaseline } from "@hitachivantara/uikit-react-core";
+
+export default function MyApp() {
+  return (
+    <HvProvider disableCssBaseline>
+      <HvCssBaseline />
+      {/* The rest of your application */}
+    </HvProvider>
+  );
+}
+```
+
+## Scoping on children
+
+When integrating with other UI frameworks or in a existing codebase, it is often necessary to scope the CSS to avoid styling conflicts.
+It's possible to apply the baseline only to children by using the `HvScopedCssBaseline` component.
+
+A root element is created, wrapping the children, and the baseline styles are applied to it.
+
+```jsx
+import * as React from "react";
+import { HvProvider, HvScopedCssBaseline } from "@hitachivantara/uikit-react-core";
+
+export default function MyApp() {
+  return (
+    <HvProvider disableCssBaseline>
+      <HvScopedCssBaseline>
+        {/* The part of your application where the baseline applies */}
+      </HvScopedCssBaseline>
+
+      {/* The rest of your application */}
+    </HvProvider>
+  );
+}
+```
+
+## Baseline styles applied
+
+### Page (global only)
+
+- The `<body>` margin is removed.
+- The [fullscreen backdrop](https://developer.mozilla.org/en-US/docs/Web/CSS/::backdrop) background color is set to the atmosphere color `.atmo3` <HvAvatar status="atmo5" backgroundColor="atmo3" size="XS" variant="square" containerProps={{ style: { display: "inline-block", verticalAlign: "middle", transform: "scale(0.8)" } }}> </HvAvatar>.
+
+### Layout
+
+- `box-sizing` is set to `border-box`, including on `*::before` and `*::after` via inheritance.
+
+### Typography
+
+- The `normalText` typography is applied.
+- The `fontWeight` of `highlightText` typography is applied to `<b>` and `<strong>` elements.
+- [Font-smoothing](https://developer.mozilla.org/en-US/docs/Web/CSS/font-smooth) is customized.
+
+### Color
+
+- Sets the text `color` to the accent color `.acce1` <HvAvatar status="atmo5" backgroundColor="acce1" size="XS" variant="square" containerProps={{ style: { display: "inline-block", verticalAlign: "middle", transform: "scale(0.8)" } }}> </HvAvatar>.
+- Sets the `background-color` to the atmosphere color `.atmo2` <HvAvatar status="atmo5" backgroundColor="atmo2" size="XS" variant="square" containerProps={{ style: { display: "inline-block", verticalAlign: "middle", transform: "scale(0.8)" } }}> </HvAvatar>.

--- a/doc/Foundation/CssBaseline/CssBaseline.stories.mdx
+++ b/doc/Foundation/CssBaseline/CssBaseline.stories.mdx
@@ -90,6 +90,7 @@ export default function MyApp() {
 - The `normalText` typography is applied.
 - The `fontWeight` of `highlightText` typography is applied to `<b>` and `<strong>` elements.
 - [Font-smoothing](https://developer.mozilla.org/en-US/docs/Web/CSS/font-smooth) is customized.
+- [text-size-adjust](https://developer.mozilla.org/en-US/docs/Web/CSS/text-size-adjust) is set to `none`.
 
 ### Color
 

--- a/doc/Foundation/CssBaseline/CssBaseline.stories.mdx
+++ b/doc/Foundation/CssBaseline/CssBaseline.stories.mdx
@@ -96,3 +96,4 @@ export default function MyApp() {
 
 - Sets the text `color` to the accent color `.acce1` <HvAvatar status="atmo5" backgroundColor="acce1" size="XS" variant="square" containerProps={{ style: { display: "inline-block", verticalAlign: "middle", transform: "scale(0.8)" } }}> </HvAvatar>.
 - Sets the `background-color` to the atmosphere color `.atmo2` <HvAvatar status="atmo5" backgroundColor="atmo2" size="XS" variant="square" containerProps={{ style: { display: "inline-block", verticalAlign: "middle", transform: "scale(0.8)" } }}> </HvAvatar>.
+- Sets the [`color-scheme`](https://developer.mozilla.org/en-US/docs/Web/CSS/color-scheme) and [`accent-color`](https://developer.mozilla.org/en-US/docs/Web/CSS/accent-color) according to the active theme.

--- a/doc/Foundation/PaletteCustomization.js
+++ b/doc/Foundation/PaletteCustomization.js
@@ -17,7 +17,7 @@ const theme = createTheme({
 
 const Palette = () => {
   return (
-    <HvProvider theme={theme}>
+    <HvProvider theme={theme} disableCssBaseline>
       <HvButton category="primary">Primary</HvButton>
       <HvButton category="secondary">Secondary</HvButton>
     </HvProvider>

--- a/doc/Foundation/Theming/Provider.stories.js
+++ b/doc/Foundation/Theming/Provider.stories.js
@@ -31,10 +31,14 @@ export default {
 
 export const Main = () => (
   <>
-    <HvProvider uiKitTheme="dawn" generateClassNameOptions={{ seed: "dawn" }}>
+    <HvProvider uiKitTheme="dawn" generateClassNameOptions={{ seed: "dawn" }} disableCssBaseline>
       <HvButtonWithMargin category="secondary">Dawn</HvButtonWithMargin>
     </HvProvider>
-    <HvProvider uiKitTheme="wicked" generateClassNameOptions={{ seed: "wicked" }}>
+    <HvProvider
+      uiKitTheme="wicked"
+      generateClassNameOptions={{ seed: "wicked" }}
+      disableCssBaseline
+    >
       <HvButtonWithMargin category="secondary">Wicked</HvButtonWithMargin>
     </HvProvider>
   </>
@@ -54,13 +58,13 @@ export const Locale = () => {
 
   return (
     <>
-      <HvProvider generateClassNameOptions={{ seed: "default" }}>
+      <HvProvider generateClassNameOptions={{ seed: "default" }} disableCssBaseline>
         <ShowLocale />
       </HvProvider>
-      <HvProvider locale="fr-FR" generateClassNameOptions={{ seed: "fr-FR" }}>
+      <HvProvider locale="fr-FR" generateClassNameOptions={{ seed: "fr-FR" }} disableCssBaseline>
         <ShowLocale />
       </HvProvider>
-      <HvProvider locale="it-IT" generateClassNameOptions={{ seed: "it-IT" }}>
+      <HvProvider locale="it-IT" generateClassNameOptions={{ seed: "it-IT" }} disableCssBaseline>
         <ShowLocale />
       </HvProvider>
     </>

--- a/doc/Foundation/Theming/Theming.stories.mdx
+++ b/doc/Foundation/Theming/Theming.stories.mdx
@@ -44,7 +44,7 @@ The UI Kit components provides the two Design System themes: **Dawn** and **Wick
 </Story>
 
 The active theme is configured through the `HvProvider`'s `uiKitTheme` property and defaults to the **Dawn** theme.
-Check <LinkTo kind="Foundation/Provider" story="Main" className="sbdocs-a">the Provider's API documentation</LinkTo> for more details.
+Check <LinkTo kind="Foundation/Provider" story="Main" className="sbdocs sbdocs-a">the Provider's API documentation</LinkTo> for more details.
 
 ## Custom themes
 

--- a/doc/Foundation/Theming/Theming.stories.mdx
+++ b/doc/Foundation/Theming/Theming.stories.mdx
@@ -25,12 +25,18 @@ import componentDefinitions from "../../GetStarted/ComponentVersioningTable/vers
 The UI Kit components provides the two Design System themes: **Dawn** and **Wicked**.
 
 <Story name="Main">
-  <HvProvider uikitTheme="dawn" generateClassNameOptions={{ seed: "dawn" }}>
-    <ThemePreviewMix />
-  </HvProvider>
-  <HvProvider uiKitTheme="wicked" generateClassNameOptions={{ seed: "wicked" }}>
-    <ThemePreviewMix />
-  </HvProvider>
+  <div style={{ display: "flex", flexWrap: "wrap" }}>
+    <HvProvider uikitTheme="dawn" generateClassNameOptions={{ seed: "dawn" }} disableCssBaseline>
+      <ThemePreviewMix />
+    </HvProvider>
+    <HvProvider
+      uiKitTheme="wicked"
+      generateClassNameOptions={{ seed: "wicked" }}
+      disableCssBaseline
+    >
+      <ThemePreviewMix />
+    </HvProvider>
+  </div>
 </Story>
 
 The active theme is configured through the `HvProvider`'s `uiKitTheme` property and defaults to the **Dawn** theme.
@@ -377,7 +383,12 @@ export const myRawCustomTheme = {
 export const myCustomTheme = createTheme(myRawCustomTheme);
 
 <Story name="Other">
-  <HvProvider uikitTheme="dawn" theme={myCustomTheme} generateClassNameOptions={{ seed: "custom" }}>
+  <HvProvider
+    uikitTheme="dawn"
+    theme={myCustomTheme}
+    generateClassNameOptions={{ seed: "custom" }}
+    disableCssBaseline
+  >
     <ThemePreviewMix />
   </HvProvider>
 </Story>

--- a/doc/Foundation/Theming/Theming.stories.mdx
+++ b/doc/Foundation/Theming/Theming.stories.mdx
@@ -2,7 +2,7 @@ import { Meta, Story, Preview } from "@storybook/addon-docs";
 
 import LinkTo from "@storybook/addon-links/react";
 
-import { HvProvider } from "@hitachivantara/uikit-react-core";
+import { HvProvider, HvScopedCssBaseline } from "@hitachivantara/uikit-react-core";
 import { createTheme } from "@material-ui/core/styles";
 
 import SpacingUsage from "./SpacingUsage";
@@ -27,14 +27,18 @@ The UI Kit components provides the two Design System themes: **Dawn** and **Wick
 <Story name="Main">
   <div style={{ display: "flex", flexWrap: "wrap" }}>
     <HvProvider uikitTheme="dawn" generateClassNameOptions={{ seed: "dawn" }} disableCssBaseline>
-      <ThemePreviewMix />
+      <HvScopedCssBaseline>
+        <ThemePreviewMix />
+      </HvScopedCssBaseline>
     </HvProvider>
     <HvProvider
       uiKitTheme="wicked"
       generateClassNameOptions={{ seed: "wicked" }}
       disableCssBaseline
     >
-      <ThemePreviewMix />
+      <HvScopedCssBaseline>
+        <ThemePreviewMix />
+      </HvScopedCssBaseline>
     </HvProvider>
   </div>
 </Story>

--- a/doc/Foundation/Typography/Typography.stories.mdx
+++ b/doc/Foundation/Typography/Typography.stories.mdx
@@ -29,7 +29,7 @@ You will **need to ensure** that the font link is referenced in your application
 The **Open Sans font** can be loaded from a CDN, using the following markup:
 
 ```html
-<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,400,500,600" />
+<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:400,600" />
 ```
 
 <Preview>

--- a/doc/GetStarted/ComponentVersioningTable/coreComponentTableConfig.js
+++ b/doc/GetStarted/ComponentVersioningTable/coreComponentTableConfig.js
@@ -32,7 +32,7 @@ const coreComponentTableConfig = [
               <LinkTo
                 kind={cellData.row._original.path}
                 story={cellData.row._original.story || "Main"}
-                className="sbdocs-a"
+                className="sbdocs sbdocs-a"
               >
                 {cellData.row._original.component}
               </LinkTo>

--- a/doc/GetStarted/ComponentVersioningTable/labComponentTableConfig.js
+++ b/doc/GetStarted/ComponentVersioningTable/labComponentTableConfig.js
@@ -17,7 +17,7 @@ const labComponentTableConfig = [
               <LinkTo
                 kind={cellData.row._original.path}
                 story={cellData.row._original.story || "Main"}
-                className="sbdocs-a"
+                className="sbdocs sbdocs-a"
               >
                 {cellData.row._original.component}
               </LinkTo>

--- a/doc/GetStarted/Instalation.stories.mdx
+++ b/doc/GetStarted/Instalation.stories.mdx
@@ -54,7 +54,7 @@ function App({ children }) {
 ```
 
 Optionally, you can configure the active theme and locale, among others.
-Check <LinkTo kind="Foundation/Provider" story="Main" className="sbdocs-a">the Provider's API documentation</LinkTo> for further details.
+Check <LinkTo kind="Foundation/Provider" story="Main" className="sbdocs sbdocs-a">the Provider's API documentation</LinkTo> for further details.
 
 2. Now you can start using components:
 
@@ -65,3 +65,6 @@ function Example() {
   return <HvButton>Hello from UI Kit!</HvButton>;
 }
 ```
+
+3. For a fully functioning setup, you'll also need to setup a <LinkTo kind="Foundation/CSS Baseline" story="Page" className="sbdocs sbdocs-a">CSS Baseline</LinkTo>
+   and ensure <LinkTo kind="Foundation/Typography" story="Description" className="sbdocs sbdocs-a">the loading of the Open Sans font</LinkTo>.

--- a/packages/core/config/jest-utils/testing-utils.js
+++ b/packages/core/config/jest-utils/testing-utils.js
@@ -8,7 +8,7 @@ import { render } from "@testing-library/react";
 import { HvProvider } from "../../src";
 
 // eslint-disable-next-line react/prop-types
-const AllTheProviders = ({ children }) => <HvProvider>{children}</HvProvider>;
+const AllTheProviders = ({ children }) => <HvProvider disableCssBaseline>{children}</HvProvider>;
 
 const customRender = (ui, options) => render(ui, { wrapper: AllTheProviders, ...options });
 

--- a/packages/core/src/ActionBar/tests/ActionBar.test.js
+++ b/packages/core/src/ActionBar/tests/ActionBar.test.js
@@ -5,7 +5,7 @@ import { HvActionBar, HvProvider } from "../..";
 
 describe("Action Bar", () => {
   const wrapper = mount(
-    <HvProvider>
+    <HvProvider disableCssBaseline>
       <Main />
     </HvProvider>
   );

--- a/packages/core/src/ActionsGeneric/tests/actionsGeneric.test.js
+++ b/packages/core/src/ActionsGeneric/tests/actionsGeneric.test.js
@@ -21,7 +21,7 @@ describe("Actions with array", () => {
 
   beforeEach(() => {
     wrapper = mount(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <ActionsGeneric
           id="actions"
           actions={actions}
@@ -70,7 +70,7 @@ describe("Actions with custom actions", () => {
   it("should render if React element", () => {
     const label = "Test";
     wrapper = mount(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <ActionsGeneric actions={<HvButton>{label}</HvButton>} />
       </HvProvider>
     );

--- a/packages/core/src/AssetInventory/CardView/tests/cardView.test.js
+++ b/packages/core/src/AssetInventory/CardView/tests/cardView.test.js
@@ -5,7 +5,7 @@ import { Main } from "../stories/CardView.stories";
 
 describe("CardView", () => {
   const wrapper = mount(
-    <HvProvider>
+    <HvProvider disableCssBaseline>
       <Main />
     </HvProvider>
   );

--- a/packages/core/src/AssetInventory/ListView/tests/listview.test.js
+++ b/packages/core/src/AssetInventory/ListView/tests/listview.test.js
@@ -11,7 +11,7 @@ describe(" AssetInventory ListView", () => {
 
   it("should be defined", () => {
     wrapper = mount(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <Main />
       </HvProvider>
     );

--- a/packages/core/src/AssetInventory/tests/assetInventory.test.js
+++ b/packages/core/src/AssetInventory/tests/assetInventory.test.js
@@ -9,7 +9,7 @@ describe("Asset Inventory ", () => {
   const MockView = (id) => <div id={id} />;
 
   const setupComponent = (props, children = <MockView id="id" />) => (
-    <HvProvider>
+    <HvProvider disableCssBaseline>
       <HvAssetInventory {...props}>{children}</HvAssetInventory>
     </HvProvider>
   );

--- a/packages/core/src/Avatar/tests/avatar.test.js
+++ b/packages/core/src/Avatar/tests/avatar.test.js
@@ -28,7 +28,7 @@ describe("Avatar ", () => {
   describe("image avatar", () => {
     it("should render a div containing an img", () => {
       const [, , rootNode] = mountAndReturnAvatarAndRootNode(
-        <HvProvider>
+        <HvProvider disableCssBaseline>
           <HvAvatar src="something.jpg" alt="Hello World!" />
         </HvProvider>
       );
@@ -44,7 +44,7 @@ describe("Avatar ", () => {
       const onError = jest.fn();
 
       const [, , rootNode] = mountAndReturnAvatarAndRootNode(
-        <HvProvider>
+        <HvProvider disableCssBaseline>
           <HvAvatar src="something.jpg" imgProps={{ onError, other: "my value" }} />
         </HvProvider>
       );
@@ -60,7 +60,7 @@ describe("Avatar ", () => {
 
     it("should not render children", () => {
       const [, , rootNode] = mountAndReturnAvatarAndRootNode(
-        <HvProvider>
+        <HvProvider disableCssBaseline>
           <HvAvatar src="something.jpg">MB</HvAvatar>
         </HvProvider>
       );
@@ -72,7 +72,7 @@ describe("Avatar ", () => {
 
     it("snapshot", async () => {
       const [, avatar] = mountAndReturnAvatarAndRootNode(
-        <HvProvider>
+        <HvProvider disableCssBaseline>
           <HvAvatar src="something.jpg" imgProps={{ onError: () => 1, other: "my value" }}>
             MB
           </HvAvatar>
@@ -86,7 +86,7 @@ describe("Avatar ", () => {
 
   describe("icon avatar", () => {
     const [, avatar, rootNode] = mountAndReturnAvatarAndRootNode(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <HvAvatar>
           <LogIn iconSize="XS" />
         </HvAvatar>
@@ -106,7 +106,7 @@ describe("Avatar ", () => {
 
   describe("letter avatar", () => {
     const [, avatar, rootNode] = mountAndReturnAvatarAndRootNode(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <HvAvatar>OT</HvAvatar>
       </HvProvider>
     );
@@ -123,7 +123,7 @@ describe("Avatar ", () => {
 
   describe("default avatar", () => {
     const [, avatar, rootNode] = mountAndReturnAvatarAndRootNode(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <HvAvatar />
       </HvProvider>
     );
@@ -142,7 +142,7 @@ describe("Avatar ", () => {
   describe("colors", () => {
     it("should inline default colors", () => {
       const [, , rootNode] = mountAndReturnAvatarAndRootNode(
-        <HvProvider>
+        <HvProvider disableCssBaseline>
           <HvAvatar />
         </HvProvider>
       );
@@ -154,7 +154,7 @@ describe("Avatar ", () => {
 
     it("should inline custom colors", () => {
       const [, , rootNode] = mountAndReturnAvatarAndRootNode(
-        <HvProvider>
+        <HvProvider disableCssBaseline>
           <HvAvatar backgroundColor="sema1" color="sema2" />
         </HvProvider>
       );
@@ -166,7 +166,7 @@ describe("Avatar ", () => {
 
     it("should set default user icon color", () => {
       const [, , rootNode] = mountAndReturnAvatarAndRootNode(
-        <HvProvider>
+        <HvProvider disableCssBaseline>
           <HvAvatar backgroundColor="sema1" color="sema2" />
         </HvProvider>
       );
@@ -177,7 +177,7 @@ describe("Avatar ", () => {
 
     it("should not inline colors when displaying an image", () => {
       const [, , rootNode] = mountAndReturnAvatarAndRootNode(
-        <HvProvider>
+        <HvProvider disableCssBaseline>
           <HvAvatar src="something.jpg" backgroundColor="sema1" color="sema2" />
         </HvProvider>
       );
@@ -192,7 +192,7 @@ describe("Avatar ", () => {
     it("should set default user icon size to size below", () => {
       const getDefaultUserIcon = (size) => {
         const [, , rootNode] = mountAndReturnAvatarAndRootNode(
-          <HvProvider>
+          <HvProvider disableCssBaseline>
             <HvAvatar size={size} />
           </HvProvider>
         );
@@ -210,7 +210,7 @@ describe("Avatar ", () => {
   describe("container", () => {
     it("should default to div", () => {
       const [, , rootNode] = mountAndReturnAvatarAndRootNode(
-        <HvProvider>
+        <HvProvider disableCssBaseline>
           <HvAvatar />
         </HvProvider>
       );
@@ -220,7 +220,7 @@ describe("Avatar ", () => {
 
     it("should support html tag", () => {
       const [, , rootNode] = mountAndReturnAvatarAndRootNode(
-        <HvProvider>
+        <HvProvider disableCssBaseline>
           <HvAvatar component="span" />
         </HvProvider>
       );
@@ -230,7 +230,7 @@ describe("Avatar ", () => {
 
     it("should support custom tag", () => {
       const [, , rootNode] = mountAndReturnAvatarAndRootNode(
-        <HvProvider>
+        <HvProvider disableCssBaseline>
           <HvAvatar component="not-standard" />
         </HvProvider>
       );
@@ -240,7 +240,7 @@ describe("Avatar ", () => {
 
     it("should support react component", () => {
       const [, , rootNode] = mountAndReturnAvatarAndRootNode(
-        <HvProvider>
+        <HvProvider disableCssBaseline>
           <HvAvatar component={HvButton} />
         </HvProvider>
       );
@@ -256,7 +256,7 @@ describe("Avatar ", () => {
       const customValue = "my value";
 
       const [, avatar] = mountAndReturnAvatarAndRootNode(
-        <HvProvider>
+        <HvProvider disableCssBaseline>
           <HvAvatar className={className} custom={customValue} />
         </HvProvider>
       );

--- a/packages/core/src/Badge/tests/badge.test.js
+++ b/packages/core/src/Badge/tests/badge.test.js
@@ -10,7 +10,7 @@ describe("Badge ", () => {
 
   beforeEach(() => {
     wrapper = shallow(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <Badge count={0} />
       </HvProvider>
     );
@@ -26,7 +26,7 @@ describe("Badge ", () => {
 
   it("should render a small dot when count>0 without showCount", () => {
     wrapper = mount(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <Badge count={12} />
       </HvProvider>
     );
@@ -41,7 +41,7 @@ describe("Badge ", () => {
 
   it("should render correctly with showCount", () => {
     wrapper = mount(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <Badge count={12} showCount />
       </HvProvider>
     );
@@ -56,7 +56,7 @@ describe("Badge ", () => {
 
   it("should render correctly with showCount and one-digit count", () => {
     wrapper = mount(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <Badge count={9} showCount />
       </HvProvider>
     );
@@ -71,7 +71,7 @@ describe("Badge ", () => {
 
   it("should render nothing when count is 0 even with showCount", () => {
     wrapper = mount(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <Badge count={0} showCount />
       </HvProvider>
     );
@@ -86,7 +86,7 @@ describe("Badge ", () => {
 
   it("should render correctly with maxCount", () => {
     wrapper = mount(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <Badge count={100} showCount />
       </HvProvider>
     );
@@ -97,7 +97,7 @@ describe("Badge ", () => {
 
   it("should render correctly with text", () => {
     wrapper = mount(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <Badge count={100} showCount text="hello" textVariant="sTitle" />
       </HvProvider>
     );
@@ -111,7 +111,7 @@ describe("Badge ", () => {
 
   it("should render correctly with svg", () => {
     wrapper = mount(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <Badge count={100} showCount icon={<Alert />} />
       </HvProvider>
     );
@@ -125,7 +125,7 @@ describe("Badge ", () => {
 
   it("should render correctly with custom label", () => {
     wrapper = mount(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <Badge label="New!" />
       </HvProvider>
     );
@@ -140,7 +140,7 @@ describe("Badge ", () => {
 
   it("should render correctly with custom one-character label", () => {
     wrapper = mount(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <Badge label="!" />
       </HvProvider>
     );
@@ -155,7 +155,7 @@ describe("Badge ", () => {
 
   it("should render custom label but not count when both are specified", () => {
     wrapper = mount(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <Badge label="New!" count={23} showCount />
       </HvProvider>
     );

--- a/packages/core/src/Banner/tests/banner.test.js
+++ b/packages/core/src/Banner/tests/banner.test.js
@@ -10,7 +10,7 @@ import iconVariant from "../../utils/iconVariant";
 
 describe("Banner ", () => {
   const wrapper = mount(
-    <HvProvider>
+    <HvProvider disableCssBaseline>
       <HvBanner id="banner" variant="default" open={false} onClose={() => {}} />
     </HvProvider>
   );
@@ -35,7 +35,7 @@ describe("Banner ", () => {
 
   it("should render the BannerContentWrapper component", () => {
     const bannerComponent = mount(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <HvBanner id="banner" variant="default" label="label" open onClose={() => {}} />
       </HvProvider>
     ).find(HvBannerContentWrapper);
@@ -44,7 +44,7 @@ describe("Banner ", () => {
 
   it("should render the icon in the component", () => {
     const iconComponent = mount(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <HvBanner id="banner" variant="error" label="label" open showIcon onClose={() => {}} />
       </HvProvider>
     ).find(Fail);
@@ -53,7 +53,7 @@ describe("Banner ", () => {
 
   it("shouldn't render the icon in the component", () => {
     const iconComponent = mount(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <HvBanner
           id="banner"
           variant="error"
@@ -69,7 +69,7 @@ describe("Banner ", () => {
 
   it("should render a custom icon in the component", () => {
     const iconComponent = mount(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <HvBanner
           id="banner"
           variant="default"
@@ -90,7 +90,7 @@ describe("Banner ", () => {
       </div>
     );
     const buttonComponent = mount(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <HvBanner
           id="banner"
           label="label"
@@ -107,7 +107,7 @@ describe("Banner ", () => {
 
   it("should render a action by passing a structure on the message", () => {
     const buttonComponent = mount(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <HvBanner
           id="banner1"
           variant="default"
@@ -134,7 +134,7 @@ describe("Banner ", () => {
       </div>
     );
     const buttonComponent = mount(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <HvBanner
           id="banner"
           variant="default"
@@ -151,7 +151,7 @@ describe("Banner ", () => {
 
   it("should render a action by passing a structure on the action container", () => {
     const buttonComponent = mount(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <HvBanner
           id="Snackbar"
           variant="default"
@@ -174,7 +174,7 @@ describe("Banner ", () => {
   it("should render with the correct offset", () => {
     const offset = 10;
     let component = mount(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <HvBanner open offset={offset} onClose={() => {}} label="label" />
       </HvProvider>
     ).find(MaterialSnackbar);
@@ -182,7 +182,7 @@ describe("Banner ", () => {
     expect(component.get(0).props.style).toEqual({ top: `${offset}px` });
 
     component = mount(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <HvBanner open offset={offset} anchorOrigin="bottom" label="label" onClose={() => {}} />
       </HvProvider>
     ).find(MaterialSnackbar);

--- a/packages/core/src/BaseInput/styles.js
+++ b/packages/core/src/BaseInput/styles.js
@@ -35,6 +35,23 @@ const styles = (theme) => ({
         border: `1px solid ${theme.hv.palette.accent.acce1}`,
       },
     },
+
+    "@global": {
+      "input:-webkit-autofill": {
+        "-webkit-box-shadow": `0 0 0px 1000px ${theme.hv.palette.atmosphere.atmo1} inset`,
+        "-webkit-text-fill-color": theme.hv.typography.normalText.color,
+      },
+
+      /* clears input's clear and reveal buttons from IE */
+      "input[type=search]::-ms-clear": { display: "none", width: 0, height: 0 },
+      "input[type=search]::-ms-reveal": { display: "none", width: 0, height: 0 },
+
+      /* clears input's clear button from Chrome */
+      "input[type=search]::-webkit-search-decoration": { display: "none" },
+      "input[type=search]::-webkit-search-cancel-button": { display: "none" },
+      "input[type=search]::-webkit-search-results-button": { display: "none" },
+      "input[type=search]::-webkit-search-results-decoration": { display: "none" },
+    },
   },
   resizable: {
     width: "auto",
@@ -190,13 +207,6 @@ const styles = (theme) => ({
     top: "31px",
     left: "2px",
     backgroundColor: theme.hv.palette.atmosphere.atmo4,
-  },
-
-  "@global": {
-    "input:-webkit-autofill": {
-      "-webkit-box-shadow": `0 0 0px 1000px ${theme.hv.palette.atmosphere.atmo1} inset`,
-      "-webkit-text-fill-color": theme.hv.typography.normalText.color,
-    },
   },
 });
 

--- a/packages/core/src/BaseInput/tests/baseinput.test.js
+++ b/packages/core/src/BaseInput/tests/baseinput.test.js
@@ -17,7 +17,7 @@ describe("Input", () => {
 
   beforeEach(async () => {
     wrapper = mount(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <BaseInput placeholder="test" inputProps={inputProps} />
       </HvProvider>
     );
@@ -38,7 +38,7 @@ describe("Input", () => {
 
   it("should disable the Base Input component", () => {
     wrapper = mount(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <BaseInput placeholder="test" disabled />
       </HvProvider>
     );
@@ -50,7 +50,7 @@ describe("Input", () => {
 
   it("should render the Input component with the multiline style", () => {
     const wrapperTextArea = mount(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <BaseInput placeholder="test" multiline />
       </HvProvider>
     );

--- a/packages/core/src/BreadCrumb/tests/breadcrumb.test.js
+++ b/packages/core/src/BreadCrumb/tests/breadcrumb.test.js
@@ -12,7 +12,7 @@ import {
 
 describe("Breadcrumb", () => {
   const wrapper = mount(
-    <HvProvider>
+    <HvProvider disableCssBaseline>
       <Main />
     </HvProvider>
   );
@@ -37,7 +37,7 @@ describe("Breadcrumb", () => {
 
   it("should create a breadcrumb with submenu", () => {
     const existsDropdownMenu = mount(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <LimitedToFivePaths />
       </HvProvider>
     ).exists("DropDownMenu");
@@ -47,7 +47,7 @@ describe("Breadcrumb", () => {
 
   it("should present always two paths", () => {
     const separatorList = mount(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <LimitedToTwoPaths />
       </HvProvider>
     ).find(DropRightXS);
@@ -57,7 +57,7 @@ describe("Breadcrumb", () => {
 
   it("should create a breadcrumb with 4 pages from url", () => {
     const separatorList = mount(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <WithURL />
       </HvProvider>
     ).find(DropRightXS);

--- a/packages/core/src/BulkActions/tests/BulkActions.test.js
+++ b/packages/core/src/BulkActions/tests/BulkActions.test.js
@@ -10,7 +10,7 @@ describe("BulkActions", () => {
 
   it("should be defined", () => {
     wrapper = mount(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <Main />
       </HvProvider>
     );
@@ -42,7 +42,7 @@ describe("BulkActions controlled with actions", () => {
 
   it("should be defined", () => {
     wrapper = mount(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <WithActions />
       </HvProvider>
     );
@@ -80,7 +80,7 @@ describe("BulkActions with selection", () => {
 
   it("should be defined", () => {
     wrapper = mount(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <HvBulkActions
           numTotal={5}
           numSelected={3}
@@ -127,7 +127,7 @@ describe("BulkActions with custom label", () => {
 
   it("should be defined", () => {
     wrapper = mount(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <HvBulkActions numTotal={5} numSelected={0} selectAllLabel={labelMock} />
       </HvProvider>
     );

--- a/packages/core/src/Calendar/CalendarHeader/tests/CalendarHeader.test.js
+++ b/packages/core/src/Calendar/CalendarHeader/tests/CalendarHeader.test.js
@@ -12,7 +12,7 @@ describe("<CalendarHeader />", () => {
 
   beforeEach(async () => {
     wrapper = mount(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <CalendarHeader id="default" value={inputDate} locale={locale} />
       </HvProvider>
     );

--- a/packages/core/src/Calendar/CalendarNavigation/ComposedNavigation/tests/composedNavigation.test.js
+++ b/packages/core/src/Calendar/CalendarNavigation/ComposedNavigation/tests/composedNavigation.test.js
@@ -9,7 +9,7 @@ describe("<Navigation />", () => {
 
   beforeEach(async () => {
     wrapper = mount(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <HvComposedNavigation locale="en" visibleYear={2020} visibleMonth={4} />
       </HvProvider>
     );

--- a/packages/core/src/Calendar/CalendarNavigation/Navigation/tests/navigation.test.js
+++ b/packages/core/src/Calendar/CalendarNavigation/Navigation/tests/navigation.test.js
@@ -17,7 +17,7 @@ describe("<Navigation />", () => {
 
   beforeEach(async () => {
     wrapper = mount(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <Navigation
           id="id1"
           onNavigatePrevious={onNavigatePreviousMock}

--- a/packages/core/src/Calendar/tests/calendar.test.js
+++ b/packages/core/src/Calendar/tests/calendar.test.js
@@ -9,7 +9,7 @@ describe("<Calendar /> with minimum configuration", () => {
 
   beforeEach(async () => {
     wrapper = mount(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <HvCalendar id="calendar" locale="en-US" />
       </HvProvider>
     );
@@ -28,7 +28,7 @@ describe("<Calendar /> with configurations", () => {
 
   beforeEach(async () => {
     wrapper = mount(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <HvCalendar
           id="default"
           value={selectedDate}

--- a/packages/core/src/Card/tests/Card.test.js
+++ b/packages/core/src/Card/tests/Card.test.js
@@ -11,7 +11,7 @@ describe("Card", () => {
 
   it("should be able to render with every property defined", () => {
     wrapper = mount(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <Main />
       </HvProvider>
     );
@@ -21,7 +21,7 @@ describe("Card", () => {
 
   it("should render all the card components", () => {
     wrapper = mount(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <AllComponents />
       </HvProvider>
     );

--- a/packages/core/src/Chart/tests/chart.test.js
+++ b/packages/core/src/Chart/tests/chart.test.js
@@ -27,7 +27,7 @@ describe("Chart withStyles", () => {
 
   beforeEach(() => {
     wrapper = mount(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <Chart data={data} layout={layout} />
       </HvProvider>
     );
@@ -43,7 +43,7 @@ describe("Chart withStyles", () => {
 
   it("should render the Chart", () => {
     wrapper = mount(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <Chart data={data} layout={layout} />
       </HvProvider>
     );
@@ -53,7 +53,7 @@ describe("Chart withStyles", () => {
 
   it("should render the Plot", () => {
     wrapper = mount(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <Chart data={data} layout={layout} />
       </HvProvider>
     );
@@ -69,7 +69,7 @@ describe("Tooltip withStyles", () => {
 
   beforeEach(() => {
     wrapper = mount(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <Tooltip data={data} coordinates={coordinates} />
       </HvProvider>
     );
@@ -88,7 +88,7 @@ describe("Tooltip withStyles", () => {
     const singleData = { title: "title", elements: [{ value: 22 }] };
 
     wrapper = mount(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <Tooltip data={singleData} coordinates={coord} useSingle />
       </HvProvider>
     );
@@ -102,7 +102,7 @@ describe("Tooltip withStyles", () => {
     const singleData = { title: "title", elements: [{ name: "name", value: 22 }] };
 
     wrapper = mount(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <Tooltip data={singleData} coordinates={coord} />
       </HvProvider>
     );

--- a/packages/core/src/Dialog/DialogActions/tests/modalActions.test.js
+++ b/packages/core/src/Dialog/DialogActions/tests/modalActions.test.js
@@ -11,7 +11,7 @@ describe("DialogActions withStyles", () => {
 
   beforeEach(async () => {
     wrapper = shallow(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <DialogActions>Dialog Content</DialogActions>
       </HvProvider>
     );
@@ -27,7 +27,7 @@ describe("DialogActions Component", () => {
 
   beforeEach(async () => {
     wrapper = shallow(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <DialogActions>Dialog Content</DialogActions>
       </HvProvider>
     );
@@ -39,7 +39,7 @@ describe("DialogActions Component", () => {
 
   it("allows external props to be added", () => {
     wrapper = shallow(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <DialogActions disableActionSpacing>Dialog Content</DialogActions>
       </HvProvider>
     );
@@ -48,7 +48,7 @@ describe("DialogActions Component", () => {
 
   it("allows external styles to be added", () => {
     wrapper = shallow(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <DialogActions
           classes={{
             root: "testClassRoot",

--- a/packages/core/src/Dialog/DialogTitle/tests/modalTitle.test.js
+++ b/packages/core/src/Dialog/DialogTitle/tests/modalTitle.test.js
@@ -11,7 +11,7 @@ describe("DialogContent withStyles", () => {
 
   beforeEach(async () => {
     wrapper = shallow(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <DialogTitle>Dialog Content</DialogTitle>
       </HvProvider>
     );
@@ -27,7 +27,7 @@ describe("DialogTitle Component", () => {
 
   beforeEach(async () => {
     wrapper = shallow(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <DialogTitle>Dialog Content</DialogTitle>
       </HvProvider>
     );

--- a/packages/core/src/Dialog/tests/Dialog.test.js
+++ b/packages/core/src/Dialog/tests/Dialog.test.js
@@ -12,7 +12,7 @@ describe("Dialog withStyles", () => {
 
   beforeEach(async () => {
     wrapper = shallow(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <Dialog>Dialog Content</Dialog>
       </HvProvider>
     );
@@ -30,7 +30,7 @@ describe("Dialog Component", () => {
 
   beforeEach(async () => {
     wrapper = shallow(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <Dialog open={open} onClose={onCloseMock}>
           Dialog Content
         </Dialog>
@@ -45,7 +45,7 @@ describe("Dialog Component", () => {
 
   it("should render correctly if closed", () => {
     wrapper = shallow(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <Dialog open={false} onClose={onCloseMock}>
           Dialog Content
         </Dialog>
@@ -56,7 +56,7 @@ describe("Dialog Component", () => {
 
   it("allows external props to be added", () => {
     wrapper = shallow(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <Dialog open={open} onClose={onCloseMock} disableBackdropClick disableEscapeKeyDown>
           Dialog Content
         </Dialog>
@@ -67,7 +67,7 @@ describe("Dialog Component", () => {
 
   it("allows external styles to be added", () => {
     wrapper = shallow(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <Dialog
           classes={{
             root: "testClassRoot",
@@ -86,7 +86,7 @@ describe("Dialog Component", () => {
 
   it("onClose should be called when close is triggered in the dialog", () => {
     wrapper = mount(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <Dialog classes={{}} open={open} onClose={onCloseMock}>
           Dialog Content
         </Dialog>

--- a/packages/core/src/Donutchart/tests/donutchart.test.js
+++ b/packages/core/src/Donutchart/tests/donutchart.test.js
@@ -19,7 +19,7 @@ const data = [
 describe("Donuchart", () => {
   describe("Regular", () => {
     const wrapper = mount(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <Main />
       </HvProvider>
     );
@@ -54,7 +54,7 @@ describe("Donuchart", () => {
 
   describe("Thin", () => {
     const wrapper = mount(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <DonutChartThin />
       </HvProvider>
     );

--- a/packages/core/src/EmptyState/tests/emptyState.test.js
+++ b/packages/core/src/EmptyState/tests/emptyState.test.js
@@ -7,7 +7,7 @@ import { CustomMessages } from "../stories/EmptyState.stories";
 
 describe("<HvEmptyState /> with String title/message", () => {
   const wrapper = mount(
-    <HvProvider>
+    <HvProvider disableCssBaseline>
       <CustomMessages />
     </HvProvider>
   );
@@ -27,7 +27,7 @@ describe("<EmptyState /> with Element title/message/action", () => {
   const MockAction = () => <div>mockAction</div>;
 
   const wrapper = mount(
-    <HvProvider>
+    <HvProvider disableCssBaseline>
       <HvEmptyState
         title={<MockTitle />}
         message={<MockMessage />}

--- a/packages/core/src/FileUploader/DropZone/tests/dropzone.test.js
+++ b/packages/core/src/FileUploader/DropZone/tests/dropzone.test.js
@@ -38,7 +38,7 @@ const onClickCallback = jest.fn();
 
 const setupComponent = (props = {}) =>
   mount(
-    <HvProvider>
+    <HvProvider disableCssBaseline>
       <DropZone id="dropzone1" {...props} />
     </HvProvider>
   );

--- a/packages/core/src/FileUploader/File/tests/file.test.js
+++ b/packages/core/src/FileUploader/File/tests/file.test.js
@@ -30,7 +30,7 @@ const onClickCallback = jest.fn();
 
 describe("File withStyles - Invalid File", () => {
   wrapper = mount(
-    <HvProvider>
+    <HvProvider disableCssBaseline>
       <File
         data={dataFail}
         onFilesAdded={() => {}}
@@ -56,7 +56,7 @@ describe("File withStyles - Invalid File", () => {
 
 describe("File withStyles - Valid File", () => {
   wrapper = mount(
-    <HvProvider>
+    <HvProvider disableCssBaseline>
       <File
         data={dataSuccess}
         unit="mb"

--- a/packages/core/src/FileUploader/FileList/tests/fileList.test.js
+++ b/packages/core/src/FileUploader/FileList/tests/fileList.test.js
@@ -34,7 +34,7 @@ const files = [
 describe("FileList withStyles", () => {
   it("should be defined", () => {
     wrapper = mount(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <FileList
           list={files}
           removeFileButtonLabel="removeFileButtonLabel"

--- a/packages/core/src/FileUploader/tests/fileuploader.test.js
+++ b/packages/core/src/FileUploader/tests/fileuploader.test.js
@@ -28,7 +28,7 @@ const onClickCallback = jest.fn();
 
 const setupComponent = (props = {}) =>
   mount(
-    <HvProvider>
+    <HvProvider disableCssBaseline>
       <FileUploader {...props} />
     </HvProvider>
   );

--- a/packages/core/src/Footer/tests/Footer.test.js
+++ b/packages/core/src/Footer/tests/Footer.test.js
@@ -10,7 +10,7 @@ describe("Footer", () => {
 
   it("should be defined", () => {
     wrapper = mount(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <Main />
       </HvProvider>
     );

--- a/packages/core/src/Forms/Adornment/tests/Adornment.test.js
+++ b/packages/core/src/Forms/Adornment/tests/Adornment.test.js
@@ -12,7 +12,7 @@ describe("Adornment", () => {
 
   beforeEach(async () => {
     wrapper = mount(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <HvAdornment icon={<CloseXS />} />
       </HvProvider>
     );

--- a/packages/core/src/Forms/CharCounter/tests/charCounter.test.js
+++ b/packages/core/src/Forms/CharCounter/tests/charCounter.test.js
@@ -12,7 +12,7 @@ describe("charCounter", () => {
 
   beforeEach(async () => {
     wrapper = mount(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <HvCharCounter id="charCounter" currentCharQuantity={0} maxCharQuantity={1500} />
       </HvProvider>
     );
@@ -33,7 +33,7 @@ describe("charCounter", () => {
 
   it("should render the char counter component overloaded", () => {
     const wrapperOverloaded = mount(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <HvCharCounter id="charCounter" currentCharQuantity={1600} maxCharQuantity={1500} />
       </HvProvider>
     );

--- a/packages/core/src/Forms/FormElement/tests/FormElement.test.js
+++ b/packages/core/src/Forms/FormElement/tests/FormElement.test.js
@@ -8,7 +8,7 @@ describe.only("FormElement ", () => {
 
   beforeEach(() => {
     wrapper = shallow(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <HvFormElement status="valid">
           <HvLabel key="1" id="test" label="First name">
             <HvBaseInput id="id-test" placeholder="Insert your name" defaultValue="George" />

--- a/packages/core/src/Forms/InfoMessage/tests/InfoMessage.test.js
+++ b/packages/core/src/Forms/InfoMessage/tests/InfoMessage.test.js
@@ -12,7 +12,7 @@ describe("InfoMessage", () => {
 
   beforeEach(async () => {
     wrapper = mount(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <HvInfoMessage id="base">test</HvInfoMessage>
       </HvProvider>
     );

--- a/packages/core/src/Forms/Label/tests/Label.test.js
+++ b/packages/core/src/Forms/Label/tests/Label.test.js
@@ -12,7 +12,7 @@ describe("Label", () => {
 
   beforeEach(async () => {
     wrapper = mount(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <HvLabel label="description" />
       </HvProvider>
     );

--- a/packages/core/src/Forms/Suggestions/tests/Suggestions.test.js
+++ b/packages/core/src/Forms/Suggestions/tests/Suggestions.test.js
@@ -10,7 +10,7 @@ describe("Suggestions", () => {
 
   it("should be defined", () => {
     wrapper = mount(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <Main />
       </HvProvider>
     );

--- a/packages/core/src/Forms/WarningText/WarningText.d.ts
+++ b/packages/core/src/Forms/WarningText/WarningText.d.ts
@@ -6,8 +6,7 @@ export type HvWarningTextClassKey =
   | "topBorder"
   | "topGutter"
   | "showText"
-  | "defaultIcon"
-  | "@global";
+  | "defaultIcon";
 
 export interface HvWarningTextProps
   extends StandardProps<React.HTMLAttributes<HTMLDivElement>, HvWarningTextClassKey> {

--- a/packages/core/src/Forms/WarningText/WarningText.js
+++ b/packages/core/src/Forms/WarningText/WarningText.js
@@ -109,10 +109,6 @@ HvWarningText.propTypes = {
      * but the text is to be not visible.
      */
     hideText: PropTypes.string,
-    /**
-     * IE11 specific styling.
-     */
-    "@global": PropTypes.string,
   }).isRequired,
   /**
    * Icon to be rendered alongside the warning text.

--- a/packages/core/src/Forms/WarningText/styles.js
+++ b/packages/core/src/Forms/WarningText/styles.js
@@ -28,12 +28,6 @@ const styles = (theme) => ({
     margin: 0,
     overflow: "hidden",
   },
-  "@global": {
-    "input:-webkit-autofill": {
-      "-webkit-box-shadow": `0 0 0px 1000px ${theme.hv.palette.atmosphere.atmo1} inset`,
-      "-webkit-text-fill-color": theme.hv.typography.normalText.color,
-    },
-  },
 });
 
 export default styles;

--- a/packages/core/src/Forms/WarningText/tests/WarningText.test.js
+++ b/packages/core/src/Forms/WarningText/tests/WarningText.test.js
@@ -12,7 +12,7 @@ describe("HelperText", () => {
 
   beforeEach(async () => {
     wrapper = mount(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <HvWarningText id="base">test</HvWarningText>
       </HvProvider>
     );

--- a/packages/core/src/Grid/tests/grid.test.js
+++ b/packages/core/src/Grid/tests/grid.test.js
@@ -6,7 +6,7 @@ import { Main } from "../stories/Grid.stories";
 
 describe("Grid", () => {
   const wrapper = mount(
-    <HvProvider>
+    <HvProvider disableCssBaseline>
       <Main />
     </HvProvider>
   );

--- a/packages/core/src/Header/Actions/tests/Actions.test.js
+++ b/packages/core/src/Header/Actions/tests/Actions.test.js
@@ -19,7 +19,7 @@ describe("Actions withStyles", () => {
 
   it("should be able to render", () => {
     wrapper = mount(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <Actions />
       </HvProvider>
     );

--- a/packages/core/src/Header/Brand/tests/Brand.test.js
+++ b/packages/core/src/Header/Brand/tests/Brand.test.js
@@ -9,7 +9,7 @@ describe("Brand withStyles", () => {
 
   it("should be able to render", () => {
     wrapper = mount(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <Brand name="test" />
       </HvProvider>
     );

--- a/packages/core/src/Header/Navigation/MenuBar/tests/MenuBar.test.js
+++ b/packages/core/src/Header/Navigation/MenuBar/tests/MenuBar.test.js
@@ -9,7 +9,7 @@ describe("MenuBar withStyles", () => {
 
   it("should be able to render", () => {
     wrapper = mount(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <MenuBar type="menubar" />
       </HvProvider>
     );

--- a/packages/core/src/Header/Navigation/MenuItem/tests/MenuItem.test.js
+++ b/packages/core/src/Header/Navigation/MenuItem/tests/MenuItem.test.js
@@ -12,7 +12,7 @@ describe("MenuItem withStyles", () => {
 
   it("should be able to render", () => {
     wrapper = mount(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <SelectionContext.Provider value={contextValue}>
           <MenuItem item={{ id: "someId ", label: "someLabel" }} type="menubar" />
         </SelectionContext.Provider>

--- a/packages/core/src/Header/Navigation/tests/Navigation.test.js
+++ b/packages/core/src/Header/Navigation/tests/Navigation.test.js
@@ -17,7 +17,7 @@ describe("Navigation withStyles", () => {
 
   it("should be able to render", () => {
     wrapper = mount(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <Navigation data={[{ id: "someId", label: "someLabel" }]} />
       </HvProvider>
     );

--- a/packages/core/src/Header/tests/Header.test.js
+++ b/packages/core/src/Header/tests/Header.test.js
@@ -9,7 +9,7 @@ describe("Header", () => {
 
   it("should be able to render", () => {
     wrapper = mount(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <Main />
       </HvProvider>
     );

--- a/packages/core/src/Input/styles.js
+++ b/packages/core/src/Input/styles.js
@@ -91,13 +91,6 @@ const styles = (theme) => ({
       display: "none",
     },
   },
-
-  "@global": {
-    "input:-webkit-autofill": {
-      "-webkit-box-shadow": `0 0 0px 1000px ${theme.hv.palette.atmosphere.atmo1} inset`,
-      "-webkit-text-fill-color": theme.hv.typography.normalText.color,
-    },
-  },
 });
 
 export default styles;

--- a/packages/core/src/Input/tests/input.test.js
+++ b/packages/core/src/Input/tests/input.test.js
@@ -25,7 +25,7 @@ describe("Input", () => {
 
   beforeEach(async () => {
     wrapper = mount(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <HvInput />
       </HvProvider>
     );
@@ -46,7 +46,7 @@ describe("Input", () => {
 
   it("should disable the Input component", () => {
     wrapper = mount(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <HvInput disabled />
       </HvProvider>
     );
@@ -58,7 +58,7 @@ describe("Input", () => {
 
   it("should pass other props to the child input component", () => {
     wrapper = mount(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <HvInput
           inputProps={{
             maxLength: 250,
@@ -71,7 +71,7 @@ describe("Input", () => {
 
   it("should show the custom map icon", () => {
     wrapper = mount(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <HvInput labels={labels} endAdornment={<Map />} />
       </HvProvider>
     );

--- a/packages/core/src/Linechart/tests/linechart.test.js
+++ b/packages/core/src/Linechart/tests/linechart.test.js
@@ -21,7 +21,7 @@ describe("Linechart", () => {
 
   beforeEach(() => {
     wrapper = mount(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <Main />
       </HvProvider>
     );
@@ -37,7 +37,7 @@ describe("Linechart", () => {
 
   it("should render the Linechart", () => {
     wrapper = mount(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <HvLinechart data={data} layout={layout} />
       </HvProvider>
     );

--- a/packages/core/src/List/tests/list.test.js
+++ b/packages/core/src/List/tests/list.test.js
@@ -34,7 +34,7 @@ describe("<List />", () => {
   describe("Single selection", () => {
     beforeEach(async () => {
       wrapper = mount(
-        <HvProvider>
+        <HvProvider disableCssBaseline>
           <HvList
             values={mockDataSingleSelection}
             onChange={onChangeMock}
@@ -53,7 +53,7 @@ describe("<List />", () => {
   describe("Single selection with selectors", () => {
     beforeEach(async () => {
       wrapper = mount(
-        <HvProvider>
+        <HvProvider disableCssBaseline>
           <HvList values={mockDataSingleSelection} useSelector />
         </HvProvider>
       );
@@ -67,7 +67,7 @@ describe("<List />", () => {
   describe("Single selection with icons", () => {
     beforeEach(async () => {
       wrapper = mount(
-        <HvProvider>
+        <HvProvider disableCssBaseline>
           <HvList values={mockDataSingleSelectionWithIcons} />
         </HvProvider>
       );

--- a/packages/core/src/ListContainer/ListItem/tests/ListItem.test.js
+++ b/packages/core/src/ListContainer/ListItem/tests/ListItem.test.js
@@ -9,7 +9,7 @@ describe("ListItem", () => {
 
   it("should be defined", () => {
     wrapper = mount(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <HvListItem />
       </HvProvider>
     );

--- a/packages/core/src/ListContainer/tests/ListContainer.test.js
+++ b/packages/core/src/ListContainer/tests/ListContainer.test.js
@@ -10,7 +10,7 @@ describe("ListContainer", () => {
 
   it("should be defined", () => {
     wrapper = mount(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <Main />
       </HvProvider>
     );

--- a/packages/core/src/Loading/tests/Loading.test.js
+++ b/packages/core/src/Loading/tests/Loading.test.js
@@ -7,7 +7,7 @@ import { Main } from "../stories/Loading.stories";
 describe("Loading", () => {
   it("should show Loading ", () => {
     const wrapper = mount(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <Main />
       </HvProvider>
     );

--- a/packages/core/src/Login/tests/Login.test.js
+++ b/packages/core/src/Login/tests/Login.test.js
@@ -12,7 +12,7 @@ describe("Login ", () => {
 
   beforeEach(async () => {
     wrapper = mount(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <Login>
           <MockFrom />
         </Login>

--- a/packages/core/src/MultiButton/tests/multibutton.test.js
+++ b/packages/core/src/MultiButton/tests/multibutton.test.js
@@ -8,7 +8,7 @@ import { Main, OnlyIcons, OnlyLabels } from "../stories/MultiButton.stories";
 
 describe("Multibutton withStyles - Icons Only", () => {
   const wrapper = mount(
-    <HvProvider>
+    <HvProvider disableCssBaseline>
       <OnlyIcons />
     </HvProvider>
   );
@@ -30,7 +30,7 @@ describe("Multibutton withStyles - Icons Only", () => {
 
 describe("Multibutton - Text Only", () => {
   const wrapper = mount(
-    <HvProvider>
+    <HvProvider disableCssBaseline>
       <OnlyLabels />
     </HvProvider>
   );
@@ -47,7 +47,7 @@ describe("Multibutton - Text Only", () => {
 
 describe("Multibutton - Text and Icons", () => {
   const wrapper = mount(
-    <HvProvider>
+    <HvProvider disableCssBaseline>
       <Main />
     </HvProvider>
   );

--- a/packages/core/src/Pagination/tests/pagination.test.js
+++ b/packages/core/src/Pagination/tests/pagination.test.js
@@ -10,7 +10,7 @@ import Select from "../Select";
 
 describe("Default Pagination", () => {
   const wrapper = mount(
-    <HvProvider>
+    <HvProvider disableCssBaseline>
       <Main />
     </HvProvider>
   );
@@ -37,7 +37,7 @@ describe("Default Pagination", () => {
 
 describe("Pagination without pageJump Input", () => {
   const wrapper = mount(
-    <HvProvider>
+    <HvProvider disableCssBaseline>
       <HvPagination showPageJump={false} />
     </HvProvider>
   );
@@ -50,7 +50,7 @@ describe("Pagination without pageJump Input", () => {
 
 describe("Pagination without pageSize select", () => {
   const wrapper = mount(
-    <HvProvider>
+    <HvProvider disableCssBaseline>
       <HvPagination showPageSizeOptions={false} />
     </HvProvider>
   );

--- a/packages/core/src/Panel/tests/Panel.test.js
+++ b/packages/core/src/Panel/tests/Panel.test.js
@@ -10,7 +10,7 @@ describe("Panel", () => {
 
   it("should be defined", () => {
     wrapper = mount(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <Main />
       </HvProvider>
     );

--- a/packages/core/src/Provider/Provider.d.ts
+++ b/packages/core/src/Provider/Provider.d.ts
@@ -63,6 +63,21 @@ export interface HvProviderProps {
    * Disables the generation of the styles.
    */
   disableStylesGeneration?: boolean;
+
+  /**
+   * Disables the generation of the baseline css styles.
+   *
+   * This will be the default behavior in the future.
+   *
+   * The application using UI Kit should be responsible for adding the baseline css styles, by
+   * either using the `<HvCssBaseline />` component, using the `<HvScopedCssBaseline />` component,
+   * or ensuring that the necessary base styles are applied.
+   *
+   * Defaults to `false`. Will be removed in the next major release.
+   *
+   * @see https://lumada-design.github.io/uikit/master/?path=/docs/foundation-css-baseline--main
+   */
+  disableCssBaseline?: boolean;
 }
 
 export default function HvProvider(props: HvProviderProps): JSX.Element | null;

--- a/packages/core/src/Provider/Provider.js
+++ b/packages/core/src/Provider/Provider.js
@@ -16,9 +16,11 @@ import {
 } from "@material-ui/core";
 import { createTheme } from "@material-ui/core/styles";
 
-import { themeBuilder, createGenerateClassName, CssBaseline, getTheme } from "../theme";
+import { themeBuilder, createGenerateClassName, HvCssBaseline, getTheme } from "../theme";
 
 import ConfigContext from "./context";
+
+let warnedOnce = false;
 
 /**
  * Augments the target theme with the differences found in the source theme.
@@ -58,8 +60,8 @@ const applyCustomTheme = (InputTargetTheme, InputSourceTheme) => {
  * <HvProvider/>
  * ```
  *
- * If several `HvProvider`'s are used, either nested or in paralel, the `generateClassNameOptions`
- * must be tweaked to avoid CSS classnames colision. Or a custom JSS's class name generator can
+ * If several `HvProvider`'s are used, either nested or in parallel, the `generateClassNameOptions`
+ * must be tweaked to avoid CSS classnames collision. Or a custom JSS's class name generator can
  * be provided via the `generateClassName` property.
  *
  * **UI Kit components will not work at all if the `HvProvider` is not configured correctly**,
@@ -79,7 +81,21 @@ const HvProvider = ({
   generateClassNameOptions,
   injectStylesFirst = false,
   disableStylesGeneration = false,
+
+  disableCssBaseline = false,
 }) => {
+  if (process.env.NODE_ENV !== "production") {
+    if (!warnedOnce && !disableCssBaseline) {
+      warnedOnce = true;
+      // eslint-disable-next-line no-console
+      console.warn(
+        "UI Kit HvProvider's automatic definition of a css styles baseline will be removed in the next major version.\n" +
+          "You can use the `disableCssBaseline` property to disable it already.\n" +
+          "See https://lumada-design.github.io/uikit/master/?path=/docs/foundation-css-baseline--main"
+      );
+    }
+  }
+
   const localeSetting = locale || (navigator?.language ?? "en-US");
 
   const rawUiKitTheme = getTheme(uiKitTheme);
@@ -100,7 +116,7 @@ const HvProvider = ({
       disableGeneration={disableStylesGeneration}
     >
       <MuiThemeProvider theme={customTheme}>
-        <CssBaseline />
+        {!disableCssBaseline && <HvCssBaseline />}
         <ConfigContext.Provider value={pConfig}>{children}</ConfigContext.Provider>
       </MuiThemeProvider>
     </MuiStylesProvider>
@@ -174,6 +190,21 @@ HvProvider.propTypes = {
    * Disables the generation of the styles.
    */
   disableStylesGeneration: PropTypes.bool,
+
+  /**
+   * Disables the generation of the baseline css styles.
+   *
+   * This will be the default behavior in the future.
+   *
+   * The application using UI Kit should be responsible for adding the baseline css styles, by
+   * either using the `<HvCssBaseline />` component, using the `<HvScopedCssBaseline />` component,
+   * or ensuring that the necessary base styles are applied.
+   *
+   * Defaults to `false`. Will be removed in the next major release.
+   *
+   * @see https://lumada-design.github.io/uikit/master/?path=/docs/foundation-css-baseline--main
+   */
+  disableCssBaseline: PropTypes.bool,
 };
 
 export default HvProvider;

--- a/packages/core/src/Provider/tests/Provider.generateClassName.test.js
+++ b/packages/core/src/Provider/tests/Provider.generateClassName.test.js
@@ -9,7 +9,7 @@ import { HvProvider, HvButton } from "../..";
 describe("HvProvider", () => {
   it("should generate global classnames by default", () => {
     const { getByRole } = render(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <HvButton>Hello</HvButton>
       </HvProvider>
     );
@@ -25,7 +25,7 @@ describe("HvProvider", () => {
     mockGenerateClassName.mockReturnValue("SameClassName");
 
     const { getByRole } = render(
-      <HvProvider generateClassName={mockGenerateClassName}>
+      <HvProvider disableCssBaseline generateClassName={mockGenerateClassName}>
         <HvButton>Hello</HvButton>
       </HvProvider>
     );
@@ -38,7 +38,7 @@ describe("HvProvider", () => {
 
   it("should use a seed", () => {
     const { getByRole } = render(
-      <HvProvider generateClassNameOptions={{ seed: "test" }}>
+      <HvProvider disableCssBaseline generateClassNameOptions={{ seed: "test" }}>
         <HvButton>Hello</HvButton>
       </HvProvider>
     );
@@ -50,7 +50,7 @@ describe("HvProvider", () => {
 
   it("should disable global classnames", () => {
     const { getByRole } = render(
-      <HvProvider generateClassNameOptions={{ disableGlobal: true }}>
+      <HvProvider disableCssBaseline generateClassNameOptions={{ disableGlobal: true }}>
         <HvButton>Hello</HvButton>
       </HvProvider>
     );
@@ -65,7 +65,10 @@ describe("HvProvider", () => {
 
   it("should disable global classnames and use a seed", () => {
     const { getByRole } = render(
-      <HvProvider generateClassNameOptions={{ seed: "test", disableGlobal: true }}>
+      <HvProvider
+        disableCssBaseline
+        generateClassNameOptions={{ seed: "test", disableGlobal: true }}
+      >
         <HvButton>Hello</HvButton>
       </HvProvider>
     );
@@ -80,7 +83,7 @@ describe("HvProvider", () => {
 
   it("should disable classnames generation", () => {
     const { getByRole } = render(
-      <HvProvider disableStylesGeneration>
+      <HvProvider disableCssBaseline disableStylesGeneration>
         <HvButton>Hello</HvButton>
       </HvProvider>
     );

--- a/packages/core/src/Provider/tests/Provider.test.js
+++ b/packages/core/src/Provider/tests/Provider.test.js
@@ -21,7 +21,11 @@ describe("Provider", () => {
   });
 
   beforeEach(async () => {
-    wrapper = shallow(<HvProvider theme={mockOverriden}>Mock</HvProvider>);
+    wrapper = shallow(
+      <HvProvider disableCssBaseline theme={mockOverriden}>
+        Mock
+      </HvProvider>
+    );
   });
 
   it("should be defined", () => {
@@ -29,7 +33,7 @@ describe("Provider", () => {
   });
 
   it("should render correctly", () => {
-    const mountedWrapper = mount(<HvProvider> Mock </HvProvider>);
+    const mountedWrapper = mount(<HvProvider disableCssBaseline> Mock </HvProvider>);
     expect(mountedWrapper).toMatchSnapshot();
   });
 
@@ -51,7 +55,7 @@ describe("Provider", () => {
   });
 
   it("should not override the hv-theme if there is no app theme defined", () => {
-    const wrapperNotOverriden = shallow(<HvProvider> Mock </HvProvider>);
+    const wrapperNotOverriden = shallow(<HvProvider disableCssBaseline> Mock </HvProvider>);
     const muiThemeProvider = wrapperNotOverriden.find(MuiThemeProvider);
     expect(muiThemeProvider.props().theme.typography.h1.fontSize).not.toEqual(
       mockOverriden.typography.h1.fontSize
@@ -63,7 +67,11 @@ describe("Provider with locale", () => {
   let wrapper;
 
   beforeEach(async () => {
-    wrapper = shallow(<HvProvider locale="en-UK">Mock</HvProvider>);
+    wrapper = shallow(
+      <HvProvider disableCssBaseline locale="en-UK">
+        Mock
+      </HvProvider>
+    );
   });
 
   it("should be defined", () => {
@@ -77,7 +85,7 @@ describe("Provider with locale", () => {
   });
 
   it("should apply en-US fallback, when locale is not configured", () => {
-    wrapper = shallow(<HvProvider>Mock</HvProvider>);
+    wrapper = shallow(<HvProvider disableCssBaseline>Mock</HvProvider>);
     const provider = wrapper.find(ConfigContext.Provider);
     expect(provider.props().value.locale).toBeDefined();
     expect(provider.props().value.locale).toBe("en-US");
@@ -89,7 +97,7 @@ describe("Provider with locale", () => {
       return <div>{locale}</div>;
     };
     wrapper = mount(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <MockComponent />
       </HvProvider>
     );
@@ -103,7 +111,7 @@ describe("Provider with locale", () => {
       return <div>{locale}</div>;
     };
     wrapper = mount(
-      <HvProvider locale="fr_CA">
+      <HvProvider disableCssBaseline locale="fr_CA">
         <MockComponent />
       </HvProvider>
     );

--- a/packages/core/src/Provider/tests/__snapshots__/Provider.test.js.snap
+++ b/packages/core/src/Provider/tests/__snapshots__/Provider.test.js.snap
@@ -1,7 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Provider should render correctly 1`] = `
-<HvProvider>
+<HvProvider
+  disableCssBaseline={true}
+>
   <StylesProvider
     disableGeneration={false}
     generateClassName={[Function]}
@@ -762,7 +764,6 @@ exports[`Provider should render correctly 1`] = `
         }
       }
     >
-      <CssBaseline />
        Mock 
     </ThemeProvider>
   </StylesProvider>

--- a/packages/core/src/SimpleGrid/tests/SimpleGrid.test.js
+++ b/packages/core/src/SimpleGrid/tests/SimpleGrid.test.js
@@ -17,7 +17,7 @@ export default {
 describe("SimplelGrid", () => {
   it("correct render children", () => {
     const { getByTestId } = render(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <SimpleGrid data-testid="ancestor">
           <p data-testid="descendant">Hello world</p>
         </SimpleGrid>

--- a/packages/core/src/Snackbar/tests/snackbar.test.js
+++ b/packages/core/src/Snackbar/tests/snackbar.test.js
@@ -10,7 +10,7 @@ import { HvButton, HvProvider, HvSnackbar, HvSnackbarContent } from "../..";
 
 describe("Snackbar ", () => {
   const wrapper = mount(
-    <HvProvider>
+    <HvProvider disableCssBaseline>
       <HvSnackbar id="Snackbar" />
     </HvProvider>
   );
@@ -35,7 +35,7 @@ describe("Snackbar ", () => {
 
   it("should render the SnackbarComponent component as the Snackbar is open", () => {
     const component = mount(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <HvSnackbar open transitionDirection="right" />
       </HvProvider>
     ).find(HvSnackbarContent);
@@ -44,7 +44,7 @@ describe("Snackbar ", () => {
 
   it("shouldn't render icon when default", () => {
     const component = mount(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <HvSnackbar open showIcon transitionDirection="up" />
       </HvProvider>
     )
@@ -56,7 +56,7 @@ describe("Snackbar ", () => {
 
   it("shouldn't render the success icon", () => {
     const component = mount(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <HvSnackbar open variant="success" showIcon={false} transitionDirection="down" />
       </HvProvider>
     )
@@ -68,7 +68,7 @@ describe("Snackbar ", () => {
 
   it("should render the success icon", () => {
     const component = mount(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <HvSnackbar open variant="success" showIcon />
       </HvProvider>
     )
@@ -80,7 +80,7 @@ describe("Snackbar ", () => {
 
   it("should render the error icon", () => {
     const component = mount(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <HvSnackbar open variant="error" showIcon />
       </HvProvider>
     )
@@ -92,7 +92,7 @@ describe("Snackbar ", () => {
 
   it("should render the custom icon", () => {
     const component = mount(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <HvSnackbar open customIcon={<Add />} />
       </HvProvider>
     )
@@ -104,7 +104,7 @@ describe("Snackbar ", () => {
 
   it("should render the action when a component is passed", () => {
     const component = mount(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <HvSnackbar open variant="success" action={<a href=" ">Event</a>} />
       </HvProvider>
     )
@@ -117,7 +117,7 @@ describe("Snackbar ", () => {
   it("should render with the correct offset", () => {
     const offset = 10;
     let component = mount(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <HvSnackbar open offset={offset} />
       </HvProvider>
     ).find(MaterialSnackbar);
@@ -125,7 +125,7 @@ describe("Snackbar ", () => {
     expect(component.get(0).props.style).toEqual({ top: `${offset}px` });
 
     component = mount(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <HvSnackbar
           open
           offset={offset}
@@ -142,7 +142,7 @@ describe("Snackbar ", () => {
 
   it("should render the action when a structure is passed", () => {
     const component = mount(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <HvSnackbar
           id="Snackbar"
           open

--- a/packages/core/src/Tab/tests/tab.test.js
+++ b/packages/core/src/Tab/tests/tab.test.js
@@ -11,7 +11,7 @@ describe("Tab withStyles", () => {
 
   beforeEach(async () => {
     wrapper = mount(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <Tab label="Clickable Tab" />
       </HvProvider>
     );

--- a/packages/core/src/Table/tests/table.test.js
+++ b/packages/core/src/Table/tests/table.test.js
@@ -10,6 +10,9 @@ import { CustomEmpty } from "../stories/Table.stories";
 
 /* eslint-disable no-console */
 
+// eslint-disable-next-line react/prop-types
+const HvProviderWrapper = ({ children }) => <HvProvider disableCssBaseline>{children}</HvProvider>;
+
 describe("Hv Table", () => {
   let wrapper;
 
@@ -38,7 +41,7 @@ describe("Hv Table", () => {
       console.warn = jest.fn();
 
       wrapper = mount(
-        <HvProvider>
+        <HvProvider disableCssBaseline>
           <HvTable
             columns={[{ id: 1, headerText: "test 1", accessor: "t1" }]}
             data={[{ t1: "test1" }, { t1: "test2" }, { t1: "test3" }]}
@@ -80,7 +83,7 @@ describe("Hv Table", () => {
 
     it("and if 'columns' is available it is rendered", () => {
       wrapper = mount(
-        <HvProvider>
+        <HvProvider disableCssBaseline>
           <HvTable
             columns={[{ id: 1, headerText: "test 1", accessor: "t1" }]}
             data={[{ t1: "test1" }, { t1: "test2" }, { t1: "test3" }]}
@@ -94,7 +97,7 @@ describe("Hv Table", () => {
 
     it("and if 'columns' is not empty, columns are displayed", () => {
       wrapper = mount(
-        <HvProvider>
+        <HvProvider disableCssBaseline>
           <HvTable
             columns={[
               { id: 1, Header: "column 1" },
@@ -112,7 +115,7 @@ describe("Hv Table", () => {
 
     it("and if 'data' is provided, rows are the same length of 'data'", () => {
       wrapper = mount(
-        <HvProvider>
+        <HvProvider disableCssBaseline>
           <HvTable
             columns={[{ id: 1, headerText: "test 1", accessor: "t1" }]}
             data={[{ t1: "test1" }, { t1: "test2" }, { t1: "test3" }]}
@@ -126,7 +129,7 @@ describe("Hv Table", () => {
 
     it("and if 'pageSize' is provided and showPagination is true, defaultPageSize is set", () => {
       wrapper = mount(
-        <HvProvider>
+        <HvProvider disableCssBaseline>
           <HvTable
             columns={[]}
             data={[{ t1: "test1" }, { t1: "test2" }, { t1: "test3" }]}
@@ -148,7 +151,7 @@ describe("Hv Table", () => {
           showPagination={false}
         />,
         {
-          wrappingComponent: HvProvider,
+          wrappingComponent: HvProviderWrapper,
         }
       );
 
@@ -172,7 +175,7 @@ describe("Hv Table", () => {
           showPagination={false}
         />,
         {
-          wrappingComponent: HvProvider,
+          wrappingComponent: HvProviderWrapper,
         }
       );
 
@@ -203,7 +206,7 @@ describe("Hv Table", () => {
             onPageSizeChange={onPageSizeChange}
           />,
           {
-            wrappingComponent: HvProvider,
+            wrappingComponent: HvProviderWrapper,
           }
         );
 
@@ -216,7 +219,7 @@ describe("Hv Table", () => {
 
     it("and if 'data' is empty, don't render pagination", () => {
       wrapper = mount(
-        <HvProvider>
+        <HvProvider disableCssBaseline>
           <HvTable columns={[]} data={[]} pageSize={5} />
         </HvProvider>
       );
@@ -226,7 +229,7 @@ describe("Hv Table", () => {
 
     it("should render no data component if no data exists", () => {
       wrapper = mount(
-        <HvProvider>
+        <HvProvider disableCssBaseline>
           <HvTable columns={[]} data={[]} pageSize={5} />
         </HvProvider>
       );
@@ -236,7 +239,7 @@ describe("Hv Table", () => {
 
     it("should render a custom no data component when passed and no data exists", () => {
       wrapper = mount(
-        <HvProvider>
+        <HvProvider disableCssBaseline>
           <CustomEmpty />
         </HvProvider>
       );
@@ -247,7 +250,7 @@ describe("Hv Table", () => {
     it("should add an expander if the subElementTemplate is defined", () => {
       const subElementTemplate = () => <div />;
       wrapper = mount(
-        <HvProvider>
+        <HvProvider disableCssBaseline>
           <HvTable
             classes={{}}
             columns={column}
@@ -277,7 +280,7 @@ describe("Hv Table", () => {
         { id: 3, Header: "column 3" },
       ];
       wrapper = mount(
-        <HvProvider>
+        <HvProvider disableCssBaseline>
           <HvTable
             classes={classesToApply}
             columns={columns}
@@ -313,7 +316,7 @@ describe("Hv Table", () => {
         { id: 3, Header: "column 3" },
       ];
       wrapper = mount(
-        <HvProvider>
+        <HvProvider disableCssBaseline>
           <HvTable
             classes={classesToApply}
             columns={columns}

--- a/packages/core/src/Tabs/tests/tabs.test.js
+++ b/packages/core/src/Tabs/tests/tabs.test.js
@@ -8,7 +8,7 @@ import { Main } from "../stories/Tabs.stories";
 
 describe("Tabs", () => {
   const wrapper = mount(
-    <HvProvider>
+    <HvProvider disableCssBaseline>
       <HvTabs />
     </HvProvider>
   );
@@ -20,7 +20,7 @@ describe("Tabs", () => {
 
 describe("Compose Tabs withStyles", () => {
   const wrapper = mount(
-    <HvProvider>
+    <HvProvider disableCssBaseline>
       <Main />
     </HvProvider>
   );

--- a/packages/core/src/TagsInput/tests/tagsInput.test.js
+++ b/packages/core/src/TagsInput/tests/tagsInput.test.js
@@ -138,7 +138,7 @@ describe("TagsInput Component", () => {
 
   it("should render the label correctly", () => {
     const { getByText } = render(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <HvTagsInput id="tags-list" label="Custom label" classes={mockClasses} />
       </HvProvider>
     );
@@ -147,7 +147,7 @@ describe("TagsInput Component", () => {
 
   it("should render the text area with tags when controlled and input value is an array of strings", () => {
     const { getByText, getAllByRole } = render(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <HvTagsInput
           id="tags-list"
           label="Custom label"
@@ -166,7 +166,7 @@ describe("TagsInput Component", () => {
 
   it("should render the text area with tags when controlled and input value is an array of tags", () => {
     const { getByText, getAllByRole } = render(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <HvTagsInput
           id="tags-list"
           label="Custom label"
@@ -189,7 +189,7 @@ describe("TagsInput Component", () => {
     const onChangeSpy = jest.fn();
     const onDeleteSpy = jest.fn();
     const { getByText, getAllByRole, findAllByRole } = render(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <HvTagsInput
           id="tags-list"
           label="Custom label"
@@ -225,7 +225,7 @@ describe("TagsInput Component", () => {
     const onChangeSpy = jest.fn();
     const onAddSpy = jest.fn();
     const { getByText, getAllByRole, findAllByRole, getByRole } = render(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <HvTagsInput
           id="tags-list"
           label="Custom label"
@@ -266,7 +266,7 @@ describe("TagsInput Component", () => {
     const onChangeSpy = jest.fn();
     const onBlurSpy = jest.fn();
     const { getByText, getAllByRole, findAllByRole, getByRole } = render(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <HvTagsInput
           id="tags-list"
           label="Custom label"
@@ -299,7 +299,7 @@ describe("TagsInput Component", () => {
 
   it("should have a disabled tag if the `disabled` property is set to true", () => {
     const { queryAllByRole } = render(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <HvTagsInput
           id="tags-list"
           label="Custom label"
@@ -316,7 +316,7 @@ describe("TagsInput Component", () => {
 
   it("should not display close buttons on readOnly tags", () => {
     const { queryAllByRole } = render(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <HvTagsInput
           id="tags-list"
           label="Custom label"
@@ -335,7 +335,7 @@ describe("TagsInput Component", () => {
     const suggestionHandler = jest.fn();
 
     const { getByRole } = render(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <HvTagsInput
           id="tags-list"
           label="Custom label"

--- a/packages/core/src/TextArea/tests/textArea.test.js
+++ b/packages/core/src/TextArea/tests/textArea.test.js
@@ -11,7 +11,7 @@ describe("TextArea", () => {
 
   beforeEach(async () => {
     wrapper = shallow(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <Main />
       </HvProvider>
     );
@@ -27,7 +27,7 @@ describe("TextArea Component", () => {
 
   beforeEach(async () => {
     wrapper = shallow(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <HvTextArea rows={4} />
       </HvProvider>
     );
@@ -39,7 +39,7 @@ describe("TextArea Component", () => {
 
   it("should render the count label correctly", () => {
     const wrapperMount = mount(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <HvTextArea rows={4} defaultValue="test" middleCountLabel="of" maxCharQuantity={10} />
       </HvProvider>
     );
@@ -49,7 +49,7 @@ describe("TextArea Component", () => {
 
   it("should render the count label correctly and show the warning", () => {
     const wrapperMount = mount(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <HvTextArea rows={4} defaultValue="tests" middleCountLabel="of" maxCharQuantity={3} />
       </HvProvider>
     );
@@ -63,7 +63,7 @@ describe("TextArea Component", () => {
     expect(ref.current).toBe(null);
 
     mount(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <HvTextArea inputRef={ref} />
       </HvProvider>
     );

--- a/packages/core/src/TimePicker/PeriodPicker/tests/PeriodPicker.test.js
+++ b/packages/core/src/TimePicker/PeriodPicker/tests/PeriodPicker.test.js
@@ -15,7 +15,7 @@ describe("PeriodPicker", () => {
 
   it("should rednder correctly", () => {
     const { container } = render(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <PeriodPicker period={defaultPeriod} onChangePeriod={mockOnChangePeriod} />
       </HvProvider>
     );
@@ -24,7 +24,7 @@ describe("PeriodPicker", () => {
 
   it("should change the period after clicking the period selector", () => {
     const { getByRole, getByText, queryByText } = render(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <PeriodPicker period={defaultPeriod} onChangePeriod={mockOnChangePeriod} />
       </HvProvider>
     );

--- a/packages/core/src/TimePicker/UnitTimePicker/tests/UnitTimePicker.test.js
+++ b/packages/core/src/TimePicker/UnitTimePicker/tests/UnitTimePicker.test.js
@@ -14,20 +14,18 @@ describe("UnitTimePicker", () => {
 
   it("should render correctly", () => {
     const { container } = render(
-      <HvProvider>
-        <UnitTimePicker
-          unit={TimePickerUnits.MINUTE.type}
-          unitValue={defaultUnitValue}
-          onChangeUnitTimeValue={mockOnChangeUnitTimeValue}
-        />
-      </HvProvider>
+      <UnitTimePicker
+        unit={TimePickerUnits.MINUTE.type}
+        unitValue={defaultUnitValue}
+        onChangeUnitTimeValue={mockOnChangeUnitTimeValue}
+      />
     );
     expect(container).toMatchSnapshot();
   });
 
   it("should render the input with the correct unit value", () => {
     const { getByRole } = render(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <UnitTimePicker
           id="unittimepicker"
           unit={TimePickerUnits.MINUTE.type}

--- a/packages/core/src/TimePicker/UnitTimePicker/tests/__snapshots__/UnitTimePicker.test.js.snap
+++ b/packages/core/src/TimePicker/UnitTimePicker/tests/__snapshots__/UnitTimePicker.test.js.snap
@@ -30,11 +30,11 @@ exports[`UnitTimePicker should render correctly 1`] = `
         class="HvBaseInput-root"
       >
         <div
-          class="MuiInputBase-root-12 MuiInput-root-1 HvBaseInput-inputRoot HvInput-inputRoot HvTimePickerUnitTimePicker-unitTimeInputRoot"
+          class="MuiInputBase-root MuiInput-root HvBaseInput-inputRoot HvInput-inputRoot HvTimePickerUnitTimePicker-unitTimeInputRoot"
         >
           <input
             autocomplete="off"
-            class="MuiInputBase-input-20 MuiInput-input-8 HvBaseInput-input HvInput-input HvTimePickerUnitTimePicker-unitTimeInput"
+            class="MuiInputBase-input MuiInput-input HvBaseInput-input HvInput-input HvTimePickerUnitTimePicker-unitTimeInput"
             max="59"
             min="0"
             required=""

--- a/packages/core/src/ToggleButton/tests/toggleButton.test.js
+++ b/packages/core/src/ToggleButton/tests/toggleButton.test.js
@@ -10,7 +10,7 @@ let wrapper;
 
 describe("ToggleButton", () => {
   wrapper = mount(
-    <HvProvider>
+    <HvProvider disableCssBaseline>
       <Main />
     </HvProvider>
   );
@@ -37,7 +37,7 @@ describe("ToggleButton", () => {
     const onClickMock = jest.fn(() => "mock");
 
     wrapper = mount(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <HvToggleButton
           notSelectedIcon={<Unlock />}
           selectedIcon={<Lock />}

--- a/packages/core/src/Tooltip/tests/tooltip.test.js
+++ b/packages/core/src/Tooltip/tests/tooltip.test.js
@@ -28,7 +28,7 @@ describe("Single Line Tooltip", () => {
 
   beforeEach(async () => {
     wrapper = mount(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <HvTooltip title={<HvTypography variant="highlightText">Grid View</HvTypography>}>
           {Anchor}
         </HvTooltip>
@@ -66,7 +66,7 @@ describe("Multi Line Tooltip - No Header", () => {
 
   beforeEach(async () => {
     wrapper = mount(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <HvTooltip title={title} useSingle={false}>
           {Anchor}
         </HvTooltip>
@@ -103,7 +103,7 @@ describe("Multi Line Tooltip - With Header", () => {
 
   beforeEach(async () => {
     wrapper = mount(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <HvTooltip title={title} useSingle={false}>
           {Anchor}
         </HvTooltip>

--- a/packages/core/src/UserPreferences/Actions/tests/Actions.test.js
+++ b/packages/core/src/UserPreferences/Actions/tests/Actions.test.js
@@ -11,7 +11,7 @@ describe("Actions", () => {
 
   it("should be able to render", () => {
     wrapper = mount(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <Actions>
           <Action label="Action 1" icon={<Play />} />
           <Action label="Action 2" />

--- a/packages/core/src/UserPreferences/Options/Group/tests/group.test.js
+++ b/packages/core/src/UserPreferences/Options/Group/tests/group.test.js
@@ -10,7 +10,7 @@ describe("Group withStyles", () => {
 
   beforeEach(async () => {
     wrapper = shallow(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <Group>
           <div />
         </Group>
@@ -28,7 +28,7 @@ describe("Group withStyles", () => {
 
   it("should render the label", () => {
     wrapper = mount(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <Group id="test" label="hello">
           <div />
         </Group>

--- a/packages/core/src/UserPreferences/Options/Label/tests/label.test.js
+++ b/packages/core/src/UserPreferences/Options/Label/tests/label.test.js
@@ -10,7 +10,7 @@ describe("Label withStyles", () => {
 
   beforeEach(async () => {
     wrapper = mount(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <Label>Example</Label>
       </HvProvider>
     );

--- a/packages/core/src/UserPreferences/Options/tests/Option.test.js
+++ b/packages/core/src/UserPreferences/Options/tests/Option.test.js
@@ -11,7 +11,7 @@ describe("Options", () => {
 
   it("should be able to render", () => {
     wrapper = mount(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <Options>
           <Option label="Action 1" icon={<Play />} />
           <Option label="Action 2" />
@@ -28,7 +28,7 @@ describe("Options", () => {
     const mockFn = jest.fn();
 
     wrapper = mount(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <Options onClick={mockFn}>
           <Option label="Action 1" id="a1" icon={<Play />} />
           <Option label="Action 2" id="a2" />

--- a/packages/core/src/UserPreferences/tests/userPreferences.test.js
+++ b/packages/core/src/UserPreferences/tests/userPreferences.test.js
@@ -7,7 +7,7 @@ import { Main } from "../stories/UserPreferences.stories";
 import UserPreferences, { Action, Actions, Options, Group, Option } from "..";
 
 const setupComponent = (
-  <HvProvider>
+  <HvProvider disableCssBaseline>
     <Main />
   </HvProvider>
 );

--- a/packages/core/src/VerticalNavigation/Actions/tests/Actions.test.js
+++ b/packages/core/src/VerticalNavigation/Actions/tests/Actions.test.js
@@ -13,7 +13,7 @@ describe("Actions", () => {
 
   it("should be able to render", () => {
     wrapper = mount(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <Actions>
           <Action label="Action 1" icon={<Play />} />
           <Action label="Action 2" />

--- a/packages/core/src/VerticalNavigation/Navigation/tests/navigation.test.js
+++ b/packages/core/src/VerticalNavigation/Navigation/tests/navigation.test.js
@@ -50,7 +50,7 @@ describe("<Navigation />", () => {
 
     beforeEach(async () => {
       wrapper = mount(
-        <HvProvider>
+        <HvProvider disableCssBaseline>
           <Navigation
             aria-label="Example 1 navigation"
             selected={value}

--- a/packages/core/src/VerticalNavigation/TreeView/tests/treeview.test.js
+++ b/packages/core/src/VerticalNavigation/TreeView/tests/treeview.test.js
@@ -15,7 +15,7 @@ describe("<TreeView />", () => {
   describe("navigation tree", () => {
     beforeEach(async () => {
       wrapper = mount(
-        <HvProvider>
+        <HvProvider disableCssBaseline>
           <TreeView selected="4" onChange={onChangeMock} mode="navigation">
             <TreeViewItem icon={<Play />} nodeId="1" label="System">
               <TreeViewItem nodeId="2" label="SCPodF">
@@ -52,7 +52,7 @@ describe("<TreeView />", () => {
   describe("treeview", () => {
     beforeEach(async () => {
       wrapper = mount(
-        <HvProvider>
+        <HvProvider disableCssBaseline>
           <TreeView selected="4" onChange={onChangeMock}>
             <TreeViewItem icon={<Play />} nodeId="1" label="System">
               <TreeViewItem nodeId="2" label="SCPodF">

--- a/packages/core/src/VerticalNavigation/VerticalContainer/tests/verticalContainer.test.js
+++ b/packages/core/src/VerticalNavigation/VerticalContainer/tests/verticalContainer.test.js
@@ -9,7 +9,7 @@ const Content = <div id="test_div" />;
 
 const setupComponent = (props = {}) =>
   mount(
-    <HvProvider>
+    <HvProvider disableCssBaseline>
       <VerticalContainer id="test" {...props}>
         {Content}
       </VerticalContainer>
@@ -21,7 +21,7 @@ describe("VerticalContainer withStyles", () => {
 
   beforeEach(async () => {
     wrapper = shallow(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <VerticalContainer>{Content}</VerticalContainer>
       </HvProvider>
     );

--- a/packages/core/src/VerticalNavigation/tests/verticalnavigation.test.js
+++ b/packages/core/src/VerticalNavigation/tests/verticalnavigation.test.js
@@ -11,7 +11,7 @@ describe("<VerticalNavigation />", () => {
   let wrapper;
   describe("collapsable closed vertical navigation", () => {
     wrapper = mount(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <Main />
       </HvProvider>
     );
@@ -27,7 +27,7 @@ describe("<VerticalNavigation />", () => {
       consoleSpy.mockReset();
       console.error = consoleSpy;
       wrapper = mount(
-        <HvProvider>
+        <HvProvider disableCssBaseline>
           <Collapsable />
         </HvProvider>
       );
@@ -55,7 +55,7 @@ describe("<VerticalNavigation />", () => {
       consoleSpy.mockReset();
       console.error = consoleSpy;
       wrapper = mount(
-        <HvProvider>
+        <HvProvider disableCssBaseline>
           <HvVerticalNavigation
             isOpen
             isCollapsable={false}
@@ -91,7 +91,7 @@ describe("<VerticalNavigation />", () => {
   describe("non-collapsable open vertical navigation", () => {
     beforeEach(async () => {
       wrapper = mount(
-        <HvProvider>
+        <HvProvider disableCssBaseline>
           <HvVerticalNavigation
             isOpen={false}
             isCollapsable={false}

--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -122,7 +122,7 @@ export { default as useUniqueId } from "./useUniqueId";
 // theme
 export { default as hvTheme } from "./theme";
 export { themeBuilder, getTheme } from "./theme";
-export { HvCssBaseline } from "./theme";
+export { HvCssBaseline, HvScopedCssBaseline } from "./theme";
 
 // provider
 export { default as HvProvider } from "./Provider";

--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -122,6 +122,7 @@ export { default as useUniqueId } from "./useUniqueId";
 // theme
 export { default as hvTheme } from "./theme";
 export { themeBuilder, getTheme } from "./theme";
+export { HvCssBaseline } from "./theme";
 
 // provider
 export { default as HvProvider } from "./Provider";

--- a/packages/core/src/theme/CssBaseline.d.ts
+++ b/packages/core/src/theme/CssBaseline.d.ts
@@ -1,0 +1,1 @@
+export default function HvCssBaseline(): null;

--- a/packages/core/src/theme/CssBaseline.js
+++ b/packages/core/src/theme/CssBaseline.js
@@ -1,6 +1,6 @@
 import { makeStyles } from "@material-ui/core/styles";
 
-const html = {
+export const html = {
   WebkitFontSmoothing: "antialiased", // Antialiasing.
   MozOsxFontSmoothing: "grayscale", // Antialiasing.
   // Change from `box-sizing: content-box` so that `width`
@@ -8,7 +8,7 @@ const html = {
   boxSizing: "border-box",
 };
 
-const body = (theme) => ({
+export const body = (theme) => ({
   fontFamily: theme.hv.typography.fontFamily,
   ...theme.hv.typography.normalText,
   backgroundColor: theme.hv.palette.atmosphere.atmo2,

--- a/packages/core/src/theme/CssBaseline.js
+++ b/packages/core/src/theme/CssBaseline.js
@@ -6,6 +6,11 @@ export const html = {
   // Change from `box-sizing: content-box` so that `width`
   // is not affected by `padding` or `border`.
   boxSizing: "border-box",
+
+  // Prevent adjustments of font size after orientation changes in iOS.
+  TextSizeAdjust: "none",
+  WebkitTextSizeAdjust: "none",
+  MozTextSizeAdjust: "none",
 };
 
 export const body = (theme) => ({

--- a/packages/core/src/theme/CssBaseline.js
+++ b/packages/core/src/theme/CssBaseline.js
@@ -36,16 +36,6 @@ const useStyles = makeStyles((theme) => ({
         backgroundColor: theme.hv.palette.atmosphere.atmo3,
       },
     },
-
-    /* clears input's clear and reveal buttons from IE */
-    "input[type=search]::-ms-clear": { display: "none", width: 0, height: 0 },
-    "input[type=search]::-ms-reveal": { display: "none", width: 0, height: 0 },
-
-    /* clears input's clear button from Chrome */
-    'input[type="search"]::-webkit-search-decoration': { display: "none" },
-    'input[type="search"]::-webkit-search-cancel-button': { display: "none" },
-    'input[type="search"]::-webkit-search-results-button': { display: "none" },
-    'input[type="search"]::-webkit-search-results-decoration': { display: "none" },
   },
 }));
 

--- a/packages/core/src/theme/CssBaseline.js
+++ b/packages/core/src/theme/CssBaseline.js
@@ -16,7 +16,12 @@ export const html = {
 export const body = (theme) => ({
   fontFamily: theme.hv.typography.fontFamily,
   ...theme.hv.typography.normalText,
+
+  color: theme.hv.palette.accent.acce1,
   backgroundColor: theme.hv.palette.atmosphere.atmo2,
+
+  colorScheme: theme.hv.type,
+  accentColor: theme.hv.palette.accent.acce1,
 
   "@media print": {
     backgroundColor: "white",

--- a/packages/core/src/theme/ScopedCssBaseline.d.ts
+++ b/packages/core/src/theme/ScopedCssBaseline.d.ts
@@ -1,0 +1,13 @@
+import * as React from "react";
+import { StandardProps } from "@material-ui/core";
+
+export interface HvScopedCssBaselineProps<D extends React.ElementType = "div">
+  extends StandardProps<React.HTMLAttributes<D>, ""> {
+  /**
+   * The component used for the root node. Either a string to use a HTML element or a component.
+   * Defaults to `div`.
+   */
+  component?: React.ElementType<React.HTMLAttributes<HTMLElement>>;
+}
+
+export default function HvScopedCssBaseline(props: HvScopedCssBaselineProps): JSX.Element | null;

--- a/packages/core/src/theme/ScopedCssBaseline.js
+++ b/packages/core/src/theme/ScopedCssBaseline.js
@@ -1,0 +1,52 @@
+import * as React from "react";
+import PropTypes from "prop-types";
+import clsx from "clsx";
+
+import { makeStyles } from "@material-ui/core/styles";
+
+import { html, body } from "./CssBaseline";
+
+const useStyles = makeStyles((theme) => ({
+  /* Styles applied to the root element. */
+  root: {
+    ...html,
+    ...body(theme),
+    "& *, & *::before, & *::after": {
+      boxSizing: "inherit",
+    },
+    "& strong, & b": {
+      fontWeight: theme.hv.typography.highlightText.fontWeight,
+    },
+  },
+}));
+
+const ScopedCssBaseline = React.forwardRef(function ScopedCssBaseline(props, ref) {
+  const { component: RootComponent = "div", className, children, ...other } = props;
+
+  const classes = useStyles();
+
+  return (
+    <RootComponent className={clsx(classes.root, className)} ref={ref} {...other}>
+      {children}
+    </RootComponent>
+  );
+});
+
+ScopedCssBaseline.propTypes = {
+  /**
+   * The content of the component.
+   */
+  children: PropTypes.node,
+  /**
+   * The component used for the root node.
+   * Either a string to use a HTML element or a component.
+   * Defaults to `div`.
+   */
+  component: PropTypes.elementType,
+  /**
+   * @ignore
+   */
+  className: PropTypes.string,
+};
+
+export default ScopedCssBaseline;

--- a/packages/core/src/theme/index.d.ts
+++ b/packages/core/src/theme/index.d.ts
@@ -149,4 +149,4 @@ export function getTheme(theme: string): object;
 export default Theme;
 
 export { default as createGenerateClassName } from "./createGenerateClassName";
-export { default as CssBaseline } from "./CssBaseline";
+export { default as HvCssBaseline } from "./CssBaseline";

--- a/packages/core/src/theme/index.d.ts
+++ b/packages/core/src/theme/index.d.ts
@@ -150,3 +150,4 @@ export default Theme;
 
 export { default as createGenerateClassName } from "./createGenerateClassName";
 export { default as HvCssBaseline } from "./CssBaseline";
+export { default as HvScopedCssBaseline } from "./ScopedCssBaseline";

--- a/packages/core/src/theme/index.js
+++ b/packages/core/src/theme/index.js
@@ -76,7 +76,7 @@ const themeBuilder = (theme) => {
 const defaultTheme = themeBuilder(getTheme("dawn"));
 
 export { default as createGenerateClassName } from "./createGenerateClassName";
-export { default as CssBaseline } from "./CssBaseline";
+export { default as HvCssBaseline } from "./CssBaseline";
 export { getTheme };
 
 export { themeBuilder };

--- a/packages/core/src/theme/index.js
+++ b/packages/core/src/theme/index.js
@@ -77,6 +77,7 @@ const defaultTheme = themeBuilder(getTheme("dawn"));
 
 export { default as createGenerateClassName } from "./createGenerateClassName";
 export { default as HvCssBaseline } from "./CssBaseline";
+export { default as HvScopedCssBaseline } from "./ScopedCssBaseline";
 export { getTheme };
 
 export { themeBuilder };

--- a/packages/lab/config/jest-utils/testing-utils.js
+++ b/packages/lab/config/jest-utils/testing-utils.js
@@ -8,7 +8,7 @@ import { render } from "@testing-library/react";
 import { HvProvider } from "@hitachivantara/uikit-react-core";
 
 // eslint-disable-next-line react/prop-types
-const AllTheProviders = ({ children }) => <HvProvider>{children}</HvProvider>;
+const AllTheProviders = ({ children }) => <HvProvider disableCssBaseline>{children}</HvProvider>;
 
 const customRender = (ui, options) => render(ui, { wrapper: AllTheProviders, ...options });
 

--- a/packages/lab/src/AppSwitcherPanel/Action/tests/actions.test.js
+++ b/packages/lab/src/AppSwitcherPanel/Action/tests/actions.test.js
@@ -35,7 +35,7 @@ describe("<Action /> with description", () => {
 
   beforeEach(async () => {
     wrapper = mount(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <ActionWrapper key="mockKey" application={mockApplications} />
       </HvProvider>
     );
@@ -71,7 +71,7 @@ describe("<Action /> without description", () => {
 
   beforeEach(async () => {
     wrapper = mount(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <ActionWrapper key="mockKey" application={mockApplications} />
       </HvProvider>
     );
@@ -107,7 +107,7 @@ describe("<Action /> with an element icon", () => {
 
   beforeEach(async () => {
     wrapper = mount(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <ActionWrapper key="mockKey" application={mockApplications} />
       </HvProvider>
     );

--- a/packages/lab/src/AppSwitcherPanel/tests/appSwitcherPanel.test.js
+++ b/packages/lab/src/AppSwitcherPanel/tests/appSwitcherPanel.test.js
@@ -71,7 +71,7 @@ describe("<AppSwitcherPanel /> with minimum configuration", () => {
     console.warn = consoleWarnSpy;
 
     wrapper = mount(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <AppSwitcherPanelWithStyles {...mockAppSwitcherPanelProps} />
       </HvProvider>
     );
@@ -156,7 +156,7 @@ describe("<AppSwitcherPanel /> Applications without a name should not be rendere
     console.error = consoleErrorSpy;
     console.warn = consoleWarnSpy;
     wrapper = mount(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <AppSwitcherPanelWithStyles {...mockAppSwitcherPanelProps} />
       </HvProvider>
     );

--- a/packages/lab/src/Drawer/tests/Drawer.test.js
+++ b/packages/lab/src/Drawer/tests/Drawer.test.js
@@ -12,7 +12,7 @@ describe("HvDrawer withStyles", () => {
 
   beforeEach(async () => {
     wrapper = shallow(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <HvDrawer>Drawer Content</HvDrawer>
       </HvProvider>
     );
@@ -30,7 +30,7 @@ describe("HvDrawer Component", () => {
 
   beforeEach(async () => {
     wrapper = shallow(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <HvDrawer open={open} onClose={onCloseMock}>
           HvDrawer Content
         </HvDrawer>
@@ -45,7 +45,7 @@ describe("HvDrawer Component", () => {
 
   it("should render correctly if closed", () => {
     wrapper = shallow(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <HvDrawer open={false} onClose={onCloseMock}>
           HvDrawer Content
         </HvDrawer>
@@ -56,7 +56,7 @@ describe("HvDrawer Component", () => {
 
   it("allows external props to be added", () => {
     wrapper = shallow(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <HvDrawer
           open={open}
           onClose={onCloseMock}
@@ -72,7 +72,7 @@ describe("HvDrawer Component", () => {
 
   it("allows external styles to be added", () => {
     wrapper = shallow(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <HvDrawer
           classes={{
             root: "testClassRoot",
@@ -91,7 +91,7 @@ describe("HvDrawer Component", () => {
 
   it("onClose should be called when close is triggered in the HvDrawer", () => {
     wrapper = mount(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <HvDrawer classes={{}} open={open} onClose={onCloseMock}>
           HvDrawer Content
         </HvDrawer>

--- a/packages/lab/src/FormComposer/tests/formComposer.test.js
+++ b/packages/lab/src/FormComposer/tests/formComposer.test.js
@@ -17,7 +17,7 @@ describe("FormComposer", () => {
 
   beforeEach(() => {
     wrapper = mount(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <FormComposer groups={groups} />
       </HvProvider>
     );

--- a/packages/lab/src/NavigationAnchors/tests/navigationAnchors.test.js
+++ b/packages/lab/src/NavigationAnchors/tests/navigationAnchors.test.js
@@ -27,7 +27,7 @@ describe("User withStyles", () => {
 
   beforeEach(async () => {
     wrapper = shallow(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <NavigationAnchors options={options} />
       </HvProvider>
     );
@@ -43,7 +43,7 @@ describe("User withStyles", () => {
 
   it("should render correctly with props", () => {
     wrapper = mount(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <NavigationAnchors options={options} />
       </HvProvider>
     );
@@ -55,7 +55,7 @@ describe("User withStyles", () => {
     const onClickCallback = () => onClick();
 
     wrapper = mount(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <NavigationAnchors options={options} onClick={onClickCallback} />
       </HvProvider>
     );

--- a/packages/lab/src/Slider/tests/slider.test.js
+++ b/packages/lab/src/Slider/tests/slider.test.js
@@ -67,7 +67,7 @@ describe("Slider ", () => {
     myMock = jest.fn(() => "mock");
     console.warn = consoleWarnSpy;
     wrapper = mount(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <HvSlider knobProperties={knobProperties} defaultValues={knobPropertiesDefaults} />
       </HvProvider>
     );
@@ -92,7 +92,7 @@ describe("Slider ", () => {
 
   it("should call the format mark function", () => {
     mount(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <HvSlider
           knobProperties={knobProperties}
           defaultValues={knobPropertiesDefaults}
@@ -107,7 +107,7 @@ describe("Slider ", () => {
   // TODO: Review test on calling formatMark function
   it("shouldn't call the format mark function more than one time for each knob when the markProps exist", () => {
     mount(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <HvSlider
           markProperties={[{ position: 2, label: "asd" }]}
           knobProperties={knobProperties}
@@ -122,7 +122,7 @@ describe("Slider ", () => {
 
   it("should define the start of the range with the passed value", () => {
     mount(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <HvSlider
           minPointValue={15}
           knobProperties={knobProperties}
@@ -137,7 +137,7 @@ describe("Slider ", () => {
 
   it("should define the end of the range with the passed value", () => {
     mount(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <HvSlider
           maxPointValue={87}
           knobProperties={knobProperties}
@@ -152,7 +152,7 @@ describe("Slider ", () => {
 
   it("should define the end of the range with the passed value", () => {
     mount(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <HvSlider
           divisionQuantity={87}
           knobProperties={knobProperties}
@@ -168,7 +168,7 @@ describe("Slider ", () => {
 
   it("should call onBefore method just once", () => {
     const myMount = mount(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <HvSlider
           divisionQuantity={87}
           knobProperties={knobProperties}
@@ -187,7 +187,7 @@ describe("Slider ", () => {
 
   it("should call onAfter method just once", () => {
     const myMount = mount(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <HvSlider
           divisionQuantity={87}
           knobProperties={knobProperties}
@@ -213,7 +213,7 @@ describe("Slider ", () => {
     };
 
     const myMount = mount(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <HvSlider
           maxPointValue={1}
           knobProperties={knobPropertiesScaled}
@@ -233,7 +233,7 @@ describe("Slider ", () => {
     const onChangeMock = jest.fn(() => "mock");
 
     const myMount = mount(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <HvSlider
           knobProperties={knobProperties}
           defaultValues={knobPropertiesDefaults}

--- a/packages/lab/src/Table/stories/TableColumnRenderers.stories.mdx
+++ b/packages/lab/src/Table/stories/TableColumnRenderers.stories.mdx
@@ -21,7 +21,8 @@ import {
 <Meta title="Lab/Table Column Renderers" />
 
 # Table column renderers
-The UI Kit library provides a collection of utility functions that, together with the <LinkTo kind="Lab/Table Hooks" story="Main" className="sbdocs-a">Table Hooks</LinkTo>, 
+
+The UI Kit library provides a collection of utility functions that, together with the <LinkTo kind="Lab/Table Hooks" story="Main" className="sbdocs sbdocs-a">Table Hooks</LinkTo>,
 ease the setup of common column configurations, including the render function, alignment, missing data fallbacks and cell overflow.
 
 They add a set of out of the box features, not meant to be 100% feature complete, but instead, ease the majority of use-cases we have been encountering. If you need any customization or extension to these renderers, please feel free to copy and customize them.

--- a/packages/lab/src/Table/stories/TableHooks.stories.mdx
+++ b/packages/lab/src/Table/stories/TableHooks.stories.mdx
@@ -12,7 +12,7 @@ import * as stories from "./TableHooks.stories.js";
 
 # Table hooks
 
-The UI Kit library provides a collection of **custom hooks** that ease the integration with the <LinkTo kind="Lab/Table" story="Main" className="sbdocs-a">HvTable elements</LinkTo> and allows more advanced use cases and better data handling.
+The UI Kit library provides a collection of **custom hooks** that ease the integration with the <LinkTo kind="Lab/Table" story="Main" className="sbdocs sbdocs-a">HvTable elements</LinkTo> and allows more advanced use cases and better data handling.
 
 Our custom hooks are built on top of [React Table](https://react-table.tanstack.com) which is an "headless" UI utility library to build data tables while retaining control over markup and styles. It consists of a collection of, lightweight, composable and extensible custom React hooks.
 

--- a/packages/lab/src/Tag/tests/tag.test.js
+++ b/packages/lab/src/Tag/tests/tag.test.js
@@ -22,7 +22,7 @@ describe("HvTags", () => {
 
     it("Default", () => {
       const { container } = render(
-        <HvProvider>
+        <HvProvider disableCssBaseline>
           <Default />
         </HvProvider>
       );
@@ -34,7 +34,7 @@ describe("HvTags", () => {
     });
     it("renders a tag as expected", () => {
       const { container, getByText } = render(
-        <HvProvider>
+        <HvProvider disableCssBaseline>
           <Default />
         </HvProvider>
       );

--- a/packages/lab/src/TimeAgo/tests/TimeAgo.compat.test.js
+++ b/packages/lab/src/TimeAgo/tests/TimeAgo.compat.test.js
@@ -44,7 +44,7 @@ describe("TimeAgo", () => {
 
     jest.useFakeTimers();
     const wrapper = mount(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <HvTimeAgo timestamp={dateNow} />
       </HvProvider>
     );
@@ -70,7 +70,7 @@ describe("TimeAgo", () => {
     // eslint-disable-next-line react/prop-types
     const mockRenderComponent = ({ children }) => <div>{children}</div>;
     const wrapper = mount(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <HvTimeAgo timestamp={dateNow} component={mockRenderComponent} />
       </HvProvider>
     );
@@ -94,7 +94,7 @@ describe("TimeAgo", () => {
 
     jest.useFakeTimers();
     const wrapper = mount(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <HvTimeAgo timestamp={dateNow} />
       </HvProvider>
     );
@@ -122,7 +122,7 @@ describe("TimeAgo", () => {
     formatTimeAgo.mockImplementation(formatTimeAgoMockSeconds);
 
     const wrapper = mount(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <HvTimeAgo timestamp={dateNow} showSeconds />
       </HvProvider>
     );
@@ -138,7 +138,7 @@ describe("TimeAgo", () => {
 
   it("should render a Typography with a dash when timestamp is not defined", () => {
     const wrapper = mount(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <HvTimeAgo />
       </HvProvider>
     );

--- a/packages/lab/src/TimeAgo/tests/TimeAgo.test.js
+++ b/packages/lab/src/TimeAgo/tests/TimeAgo.test.js
@@ -19,7 +19,7 @@ describe("TimeAgo without timestamp", () => {
 
   it("should be defined", () => {
     wrapper = render(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <HvTimeAgo />
       </HvProvider>
     );
@@ -28,7 +28,7 @@ describe("TimeAgo without timestamp", () => {
 
   it("should render the emptyElement", () => {
     wrapper = render(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <HvTimeAgo />
       </HvProvider>
     );
@@ -40,7 +40,7 @@ describe("TimeAgo without timestamp", () => {
   it("should render the custom emptyElement", () => {
     const MOCK_EMPTY = "EMPTY";
     wrapper = render(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <HvTimeAgo emptyElement={MOCK_EMPTY} />
       </HvProvider>
     );
@@ -55,7 +55,7 @@ describe("TimeAgo with timestamp", () => {
 
   it("should be defined", () => {
     const { container } = render(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <HvTimeAgo timestamp={timestamp} />
       </HvProvider>
     );
@@ -65,7 +65,7 @@ describe("TimeAgo with timestamp", () => {
 
   it("should contain the relative time", () => {
     const { getByText } = render(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <HvTimeAgo timestamp={timestamp} />
       </HvProvider>
     );
@@ -80,7 +80,7 @@ describe("TimeAgo with custom Button element", () => {
 
   it("should be defined", () => {
     const { container } = render(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <HvTimeAgo timestamp={timestamp} component={HvButton} />
       </HvProvider>
     );
@@ -90,7 +90,7 @@ describe("TimeAgo with custom Button element", () => {
 
   it("should render the Button", () => {
     const { getByRole } = render(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <HvTimeAgo timestamp={timestamp} component={HvButton} />
       </HvProvider>
     );

--- a/packages/lab/src/TimePicker/PeriodPicker/tests/PeriodPicker.test.js
+++ b/packages/lab/src/TimePicker/PeriodPicker/tests/PeriodPicker.test.js
@@ -15,7 +15,7 @@ describe("PeriodPicker", () => {
   beforeEach(async () => {
     mockOnChangePeriod = jest.fn();
     wrapper = mount(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <PeriodPicker period={defaultPeriod} onChangePeriod={mockOnChangePeriod} />
       </HvProvider>
     );

--- a/packages/lab/src/TimePicker/UnitTimePicker/tests/UnitTimePicker.test.js
+++ b/packages/lab/src/TimePicker/UnitTimePicker/tests/UnitTimePicker.test.js
@@ -16,7 +16,7 @@ describe("UnitTimePicker", () => {
   beforeEach(async () => {
     mockOnChangeUnitTimeValue = jest.fn();
     wrapper = mount(
-      <HvProvider>
+      <HvProvider disableCssBaseline>
         <UnitTimePicker
           unit={TimePickerUnits.MINUTE.type}
           unitValue={defaultUnitValue}

--- a/packages/lab/src/TimePicker/tests/TimePicker.test.js
+++ b/packages/lab/src/TimePicker/tests/TimePicker.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import React from "react";
 
 import { render } from "testing-utils";


### PR DESCRIPTION
For reference, this is what
```jsx
<>
  <HvProvider uikitTheme="dawn" generateClassNameOptions={{ seed: "dawn" }}>
    <ThemePreviewMix />
  </HvProvider>

  <HvProvider uiKitTheme="wicked" generateClassNameOptions={{ seed: "wicked" }}>
    <ThemePreviewMix />
  </HvProvider>
</>
```
looks like:
![image](https://user-images.githubusercontent.com/209365/171438100-dcb8b3e1-6b08-4927-8fb5-06075efb9df0.png)
_from https://lumada-design.github.io/uikit/master/iframe.html?id=foundation-theming--main&viewMode=story_

And what 
```jsx
<>
  <HvProvider disableCssBaseline uikitTheme="dawn" generateClassNameOptions={{ seed: "dawn" }}>
    <HvScopedCssBaseline>
      <ThemePreviewMix />
    </HvScopedCssBaseline>
  </HvProvider>

  <HvProvider disableCssBaseline uiKitTheme="wicked" generateClassNameOptions={{ seed: "wicked" }}>
    <HvScopedCssBaseline>
      <ThemePreviewMix />
    </HvScopedCssBaseline>
  </HvProvider>
</>
```
looks like:
![image](https://user-images.githubusercontent.com/209365/171438934-83e890a5-a085-4a99-8cb2-f28b7a5a9324.png)
_from  https://lumada-design.github.io/uikit/pr-2792/iframe.html?id=foundation-theming--main&viewMode=story_

The _wicked_ `background-color` no longer affects the _dawn_ container, nor the page's own background.