### PR TITLE
test(FilterGroup): typings for `filterContentProps`

### DIFF
--- a/packages/core/src/FilterGroup/FilterGroup.d.ts
+++ b/packages/core/src/FilterGroup/FilterGroup.d.ts
@@ -1,5 +1,5 @@
 import { StandardProps } from "@material-ui/core";
-import { HvFormElementProps } from "..";
+import { HvBaseDropdownProps, HvFormElementProps } from "..";
 
 export type HvFilterGroupClassKey = "root" | "labelContainer" | "label" | "description" | "error";
 
@@ -103,9 +103,9 @@ export interface HvFilterGroupProps
   height?: number | string;
 
   /**
-   * The filter content props
+   * Other props, passed to `FilterContent` and `HvBaseDropdown` components
    */
-  filterContentProps?: object;
+  filterContentProps?: Record<string, unknown> & Partial<HvBaseDropdownProps>;
 }
 
 export default function HvFilterGroup(props: HvFilterGroupProps): JSX.Element | null;


### PR DESCRIPTION
Added `Record<string, unknown>` for compatibility with the `object` that was there previously, so that `filterContentProps={{myUnknownKey: 123}}` doesn't error out