### PR TITLE
fix(FileUploader): add missing id in type definition

### DIFF
--- a/packages/core/src/FileUploader/FileUploader.d.ts
+++ b/packages/core/src/FileUploader/FileUploader.d.ts
@@ -19,6 +19,10 @@ export type HvFileUploaderClassKey = "root";
 export interface FileUploaderProps
   extends StandardProps<React.HTMLAttributes<HTMLDivElement>, HvFileUploaderClassKey> {
   /**
+   * Id to be applied to the root node.
+   */
+  id: string;
+  /**
    * An object containing all the labels.
    */
   labels?: FileUploaderLabelsProp;

--- a/packages/core/src/FileUploader/FileUploader.js
+++ b/packages/core/src/FileUploader/FileUploader.js
@@ -70,7 +70,7 @@ FileUploader.propTypes = {
   /**
    * Id to be applied to the root node.
    */
-  id: PropTypes.string,
+  id: PropTypes.string.isRequired,
   /**
    * Class names to be applied.
    */


### PR DESCRIPTION
Added required id, and added id in type definition in order to prevent the `Warning: Each child in a list should have a unique "key" prop` 

The fact that is now required changes the api but it only shows a warning.