### PR TITLE
fix(table): fix `HvFocus` import

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -50,17 +50,6 @@ module.exports = {
     "default-param-last": "off",
     "react/function-component-definition": "off",
     "no-restricted-exports": "off",
-    "no-restricted-imports": [
-      "error",
-      {
-        patterns: [
-          {
-            group: ["@hitachivantara/uikit-react-*/*"],
-            message: "Importing UI-Kit outside the root breaks ESM",
-          },
-        ],
-      },
-    ],
     "testing-library/render-result-naming-convention": "off",
     "react/jsx-no-useless-fragment": [
       "warn",

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -50,6 +50,17 @@ module.exports = {
     "default-param-last": "off",
     "react/function-component-definition": "off",
     "no-restricted-exports": "off",
+    "no-restricted-imports": [
+      "error",
+      {
+        patterns: [
+          {
+            group: ["@hitachivantara/uikit-react-*/*"],
+            message: "Importing UI-Kit outside the root breaks ESM",
+          },
+        ],
+      },
+    ],
     "testing-library/render-result-naming-convention": "off",
     "react/jsx-no-useless-fragment": [
       "warn",

--- a/packages/core/src/Focus/Focus.d.ts
+++ b/packages/core/src/Focus/Focus.d.ts
@@ -3,7 +3,7 @@ import { StandardProps } from "@material-ui/core";
 
 export type HvFocusStrategies = "listbox" | "menu" | "card" | "grid";
 
-export type ClassKey =
+export type HvFocusClassKey =
   | "root"
   | "selected"
   | "disabled"
@@ -15,7 +15,7 @@ export type ClassKey =
   | "focus";
 
 export interface HvFocusProps
-  extends StandardProps<React.HTMLAttributes<HTMLDivElement>, ClassKey> {
+  extends StandardProps<React.HTMLAttributes<HTMLDivElement>, HvFocusClassKey> {
   /**
    * The reference to the root element to hold all Focus' context.
    */
@@ -39,7 +39,7 @@ export interface HvFocusProps
   /**
    * Child node to set the focus.
    */
-  children: HTMLElement;
+  children: React.ReactNode;
   /**
    * Focus and navigation strategy to be used.
    */

--- a/packages/core/src/index.d.ts
+++ b/packages/core/src/index.d.ts
@@ -66,6 +66,9 @@ export * from "./FileUploader";
 export { default as HvFilterGroup } from "./FilterGroup";
 export * from "./FilterGroup";
 
+export { default as HvFocus } from "./Focus";
+export * from "./Focus";
+
 export { default as HvFooter } from "./Footer";
 export * from "./Footer";
 

--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -26,6 +26,7 @@ export { default as HvEmptyState } from "./EmptyState";
 export { default as HvFilterGroup } from "./FilterGroup";
 export { default as HvFileUploader } from "./FileUploader";
 export * from "./FileUploader";
+export { default as HvFocus } from "./Focus";
 export { default as HvFooter } from "./Footer";
 export * from "./Forms";
 

--- a/packages/lab/src/Table/TableBody/TableBody.js
+++ b/packages/lab/src/Table/TableBody/TableBody.js
@@ -3,9 +3,8 @@ import PropTypes from "prop-types";
 import clsx from "clsx";
 
 import { withStyles } from "@material-ui/core";
-import { useForkRef } from "@hitachivantara/uikit-react-core";
+import { HvFocus, useForkRef } from "@hitachivantara/uikit-react-core";
 
-import Focus from "@hitachivantara/uikit-react-core/dist/Focus";
 import TableContext from "../TableContext";
 import TableSectionContext from "../TableSectionContext";
 import styles from "./styles";
@@ -43,7 +42,7 @@ const HvTableBody = forwardRef(function HvTableBody(props, externalRef) {
         {withNavigation
           ? children.map((element) => {
               return (
-                <Focus
+                <HvFocus
                   rootRef={bodyRef}
                   key={`row-${element.key}`}
                   strategy="grid"
@@ -54,7 +53,7 @@ const HvTableBody = forwardRef(function HvTableBody(props, externalRef) {
                   selected={element.props.selected}
                 >
                   {element}
-                </Focus>
+                </HvFocus>
               );
             })
           : children}


### PR DESCRIPTION
The `@hitachivantara/uikit-react-core/dist/Focus` is breaking my tests that include an `HvTable`.

```
 FAIL  src/components/Wizard/FilterData/FilterData.test.tsx [ src/components/Wizard/FilterData/FilterData.test.tsx ]
 FAIL  src/routes/Publications/Publications.test.tsx [ src/routes/Publications/Publications.test.tsx ]
 FAIL  src/routes/PublicationsCreate/PublicationsCreate.test.tsx [ src/routes/PublicationsCreate/PublicationsCreate.test.tsx ]
 FAIL  src/routes/PublicationsEdit/PublicationsEdit.test.tsx [ src/routes/PublicationsEdit/PublicationsEdit.test.tsx ]
 FAIL  src/components/Wizard/Wizard.test.tsx [ src/components/Wizard/Wizard.test.tsx ]
 FAIL  src/components/Wizard/EnterDetails/EnterDetails.test.tsx [ src/components/Wizard/EnterDetails/EnterDetails.test.tsx ]
 FAIL  src/components/Wizard/TransformData/TransformData.test.tsx [ src/components/Wizard/TransformData/TransformData.test.tsx ]
 FAIL  src/components/common/ModifiedBy/ModifiedBy.test.tsx [ src/components/common/ModifiedBy/ModifiedBy.test.tsx ]
 FAIL  src/components/common/ParametersTable/ParametersTable.test.tsx [ src/components/common/ParametersTable/ParametersTable.test.tsx ]
 FAIL  src/components/common/Table/Table.test.tsx [ src/components/common/Table/Table.test.tsx ]
 FAIL  src/components/publications/ParametersTable/ParametersTable.test.tsx [ src/components/publications/ParametersTable/ParametersTable.test.tsx ]
 FAIL  src/components/publications/PublicationsTable/PublicationsTable.test.tsx [ src/components/publications/PublicationsTable/PublicationsTable.test.tsx ]
 FAIL  src/components/Wizard/TransformData/MapFieldsDialog/MapFieldsDialog.test.tsx [ src/components/Wizard/TransformData/MapFieldsDialog/MapFieldsDialog.test.tsx ]
 FAIL  src/components/Wizard/TransformData/SelectFieldTable/SelectFieldTable.test.tsx [ src/components/Wizard/TransformData/SelectFieldTable/SelectFieldTable.test.tsx ]
 FAIL  src/components/Wizard/TransformData/TransformationsList/TransformationsList.test.tsx [ src/components/Wizard/TransformData/TransformationsList/TransformationsList.test.tsx ]
Error: [vite-node] Failed to load @hitachivantara/uikit-react-core/dist/Focus
 ❯ async /Users/brhenriques/git/data-publisher/frontend/node_modules/@hitachivantara/uikit-react-lab/dist/modern/Table/TableBody/TableBody.js:17:31
 ❯ async /Users/brhenriques/git/data-publisher/frontend/node_modules/@hitachivantara/uikit-react-lab/dist/modern/Table/TableBody/index.js:1:256
```

`dist/*` imports should be avoided as they also cause issues with tree-shaking. 

- exported `HvFocus` in `core`
- added `eslint` rule to avoid `/dist*` imports happening again