### PR TITLE
chore(BannerContent): variant typings

### DIFF
--- a/packages/core/src/Banner/BannerContent/BannerContent.d.ts
+++ b/packages/core/src/Banner/BannerContent/BannerContent.d.ts
@@ -17,9 +17,9 @@ export type HvBannerContentClassKey =
   | SemanticVariantTypes;
 
 export interface HvBannerContentProps
-  extends StandardProps<SnackbarContentProps, HvBannerContentClassKey>,
+  extends StandardProps<SnackbarContentProps, HvBannerContentClassKey, "variant">,
     HvActionsGenericCommonProps,
-    Pick<NotificationsCommonProps, "showIcon" | "customIcon"> {
+    Pick<NotificationsCommonProps, "showIcon" | "customIcon" | "variant"> {
   /**
    * The position property of the header.
    */


### PR DESCRIPTION
Variant is wrongly assuming MUI variant instead of UI-Kit's