### PR TITLE
fix(Button): fix button focus

### DIFF
--- a/packages/core/src/components/Button/Button.styles.ts
+++ b/packages/core/src/components/Button/Button.styles.ts
@@ -37,15 +37,13 @@ export const StyledButton = styled("button")(
     size,
     radius,
     overrideIconColors,
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    focusVisibleClassName,
   }: StyledButtonProps) => ({
     display: "inline-flex",
     justifyContent: "center",
     textTransform: "none",
     "&:hover": {},
     "&:focus": {},
-    "&:focus-visible": {
+    "&.HvIsFocusVisible": {
       ...outlineStyles,
     },
     "&:active": {},

--- a/packages/core/src/components/Button/Button.tsx
+++ b/packages/core/src/components/Button/Button.tsx
@@ -1,6 +1,4 @@
-import clsx from "clsx";
 import React, { CSSProperties, forwardRef, ReactElement } from "react";
-
 import {
   StyledButton,
   StyledChildren,
@@ -63,6 +61,14 @@ const mapVariant = (variant: ButtonVariant): ButtonVariant => {
   return variant;
 };
 
+const onFocusHandler = (event) => {
+  event.target.classList.add("HvIsFocusVisible");
+};
+
+const onBlurHandler = (event) => {
+  event.target.classList.remove("HvIsFocusVisible");
+};
+
 /**
  * Button component is used to trigger an action or event.
  */
@@ -96,7 +102,8 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
         size={size}
         radius={radius}
         overrideIconColors={overrideIconColors}
-        focusVisibleClassName={clsx("HvIsFocusVisible", classes?.focusVisible)}
+        onFocus={onFocusHandler}
+        onBlur={onBlurHandler}
         {...others}
       >
         <StyledContentDiv>


### PR DESCRIPTION
- removed the `focusVisibleClassName` prop since that was specific of the MUI button (which is not being used here anymore)
- added `onFocus` and `onBlur` event handlers to add and remove the specific class for when the button in focused
- adjust the styles