### PR TITLE
fix(deps): add missing core-js to core/lab

### DIFF
--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -13,6 +13,7 @@
         "@types/react-table": "^7.7.12",
         "attr-accept": "^2.2.2",
         "clsx": "^1.2.1",
+        "core-js": "^3.26.1",
         "dayjs": "^1.11.4",
         "deep-diff": "^1.0.2",
         "detect-browser": "^5.3.0",
@@ -1130,6 +1131,16 @@
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
       "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
       "peer": true
+    },
+    "node_modules/core-js": {
+      "version": "3.26.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.26.1.tgz",
+      "integrity": "sha512-21491RRQVzUn0GGM9Z1Jrpr6PNPxPi+Za8OM9q4tksTSnlbXXGKK1nXNg/QvwFYettXvSX6zWKCtHHfjN4puyA==",
+      "hasInstallScript": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
     },
     "node_modules/cosmiconfig": {
       "version": "7.0.1",
@@ -3460,6 +3471,11 @@
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
       "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
       "peer": true
+    },
+    "core-js": {
+      "version": "3.26.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.26.1.tgz",
+      "integrity": "sha512-21491RRQVzUn0GGM9Z1Jrpr6PNPxPi+Za8OM9q4tksTSnlbXXGKK1nXNg/QvwFYettXvSX6zWKCtHHfjN4puyA=="
     },
     "cosmiconfig": {
       "version": "7.0.1",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -50,6 +50,7 @@
     "@types/react-table": "^7.7.12",
     "attr-accept": "^2.2.2",
     "clsx": "^1.2.1",
+    "core-js": "^3.26.1",
     "dayjs": "^1.11.4",
     "deep-diff": "^1.0.2",
     "detect-browser": "^5.3.0",

--- a/packages/lab/package-lock.json
+++ b/packages/lab/package-lock.json
@@ -10,6 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "clsx": "^1.2.1",
+        "core-js": "^3.26.1",
         "dayjs": "^1.11.4",
         "lodash": "^4.17.21",
         "prop-types": "^15.8.1",
@@ -1047,6 +1048,16 @@
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
       "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
       "peer": true
+    },
+    "node_modules/core-js": {
+      "version": "3.26.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.26.1.tgz",
+      "integrity": "sha512-21491RRQVzUn0GGM9Z1Jrpr6PNPxPi+Za8OM9q4tksTSnlbXXGKK1nXNg/QvwFYettXvSX6zWKCtHHfjN4puyA==",
+      "hasInstallScript": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
     },
     "node_modules/cosmiconfig": {
       "version": "7.0.1",
@@ -2538,6 +2549,11 @@
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
       "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
       "peer": true
+    },
+    "core-js": {
+      "version": "3.26.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.26.1.tgz",
+      "integrity": "sha512-21491RRQVzUn0GGM9Z1Jrpr6PNPxPi+Za8OM9q4tksTSnlbXXGKK1nXNg/QvwFYettXvSX6zWKCtHHfjN4puyA=="
     },
     "cosmiconfig": {
       "version": "7.0.1",

--- a/packages/lab/package.json
+++ b/packages/lab/package.json
@@ -47,6 +47,7 @@
     "@hitachivantara/uikit-react-core": "^4.3.1",
     "@hitachivantara/uikit-react-icons": "^4.0.4",
     "clsx": "^1.2.1",
+    "core-js": "^3.26.1",
     "dayjs": "^1.11.4",
     "lodash": "^4.17.21",
     "prop-types": "^15.8.1",


### PR DESCRIPTION
`core-js@3` is missing from `core`/`lab` packages.

The bundles will fail with multiple errors, such as ([demo](https://stackblitz.com/edit/uikit-no-corejs?file=package.json)):
```
✘ [ERROR] Could not resolve "core-js/modules/es.array.from.js"
    node_modules/@hitachivantara/uikit-react-core/dist/legacy/Slider/utils.js:20:7:
      20 │ import "core-js/modules/es.array.from.js";
```