### PR TITLE
feat(panel): add panel component

### DIFF
--- a/packages/core/src/components/Panel/Panel.stories.tsx
+++ b/packages/core/src/components/Panel/Panel.stories.tsx
@@ -1,0 +1,90 @@
+import styled from "@emotion/styled";
+import { Close, Edit } from "@hitachivantara/uikit-icons";
+import { Meta, StoryObj } from "@storybook/react";
+import { HvButton, HvTypography, theme } from "index";
+import { HvPanel, PanelProps } from "./Panel";
+
+const meta: Meta<typeof HvPanel> = {
+  title: "Layout/Panel",
+  component: HvPanel,
+};
+export default meta;
+
+export const Main: StoryObj<PanelProps> = {
+  render: () => {
+    return (
+      <HvPanel>
+        <HvTypography>Panel Content</HvTypography>
+      </HvPanel>
+    );
+  },
+};
+
+export const WithScroll: StoryObj<PanelProps> = {
+  render: () => {
+    return (
+      <HvPanel style={{ width: "400px", height: "400px" }}>
+        <div style={{ height: 600, backgroundColor: theme.colors.atmo4 }}>
+          &nbsp;
+        </div>
+      </HvPanel>
+    );
+  },
+};
+
+const StyledButton = styled(HvButton)({
+  position: "absolute",
+  top: theme.space.sm,
+  right: theme.space.sm,
+  width: "32px",
+  height: "32px",
+});
+
+export const FullWidth: StoryObj<PanelProps> = {
+  render: () => {
+    return (
+      <HvPanel style={{ width: "100%", height: "200px" }}>
+        <HvTypography>Panel Content</HvTypography>
+        <StyledButton icon aria-label="Edit" variant="secondaryGhost">
+          <Edit />
+        </StyledButton>
+      </HvPanel>
+    );
+  },
+};
+
+const CloseButton = styled(HvButton)({
+  position: "absolute",
+  top: theme.space.sm,
+  right: theme.space.sm,
+  width: "32px",
+  height: "32px",
+});
+
+const Overlay = styled("div")({
+  backgroundColor: theme.colors.atmo3,
+  opacity: 0.8,
+  width: "100%",
+  padding: theme.space.md,
+});
+
+export const Modal: StoryObj<PanelProps> = {
+  render: () => {
+    return (
+      <Overlay>
+        <HvPanel
+          style={{
+            width: "100%",
+            height: "200px",
+            boxShadow: theme.shadows.sm,
+          }}
+        >
+          <HvTypography>Panel Content</HvTypography>
+          <CloseButton icon aria-label="Close" variant="secondaryGhost">
+            <Close />
+          </CloseButton>
+        </HvPanel>
+      </Overlay>
+    );
+  },
+};

--- a/packages/core/src/components/Panel/Panel.styles.tsx
+++ b/packages/core/src/components/Panel/Panel.styles.tsx
@@ -1,0 +1,9 @@
+import styled from "@emotion/styled";
+import { theme } from "@hitachivantara/uikit-styles";
+
+export const StyledDiv = styled("div")({
+  position: "relative",
+  padding: theme.space.sm,
+  backgroundColor: theme.colors.atmo1,
+  overflow: "auto",
+});

--- a/packages/core/src/components/Panel/Panel.test.tsx
+++ b/packages/core/src/components/Panel/Panel.test.tsx
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { render } from "@testing-library/react";
+import { HvPanel, HvTypography } from "../..";
+
+describe("Panel", () => {
+  it("should be defined", () => {
+    const { container } = render(
+      <HvPanel>
+        <HvTypography>Panel Content</HvTypography>
+      </HvPanel>
+    );
+    expect(container).toBeDefined();
+  });
+
+  it("should render correctly", () => {
+    const { container } = render(
+      <HvPanel>
+        <HvTypography>Panel Content</HvTypography>
+      </HvPanel>
+    );
+    expect(container).toMatchSnapshot();
+  });
+
+  it("should render the Panel", async () => {
+    const { container, findAllByText } = render(
+      <HvPanel>
+        <HvTypography>Panel Content</HvTypography>
+      </HvPanel>
+    );
+    const component = await findAllByText("Panel Content");
+    expect(component.length).toBe(1);
+    expect(container).toBeDefined();
+  });
+});

--- a/packages/core/src/components/Panel/Panel.tsx
+++ b/packages/core/src/components/Panel/Panel.tsx
@@ -1,0 +1,38 @@
+import clsx from "clsx";
+import { HvBaseProps } from "../../types";
+import { StyledDiv } from "./Panel.styles";
+
+/**
+ * A panel is a container used in a variety of patterns (e.g. dropdown, filter group, details section).
+ * It can be horizontal or vertical and its size is defined by its content and how it relates to surrounding patterns.
+ * Regardless of its content, a panel look and feel should be consistent.
+ */
+export const HvPanel = (props: PanelProps) => {
+  const { id, className, classes, children, ...others } = props;
+
+  return (
+    <StyledDiv id={id} className={clsx(className, classes?.root)} {...others}>
+      {children}
+    </StyledDiv>
+  );
+};
+
+export type PanelProps = HvBaseProps & {
+  /**
+   * Id to be applied to the root node.
+   */
+  id?: string;
+  /**
+   * Class names to be applied.
+   */
+  className?: string;
+  /**
+   * A Jss Object used to override or extend the styles applied.
+   */
+  classes?: {
+    /**
+     * Styles applied to the component root class.
+     */
+    root?: string;
+  };
+};

--- a/packages/core/src/components/Panel/__snapshots__/Panel.test.tsx.snap
+++ b/packages/core/src/components/Panel/__snapshots__/Panel.test.tsx.snap
@@ -1,0 +1,15 @@
+// Vitest Snapshot v1
+
+exports[`Panel > should render correctly 1`] = `
+<div>
+  <div
+    class=" css-r49k44-StyledDiv e1sxb3mk0"
+  >
+    <p
+      class="css-tzfv7m-StyledTypography e1bct5r50"
+    >
+      Panel Content
+    </p>
+  </div>
+</div>
+`;

--- a/packages/core/src/components/Panel/index.ts
+++ b/packages/core/src/components/Panel/index.ts
@@ -1,0 +1,1 @@
+export * from "./Panel";

--- a/packages/core/src/components/index.ts
+++ b/packages/core/src/components/index.ts
@@ -17,6 +17,7 @@ export * from "./Header";
 export * from "./Link";
 export * from "./Loading";
 export * from "./MultiButton";
+export * from "./Panel";
 export * from "./ProgressBar";
 export * from "./SimpleGrid";
 export * from "./Stack";


### PR DESCRIPTION
In the previous component it was possible to add certain styles directly like so: `<HvPanel width="100%" height="200px" boxShadow={theme.hv.shadows[1]}>`

In this version the styles are added with a style object like so: 
` <HvPanel style={{ width: "100%", height: "200px", boxShadow: theme.shadows.sm,  }}>`
I don't know if it is worth it to add those style props.