### PR TITLE
fix(Tag): add ellipsis on overflow

### DIFF
--- a/packages/core/src/Tag/Tag.js
+++ b/packages/core/src/Tag/Tag.js
@@ -103,7 +103,11 @@ const HvTag = (props) => {
 
   const chipLabel = useMemo(() => {
     if (typeof label === "string") {
-      return <HvTypography variant="normalText">{label}</HvTypography>;
+      return (
+        <HvTypography noWrap variant="normalText">
+          {label}
+        </HvTypography>
+      );
     }
 
     return label;

--- a/packages/core/src/Tag/Tag.js
+++ b/packages/core/src/Tag/Tag.js
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from "react";
+import React, { useState } from "react";
 
 import { Chip, withStyles, useTheme } from "@material-ui/core";
 
@@ -7,7 +7,7 @@ import clsx from "clsx";
 import { CloseXS } from "@hitachivantara/uikit-react-icons";
 import fade from "../utils/hexToRgbA";
 
-import { HvButton, HvTypography } from "..";
+import { HvButton } from "..";
 
 import styles from "./styles";
 
@@ -101,21 +101,9 @@ const HvTag = (props) => {
 
   const [hover, setHover] = useState(false);
 
-  const chipLabel = useMemo(() => {
-    if (typeof label === "string") {
-      return (
-        <HvTypography noWrap variant="normalText">
-          {label}
-        </HvTypography>
-      );
-    }
-
-    return label;
-  }, [label]);
-
   return (
     <Chip
-      label={chipLabel}
+      label={label}
       className={clsx(classes.root, className)}
       onMouseEnter={() => {
         setHover(!!onClick);

--- a/packages/core/src/Tag/stories/Tag.stories.js
+++ b/packages/core/src/Tag/stories/Tag.stories.js
@@ -2,7 +2,7 @@ import React from "react";
 
 import { makeStyles } from "@material-ui/core/styles";
 
-import { HvTag, HvTypography, HvTooltip, HvListContainer, HvListItem } from "../..";
+import { HvTag, HvListContainer, HvListItem, HvOverflowTooltip } from "../..";
 
 export default {
   title: "Display/Tag",
@@ -32,30 +32,11 @@ export const Main = () => {
 };
 
 export const LongLabelText = () => {
-  const tooltipWrapper = (tagLabel, textComponent) => {
-    const tooltipText = <HvTypography>{tagLabel}</HvTypography>;
-    return <HvTooltip title={tooltipText}>{textComponent}</HvTooltip>;
-  };
-
-  const tagLength = 30;
-
-  const textElement = (tagLabel) => {
-    const isLongLabel = tagLabel.length > tagLength;
-
-    const TagText = (
-      <HvTypography variant="normalText" noWrap={isLongLabel}>
-        {tagLabel}
-      </HvTypography>
-    );
-
-    return isLongLabel ? tooltipWrapper(tagLabel, TagText) : TagText;
-  };
-
   const longText = "This is an example of a very long tag";
 
   return (
     <div style={{ display: "flex", gap: 20 }}>
-      <HvTag label={textElement(longText)} />
+      <HvTag label={<HvOverflowTooltip data={longText} />} />
       <HvTag label={`${longText} with default overflow`} />
     </div>
   );

--- a/packages/core/src/Tag/stories/Tag.stories.js
+++ b/packages/core/src/Tag/stories/Tag.stories.js
@@ -2,8 +2,6 @@ import React from "react";
 
 import { makeStyles } from "@material-ui/core/styles";
 
-import clsx from "clsx";
-
 import { HvTag, HvTypography, HvTooltip, HvListContainer, HvListItem } from "../..";
 
 export default {
@@ -34,15 +32,6 @@ export const Main = () => {
 };
 
 export const LongLabelText = () => {
-  const useStyles = makeStyles(() => ({
-    titleOverflow: {
-      whiteSpace: "nowrap",
-      overflow: "hidden",
-      textOverflow: "ellipsis",
-    },
-  }));
-  const classes = useStyles();
-
   const tooltipWrapper = (tagLabel, textComponent) => {
     const tooltipText = <HvTypography>{tagLabel}</HvTypography>;
     return <HvTooltip title={tooltipText}>{textComponent}</HvTooltip>;
@@ -54,30 +43,20 @@ export const LongLabelText = () => {
     const isLongLabel = tagLabel.length > tagLength;
 
     const TagText = (
-      <HvTypography
-        className={clsx({
-          [classes.titleOverflow]: isLongLabel,
-        })}
-        variant="normalText"
-      >
+      <HvTypography variant="normalText" noWrap={isLongLabel}>
         {tagLabel}
       </HvTypography>
     );
 
-    return tagLabel.length > tagLength ? tooltipWrapper(tagLabel, TagText) : TagText;
+    return isLongLabel ? tooltipWrapper(tagLabel, TagText) : TagText;
   };
 
   const longText = "This is an example of a very long tag";
 
   return (
-    <div
-      style={{
-        width: "300px",
-        display: "flex",
-        justifyContent: "space-between",
-      }}
-    >
+    <div style={{ display: "flex", gap: 20 }}>
       <HvTag label={textElement(longText)} />
+      <HvTag label={`${longText} with default overflow`} />
     </div>
   );
 };

--- a/packages/core/src/Tag/styles.js
+++ b/packages/core/src/Tag/styles.js
@@ -22,6 +22,8 @@ const styles = (theme) => ({
   label: {
     paddingLeft: theme.hv.spacing.xs,
     paddingRight: theme.hv.spacing.xs,
+    ...theme.hv.typography.normalText,
+    color: theme.palette.base2,
     "& p": {
       color: theme.hv.palette.base.base2,
     },


### PR DESCRIPTION
`HvTag` has a default max size, but if the `label` is long enough it doesn't overflow correctly.

MUI's `Chip` already takes care of this issue (overflowing), but since the user-provided string `label` is wrapped in an `HvTypography`, it essentially overrides the fix.


**Actual (left) vs Expected (right):**
![image](https://user-images.githubusercontent.com/638946/186381007-2b183ee7-2f6e-4f30-b3f0-222b31ee72ed.png)


This PR
- fixes the overflow issue by removing the `HvTypography` that _breaks_ `Chip` overflow fix.
- simplifies Long Label sample by leveraging `HvOverflowTooltip`