### PR TITLE
docs: fix storybook config

### DIFF
--- a/.storybook/manager.js
+++ b/.storybook/manager.js
@@ -7,6 +7,7 @@ addons.setConfig({
   isFullscreen: false,
   showNav: true,
   showPanel: true,
+  showToolbar: true,
   panelPosition: "bottom",
   sidebarAnimations: true,
   previewTabs: {
@@ -17,8 +18,6 @@ addons.setConfig({
   // enable keyboard shortcuts
   // (even thou we're hidding the button)
   enableShortcuts: true,
-  // show tool bar
-  isToolshown: true,
   // display the top-level grouping as a "root" in the sidebar
   sidebar: {
     showRoots: true,

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -14,7 +14,7 @@ export const parameters = {
   actions: { argTypesRegex: "^on[A-Z].*" },
   docs: { page: DocsPage, container: DocsContainer, extractArgTypes },
   options: {
-    isToolshown: true,
+    showToolbar: true,
     storySort: {
       method: "alphabetical",
       order: [

--- a/.storybook/theme/styles/docs.js
+++ b/.storybook/theme/styles/docs.js
@@ -64,6 +64,7 @@ export const getDocsStyles = (theme) => ({
         "& .os-content>pre": {
           backgroundColor: theme.hv.palette.atmosphere.atmo1,
           borderTop: `1px solid ${theme.hv.palette.atmosphere.atmo4}`,
+          color: theme.hv.palette.accent.acce1,
         },
       },
 


### PR DESCRIPTION
After upgrading SB for latest version we got two problems:

1. The theme was not being properly set on the preview code block;
2. The `isToolShown` options was [deprecated](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#renamed-istoolshown-to-showtoolbar) and renamed to `showToolbar `;

<img width="517" alt="Screenshot 2022-07-11 at 16 20 23" src="https://user-images.githubusercontent.com/14975353/178298843-0c251842-3cb3-4fa8-ab76-f3a44574baba.png">

