### PR TITLE
feat(FilterGroup): add configurable `emptyElement`

### DIFF
--- a/packages/core/src/FilterGroup/FilterContent/FilterContent.d.ts
+++ b/packages/core/src/FilterGroup/FilterContent/FilterContent.d.ts
@@ -1,0 +1,49 @@
+import React from "react";
+import { StandardProps } from "@material-ui/core";
+import { FilterValue, HvBaseDropdownProps } from "../..";
+
+export type HvFilterContentClassKey =
+  | "root"
+  | "panel"
+  | "actionBar"
+  | "space"
+  | "header"
+  | "baseDropdownSelection"
+  | "leftSidePanel"
+  | "rightSidePanel";
+
+export interface HvFilterContentProps
+  extends StandardProps<HvBaseDropdownProps, HvFilterContentClassKey, "onChange"> {
+  description?: React.ReactNode;
+  status?: "standBy" | "valid" | "invalid";
+
+  onChange?: (evt: React.MouseEventHandler<HTMLButtonElement>, filterValues: FilterValue[]) => void;
+  onCancel?: (evt: any[]) => void;
+  onClear?: (evt: React.MouseEventHandler<HTMLButtonElement>) => void;
+
+  labels?: {
+    applyLabel?: string;
+    cancelLabel?: string;
+    clearLabel?: string;
+    placeholder?: string;
+    searchBoxPlaceholder?: string;
+    selectAll?: string;
+    multiSelectionConjunction?: string;
+  };
+
+  horizontalPlacement?: "left" | "right";
+  disablePortal?: boolean;
+  escapeWithReference?: boolean;
+  height?: any;
+
+  /**
+   * Element to render when there are no filters
+   */
+  leftEmptyElement?: React.ReactNode;
+  /**
+   * Element to render when the selected filter has no values
+   */
+  rightEmptyElement?: React.ReactNode;
+}
+
+export default function HvFilterContent(props: HvFilterContentProps): JSX.Element | null;

