### PR TITLE
fix: remove static width and height from the button when in icon mode

### DIFF
--- a/packages/core/src/components/Button/Button.styles.ts
+++ b/packages/core/src/components/Button/Button.styles.ts
@@ -249,8 +249,6 @@ export const StyledButton = styled("button")(
     ...(iconOnly && {
       margin: 0,
       padding: 0,
-      width: theme.sizes.sm,
-      height: theme.sizes.sm,
     }),
     ...(!iconOnly && {
       minWidth: "70px",


### PR DESCRIPTION
I don't think we need this here. The button will take whatever size the icon inside has and we might need icons bigger than 32px (check the `Avatar` stories).