### PR TITLE
fix(SimpleGrid): typings & docs

### DIFF
--- a/packages/core/src/SimpleGrid/SimpleGrid.d.ts
+++ b/packages/core/src/SimpleGrid/SimpleGrid.d.ts
@@ -1,4 +1,7 @@
-export type Spacing = "xs" | "sm" | "md" | "lg";
+import React from "react";
+import { HvSpacingKeys } from "../theme";
+
+export type Spacing = HvSpacingKeys;
 export type Breakpoint = {
   cols?: number;
   maxWidth?: number;
@@ -7,7 +10,7 @@ export type Breakpoint = {
 };
 
 export interface SimpleGridProps {
-  children?: JSX.Element | JSX.Element[];
+  children?: React.ReactNode;
   spacing?: Spacing;
   cols?: number;
   breakpoints?: Breakpoint[];

--- a/packages/core/src/SimpleGrid/SimpleGrid.js
+++ b/packages/core/src/SimpleGrid/SimpleGrid.js
@@ -3,6 +3,10 @@ import PropTypes from "prop-types";
 import { withStyles } from "@mui/styles";
 import useStyles from "./styles";
 
+/**
+ * SimpleGrid is a flexbox container where each child is treated as a column.
+ * Each column takes equal amount of space.
+ */
 const HvSimpleGrid = ({ children, breakpoints, spacing = "sm", cols, ...others }) => {
   const classes = useStyles({ breakpoints, cols, spacing })();
   return (
@@ -20,7 +24,7 @@ HvSimpleGrid.propTypes = {
   /**
    * Spacing with pre-defined values according the values defined in the theme
    */
-  spacing: PropTypes.oneOf(["sm", "md", "lg", "xl"]),
+  spacing: PropTypes.oneOf(["xs", "sm", "md", "lg", "xl"]),
   /**
    * Provide an array to define responsive behavior:
    *
@@ -35,7 +39,7 @@ HvSimpleGrid.propTypes = {
       maxWidth: PropTypes.number,
       minWidth: PropTypes.number,
       cols: PropTypes.number,
-      spacing: PropTypes.oneOf(["sm", "md", "lg", "xl"]),
+      spacing: PropTypes.oneOf(["xs", "sm", "md", "lg", "xl"]),
     })
   ),
   /**

--- a/packages/core/src/SimpleGrid/stories/SimpleGrid.stories.js
+++ b/packages/core/src/SimpleGrid/stories/SimpleGrid.stories.js
@@ -4,8 +4,7 @@ import HvSimpleGrid from "../SimpleGrid";
 export default {
   title: "Layout/SimpleGrid",
   parameters: {
-    componentSubtitle:
-      "SimpleGrid is a simple flexbox container where each child is treated as a column. Each column takes equal amount of space.",
+    componentSubtitle: null,
     usage: 'import { HvSimpleGrid } from "@hitachivantara/uikit-react-core"',
   },
   component: HvSimpleGrid,


### PR DESCRIPTION
Fixes `SimpleGrid`'s typings (`spacing` and `children` mismatch with PropTypes) and docs (invisible in `wicked`)