### PR TITLE
fix(querybuilder): stable `id`/`key`

### DIFF
--- a/packages/lab/src/QueryBuilder/Rule/Rule.js
+++ b/packages/lab/src/QueryBuilder/Rule/Rule.js
@@ -42,25 +42,13 @@ const Rule = ({ id, combinator, attribute, operator, value, disabled, isInvalid 
       </HvGrid>
       {attribute != null && availableOperators > 0 && (
         <HvGrid item xs={2} lg={3}>
-          <Operator
-            key={id + combinator + attribute + operator}
-            id={id}
-            combinator={combinator}
-            attribute={attribute}
-            operator={operator}
-          />
+          <Operator id={id} combinator={combinator} attribute={attribute} operator={operator} />
         </HvGrid>
       )}
       {attribute != null && (operator != null || availableOperators === 0) && (
         <HvGrid item xs>
           {shouldShowValueInput && (
-            <Value
-              key={id + combinator + attribute + operator}
-              attribute={attribute}
-              id={id}
-              operator={operator}
-              value={value}
-            />
+            <Value attribute={attribute} id={id} operator={operator} value={value} />
           )}
         </HvGrid>
       )}

--- a/packages/lab/src/QueryBuilder/RuleGroup/RuleGroup.js
+++ b/packages/lab/src/QueryBuilder/RuleGroup/RuleGroup.js
@@ -126,7 +126,7 @@ const RuleGroup = ({ level = 0, id, combinator = "and", rules = [], classes }) =
             if ("combinator" in rule) {
               return (
                 <RuleGroup
-                  key={rule.id || Math.random()}
+                  key={rule.id ?? index}
                   level={level + 1}
                   {...rule}
                   id={rule.id}
@@ -148,7 +148,7 @@ const RuleGroup = ({ level = 0, id, combinator = "and", rules = [], classes }) =
 
             return (
               <Rule
-                key={rule.id || Math.random()}
+                key={rule.id ?? index}
                 {...rule}
                 isInvalid={isInvalid}
                 id={rule.id}

--- a/packages/lab/src/QueryBuilder/types.d.ts
+++ b/packages/lab/src/QueryBuilder/types.d.ts
@@ -30,7 +30,7 @@ export type QueryRuleValue =
   | DateTimeRange;
 
 export interface QueryRule {
-  id?: number;
+  id?: number | string;
   attribute?: string;
   operator?: string;
   value?: QueryRuleValue;


### PR DESCRIPTION
`HvQueryBuilder` behaves _strangely_ when no `id`s are passed to `Rule`, because of a `Math.random()` fallback on the `key`. These unstable `key` lead to different rules re-rendering updating when changing their values.

Demo: https://stackblitz.com/edit/uikit-querybuilder-key?file=src%2FApp.tsx

Video:

https://user-images.githubusercontent.com/638946/177589780-65fe197f-36b4-4e60-ad65-b88c0440f1ff.mov


