### PR TITLE
chore: make css/svg imports dynamic

### DIFF
--- a/packages/core/src/Login/Login.js
+++ b/packages/core/src/Login/Login.js
@@ -1,14 +1,32 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import clsx from "clsx";
 import PropTypes from "prop-types";
 import { withStyles } from "@material-ui/core";
 import styles from "./styles";
-import bg from "./resources/background.svg";
+
+/**
+ * Loads the default background svg image asynchronously
+ */
+function useBackground() {
+  const [svg, setSvg] = useState();
+
+  useEffect(() => {
+    const importIcon = async () => {
+      const svgModule = await import(`./resources/background.svg`);
+      setSvg(svgModule.default);
+    };
+    importIcon();
+  }, []);
+
+  return svg;
+}
 
 /**
  * Container layout for the login form.
  */
 const HvLogin = ({ id, className, classes, children, background, ...others }) => {
+  const bg = useBackground();
+
   return (
     <div
       id={id}

--- a/packages/core/src/Login/Login.js
+++ b/packages/core/src/Login/Login.js
@@ -1,38 +1,19 @@
-import React, { useEffect, useState } from "react";
+import React from "react";
 import clsx from "clsx";
 import PropTypes from "prop-types";
 import { withStyles } from "@material-ui/core";
 import styles from "./styles";
 
 /**
- * Loads the default background svg image asynchronously
- */
-function useBackground() {
-  const [svg, setSvg] = useState();
-
-  useEffect(() => {
-    const importIcon = async () => {
-      const svgModule = await import(`./resources/background.svg`);
-      setSvg(svgModule.default);
-    };
-    importIcon();
-  }, []);
-
-  return svg;
-}
-
-/**
  * Container layout for the login form.
  */
 const HvLogin = ({ id, className, classes, children, background, ...others }) => {
-  const bg = useBackground();
-
   return (
     <div
       id={id}
       className={clsx(className, classes.root)}
       style={{
-        backgroundImage: `url(${background || bg})`,
+        backgroundImage: background && `url(${background})`,
       }}
       {...others}
     >

--- a/packages/core/src/Slider/Slider.js
+++ b/packages/core/src/Slider/Slider.js
@@ -3,7 +3,6 @@ import clsx from "clsx";
 import PropTypes from "prop-types";
 import Slider from "rc-slider";
 import Tooltip from "rc-tooltip";
-import "rc-slider/assets/index.css";
 import { withStyles } from "@material-ui/core";
 import { HvFormElement, useControlled, useUniqueId, HvLabel, setId, HvWarningText } from "..";
 import validationStates from "../Forms/FormElement/validationStates";
@@ -158,6 +157,8 @@ const HvSlider = (props) => {
     }
     setValidationMessage("");
   }, [knobsPositions, requiredMessage, setValidationMessage, setValidationState]);
+
+  useEffect(() => import("rc-slider/assets/index.css"), []);
 
   useEffect(() => {
     const stepVl = calculateStepValue(maxPointValue, minPointValue, divisionQuantity);

--- a/packages/lab/src/Slider/Slider.js
+++ b/packages/lab/src/Slider/Slider.js
@@ -9,7 +9,6 @@ import { Range, Handle } from "rc-slider";
 import Tooltip from "rc-tooltip";
 import { withStyles } from "@material-ui/core";
 import KnobRing from "./KnobRing";
-import "rc-slider/assets/index.css";
 import styleCreator from "./styles";
 
 /**
@@ -101,6 +100,8 @@ class HvSlider extends React.Component {
       stepValue,
       inverseStepValue,
     };
+
+    import("rc-slider/assets/index.css");
   }
 
   static getDerivedStateFromProps(props, state) {


### PR DESCRIPTION
Hello 👋 

Our team tried updating to UI-Kit's latest release, but `vitest` tests started breaking with:

```
SyntaxError: Unexpected token '.'
 ❯ Object.compileFunction node:vm:352:18
 ❯ Object.<anonymous> node_modules/@hitachivantara/uikit-react-core/dist/Slider/Slider.js:66:1
```

This seems to have happened because: 
- with the latest `package.json` `exports` changes, `vitest` is now pointing to `./dist/index.js` instead of `./dist/modern/index.js`
- leading to the whole package being imported (as opposed to only the components we use)
- which means `HvSlider` and `HvLogin` are imported
- which have direct imports to `.css` and `.svg` files
- which we don't have any special loaders to

The same error would happen if we tried to use `HvLogin` or `HvSlider` in our codebase.

These `.css` and `.svg` imports will cause similar errors in other tools, such as NextJS ([error link](https://nextjs.org/docs/messages/css-npm)), Remix and Snowpack.

Having these imports will require applications using UI-Kit to have extra transformers to handle them, making UI-Kit not usable out-of-the-box.

As [NextJS in the linked error](https://nextjs.org/docs/messages/css-npm) suggests, libraries should avoid linking to these files directly.

This PR changes the static `import`s to dynamic, which seems to be enough for `vitest`/NextJS/Remix (those which I tested) to start working OOTB; minimising component changes.
With these changes, our `vitest` runs will start passing, and NextJS and Remix (those which I tested) should work out-of-the-box. Other tools should too.