### PR TITLE
feat(DatePicker): expose `HvCalendar` props

### DIFF
--- a/packages/core/src/DatePicker/DatePicker.d.ts
+++ b/packages/core/src/DatePicker/DatePicker.d.ts
@@ -1,5 +1,6 @@
 import { StandardProps } from "@mui/material";
 import { HvFormElementProps } from "..";
+import { HvCalendarProps } from "../Calendar/Calendar";
 
 export type HvDatePickerClassKey =
   | "root"
@@ -105,6 +106,10 @@ export interface HvDatePickerProps
    * If `true` the DatePicker will be in read only mode, unable to be interacted.
    */
   readOnly?: boolean;
+  /**
+   * Additional props passed to the HvCalendar component.
+   */
+  calendarProps?: Partial<HvCalendarProps>;
 }
 
 export default function HvDatePicker(props: HvDatePickerProps): JSX.Element | null;

--- a/packages/core/src/DatePicker/DatePicker.js
+++ b/packages/core/src/DatePicker/DatePicker.js
@@ -45,6 +45,7 @@ const HvDatePicker = (props) => {
 
     required = false,
     disabled = false,
+    readOnly,
 
     label,
     "aria-label": ariaLabel,
@@ -76,7 +77,7 @@ const HvDatePicker = (props) => {
     disablePortal = true,
     escapeWithReference = true,
     dropdownProps,
-    readOnly,
+    calendarProps,
     ...others
   } = props;
 
@@ -389,6 +390,7 @@ const HvDatePicker = (props) => {
           }}
           locale={locale}
           {...visibleDate}
+          {...calendarProps}
         />
         {(rangeMode || showActions) && renderActions()}
       </HvBaseDropdown>
@@ -621,6 +623,10 @@ HvDatePicker.propTypes = {
    * If `true` the DatePicker will be in read only mode, unable to be interacted.
    */
   readOnly: PropTypes.bool,
+  /**
+   * Additional props passed to the HvCalendar component.
+   */
+  calendarProps: PropTypes.instanceOf(Object),
 };
 
 export default withStyles(styles, { name: "HvDatePicker", index: 1 })(HvDatePicker);

--- a/packages/core/src/DatePicker/stories/Datepicker.stories.js
+++ b/packages/core/src/DatePicker/stories/Datepicker.stories.js
@@ -41,13 +41,14 @@ export const DefaultValue = () => (
     id="DatePicker"
     aria-label="Date"
     placeholder="Select date"
-    value={new Date(2020, 9, 10)}
+    value={new Date("2020-10-10")}
+    calendarProps={{ minimumDate: "2020-10-03", maximumDate: "2020-10-20" }}
   />
 );
 
 DefaultValue.parameters = {
   docs: {
-    description: { story: "Datepicker sample with a value already set." },
+    description: { story: "Datepicker default value and limit selection range." },
   },
 };
 


### PR DESCRIPTION
Expose `HvCalendar` props via `calendarProps` prop, to allow configuration of `minimumDate`, `maximumDate`, and others