--- a/packages/core/src/FilterGroup/FilterContent/FilterContent.js
+++ b/packages/core/src/FilterGroup/FilterContent/FilterContent.js
@@ -31,6 +31,8 @@ const FilterContent = ({
   escapeWithReference = true,
 
   height,
+  leftEmptyElement,
+  rightEmptyElement,
 
   ...others
 }) => {
@@ -117,8 +119,13 @@ const FilterContent = ({
     >
       <div ref={focusTarget} tabIndex={-1} />
       <div className={classes.root} style={{ height }}>
-        <LeftPanel id={id} className={classes.leftSidePanel} />
-        <RightPanel id={id} className={classes.rightSidePanel} labels={labels} />
+        <LeftPanel id={id} className={classes.leftSidePanel} emptyElement={leftEmptyElement} />
+        <RightPanel
+          id={id}
+          className={classes.rightSidePanel}
+          emptyElement={rightEmptyElement}
+          labels={labels}
+        />
       </div>
       <HvActionBar className={classes.actionBar}>
         <HvButton
@@ -180,6 +187,8 @@ FilterContent.propTypes = {
   disablePortal: PropTypes.bool,
   escapeWithReference: PropTypes.bool,
   height: PropTypes.any,
+  leftEmptyElement: PropTypes.node,
+  rightEmptyElement: PropTypes.node,
 };
 
 export default FilterContent;

--- a/packages/core/src/FilterGroup/FilterContent/index.d.ts
+++ b/packages/core/src/FilterGroup/FilterContent/index.d.ts
@@ -1,0 +1,2 @@
+export { default } from "./FilterContent";
+export * from "./FilterContent";

--- a/packages/core/src/FilterGroup/FilterGroup.d.ts
+++ b/packages/core/src/FilterGroup/FilterGroup.d.ts
@@ -1,5 +1,6 @@
 import { StandardProps } from "@material-ui/core";
-import { HvBaseDropdownProps, HvFormElementProps } from "..";
+import { HvFormElementProps } from "..";
+import { HvFilterContentProps } from "./FilterContent";
 
 export type HvFilterGroupClassKey = "root" | "labelContainer" | "label" | "description" | "error";
 
@@ -105,7 +106,7 @@ export interface HvFilterGroupProps
   /**
    * Other props, passed to `FilterContent` and `HvBaseDropdown` components
    */
-  filterContentProps?: Record<string, unknown> & Partial<HvBaseDropdownProps>;
+  filterContentProps?: Partial<HvFilterContentProps>;
 }
 
 export default function HvFilterGroup(props: HvFilterGroupProps): JSX.Element | null;

--- a/packages/core/src/FilterGroup/LeftPanel/LeftPanel.js
+++ b/packages/core/src/FilterGroup/LeftPanel/LeftPanel.js
@@ -7,29 +7,33 @@ import Counter from "../Counter";
 import useStyles from "./styles";
 import { wrapperTooltip } from "../../List/utils";
 
-const LeftPanel = ({ id, className }) => {
+const LeftPanel = ({ id, className, emptyElement }) => {
   const classes = useStyles();
   const { filterOptions, activeGroup, setActiveGroup } = useContext(FilterGroupContext);
 
   return (
     <HvPanel id={setId(id, "leftPanel")} className={clsx(className, classes.root)}>
-      <HvListContainer id={setId(id, "leftPanel-list")} condensed interactive>
-        {filterOptions.map((group, index) => {
-          const ItemText = wrapperTooltip(true, group.name, group.name);
-          return (
-            <HvListItem
-              id={group.id}
-              className={classes.filterItem}
-              key={group.name}
-              onClick={() => setActiveGroup(index)}
-              selected={filterOptions[activeGroup].id === group.id}
-              endAdornment={<Counter id={group.id} />}
-            >
-              <ItemText />
-            </HvListItem>
-          );
-        })}
-      </HvListContainer>
+      {filterOptions.length > 0 ? (
+        <HvListContainer id={setId(id, "leftPanel-list")} condensed interactive>
+          {filterOptions.map((group, index) => {
+            const ItemText = wrapperTooltip(true, group.name, group.name);
+            return (
+              <HvListItem
+                id={group.id}
+                className={classes.filterItem}
+                key={group.name}
+                onClick={() => setActiveGroup(index)}
+                selected={filterOptions[activeGroup].id === group.id}
+                endAdornment={<Counter id={group.id} />}
+              >
+                <ItemText />
+              </HvListItem>
+            );
+          })}
+        </HvListContainer>
+      ) : (
+        emptyElement
+      )}
     </HvPanel>
   );
 };
@@ -37,6 +41,7 @@ const LeftPanel = ({ id, className }) => {
 LeftPanel.propTypes = {
   id: PropTypes.string,
   className: PropTypes.string,
+  emptyElement: PropTypes.node,
 };
 
 export default LeftPanel;

--- a/packages/core/src/FilterGroup/RightPanel/RightPanel.js
+++ b/packages/core/src/FilterGroup/RightPanel/RightPanel.js
@@ -6,7 +6,7 @@ import { FilterGroupContext } from "../FilterGroupContext";
 import useStyles from "./styles";
 import { setId, HvTypography, HvList, HvInput, HvPanel, HvCheckBox } from "../..";
 
-const RightPanel = ({ id, className, labels }) => {
+const RightPanel = ({ id, className, labels, emptyElement }) => {
   const classes = useStyles();
   const [searchStr, setSearchStr] = useState("");
   const [allSelected, setAllSelected] = useState(false);
@@ -124,30 +124,36 @@ const RightPanel = ({ id, className, labels }) => {
 
   return (
     <HvPanel id={setId(id, "rightPanel")} className={clsx(className, classes.root)}>
-      <HvInput
-        id={setId(id, "search")}
-        classes={{
-          root: classes.search,
-        }}
-        type="search"
-        placeholder={labels.searchBoxPlaceholder}
-        value={searchStr}
-        onChange={(event, str) => setSearchStr(str)}
-      />
-      <SelectAll />
-      <HvList
-        key={activeGroup}
-        id={setId(id, "list")}
-        className={classes.list}
-        values={listValues}
-        multiSelect
-        useSelector
-        showSelectAll={false}
-        onChange={onChangeHandler}
-        selectable
-        condensed
-        hasTooltips
-      />
+      {listValues.length > 0 ? (
+        <>
+          <HvInput
+            id={setId(id, "search")}
+            classes={{
+              root: classes.search,
+            }}
+            type="search"
+            placeholder={labels.searchBoxPlaceholder}
+            value={searchStr}
+            onChange={(event, str) => setSearchStr(str)}
+          />
+          <SelectAll />
+          <HvList
+            key={activeGroup}
+            id={setId(id, "list")}
+            className={classes.list}
+            values={listValues}
+            multiSelect
+            useSelector
+            showSelectAll={false}
+            onChange={onChangeHandler}
+            selectable
+            condensed
+            hasTooltips
+          />
+        </>
+      ) : (
+        emptyElement
+      )}
     </HvPanel>
   );
 };
@@ -160,6 +166,7 @@ RightPanel.propTypes = {
     selectAll: PropTypes.string,
     multiSelectionConjunction: PropTypes.string,
   }),
+  emptyElement: PropTypes.node,
 };
 
 export default RightPanel;

--- a/packages/core/src/FilterGroup/stories/FilterGroup.stories.js
+++ b/packages/core/src/FilterGroup/stories/FilterGroup.stories.js
@@ -1,5 +1,7 @@
 import React, { useState } from "react";
-import HvFilterGroup from "../FilterGroup";
+import { Info } from "@hitachivantara/uikit-react-icons";
+import { HvLoading, HvEmptyState, HvSwitch, HvTypography } from "../..";
+import HvFilterGroup from "..";
 
 export default {
   title: "Widgets/Filter Group",
@@ -105,6 +107,45 @@ export const Uncontrolled = () => {
   return (
     <div style={{ width: 180 }}>
       <HvFilterGroup id="example" filters={filters} />
+    </div>
+  );
+};
+
+export const EmptyFilters = () => {
+  const [hasFilters, setHasFilters] = useState(true);
+
+  const myFilters = hasFilters
+    ? [
+        {
+          id: "1",
+          name: "Filter with data",
+          data: Array.from(Array(5), (el, i) => ({ id: `opt${i}`, name: `Option ${i}` })),
+        },
+        {
+          id: "2",
+          name: "Filter with no data",
+          data: [],
+        },
+      ]
+    : [];
+
+  const leftEmptyElement = <HvLoading label="Loading filters..." style={{ height: "100%" }} />;
+  const rightEmptyElement = (
+    <HvEmptyState icon={<Info />} message="No values found for the filter" />
+  );
+
+  return (
+    <div style={{ display: "flex", alignItems: "center", gap: 20 }}>
+      <div style={{ width: 180 }}>
+        <HvFilterGroup
+          filters={myFilters}
+          filterContentProps={{ leftEmptyElement, rightEmptyElement }}
+        />
+      </div>
+      <HvSwitch checked={hasFilters} onChange={(evt, checked) => setHasFilters(checked)} />
+      <HvTypography>
+        {hasFilters ? "Filters in loaded state" : "Filters in loading state"}
+      </HvTypography>
     </div>
   );
 };


### PR DESCRIPTION
As of now, if there are no filters or a filter has empty data, we can't show the user any indicator (ie. `HvLoading`, `HvEmptyState`, etc.) to inform the user why

**Changes**

- add configurable `emptyElement` to `LeftPanel` and `RightPanel`
- add typings to `FilterContent`

Let me know what you think about the API!
