### PR TITLE
feat(querybuilder): allow custom attribute types

### DIFF
--- a/packages/lab/src/QueryBuilder/Context.js
+++ b/packages/lab/src/QueryBuilder/Context.js
@@ -1,6 +1,6 @@
 import { createContext } from "react";
 
-const defaultOperators = {
+export const defaultOperators = {
   numeric: [
     {
       operator: "greaterThan",
@@ -168,12 +168,12 @@ const defaultOperators = {
   ],
 };
 
-const defaultCombinators = [
+export const defaultCombinators = [
   { operand: "and", label: "AND" },
   { operand: "or", label: "OR" },
 ];
 
-const defaultLabels = {
+export const defaultLabels = {
   query: {
     delete: {
       ariaLabel: "Reset query",

--- a/packages/lab/src/QueryBuilder/Rule/Value/Value.js
+++ b/packages/lab/src/QueryBuilder/Rule/Value/Value.js
@@ -27,7 +27,8 @@ const Value = ({ id, attribute, operator, value: valueProp }) => {
       );
     }
     case "text":
-    case "textarea": {
+    case "textarea":
+    default: {
       return <TextValue id={id} value={valueProp} initialTouched={initialTouched} />;
     }
     case "dateandtime": {
@@ -39,9 +40,6 @@ const Value = ({ id, attribute, operator, value: valueProp }) => {
           initialTouched={initialTouched}
         />
       );
-    }
-    default: {
-      return null;
     }
   }
 };

--- a/packages/lab/src/QueryBuilder/index.d.ts
+++ b/packages/lab/src/QueryBuilder/index.d.ts
@@ -1,4 +1,5 @@
 export { default } from "./QueryBuilder";
 
 export * from "./QueryBuilder";
+export { defaultCombinators, defaultLabels, defaultOperators } from "./Context";
 export * from "./types";

--- a/packages/lab/src/QueryBuilder/index.js
+++ b/packages/lab/src/QueryBuilder/index.js
@@ -1,1 +1,2 @@
 export { default } from "./QueryBuilder";
+export { defaultCombinators, defaultLabels, defaultOperators } from "./Context";

--- a/packages/lab/src/QueryBuilder/stories/QueryBuilder.stories.js
+++ b/packages/lab/src/QueryBuilder/stories/QueryBuilder.stories.js
@@ -1,7 +1,7 @@
 import React, { useState, useMemo } from "react";
 
 import queryToMongo from "./queryToMongo";
-import HvQueryBuilder from "..";
+import HvQueryBuilder, { defaultOperators } from "..";
 
 export default {
   title: "Lab/QueryBuilder",
@@ -34,9 +34,18 @@ export const Main = () => {
       label: "Date & Time",
       type: "dateandtime",
     },
+    key6: {
+      label: "Custom",
+      type: "customType",
+    },
   };
 
-  return <HvQueryBuilder attributes={attributes} />;
+  const operators = {
+    ...defaultOperators,
+    customType: [...defaultOperators.text],
+  };
+
+  return <HvQueryBuilder attributes={attributes} operators={operators} />;
 };
 
 export const InitialQuery = () => {

--- a/packages/lab/src/index.js
+++ b/packages/lab/src/index.js
@@ -14,6 +14,7 @@ export { default as HvTag } from "./Tag";
 export { default as HvDrawer } from "./Drawer";
 export { default as HvColorPicker } from "./ColorPicker";
 export { default as HvQueryBuilder } from "./QueryBuilder";
+export * from "./QueryBuilder";
 export { default as HvInlineEditor } from "./InlineEditor";
 export { default as HvProgressBar } from "./ProgressBar";
 export { default as HvDotPagination } from "./DotPagination";


### PR DESCRIPTION
Allow adding custom `QueryBuilder` attribute types. For now, they will fallback to `TextValue`