### PR TITLE
feat(ActionsGeneric): add iconButton variant

### DIFF
--- a/packages/core/src/ActionsGeneric/ActionsGeneric.d.ts
+++ b/packages/core/src/ActionsGeneric/ActionsGeneric.d.ts
@@ -11,6 +11,10 @@ export type ActionGeneric = {
 
 export interface HvActionsGenericCommonProps {
   /**
+   * Whether the action buttons are of type `icon`.
+   */
+  iconButtons?: boolean;
+  /**
    * Button category.
    */
   category?: HvButtonCategories;

--- a/packages/core/src/ActionsGeneric/ActionsGeneric.js
+++ b/packages/core/src/ActionsGeneric/ActionsGeneric.js
@@ -15,6 +15,7 @@ const ActionsGeneric = ({
   actions = [],
   actionsCallback,
   maxVisibleActions = Infinity,
+  iconButtons,
   ...others
 }) => {
   if (!Array.isArray(actions)) return isValidElement(actions) ? actions : null;
@@ -28,15 +29,17 @@ const ActionsGeneric = ({
     return (
       <HvButton
         id={actionId}
+        icon={iconButtons}
         key={actionId || idx}
         category={category}
         className={classes.button}
         disabled={actDisabled ?? disabled}
         onClick={(event) => actionsCallback?.(event, id, action)}
-        startIcon={renderedIcon}
+        startIcon={iconButtons ? undefined : renderedIcon}
+        aria-label={iconButtons ? label : undefined}
         {...other}
       >
-        {label}
+        {iconButtons ? renderedIcon : label}
       </HvButton>
     );
   };
@@ -125,6 +128,10 @@ ActionsGeneric.propTypes = {
    * Component identifier.
    */
   id: PropTypes.string,
+  /**
+   * Whether the action buttons are of type `icon`.
+   */
+  iconButtons: PropTypes.bool,
   /**
    * Button category.
    */


### PR DESCRIPTION
Adds the possibility to have `ActionsGeneric` with buttons of variant `icon`.

Passing the `icon` prop isn't possible, because it's being used for something else. Also, this also implies that the label isn't visible (`aria-label` instead)

@lumada-design/imperial Let me know what you think.
