### PR TITLE
fix(themes): remove index exports

### DIFF
--- a/packages/themes/package.json
+++ b/packages/themes/package.json
@@ -4,15 +4,6 @@
   "description": "A collection of themes for use with Hitachi Vantara Components.",
   "homepage": "https://github.com/lumada-design/hv-uikit-react",
   "license": "Apache-2.0",
-  "main": "./dist/index.js",
-  "module": "./dist/legacy/index.js",
-  "types": "dist/index.d.ts",
-  "exports": {
-    ".": {
-      "require": "./dist/index.js",
-      "import": "./dist/modern/index.js"
-    }
-  },
   "sideEffects": false,
   "author": {
     "name": "Hitachi Vantara UI Kit Team"


### PR DESCRIPTION
These exports point to non-existing files. `themes` only has a couple of `.json` and `.sass` files