### PR TITLE
feat(BaseDropdown): add BaseDropdown component

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -9,6 +9,7 @@ import {
   Typography,
   Tags,
   CheckBox,
+  BaseDropdown,
 } from "./components";
 import { Tooltip } from "./components/Tooltip/Tooltip";
 import { Dialogs } from "./components/Dialogs/Dialogs";
@@ -29,6 +30,7 @@ const App = () => {
       <Header />
       <HvBox sx={styles}>
         <ThemeSwitcher />
+        <BaseDropdown />
         <CheckBox />
         <Dialogs />
         <Tags />

--- a/app/src/components/BaseDropdown/BaseDropdown.tsx
+++ b/app/src/components/BaseDropdown/BaseDropdown.tsx
@@ -1,0 +1,47 @@
+import { HvBaseDropdown } from "@hitachivantara/uikit-core";
+
+export const BaseDropdown = () => {
+  return (
+    <div style={{ width: "50%" }}>
+      <HvBaseDropdown
+        placeholder="Select..."
+        children={
+          <>
+            <div>TESTE TESTE TESTE</div>
+            <div>TESTE TESTE TESTE</div>
+            <div>TESTE TESTE TESTE</div>
+          </>
+        }
+      />
+      <br />
+      <HvBaseDropdown
+        placeholder="Disabled"
+        disabled
+        children={
+          <>
+            <div>TESTE TESTE TESTE</div>
+            <div>TESTE TESTE TESTE</div>
+            <div>TESTE TESTE TESTE</div>
+          </>
+        }
+      />
+      <br />
+      <HvBaseDropdown readOnly placeholder="Read only" />
+      <br />
+      <HvBaseDropdown
+        disablePortal
+        children={
+          <>
+            <div>TESTE TESTE TESTE</div>
+            <div>TESTE TESTE TESTE</div>
+            <div>TESTE TESTE TESTE</div>
+          </>
+        }
+      />
+      <HvBaseDropdown defaultExpanded />
+      <HvBaseDropdown variableWidth />
+      <HvBaseDropdown placement="left" />
+      <HvBaseDropdown placement="right" />
+    </div>
+  );
+};

--- a/app/src/components/BaseDropdown/index.ts
+++ b/app/src/components/BaseDropdown/index.ts
@@ -1,0 +1,1 @@
+export * from "./BaseDropdown";

--- a/app/src/components/index.ts
+++ b/app/src/components/index.ts
@@ -6,3 +6,4 @@ export * from "./Icons";
 export * from "./Tags";
 export * from "./Typography";
 export * from "./CheckBox";
+export * from "./BaseDropdown";

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -41,10 +41,12 @@
   "dependencies": {
     "@hitachivantara/uikit-icons": "workspace:*",
     "@hitachivantara/uikit-styles": "workspace:*",
+    "@popperjs/core": "^2.11.6",
     "clsx": "^1.2.1",
     "detect-browser": "^5.3.0",
     "lodash": "^4.17.21",
     "react-google-charts": "^4.0.0",
+    "react-popper": "^2.3.0",
     "react-resize-detector": "^7.1.2"
   },
   "devDependencies": {

--- a/packages/core/src/components/BaseCheckBox/BaseCheckBox.styles.ts
+++ b/packages/core/src/components/BaseCheckBox/BaseCheckBox.styles.ts
@@ -12,7 +12,7 @@ export const StyledCheckedBox = styled(
   transientOptions
 )(({ $focusVisible }: { $focusVisible: boolean }) => ({
   padding: 0,
-  borderRadius: 0,
+  borderRadius: theme.baseCheckBox.borderRadius,
   cursor: "pointer",
   "&:hover": {
     backgroundColor: theme.baseCheckBox.hoverColor,

--- a/packages/core/src/components/BaseCheckBox/__snapshots__/BaseCheckBox.test.tsx.snap
+++ b/packages/core/src/components/BaseCheckBox/__snapshots__/BaseCheckBox.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`BaseCheckBox > checked > should render correctly 1`] = `
 <div>
   <span
-    class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorDefault PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorDefault Mui-checked MuiCheckbox-root MuiCheckbox-colorDefault  e1noodtt0 css-ee113u-MuiButtonBase-root-MuiCheckbox-root-StyledCheckedBox"
+    class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorDefault PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorDefault Mui-checked MuiCheckbox-root MuiCheckbox-colorDefault  e1noodtt0 css-z4tg9a-MuiButtonBase-root-MuiCheckbox-root-StyledCheckedBox"
   >
     <input
       checked=""
@@ -49,7 +49,7 @@ exports[`BaseCheckBox > disabled > should render correctly 1`] = `
 <div>
   <span
     aria-disabled="true"
-    class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorDefault Mui-disabled PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorDefault Mui-disabled MuiCheckbox-root MuiCheckbox-colorDefault  e1noodtt0 css-ee113u-MuiButtonBase-root-MuiCheckbox-root-StyledCheckedBox"
+    class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorDefault Mui-disabled PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorDefault Mui-disabled MuiCheckbox-root MuiCheckbox-colorDefault  e1noodtt0 css-z4tg9a-MuiButtonBase-root-MuiCheckbox-root-StyledCheckedBox"
     tabindex="-1"
   >
     <input
@@ -90,7 +90,7 @@ exports[`BaseCheckBox > disabled > should render correctly 1`] = `
 exports[`BaseCheckBox > indeterminate > should render correctly 1`] = `
 <div>
   <span
-    class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-indeterminate MuiCheckbox-colorDefault PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-indeterminate MuiCheckbox-colorDefault MuiCheckbox-root MuiCheckbox-indeterminate MuiCheckbox-colorDefault  e1noodtt0 css-ee113u-MuiButtonBase-root-MuiCheckbox-root-StyledCheckedBox"
+    class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-indeterminate MuiCheckbox-colorDefault PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-indeterminate MuiCheckbox-colorDefault MuiCheckbox-root MuiCheckbox-indeterminate MuiCheckbox-colorDefault  e1noodtt0 css-z4tg9a-MuiButtonBase-root-MuiCheckbox-root-StyledCheckedBox"
   >
     <input
       class="PrivateSwitchBase-input css-1m9pwf3"
@@ -129,7 +129,7 @@ exports[`BaseCheckBox > indeterminate > should render correctly 1`] = `
 exports[`BaseCheckBox > read only > should render correctly 1`] = `
 <div>
   <span
-    class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorDefault PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-root MuiCheckbox-colorDefault  e1noodtt0 css-ee113u-MuiButtonBase-root-MuiCheckbox-root-StyledCheckedBox"
+    class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorDefault PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-root MuiCheckbox-colorDefault  e1noodtt0 css-z4tg9a-MuiButtonBase-root-MuiCheckbox-root-StyledCheckedBox"
   >
     <input
       class="PrivateSwitchBase-input css-1m9pwf3"
@@ -169,7 +169,7 @@ exports[`BaseCheckBox > read only > should render correctly 1`] = `
 exports[`BaseCheckBox > required > should render correctly 1`] = `
 <div>
   <span
-    class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorDefault PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-root MuiCheckbox-colorDefault  e1noodtt0 css-ee113u-MuiButtonBase-root-MuiCheckbox-root-StyledCheckedBox"
+    class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorDefault PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-root MuiCheckbox-colorDefault  e1noodtt0 css-z4tg9a-MuiButtonBase-root-MuiCheckbox-root-StyledCheckedBox"
   >
     <input
       class="PrivateSwitchBase-input css-1m9pwf3"
@@ -209,7 +209,7 @@ exports[`BaseCheckBox > required > should render correctly 1`] = `
 exports[`BaseCheckBox > should render correctly 1`] = `
 <div>
   <span
-    class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorDefault PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-root MuiCheckbox-colorDefault  e1noodtt0 css-ee113u-MuiButtonBase-root-MuiCheckbox-root-StyledCheckedBox"
+    class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorDefault PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-root MuiCheckbox-colorDefault  e1noodtt0 css-z4tg9a-MuiButtonBase-root-MuiCheckbox-root-StyledCheckedBox"
   >
     <input
       class="PrivateSwitchBase-input css-1m9pwf3"

--- a/packages/core/src/components/BaseDropdown/BaseDropdown.styles.tsx
+++ b/packages/core/src/components/BaseDropdown/BaseDropdown.styles.tsx
@@ -1,0 +1,213 @@
+import { CSSProperties } from "@emotion/serialize";
+import styled from "@emotion/styled";
+import { DropDownXS, DropUpXS } from "@hitachivantara/uikit-icons";
+import { theme } from "@hitachivantara/uikit-styles";
+import { HvTypography } from "components";
+import { outlineStyles } from "utils";
+import { transientOptions } from "utils/transientOptions";
+
+export const StyledRoot = styled("div")({
+  width: "100%",
+  position: "relative",
+});
+
+export const StyledAnchor = styled(
+  "div",
+  transientOptions
+)(({ $disabled }: { $disabled: boolean }) => ({
+  display: "inline-block",
+  width: "100%",
+
+  ...($disabled && {
+    cursor: "not-allowed",
+    "&:focus": {
+      outline: "none",
+    },
+  }),
+}));
+
+export const StyledHeaderRoot = styled(
+  "div",
+  transientOptions
+)(
+  ({
+    $disabled,
+    $readOnly,
+    $opened,
+    $openedUp,
+    $openedDown,
+  }: {
+    $disabled: boolean;
+    $readOnly: boolean;
+    $opened: boolean;
+    $openedUp: boolean;
+    $openedDown: boolean;
+  }) => ({
+    cursor: "pointer",
+    userSelect: "none",
+    position: "relative",
+    background: theme.colors.atmo1,
+    border: `1px solid ${theme.baseDropdown.borderColor}`,
+    borderRadius: "2px",
+    "&:hover": {
+      border: `1px solid ${theme.baseDropdown.hoverBorderColor}`,
+    },
+    "&:focus": {
+      outline: "none",
+    },
+    "&:focus-visible": {
+      ...outlineStyles,
+      border: `1px solid ${theme.baseDropdown.hoverBorderColor}`,
+    },
+
+    ...($disabled && {
+      cursor: "not-allowed",
+      pointerEvents: "none",
+      border: `1px solid ${theme.baseDropdown.disabledBorderColor}`,
+      background: theme.baseDropdown.disabledBackgroundColor,
+      "&:hover": {
+        border: `1px solid ${theme.baseDropdown.disabledBorderColor}`,
+      },
+    }),
+
+    ...($readOnly && {
+      cursor: "not-allowed",
+      pointerEvents: "none",
+      border: theme.baseDropdown.readOnlyBorder,
+      background: theme.baseDropdown.readOnlyBackgroundColor,
+      userSelect: "text",
+      "&:focus-visible": {
+        outline: "none",
+        border: theme.baseDropdown.readOnlyBorder,
+      },
+    }),
+
+    ...($opened && {
+      border: `1px solid ${theme.baseDropdown.openBorderColor}`,
+      boxShadow: theme.baseDropdown.shadow,
+      "&:hover": {
+        border: `1px solid ${theme.baseDropdown.openBorderColor}`,
+        boxShadow: theme.baseDropdown.shadow,
+      },
+    }),
+
+    ...($openedUp && {
+      borderRadius: "0px 0px 2px 2px",
+    }),
+
+    ...($openedDown && {
+      borderRadius: "2px 2px 0px 0px",
+    }),
+  })
+);
+
+export const StyledSelection = styled("div")({
+  display: "flex",
+  alignItems: "center",
+  height: "30px",
+  padding: "0px 30px 0px 10px",
+});
+
+export const StyledPlaceholder = styled(
+  HvTypography,
+  transientOptions
+)(({ $disabled }: { $disabled: boolean }) => ({
+  display: "block",
+  overflow: "hidden",
+  textOverflow: "ellipsis",
+  whiteSpace: "nowrap",
+  color: theme.baseDropdown.placeholderColor,
+  letterSpacing: theme.baseDropdown.letterSpacing,
+  lineHeight: theme.baseDropdown.lineHeight,
+  fontSize: theme.baseDropdown.fontSize,
+  fontWeight: theme.fontWeights.normal,
+
+  ...($disabled && {
+    color: theme.colors.atmo5,
+    fontWeight: theme.fontWeights.normal,
+    fontSize: theme.baseDropdown.fontSize,
+    lineHeight: theme.baseDropdown.lineHeight,
+    letterSpacing: theme.baseDropdown.letterSpacing,
+  }),
+}));
+
+const iconsStyles: CSSProperties = {
+  position: "absolute",
+  pointerEvents: "none",
+  top: -1,
+  right: -1,
+};
+
+export const StyledDropUpXS = styled(DropUpXS)({
+  ...iconsStyles,
+});
+
+export const StyledDropDownXS = styled(
+  DropDownXS,
+  transientOptions
+)(({ $disabled }: { $disabled: boolean }) => ({
+  ...iconsStyles,
+
+  ...($disabled && {
+    "& svg": {
+      "& path": {
+        fill: theme.colors.atmo5,
+      },
+    },
+  }),
+}));
+
+export const StyledContainer = styled(
+  "div",
+  transientOptions
+)(({ $zIndex }: { $zIndex: string | number }) => ({
+  zIndex: $zIndex,
+}));
+
+export const StyledExtension = styled(
+  "div",
+  transientOptions
+)(
+  ({
+    $leftPosition,
+    $openShadow,
+    $floatLeft,
+    $floatRight,
+    $backgroundColor,
+    $shadowColor,
+  }: {
+    $leftPosition: boolean;
+    $openShadow: boolean;
+    $floatLeft: boolean;
+    $floatRight: boolean;
+    $backgroundColor: string;
+    $shadowColor: string;
+  }) => ({
+    height: "10px",
+    backgroundColor: $backgroundColor,
+
+    ...($leftPosition && {
+      marginLeft: "auto",
+    }),
+
+    ...($openShadow && {
+      boxShadow: `0px 8px 0px ${$shadowColor}, 0px 0px 9px 0px rgba(65,65,65,.12)`,
+    }),
+
+    ...($floatLeft && {
+      float: "left",
+    }),
+
+    ...($floatRight && {
+      float: "right",
+    }),
+  })
+);
+
+export const StyledPanel = styled(
+  "div",
+  transientOptions
+)(({ $shadowColor }: { $shadowColor: string }) => ({
+  position: "relative",
+  boxShadow: $shadowColor,
+}));

--- a/packages/core/src/components/BaseDropdown/BaseDropdown.test.tsx
+++ b/packages/core/src/components/BaseDropdown/BaseDropdown.test.tsx
@@ -1,0 +1,142 @@
+import userEvent from "@testing-library/user-event";
+import { fireEvent, render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { HvBaseDropdown } from "./BaseDropdown";
+import { HvProvider } from "index";
+
+const Main = () => (
+  <HvProvider>
+    <div style={{ width: 121 }}>
+      <HvBaseDropdown placeholder="Placeholder..." aria-label="Main sample" />
+    </div>
+  </HvProvider>
+);
+
+describe("BaseDropDown", () => {
+  it("should be defined", () => {
+    const { container } = render(<Main />);
+
+    expect(container).toBeDefined();
+  });
+
+  it("should render correctly", () => {
+    const { container } = render(<Main />);
+
+    expect(container).toMatchSnapshot();
+  });
+
+  it("should open on click", async () => {
+    const { getByRole } = render(<Main />);
+
+    const baseDropdownHeader = getByRole("combobox");
+
+    expect(baseDropdownHeader).toHaveAttribute("aria-expanded", "false");
+
+    // Open
+    await userEvent.click(baseDropdownHeader);
+
+    expect(baseDropdownHeader).toHaveAttribute("aria-expanded", "true");
+  });
+
+  it("should close on double click", async () => {
+    const { getByRole } = render(<Main />);
+
+    const baseDropdownHeader = getByRole("combobox");
+
+    expect(baseDropdownHeader).toHaveAttribute("aria-expanded", "false");
+
+    // Open
+    await userEvent.click(baseDropdownHeader);
+
+    // Close
+    await userEvent.click(baseDropdownHeader);
+
+    expect(baseDropdownHeader).toHaveAttribute("aria-expanded", "false");
+  });
+
+  it("should open on Enter", async () => {
+    const { getByRole } = render(<Main />);
+
+    const baseDropdownHeader = getByRole("combobox");
+
+    expect(baseDropdownHeader).toHaveAttribute("aria-expanded", "false");
+
+    // Open
+    fireEvent.keyDown(baseDropdownHeader, { key: "Enter", keyCode: 13 });
+
+    expect(baseDropdownHeader).toHaveAttribute("aria-expanded", "true");
+  });
+
+  it("should close on double Enter", async () => {
+    const { getByRole } = render(<Main />);
+
+    const baseDropdownHeader = getByRole("combobox");
+
+    expect(baseDropdownHeader).toHaveAttribute("aria-expanded", "false");
+
+    // Open
+    fireEvent.keyDown(baseDropdownHeader, { key: "Enter", keyCode: 13 });
+
+    // Close
+    fireEvent.keyDown(baseDropdownHeader, { key: "Enter", keyCode: 13 });
+
+    expect(baseDropdownHeader).toHaveAttribute("aria-expanded", "false");
+  });
+
+  it("should open on Space", async () => {
+    const { getByRole } = render(<Main />);
+
+    const baseDropdownHeader = getByRole("combobox");
+
+    expect(baseDropdownHeader).toHaveAttribute("aria-expanded", "false");
+
+    // Open
+    fireEvent.keyDown(baseDropdownHeader, { key: " ", keyCode: 32 });
+
+    expect(baseDropdownHeader).toHaveAttribute("aria-expanded", "true");
+  });
+
+  it("should close on double Space", async () => {
+    const { getByRole } = render(<Main />);
+
+    const baseDropdownHeader = getByRole("combobox");
+
+    expect(baseDropdownHeader).toHaveAttribute("aria-expanded", "false");
+
+    // Open
+    fireEvent.keyDown(baseDropdownHeader, { key: " ", keyCode: 32 });
+
+    // Close
+    fireEvent.keyDown(baseDropdownHeader, { key: " ", keyCode: 32 });
+
+    expect(baseDropdownHeader).toHaveAttribute("aria-expanded", "false");
+  });
+
+  it("should open and close mixing mouse click, Enter, and Space", async () => {
+    const { getByRole } = render(<Main />);
+
+    const baseDropdownHeader = getByRole("combobox");
+
+    expect(baseDropdownHeader).toHaveAttribute("aria-expanded", "false");
+
+    // Open
+    await userEvent.click(baseDropdownHeader);
+
+    expect(baseDropdownHeader).toHaveAttribute("aria-expanded", "true");
+
+    // Close
+    fireEvent.keyDown(baseDropdownHeader, { key: "Enter", keyCode: 13 });
+
+    expect(baseDropdownHeader).toHaveAttribute("aria-expanded", "false");
+
+    // Open
+    fireEvent.keyDown(baseDropdownHeader, { key: " ", keyCode: 32 });
+
+    expect(baseDropdownHeader).toHaveAttribute("aria-expanded", "true");
+
+    // Close
+    await userEvent.click(baseDropdownHeader);
+
+    expect(baseDropdownHeader).toHaveAttribute("aria-expanded", "false");
+  });
+});

--- a/packages/core/src/components/BaseDropdown/BaseDropdown.tsx
+++ b/packages/core/src/components/BaseDropdown/BaseDropdown.tsx
@@ -1,0 +1,551 @@
+import React, { useMemo, useState, useCallback, useContext } from "react";
+import { createPortal } from "react-dom";
+import clsx from "clsx";
+import BaseDropdownContext from "./BaseDropdownContext";
+import {
+  ClickAwayListener,
+  PopperPlacementType,
+  PopperProps,
+} from "@mui/material";
+import { useControlled, useForkRef, useUniqueId } from "hooks";
+import { isKeypress, keyboardCodes, setId } from "utils";
+import { getFirstAndLastFocus } from "utils/focusableElementFinder";
+import { HvBaseProps } from "../../types";
+import {
+  StyledAnchor,
+  StyledContainer,
+  StyledDropDownXS,
+  StyledDropUpXS,
+  StyledExtension,
+  StyledHeaderRoot,
+  StyledPanel,
+  StyledPlaceholder,
+  StyledRoot,
+  StyledSelection,
+} from "./BaseDropdown.styles";
+import { usePopper } from "react-popper";
+import { detectOverflow, ModifierArguments, Options } from "@popperjs/core";
+import { ThemeContext } from "providers";
+import { theme } from "@hitachivantara/uikit-styles";
+
+const { Tab, Enter, Esc, Space, ArrowDown } = keyboardCodes;
+
+export type HvBaseDropdownProps = HvBaseProps<
+  HTMLDivElement,
+  { placeholder }
+> & {
+  /**
+   * The role of the element that triggers the popup.
+   *
+   * Defaults to "combobox" if `component` and the default
+   * "textbox" header is used, undefined otherwise.
+   */
+  role?: string;
+  /**
+   * Header placeholder.
+   */
+  placeholder?: string | React.ReactNode;
+  /**
+   * If `true` the dropdown is disabled unable to be interacted, if `false` it is enabled.
+   */
+  disabled?: boolean;
+  /**
+   * If `true` the dropdown will be in read only mode, unable to be interacted.
+   */
+  readOnly?: boolean;
+  /**
+   * Disable the portal behavior.
+   * The children stay within it's parent DOM hierarchy.
+   */
+  disablePortal?: boolean;
+  /**
+   * If `true` the dropdown width depends size of content if `false` the width depends on the header size.
+   * Defaults to `false`.
+   */
+  variableWidth?: boolean;
+  /**
+   * If `true` the dropdown starts opened if `false` it starts closed.
+   */
+  expanded?: boolean;
+  /**
+   * When uncontrolled, defines the initial expanded state.
+   */
+  defaultExpanded?: boolean;
+  /**
+   * An object containing props to be wired to the popper component.
+   */
+  popperProps?: Partial<PopperProps>;
+  /**
+   * Placement of the dropdown.
+   */
+  placement?: "left" | "right";
+  /**
+   * Replacement for the header component.
+   */
+  component?: React.ReactNode;
+  /**
+   * Adornment to replace the default arrows.
+   */
+  adornment?: React.ReactNode;
+  /**
+   * When dropdown changes the expanded state.
+   */
+  onToggle?: (event: Event, open: boolean) => void;
+  /**
+   * When user click outside the open container.
+   */
+  onClickOutside?: (event: Event) => void;
+  /**
+   * Callback called when the dropdown is opened and ready,
+   * commonly used to set focus to the content.
+   */
+  onContainerCreation?: (container: HTMLElement | null) => void;
+  /**
+   * Attributes applied to the dropdown header element.
+   */
+  dropdownHeaderProps?: React.DetailedHTMLProps<
+    React.HTMLAttributes<HTMLDivElement>,
+    HTMLDivElement
+  >;
+  /**
+   * Pass a ref to the dropdown header element.
+   */
+  dropdownHeaderRef?: React.Ref<any>;
+  /**
+   * A Jss Object used to override or extend the component styles applied.
+   */
+  classes?: {
+    root?: string;
+    rootDisabled?: string;
+    anchor?: string;
+    container?: string;
+    header?: string;
+    headerOpen?: string;
+    headerOpenUp?: string;
+    headerOpenDown?: string;
+    headerDisabled?: string;
+    headerReadOnly?: string;
+    arrow?: string;
+    selection?: string;
+    placeholder?: string;
+    selectionDisabled?: string;
+    panel?: string;
+    inputExtensionOpen?: string;
+    inputExtensionLeftPosition?: string;
+    inputExtensionOpenShadow?: string;
+    inputExtensionFloatRight?: string;
+    inputExtensionFloatLeft?: string;
+  };
+};
+
+export const HvBaseDropdown = ({
+  id,
+  className,
+  classes,
+  children,
+  role,
+  placeholder,
+  component,
+  adornment,
+  expanded,
+  dropdownHeaderProps,
+  defaultExpanded = false,
+  disabled = false,
+  readOnly = false,
+  disablePortal = false,
+  variableWidth = false,
+  placement = "right",
+  popperProps = {},
+  dropdownHeaderRef: dropdownHeaderRefProp,
+  onToggle,
+  onClickOutside,
+  onContainerCreation,
+  ...others
+}: HvBaseDropdownProps) => {
+  const { activeTheme, selectedMode } = useContext(ThemeContext);
+
+  const [isOpen, setIsOpen] = useControlled(expanded, Boolean(defaultExpanded));
+
+  const [referenceElement, setReferenceElement] = useState<HTMLElement | null>(
+    null
+  );
+  const [popperElement, setPopperElement] = useState<HTMLElement | null>(null);
+  const [popperMaxSize, setPopperMaxSize] = useState<{
+    width?: number;
+    height?: number;
+  }>({});
+
+  const handleDropdownHeaderRefProp = useForkRef(
+    dropdownHeaderRefProp,
+    dropdownHeaderProps?.ref
+  );
+  const handleDropdownHeaderRef = useForkRef(
+    setReferenceElement,
+    handleDropdownHeaderRefProp
+  );
+
+  const ariaRole = role || (component == null ? "combobox" : undefined);
+
+  const elementId = useUniqueId(id, "hvbasedropdown");
+
+  const bottom: PopperPlacementType =
+    placement && `bottom-${placement === "right" ? "start" : "end"}`;
+
+  const extensionWidth = referenceElement
+    ? referenceElement?.offsetWidth
+    : "inherit";
+
+  const { modifiers: popperPropsModifiers = [], ...otherPopperProps } =
+    popperProps;
+
+  const onFirstUpdate = useCallback(() => {
+    if (onContainerCreation) onContainerCreation(popperElement);
+  }, [onContainerCreation, popperElement]);
+
+  const widthCalculator = useCallback(
+    ({ state }: ModifierArguments<Options>) => {
+      state.styles.popper.width = `${state.rects.reference.width}px`;
+    },
+    []
+  );
+
+  const widthCalculatorEffect = useCallback(
+    ({ state }: ModifierArguments<Options>) => {
+      state.elements.popper.style.width = `${
+        (state.elements.reference as any).offsetWidth
+      }px`;
+    },
+    []
+  );
+
+  const applyMaxSizeCalculator = useCallback(
+    ({ state }: ModifierArguments<Options>) => {
+      // The `maxSize` modifier provides this data
+      const { width, height } = state.modifiersData.maxSize;
+      if (width !== popperMaxSize?.width || height !== popperMaxSize?.height) {
+        setPopperMaxSize({ width, height });
+      }
+
+      state.styles.popper = {
+        ...state.styles.popper,
+        maxWidth: `${width}px`,
+        maxHeight: `${height}px`,
+      };
+    },
+    [popperMaxSize]
+  );
+
+  const maxSizeCalculator = useCallback(
+    ({ state, name, options }: ModifierArguments<Options>) => {
+      const overflow = detectOverflow(state, options);
+
+      const x = state.modifiersData.preventOverflow?.x || 0;
+      const y = state.modifiersData.preventOverflow?.y || 0;
+
+      const popperWidth = state.rects.popper.width;
+      const popperHeight = state.rects.popper.height;
+
+      const basePlacement = state.placement.split("-")[0];
+
+      const widthProp = basePlacement === "left" ? "left" : "right";
+      const heightProp = basePlacement === "top" ? "top" : "bottom";
+
+      state.modifiersData[name] = {
+        width: popperWidth - overflow[widthProp] - x,
+        height: popperHeight - overflow[heightProp] - y,
+      };
+    },
+    []
+  );
+
+  const modifiers: any = useMemo(
+    () => [
+      {
+        name: "variableWidth",
+        enabled: !variableWidth,
+        phase: "beforeWrite",
+        requires: ["computeStyles"],
+        fn: widthCalculator,
+        effect: widthCalculatorEffect,
+      },
+      {
+        name: "maxSize",
+        enabled: true,
+        phase: "main",
+        requiresIfExists: ["offset", "preventOverflow", "flip"],
+        fn: maxSizeCalculator,
+      },
+      {
+        name: "applyMaxSize",
+        enabled: true,
+        phase: "beforeWrite",
+        requires: ["maxSize"],
+        fn: applyMaxSizeCalculator,
+      },
+      ...popperPropsModifiers,
+    ],
+    [
+      maxSizeCalculator,
+      applyMaxSizeCalculator,
+      popperPropsModifiers,
+      variableWidth,
+      widthCalculator,
+      widthCalculatorEffect,
+    ]
+  );
+
+  const { styles: popperStyles, attributes } = usePopper(
+    referenceElement,
+    popperElement,
+    {
+      placement: bottom,
+      modifiers,
+      onFirstUpdate,
+      ...otherPopperProps,
+    }
+  );
+
+  let popperPlacement = "bottom";
+  if (attributes.popper) {
+    popperPlacement = attributes.popper["data-popper-placement"];
+  }
+
+  const handleToggle = useCallback(
+    (event) => {
+      if (event && !isKeypress(event, Tab)) {
+        event.preventDefault();
+      }
+
+      // We are checking specifically for false because if "isKeypress" returns true or undefined it should continue
+      const notControlKey = [Tab, Enter, Esc, ArrowDown, Space].every(
+        (key) => isKeypress(event, key) === false
+      );
+
+      const ignoredCombinations =
+        (isKeypress(event, Esc) && !isOpen) ||
+        (isKeypress(event, ArrowDown) && isOpen) ||
+        (isKeypress(event, Tab) && !isOpen);
+
+      if (disabled || notControlKey || ignoredCombinations) return;
+
+      const newOpen = !isOpen;
+
+      /* If about to close focus on the header component. */
+      const focusHeader = () => {
+        if (!newOpen) {
+          // Focus-ring won't be visible even if using the keyboard:
+          // https://github.com/WICG/focus-visible/issues/88
+          referenceElement?.focus({ preventScroll: true });
+        }
+
+        return newOpen;
+      };
+      setIsOpen(focusHeader());
+
+      onToggle?.(event, newOpen);
+    },
+    [isOpen, disabled, setIsOpen, onToggle, referenceElement]
+  );
+
+  const headerComponent = (() => {
+    if (component) {
+      return React.cloneElement(component as React.ReactElement, {
+        ref: handleDropdownHeaderRef,
+      });
+    }
+
+    return (
+      <StyledHeaderRoot
+        id={setId(id, "header")}
+        className={clsx(
+          classes?.header,
+          disabled && classes?.headerDisabled,
+          readOnly && classes?.headerReadOnly,
+          isOpen && classes?.headerOpen,
+          isOpen && popperPlacement.includes("top") && classes?.headerOpenUp,
+          isOpen &&
+            popperPlacement.includes("bottom") &&
+            classes?.headerOpenDown
+        )}
+        $disabled={disabled}
+        $readOnly={readOnly}
+        $opened={isOpen}
+        $openedUp={isOpen && popperPlacement.includes("top")}
+        $openedDown={isOpen && popperPlacement.includes("bottom")}
+        role={ariaRole === "combobox" ? "textbox" : undefined}
+        style={disabled || readOnly ? { pointerEvents: "none" } : undefined}
+        aria-controls={
+          isOpen ? setId(elementId, "children-container") : undefined
+        }
+        aria-label={others["aria-label"] ?? undefined}
+        aria-labelledby={others["aria-labelledby"] ?? undefined}
+        // Removes the element from the navigation sequence for keyboard focus if disabled
+        tabIndex={disabled ? -1 : 0}
+        ref={handleDropdownHeaderRef}
+        {...dropdownHeaderProps}
+      >
+        <StyledSelection className={classes?.selection}>
+          {placeholder && typeof placeholder === "string" ? (
+            <StyledPlaceholder
+              className={clsx(
+                classes?.placeholder,
+                disabled && classes?.selectionDisabled
+              )}
+              $disabled={disabled}
+              variant="body"
+            >
+              {placeholder}
+            </StyledPlaceholder>
+          ) : (
+            placeholder
+          )}
+        </StyledSelection>
+        {adornment ||
+          (isOpen ? (
+            <StyledDropUpXS iconSize="XS" className={classes?.arrow} />
+          ) : (
+            <StyledDropDownXS
+              iconSize="XS"
+              className={classes?.arrow}
+              $disabled={disabled}
+            />
+          ))}
+      </StyledHeaderRoot>
+    );
+  })();
+
+  const containerComponent = (() => {
+    /**
+     *  Handle keyboard inside children container.
+     */
+    const handleContainerKeyDown = (event) => {
+      if (isKeypress(event, Esc)) {
+        handleToggle(event);
+      }
+      if (isKeypress(event, Tab) && !event.shiftKey) {
+        const focusList = getFirstAndLastFocus(popperElement);
+        if (document.activeElement === focusList?.last) {
+          event.preventDefault();
+          focusList?.first?.focus();
+        }
+      }
+    };
+
+    const handleOutside = (event) => {
+      const isButtonClick = referenceElement?.contains(event.target);
+      if (!isButtonClick) {
+        onClickOutside?.(event);
+        setIsOpen(false);
+        onToggle?.(event, false);
+      }
+    };
+
+    const container = (
+      <StyledContainer
+        role="tooltip"
+        ref={setPopperElement}
+        className={classes?.container}
+        style={popperStyles.popper}
+        {...attributes.popper}
+        // Fix CSS vars for portal
+        $zIndex={activeTheme?.zIndices?.tooltip || theme.zIndices.tooltip}
+      >
+        <ClickAwayListener onClickAway={handleOutside}>
+          <div onKeyDown={handleContainerKeyDown}>
+            {popperPlacement.includes("bottom") && (
+              <StyledExtension
+                style={{ width: extensionWidth }}
+                className={clsx(
+                  classes?.inputExtensionOpen,
+                  popperPlacement.includes("end") &&
+                    classes?.inputExtensionLeftPosition
+                )}
+                $leftPosition={popperPlacement.includes("end")}
+                $openShadow={false}
+                $floatLeft={false}
+                $floatRight={false}
+                // Fix CSS vars when the container was created using a portal
+                $backgroundColor={
+                  activeTheme?.colors?.modes[selectedMode].atmo1 ||
+                  theme.colors.atmo1
+                }
+                $shadowColor={
+                  activeTheme?.colors?.modes[selectedMode].atmo1 ||
+                  theme.colors.atmo1
+                }
+              />
+            )}
+            <BaseDropdownContext.Provider value={popperMaxSize}>
+              <StyledPanel
+                id={setId(elementId, "children-container")}
+                className={classes?.panel}
+                // Fix CSS vars when the container was created using a portal
+                $shadowColor={activeTheme.baseDropdown.shadow || "none"}
+              >
+                {children}
+              </StyledPanel>
+            </BaseDropdownContext.Provider>
+            {popperPlacement.includes("top") && (
+              <StyledExtension
+                style={{ width: extensionWidth }}
+                className={clsx(
+                  classes?.inputExtensionOpen,
+                  classes?.inputExtensionOpenShadow,
+                  popperPlacement.includes("start") &&
+                    classes?.inputExtensionFloatRight,
+                  popperPlacement.includes("end") &&
+                    classes?.inputExtensionFloatLeft
+                )}
+                $leftPosition={false}
+                $openShadow={true}
+                $floatLeft={popperPlacement.includes("end")}
+                $floatRight={popperPlacement.includes("start")}
+                // Fix CSS vars when the container was created using a portal
+                $backgroundColor={
+                  activeTheme?.colors?.modes[selectedMode].atmo1 ||
+                  theme.colors.atmo1
+                }
+                $shadowColor={
+                  activeTheme?.colors?.modes[selectedMode].atmo1 ||
+                  theme.colors.atmo1
+                }
+              />
+            )}
+          </div>
+        </ClickAwayListener>
+      </StyledContainer>
+    );
+
+    if (disablePortal) return container;
+
+    // Warning: By creating a portal, the container is not able to access the theme's CSS vars
+    return createPortal(container, document.body);
+  })();
+
+  return (
+    <StyledRoot className={classes?.root}>
+      <StyledAnchor
+        id={id}
+        role={ariaRole}
+        aria-expanded={!!isOpen}
+        aria-owns={isOpen ? setId(elementId, "children-container") : undefined}
+        className={clsx(
+          className,
+          classes?.anchor,
+          disabled && classes?.rootDisabled
+        )}
+        $disabled={disabled}
+        {...(!readOnly && {
+          onKeyDown: handleToggle,
+          onClick: handleToggle,
+        })}
+        // Removes the element from the navigation sequence for keyboard focus
+        tabIndex={-1}
+        {...others}
+      >
+        {headerComponent}
+      </StyledAnchor>
+      {isOpen && containerComponent}
+    </StyledRoot>
+  );
+};

--- a/packages/core/src/components/BaseDropdown/BaseDropdownContext/BaseDropdownContext.tsx
+++ b/packages/core/src/components/BaseDropdown/BaseDropdownContext/BaseDropdownContext.tsx
@@ -1,0 +1,10 @@
+import React from "react";
+
+const BaseDropdownContext = React.createContext<{
+  width?: number;
+  height?: number;
+}>({});
+
+BaseDropdownContext.displayName = "BaseDropdownContext";
+
+export default BaseDropdownContext;

--- a/packages/core/src/components/BaseDropdown/BaseDropdownContext/index.ts
+++ b/packages/core/src/components/BaseDropdown/BaseDropdownContext/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./BaseDropdownContext";

--- a/packages/core/src/components/BaseDropdown/__snapshots__/BaseDropdown.test.tsx.snap
+++ b/packages/core/src/components/BaseDropdown/__snapshots__/BaseDropdown.test.tsx.snap
@@ -1,0 +1,57 @@
+// Vitest Snapshot v1
+
+exports[`BaseDropDown > should render correctly 1`] = `
+<div>
+  <div
+    style="width: 121px;"
+  >
+    <div
+      class="css-1nukton-StyledRoot e1xgfj1t9"
+    >
+      <div
+        aria-expanded="false"
+        aria-label="Main sample"
+        class=" css-c41kvr-StyledAnchor e1xgfj1t8"
+        role="combobox"
+        tabindex="-1"
+      >
+        <div
+          aria-label="Main sample"
+          class=" css-z15in3-StyledHeaderRoot e1xgfj1t7"
+          role="textbox"
+          tabindex="0"
+        >
+          <div
+            class="css-1c8fpra-StyledSelection e1xgfj1t6"
+          >
+            <p
+              class=" e1xgfj1t5 css-fi1crd-StyledPlaceholder"
+              variant="body"
+            >
+              Placeholder...
+            </p>
+          </div>
+          <div
+            class="css-tgcv4t-StyledDropDownXS e1xgfj1t3 css-du18qm"
+            name="DropDownXS"
+          >
+            <svg
+              focusable="false"
+              height="12"
+              viewBox="0 0 12 12"
+              width="12"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                class="color0"
+                d="M5.99994 8.65 1.4 4.05l.7-.7L6 7.25l3.9-3.9.7.7z"
+                fill="var(--colors-acce1)"
+              />
+            </svg>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/packages/core/src/components/BaseDropdown/index.ts
+++ b/packages/core/src/components/BaseDropdown/index.ts
@@ -1,0 +1,1 @@
+export * from "./BaseDropdown";

--- a/packages/core/src/components/ListContainer/__snapshots__/ListContainer.test.tsx.snap
+++ b/packages/core/src/components/ListContainer/__snapshots__/ListContainer.test.tsx.snap
@@ -6,19 +6,19 @@ exports[`ListContainer > should render all the items 1`] = `
     class=""
   >
     <li
-      class="gutters css-rq6p2x-StyledListItem e180q0291"
+      class="root gutters css-1aiu9eb-StyledListItem e180q0291"
       role="option"
     >
       Item 1
     </li>
     <li
-      class="gutters css-rq6p2x-StyledListItem e180q0291"
+      class="root gutters css-1aiu9eb-StyledListItem e180q0291"
       role="option"
     >
       Item 2
     </li>
     <li
-      class="gutters css-rq6p2x-StyledListItem e180q0291"
+      class="root gutters css-1aiu9eb-StyledListItem e180q0291"
       role="option"
     >
       Item 3

--- a/packages/core/src/components/SelectionList/__snapshots__/SelectionList.test.tsx.snap
+++ b/packages/core/src/components/SelectionList/__snapshots__/SelectionList.test.tsx.snap
@@ -22,48 +22,54 @@ exports[`Selection List > Multi Selection List testing > Multi Selection Snapsho
     >
       <li
         aria-selected="false"
-        class="gutters condensed interactive css-1u8mpa8-StyledListItem e180q0291"
+        class="root gutters condensed interactive root focusDisabled css-7wuy46-StyledListItem e180q0291"
         role="option"
+        tabindex="-1"
         value="1"
       >
         ListItem 1
       </li>
       <li
         aria-selected="true"
-        class="gutters condensed interactive selected css-f2rz3l-StyledListItem e180q0291"
+        class="root gutters condensed interactive selected root selected focusDisabled css-1qaws6e-StyledListItem e180q0291"
         role="option"
+        tabindex="0"
         value="2"
       >
         ListItem 2
       </li>
       <li
         aria-selected="false"
-        class="gutters condensed interactive css-1u8mpa8-StyledListItem e180q0291"
+        class="root gutters condensed interactive root focusDisabled css-7wuy46-StyledListItem e180q0291"
         role="option"
+        tabindex="-1"
         value="3"
       >
         ListItem 3
       </li>
       <li
         aria-selected="false"
-        class="gutters condensed interactive css-1u8mpa8-StyledListItem e180q0291"
+        class="root gutters condensed interactive root focusDisabled css-7wuy46-StyledListItem e180q0291"
         role="option"
+        tabindex="-1"
         value="4"
       >
         ListItem 4
       </li>
       <li
         aria-selected="false"
-        class="gutters condensed interactive css-1u8mpa8-StyledListItem e180q0291"
+        class="root gutters condensed interactive root focusDisabled css-7wuy46-StyledListItem e180q0291"
         role="option"
+        tabindex="-1"
         value="5"
       >
         ListItem 5
       </li>
       <li
         aria-selected="false"
-        class="gutters condensed interactive css-1u8mpa8-StyledListItem e180q0291"
+        class="root gutters condensed interactive root focusDisabled css-7wuy46-StyledListItem e180q0291"
         role="option"
+        tabindex="-1"
         value="6"
       >
         ListItem 6
@@ -85,24 +91,27 @@ exports[`Selection List > Single Selection List testing > Selection List Snapsho
     >
       <li
         aria-selected="false"
-        class="gutters condensed interactive css-1u8mpa8-StyledListItem e180q0291"
+        class="root gutters condensed interactive root focusDisabled css-7wuy46-StyledListItem e180q0291"
         role="option"
+        tabindex="-1"
         value="1"
       >
         ListItem 1
       </li>
       <li
         aria-selected="true"
-        class="gutters condensed interactive selected css-f2rz3l-StyledListItem e180q0291"
+        class="root gutters condensed interactive selected root selected focusDisabled css-1qaws6e-StyledListItem e180q0291"
         role="option"
+        tabindex="0"
         value="2"
       >
         ListItem 2
       </li>
       <li
         aria-selected="false"
-        class="gutters condensed interactive css-1u8mpa8-StyledListItem e180q0291"
+        class="root gutters condensed interactive root focusDisabled css-7wuy46-StyledListItem e180q0291"
         role="option"
+        tabindex="-1"
         value="3"
       >
         ListItem 3

--- a/packages/core/src/components/index.ts
+++ b/packages/core/src/components/index.ts
@@ -1,4 +1,4 @@
-// Compoennts that need to be loaded first because of mutual dependencies (preserve order)
+// Components that need to be loaded first because of mutual dependencies (preserve order)
 export * from "./Typography";
 export * from "./Box";
 export * from "./Focus";
@@ -7,7 +7,7 @@ export * from "./Forms";
 export * from "./SelectionList";
 export * from "./Forms/Suggestions";
 
-// Remaining compoennts
+// Remaining components
 export * from "./ActionBar";
 export * from "./Accordion";
 export * from "./Avatar";
@@ -38,3 +38,4 @@ export * from "./Tooltip";
 export * from "./OverflowTooltip";
 export * from "./BaseCheckBox";
 export * from "./BaseRadio";
+export * from "./BaseDropdown";

--- a/packages/styles/src/theme.ts
+++ b/packages/styles/src/theme.ts
@@ -49,6 +49,21 @@ const componentsSpec = {
   },
   baseCheckBox: {
     hoverColor: "string",
+    borderRadius: "string",
+  },
+  baseDropdown: {
+    shadow: "string",
+    placeholderColor: "string",
+    letterSpacing: "string",
+    fontSize: "string",
+    lineHeight: "string",
+    borderColor: "string",
+    hoverBorderColor: "string",
+    disabledBorderColor: "string",
+    disabledBackgroundColor: "string",
+    readOnlyBorder: "string",
+    readOnlyBackgroundColor: "string",
+    openBorderColor: "string",
   },
   baseRadio: {
     hoverColor: "string",

--- a/packages/styles/src/themes/ds3Theme.ts
+++ b/packages/styles/src/themes/ds3Theme.ts
@@ -1,4 +1,4 @@
-import { colors, makeTheme } from "..";
+import { colors, makeTheme, shadows } from "..";
 
 const ds3Theme = makeTheme((theme) => ({
   colors: {
@@ -62,6 +62,21 @@ const ds3Theme = makeTheme((theme) => ({
     },
     baseCheckBox: {
       hoverColor: theme.colors.atmo3,
+      borderRadius: "0px",
+    },
+    baseDropdown: {
+      shadow: shadows.md,
+      placeholderColor: theme.colors.atmo5,
+      letterSpacing: "0.02em",
+      fontSize: "12px",
+      lineHeight: "16px",
+      borderColor: theme.colors.atmo4,
+      hoverBorderColor: theme.colors.acce1,
+      disabledBorderColor: theme.colors.atmo4,
+      disabledBackgroundColor: theme.colors.atmo3,
+      readOnlyBorder: "none",
+      readOnlyBackgroundColor: theme.colors.atmo1,
+      openBorderColor: theme.colors.atmo1,
     },
     baseRadio: {
       hoverColor: theme.colors.atmo3,

--- a/packages/styles/src/themes/ds5Theme.ts
+++ b/packages/styles/src/themes/ds5Theme.ts
@@ -77,6 +77,21 @@ const ds5Theme = makeTheme((theme) => ({
     },
     baseCheckBox: {
       hoverColor: theme.colors.acce2s,
+      borderRadius: "2px",
+    },
+    baseDropdown: {
+      shadow: "none",
+      placeholderColor: theme.colors.acce4,
+      letterSpacing: "0em",
+      fontSize: "14px",
+      lineHeight: "24px",
+      borderColor: theme.colors.acce4,
+      hoverBorderColor: theme.colors.acce2,
+      disabledBorderColor: theme.colors.atmo5,
+      disabledBackgroundColor: theme.colors.atmo2,
+      readOnlyBorder: `1px solid ${theme.colors.atmo5}`,
+      readOnlyBackgroundColor: theme.colors.atmo2,
+      openBorderColor: theme.colors.acce4,
     },
     baseRadio: {
       hoverColor: theme.colors.acce2s,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -108,6 +108,7 @@ importers:
       '@hitachivantara/uikit-icons': workspace:*
       '@hitachivantara/uikit-styles': workspace:*
       '@mui/material': ^5.11.0
+      '@popperjs/core': ^2.11.6
       '@types/react': ^18.0.25
       '@types/react-dom': ^18.0.8
       clsx: ^1.2.1
@@ -116,6 +117,7 @@ importers:
       react: ^18.2.0
       react-dom: ^18.2.0
       react-google-charts: ^4.0.0
+      react-popper: ^2.3.0
       react-resize-detector: ^7.1.2
       tsc-alias: ^1.8.2
     dependencies:
@@ -124,12 +126,14 @@ importers:
       '@hitachivantara/uikit-icons': link:../icons
       '@hitachivantara/uikit-styles': link:../styles
       '@mui/material': 5.11.2_lskpmcsdi7ipu6qpuapyu56ihm
+      '@popperjs/core': 2.11.6
       clsx: 1.2.1
       detect-browser: 5.3.0
       lodash: 4.17.21
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
       react-google-charts: 4.0.0_biqbaboplfbrettd7655fr4n2y
+      react-popper: 2.3.0_r6q5zrenym2zg7je7hgi674bti
       react-resize-detector: 7.1.2_biqbaboplfbrettd7655fr4n2y
     devDependencies:
       '@types/react': 18.0.26
@@ -14069,6 +14073,10 @@ packages:
       react-is: 17.0.2
     dev: true
 
+  /react-fast-compare/3.2.0:
+    resolution: {integrity: sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA==}
+    dev: false
+
   /react-google-charts/4.0.0_biqbaboplfbrettd7655fr4n2y:
     resolution: {integrity: sha512-9OG0EkBb9JerKEPQYdhmAXnhGLzOdOHOPS9j7l+P1a3z1kcmq9mGDa7PUoX/VQUY4IjZl2/81nsO4o+1cuYsuw==}
     peerDependencies:
@@ -14099,6 +14107,20 @@ packages:
 
   /react-is/18.2.0:
     resolution: {integrity: sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==}
+
+  /react-popper/2.3.0_r6q5zrenym2zg7je7hgi674bti:
+    resolution: {integrity: sha512-e1hj8lL3uM+sgSR4Lxzn5h1GxBlpa4CQz0XLF8kx4MDrDRWY0Ena4c97PUeSX9i5W3UAfDP0z0FXCTQkoXUl3Q==}
+    peerDependencies:
+      '@popperjs/core': ^2.0.0
+      react: ^16.8.0 || ^17 || ^18
+      react-dom: ^16.8.0 || ^17 || ^18
+    dependencies:
+      '@popperjs/core': 2.11.6
+      react: 18.2.0
+      react-dom: 18.2.0_react@18.2.0
+      react-fast-compare: 3.2.0
+      warning: 4.0.3
+    dev: false
 
   /react-refresh/0.11.0:
     resolution: {integrity: sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A==}
@@ -16611,6 +16633,12 @@ packages:
     dependencies:
       makeerror: 1.0.12
     dev: true
+
+  /warning/4.0.3:
+    resolution: {integrity: sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==}
+    dependencies:
+      loose-envify: 1.4.0
+    dev: false
 
   /watchpack-chokidar2/2.0.1:
     resolution: {integrity: sha512-nCFfBIPKr5Sh61s4LPpy1Wtfi0HE8isJ3d2Yb5/Ppw2P2B/3eVSEBjKfN0fmHJSK14+31KwMKmcrzs2GM4P0Ww==}


### PR DESCRIPTION
The `BaseDropdown` component needed the following dependencies: `react-popper`, `react-max-size-modifier`, and `@popperjs/core`. However, `react-max-size-modifier` is currently deprecated, and the maintainer recommends switching to Floating UI. Since switching to Floating UI would require dropping `react-popper` and `@popperjs/core` all together and possibly lead to some breaking changes, I added the max size modifier directly to the code and stopped using `react-max-size-modifier`. This seemed like the most appropriate solution at the moment. 