### PR TITLE
chore: align color props

### DIFF
--- a/packages/core/src/AssetInventory/ListView/ListViewCell/ListViewCell.d.ts
+++ b/packages/core/src/AssetInventory/ListView/ListViewCell/ListViewCell.d.ts
@@ -1,5 +1,6 @@
 import * as React from "react";
 import { StandardProps } from "@material-ui/core";
+import { HvAtmosphereColorKeys, HvSemanticColorKeys } from "../../..";
 
 export type HvListViewCellClassKey = "root" | "semanticBar";
 
@@ -17,33 +18,7 @@ export interface HvListViewCellProps
   /**
    *  The border color of the cell. Must be one of palette semantic colors.
    */
-  semantic?:
-    | "sema0"
-    | "sema1"
-    | "sema2"
-    | "sema3"
-    | "sema4"
-    | "sema5"
-    | "sema6"
-    | "sema7"
-    | "sema8"
-    | "sema9"
-    | "sema10"
-    | "sema11"
-    | "sema12"
-    | "sema13"
-    | "sema14"
-    | "sema15"
-    | "sema16"
-    | "sema17"
-    | "sema18"
-    | "sema19"
-    | "atmo1"
-    | "atmo2"
-    | "atmo3"
-    | "atmo4"
-    | "atmo5"
-    | "atmo6";
+  semantic?: "sema0" | HvSemanticColorKeys | HvAtmosphereColorKeys;
 }
 
 export default function HvListViewCell(props: HvListViewCellProps): JSX.Element | null;

--- a/packages/core/src/AssetInventory/ListView/ListViewRow/ListViewRow.d.ts
+++ b/packages/core/src/AssetInventory/ListView/ListViewRow/ListViewRow.d.ts
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { StandardProps } from "@material-ui/core";
 import { ListViewConfiguration } from "..";
-import { HvCheckBoxProps } from "../../..";
+import { HvAtmosphereColorKeys, HvCheckBoxProps, HvSemanticColorKeys } from "../../..";
 
 export type HvListViewRowClassKey = "root";
 
@@ -29,32 +29,7 @@ export interface HvListViewRowProps
   /**
    *  The border to the right of the checkbox
    */
-  semantic?:
-    | "sema1"
-    | "sema2"
-    | "sema3"
-    | "sema4"
-    | "sema5"
-    | "sema6"
-    | "sema7"
-    | "sema8"
-    | "sema9"
-    | "sema10"
-    | "sema11"
-    | "sema12"
-    | "sema13"
-    | "sema14"
-    | "sema15"
-    | "sema16"
-    | "sema17"
-    | "sema18"
-    | "sema19"
-    | "atmo1"
-    | "atmo2"
-    | "atmo3"
-    | "atmo4"
-    | "atmo5"
-    | "atmo6";
+  semantic?: HvSemanticColorKeys | HvAtmosphereColorKeys;
 }
 
 export default function HvListViewRow(props: HvListViewRowProps): JSX.Element | null;

--- a/packages/lab/src/Tag/Tag.d.ts
+++ b/packages/lab/src/Tag/Tag.d.ts
@@ -1,27 +1,8 @@
 import * as React from "react";
 import { StandardProps } from "@material-ui/core";
+import { HvSemanticColorKeys } from "@hitachivantara/uikit-react-core";
 
-export type Semantic =
-  | "sema1"
-  | "sema2"
-  | "sema3"
-  | "sema4"
-  | "sema5"
-  | "sema6"
-  | "sema7"
-  | "sema8"
-  | "sema9"
-  | "sema10"
-  | "sema11"
-  | "sema12"
-  | "sema13"
-  | "sema14"
-  | "sema15"
-  | "sema16"
-  | "sema17"
-  | "sema18"
-  | "sema19"
-  | "sema20";
+export type Semantic = HvSemanticColorKeys;
 
   export type HvTagClassKey =
   | "label"


### PR DESCRIPTION
There's a mismatch between the existing palette colours and variant props (eg. missing `sema20`). Also reduces duplication