### PR TITLE
fix(FilterGroup): crash if no filters are passed

### DIFF
--- a/packages/core/src/FilterGroup/RightPanel/RightPanel.js
+++ b/packages/core/src/FilterGroup/RightPanel/RightPanel.js
@@ -20,7 +20,7 @@ const RightPanel = ({ id, className, labels }) => {
   } = useContext(FilterGroupContext);
 
   const activeGroupOptions = useMemo(
-    () => filterOptions[activeGroup].data.map((option) => option.id),
+    () => (filterOptions[activeGroup]?.data || []).map((option) => option.id),
     [filterOptions, activeGroup]
   );
 
@@ -31,7 +31,7 @@ const RightPanel = ({ id, className, labels }) => {
 
   const listValues = useMemo(
     () =>
-      filterOptions[activeGroup].data.map((option) => ({
+      (filterOptions[activeGroup]?.data || []).map((option) => ({
         ...option,
         label: option.name,
         selected: filterValues[activeGroup]?.includes(option.id),


### PR DESCRIPTION
If `HvFilterGroups`'s `filters` is `[]` the component crashes when opened, because it's assuming at least one element is present.

In our case, the filters come from the server, so there's a moment where we don't yet have filters