### PR TITLE
build: modify build icons scprit to run on windows

### DIFF
--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -18,7 +18,7 @@
   "scripts": {
     "build": "npx npm-run-all --npm-path npm --serial clean:all svg-optimize build:*",
     "build:convert": "node ./src/svgToReact.js dir --input assets/ --output bin --force",
-    "build:copy": "npx cpy-cli 'src/IconBase.*' bin/",
+    "build:copy": "npx cpy-cli \"src/IconBase*\" \"bin\"",
     "build:babel": "npx npm-run-all --npm-path npm --parallel build:babel:*",
     "build:babel:node": "BABEL_ENV=commonjs npx babel --root-mode upward bin -d dist --extensions '.js,.jsx' --source-maps --ignore '**/tests','**/stories' --copy-files --no-copy-ignored",
     "build:babel:legacy": "BABEL_ENV=legacy npx babel --root-mode upward bin -d dist/legacy --extensions '.js,.jsx' --source-maps --ignore '**/tests','**/stories' --copy-files --no-copy-ignored",


### PR DESCRIPTION
The previous script would not work on windows.
It now should work on all machines.