### PR TITLE
feat(DotPagination): add DotPagination component

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -16,6 +16,7 @@ import {
   Input,
   FileUploader,
   Pagination,
+  DotPagination,
 } from "./components";
 import { Tooltip } from "./components/Tooltip/Tooltip";
 import { Dialogs } from "./components/Dialogs/Dialogs";
@@ -41,8 +42,8 @@ const App = () => {
       <HvBox sx={styles}>
         <ThemeSwitcher />
         <Typography />
-        {/* 
         <BaseDropdown />
+        <DotPagination />
         <Pagination />
         <DropDownMenu />
         <Buttons />
@@ -61,7 +62,7 @@ const App = () => {
         <EmptyState />
         <Buttons />
         <Icons />
-        <Icons /> */}
+        <BreadCrumb />
       </HvBox>
     </HvProvider>
   );

--- a/app/src/components/Pagination/Pagination.tsx
+++ b/app/src/components/Pagination/Pagination.tsx
@@ -1,5 +1,9 @@
 import styled from "@emotion/styled";
-import { HvPagination, HvTypography } from "@hitachivantara/uikit-core";
+import {
+  HvDotPagination,
+  HvPagination,
+  HvTypography,
+} from "@hitachivantara/uikit-core";
 import { useState } from "react";
 
 const StyledBox = styled(HvTypography)({
@@ -47,5 +51,51 @@ export const Pagination = () => {
         labels={{ pageSizeEntryName: "items" }}
       />
     </>
+  );
+};
+
+export const DotPagination = () => {
+  const [page, setPage] = useState<number>(0);
+  const pages = [
+    "This is page 1",
+    "And this is page 2",
+    "This is page 3",
+    "This is page 4",
+    "And finally, this is page 5",
+  ];
+
+  const StyledRoot = styled("div")({
+    width: "100%",
+    justifyContent: "center",
+  });
+
+  const StyledPage = styled("div")({
+    textAlign: "center",
+  });
+
+  return (
+    <StyledRoot>
+      <StyledPage>
+        <HvTypography>{pages[page]}</HvTypography>
+      </StyledPage>
+      <br />
+      <HvDotPagination
+        page={page}
+        pages={pages.length}
+        onPageChange={(_, value) => setPage(value)}
+        getItemAriaLabel={(pageNumber) => {
+          switch (pageNumber) {
+            case 0:
+              return "first page button aria-label";
+            case 4:
+              return "last page button aria-label";
+            default:
+              return `${pageNumber + 1} page aria-label`;
+          }
+        }}
+        role="navigation"
+        aria-label="Example Dot Navigation"
+      />
+    </StyledRoot>
   );
 };

--- a/packages/core/src/components/ActionsGeneric/__snapshots__/ActionsGeneric.test.tsx.snap
+++ b/packages/core/src/components/ActionsGeneric/__snapshots__/ActionsGeneric.test.tsx.snap
@@ -10,8 +10,6 @@ exports[`ActionsGeneric > should render correctly 1`] = `
       class="HvActionsGeneric-button e1bww73k0 css-5isxga-StyledButton-StyledButton egl9i9v0"
       disabled=""
       id="post"
-      radius="base"
-      variant="primary"
     >
       <div
         class="css-1nxr552-StyledContentDiv egl9i9v3"
@@ -49,8 +47,6 @@ exports[`ActionsGeneric > should render correctly 1`] = `
       category="primaryGhost"
       class="HvActionsGeneric-button e1bww73k0 css-3zs8og-StyledButton-StyledButton egl9i9v0"
       id="get"
-      radius="base"
-      variant="primary"
     >
       <div
         class="css-1nxr552-StyledContentDiv egl9i9v3"
@@ -88,8 +84,6 @@ exports[`ActionsGeneric > should render correctly 1`] = `
       category="primaryGhost"
       class="HvActionsGeneric-button e1bww73k0 css-3zs8og-StyledButton-StyledButton egl9i9v0"
       id="put"
-      radius="base"
-      variant="primary"
     >
       <div
         class="css-1nxr552-StyledContentDiv egl9i9v3"
@@ -127,8 +121,6 @@ exports[`ActionsGeneric > should render correctly 1`] = `
       category="primaryGhost"
       class="HvActionsGeneric-button e1bww73k0 css-3zs8og-StyledButton-StyledButton egl9i9v0"
       id="delete"
-      radius="base"
-      variant="primary"
     >
       <div
         class="css-1nxr552-StyledContentDiv egl9i9v3"

--- a/packages/core/src/components/BaseDropdown/BaseDropdown.styles.tsx
+++ b/packages/core/src/components/BaseDropdown/BaseDropdown.styles.tsx
@@ -104,8 +104,8 @@ export const StyledHeaderRoot = styled(
 export const StyledSelection = styled("div")({
   display: "flex",
   alignItems: "center",
-  height: "30px",
-  padding: "0px 30px 0px 10px",
+  height: theme.spacing(3.75),
+  padding: `0px ${theme.spacing(3.75)} 0px ${theme.spacing(1.25)}`,
 });
 
 export const StyledPlaceholder = styled(

--- a/packages/core/src/components/BaseDropdown/__snapshots__/BaseDropdown.test.tsx.snap
+++ b/packages/core/src/components/BaseDropdown/__snapshots__/BaseDropdown.test.tsx.snap
@@ -22,10 +22,10 @@ exports[`BaseDropDown > should render correctly 1`] = `
           tabindex="0"
         >
           <div
-            class="HvBaseDropdown-selection css-1c8fpra-StyledSelection e1xgfj1t6"
+            class="HvBaseDropdown-selection css-1n3tnd9-StyledSelection e1xgfj1t6"
           >
             <p
-              class="HvBaseDropdown-placeholder e1xgfj1t5 css-14mbrmu-getStyledComponent-StyledPlaceholder e1te0rfk0"
+              class="HvBaseDropdown-placeholder e1xgfj1t5 css-17knwax-getStyledComponent-StyledPlaceholder e1te0rfk0"
               variant="body"
             >
               Placeholder...

--- a/packages/core/src/components/BaseInput/__snapshots__/BaseInput.test.tsx.snap
+++ b/packages/core/src/components/BaseInput/__snapshots__/BaseInput.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`BaseInput > should render correctly 1`] = `
     class="HvBaseInput-root css-fp1w37-StyledRoot e1wsukd12"
   >
     <div
-      class="MuiInputBase-root MuiInput-root HvBaseInput-inputRoot MuiInput-underline MuiInputBase-colorPrimary  e1wsukd10 css-qhl3bu-MuiInputBase-root-MuiInput-root-StyledInput"
+      class="MuiInputBase-root MuiInput-root HvBaseInput-inputRoot MuiInput-underline MuiInputBase-colorPrimary  e1wsukd10 css-1veljhk-MuiInputBase-root-MuiInput-root-StyledInput"
     >
       <input
         class="MuiInputBase-input MuiInput-input HvBaseInput-input css-1x51dt5-MuiInputBase-input-MuiInput-input"

--- a/packages/core/src/components/CheckBox/CheckBox.styles.tsx
+++ b/packages/core/src/components/CheckBox/CheckBox.styles.tsx
@@ -60,7 +60,7 @@ export const StyledLabel = styled(
   overflow: "hidden",
   textOverflow: "ellipsis",
   verticalAlign: "middle",
-  paddingRight: "10px",
+  paddingRight: theme.spacing(1.25),
   whiteSpace: "nowrap",
   ...theme.typography.body,
   cursor: "pointer",

--- a/packages/core/src/components/CheckBox/__snapshots__/CheckBox.test.tsx.snap
+++ b/packages/core/src/components/CheckBox/__snapshots__/CheckBox.test.tsx.snap
@@ -44,7 +44,7 @@ exports[`CheckBox > general > should render correctly 1`] = `
         </div>
       </span>
       <label
-        class="HvCheckBox-label e162au071 HvLabel-root e1injmq50 css-zp8sbc-getStyledComponent-StyledTypography-StyledLabel e1te0rfk0"
+        class="HvCheckBox-label e162au071 HvLabel-root e1injmq50 css-ceg28g-getStyledComponent-StyledTypography-StyledLabel e1te0rfk0"
         for="hvcheckbox3-input"
         id="hvcheckbox3-label"
         variant="label"

--- a/packages/core/src/components/CheckBoxGroup/CheckBoxGroup.styles.tsx
+++ b/packages/core/src/components/CheckBoxGroup/CheckBoxGroup.styles.tsx
@@ -11,7 +11,9 @@ export const StyledFormElement = styled(HvFormElement)({
   verticalAlign: "top",
 });
 
-export const StyledLabel = styled(HvLabel)({ marginBottom: "10px" });
+export const StyledLabel = styled(HvLabel)({
+  marginBottom: theme.spacing(1.25),
+});
 
 export const StyledGroupContainer = styled(
   "div",
@@ -47,15 +49,15 @@ export const StyledGroupContainer = styled(
     ...($horizontal && {
       flexDirection: "row",
       flexWrap: "wrap",
-      marginLeft: "-20px",
+      marginLeft: `-${theme.spacing(2.5)}`,
 
       "&>*": {
-        marginLeft: "20px",
+        marginLeft: theme.spacing(2.5),
       },
     }),
 
     ...($invalid && {
-      paddingBottom: "10px",
+      paddingBottom: theme.spacing(1.25),
       borderBottom: `1px solid ${theme.colors.sema4}`,
     }),
   })

--- a/packages/core/src/components/CheckBoxGroup/__snapshots__/CheckBoxGroup.test.tsx.snap
+++ b/packages/core/src/components/CheckBoxGroup/__snapshots__/CheckBoxGroup.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`CheckBoxGroup > general > should render correctly 1`] = `
     class="HvCheckBoxGroup-root css-whistd-StyledFormElement e1616oom2 HvFormElement-root"
   >
     <label
-      class="HvCheckBoxGroup-label e1616oom1 HvLabel-root e1injmq50 css-d8fglj-getStyledComponent-StyledTypography-StyledLabel e1te0rfk0"
+      class="HvCheckBoxGroup-label e1616oom1 HvLabel-root e1injmq50 css-1gjgsi2-getStyledComponent-StyledTypography-StyledLabel e1te0rfk0"
       id="hvcheckboxgroup9-label"
       variant="label"
     >
@@ -59,7 +59,7 @@ exports[`CheckBoxGroup > general > should render correctly 1`] = `
             </div>
           </span>
           <label
-            class="HvCheckBox-label e162au071 HvLabel-root e1injmq50 css-zp8sbc-getStyledComponent-StyledTypography-StyledLabel e1te0rfk0"
+            class="HvCheckBox-label e162au071 HvLabel-root e1injmq50 css-ceg28g-getStyledComponent-StyledTypography-StyledLabel e1te0rfk0"
             for="hvcheckbox11-input"
             id="hvcheckbox11-label"
             variant="label"
@@ -110,7 +110,7 @@ exports[`CheckBoxGroup > general > should render correctly 1`] = `
             </div>
           </span>
           <label
-            class="HvCheckBox-label e162au071 HvLabel-root e1injmq50 css-zp8sbc-getStyledComponent-StyledTypography-StyledLabel e1te0rfk0"
+            class="HvCheckBox-label e162au071 HvLabel-root e1injmq50 css-ceg28g-getStyledComponent-StyledTypography-StyledLabel e1te0rfk0"
             for="hvcheckbox13-input"
             id="hvcheckbox13-label"
             variant="label"
@@ -161,7 +161,7 @@ exports[`CheckBoxGroup > general > should render correctly 1`] = `
             </div>
           </span>
           <label
-            class="HvCheckBox-label e162au071 HvLabel-root e1injmq50 css-zp8sbc-getStyledComponent-StyledTypography-StyledLabel e1te0rfk0"
+            class="HvCheckBox-label e162au071 HvLabel-root e1injmq50 css-ceg28g-getStyledComponent-StyledTypography-StyledLabel e1te0rfk0"
             for="hvcheckbox15-input"
             id="hvcheckbox15-label"
             variant="label"

--- a/packages/core/src/components/DotPagination/DotPagination.stories.tsx
+++ b/packages/core/src/components/DotPagination/DotPagination.stories.tsx
@@ -1,0 +1,143 @@
+import styled from "@emotion/styled";
+import {
+  CurrentStep,
+  RadioButtonUnselected,
+} from "@hitachivantara/uikit-icons";
+import { theme } from "@hitachivantara/uikit-styles";
+import { Meta, StoryObj } from "@storybook/react";
+import { HvTypography } from "components";
+import { useState } from "react";
+import { HvDotPagination, HvDotPaginationProps } from "./DotPagination";
+import dotPaginationClasses from "./dotPaginationClasses";
+
+const meta: Meta<typeof HvDotPagination> = {
+  title: "Navigation/DotPagination",
+  component: HvDotPagination,
+};
+
+export default meta;
+
+export const Main: StoryObj<HvDotPaginationProps> = {
+  argTypes: {
+    classes: { control: { disable: true } },
+  },
+  render: () => {
+    const [page, setPage] = useState<number>(0);
+    const pages = [
+      "This is page 1",
+      "And this is page 2",
+      "This is page 3",
+      "This is page 4",
+      "And finally, this is page 5",
+    ];
+
+    const StyledRoot = styled("div")({
+      width: "100%",
+      justifyContent: "center",
+    });
+
+    const StyledPage = styled("div")({
+      textAlign: "center",
+    });
+
+    return (
+      <StyledRoot>
+        <StyledPage>
+          <HvTypography>{pages[page]}</HvTypography>
+        </StyledPage>
+        <br />
+        <HvDotPagination
+          page={page}
+          pages={pages.length}
+          onPageChange={(_, value) => setPage(value)}
+          getItemAriaLabel={(pageNumber) => {
+            switch (pageNumber) {
+              case 0:
+                return "first page button aria-label";
+              case 4:
+                return "last page button aria-label";
+              default:
+                return `${pageNumber + 1} page aria-label`;
+            }
+          }}
+          role="navigation"
+          aria-label="Example Dot Navigation"
+        />
+      </StyledRoot>
+    );
+  },
+};
+
+export const CustomizedDotPagination: StoryObj<HvDotPaginationProps> = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "The `DotPagination` component was customized to be similar to the NEXT Design System 3 specifications. " +
+          "Thus, the styling was overridden and the `unselectedIcon` and `selectedIcon` properties were provided.",
+      },
+    },
+  },
+  render: () => {
+    const [page, setPage] = useState<number>(0);
+    const pages = [
+      "This is page 1",
+      "And this is page 2",
+      "Now you can see page 3",
+      "Look, it's page 4",
+      "And finally, this is page 5",
+    ];
+
+    const StyledRoot = styled("div")({
+      width: "100%",
+      justifyContent: "center",
+    });
+
+    const StyledPage = styled("div")({
+      textAlign: "center",
+    });
+
+    const StyledDotPagination = styled(HvDotPagination)({
+      [`& .${dotPaginationClasses.radioRoot}`]: {
+        marginLeft: "0px",
+      },
+
+      [`& .${dotPaginationClasses.radio}`]: {
+        height: "32px",
+
+        "&:hover": {
+          backgroundColor: theme.colors.atmo3,
+          borderRadius: 0,
+        },
+      },
+    });
+
+    return (
+      <StyledRoot>
+        <StyledPage>
+          <HvTypography>{pages[page]}</HvTypography>
+        </StyledPage>
+        <br />
+        <StyledDotPagination
+          unselectedIcon={<RadioButtonUnselected iconSize="XS" />}
+          selectedIcon={<CurrentStep iconSize="XS" />}
+          page={page}
+          pages={pages.length}
+          onPageChange={(_, value) => setPage(value)}
+          getItemAriaLabel={(pageNumber) => {
+            switch (pageNumber) {
+              case 0:
+                return "first page button aria-label";
+              case 4:
+                return "last page button aria-label";
+              default:
+                return `${pageNumber + 1} page aria-label`;
+            }
+          }}
+          role="navigation"
+          aria-label="Example Dot Navigation"
+        />
+      </StyledRoot>
+    );
+  },
+};

--- a/packages/core/src/components/DotPagination/DotPagination.styles.tsx
+++ b/packages/core/src/components/DotPagination/DotPagination.styles.tsx
@@ -1,0 +1,40 @@
+import styled from "@emotion/styled";
+import { HvRadio, HvRadioGroup } from "components";
+import { theme } from "@hitachivantara/uikit-styles";
+import dotPaginationClasses from "./dotPaginationClasses";
+import { CurrentStep, OtherStep } from "@hitachivantara/uikit-icons";
+
+export const StyledRadioGroup = styled(HvRadioGroup)({
+  display: "flex",
+  justifyContent: "center",
+
+  [`& .${dotPaginationClasses.horizontal}`]: {
+    marginLeft: 0,
+    width: "auto",
+  },
+});
+
+export const StyledRadio = styled((props) => <HvRadio {...props} />)({
+  [`&.${dotPaginationClasses.radioRoot}`]: {
+    marginLeft: "8px",
+  },
+
+  [`& .${dotPaginationClasses.radio}`]: {
+    height: "16px",
+
+    "&:hover": {
+      backgroundColor: theme.colors.sema7,
+      borderRadius: "100%",
+    },
+  },
+});
+
+export const StyledOtherStep = styled(OtherStep)({
+  width: "16px",
+  height: "16px",
+});
+
+export const StyledCurrentStep = styled(CurrentStep)({
+  width: "16px",
+  height: "16px",
+});

--- a/packages/core/src/components/DotPagination/DotPagination.test.tsx
+++ b/packages/core/src/components/DotPagination/DotPagination.test.tsx
@@ -1,0 +1,200 @@
+import { render } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { HvTypography } from "components";
+import { useState } from "react";
+import { describe, expect, it } from "vitest";
+import { HvDotPagination } from "./DotPagination";
+
+const Pagination = ({ page }: { page: number }) => (
+  <HvDotPagination
+    page={page}
+    pages={3}
+    getItemAriaLabel={(pageNumber) => {
+      switch (pageNumber) {
+        case 0:
+          return "first page button aria-label";
+        case 2:
+          return "last page button aria-label";
+        default:
+          return `${pageNumber + 1} page aria-label`;
+      }
+    }}
+    role="navigation"
+  />
+);
+
+const PaginationWithState = () => {
+  const [page, setPage] = useState<number>(0);
+  const pages = ["Page 1", "Page 2", "Page 3", "Page 4", "Page 5"];
+
+  return (
+    <div>
+      <div>
+        <HvTypography>{pages[page]}</HvTypography>
+      </div>
+      <br />
+      <HvDotPagination
+        page={page}
+        pages={pages.length}
+        onPageChange={(_, value) => setPage(value)}
+        getItemAriaLabel={(pageNumber) => {
+          switch (pageNumber) {
+            case 0:
+              return "first page button aria-label";
+            case 4:
+              return "last page button aria-label";
+            default:
+              return `${pageNumber + 1} page aria-label`;
+          }
+        }}
+        role="navigation"
+        aria-label="Example Dot Navigation"
+      />
+    </div>
+  );
+};
+
+describe("DotPagination", () => {
+  it("should be defined", () => {
+    const { container } = render(<Pagination page={0} />);
+
+    expect(container).toBeDefined();
+  });
+
+  it("should render correctly", () => {
+    const { container } = render(<Pagination page={0} />);
+
+    expect(container).toMatchSnapshot();
+  });
+
+  it("should have dot navigation on the first page", async () => {
+    const { getByLabelText, findByRole } = render(<Pagination page={0} />);
+
+    const dotPagination = await findByRole("navigation");
+
+    expect(dotPagination).toBeInTheDocument();
+
+    // Check if all buttons are present, have the right aria label and get their reference
+    const radioButton1 = getByLabelText("first page button aria-label");
+    const radioButton2 = getByLabelText("2 page aria-label");
+    const radioButton3 = getByLabelText("last page button aria-label");
+
+    expect(radioButton1).toBeInTheDocument();
+    expect(radioButton2).toBeInTheDocument();
+    expect(radioButton3).toBeInTheDocument();
+
+    expect(radioButton1).toBeChecked();
+    expect(radioButton2).not.toBeChecked();
+    expect(radioButton3).not.toBeChecked();
+  });
+
+  it("should have dot navigation on the second page", async () => {
+    const { getByLabelText, findByRole } = render(<Pagination page={1} />);
+
+    const dotPagination = await findByRole("navigation");
+
+    expect(dotPagination).toBeInTheDocument();
+
+    // Check if all buttons are present, have the right aria label and get their reference
+    const radioButton1 = getByLabelText("first page button aria-label");
+    const radioButton2 = getByLabelText("2 page aria-label");
+    const radioButton3 = getByLabelText("last page button aria-label");
+
+    expect(radioButton1).toBeInTheDocument();
+    expect(radioButton2).toBeInTheDocument();
+    expect(radioButton3).toBeInTheDocument();
+
+    expect(radioButton1).not.toBeChecked();
+    expect(radioButton2).toBeChecked();
+    expect(radioButton3).not.toBeChecked();
+  });
+
+  it("should have dot navigation on the last page", async () => {
+    const { getByLabelText, findByRole } = render(<Pagination page={2} />);
+
+    const dotPagination = await findByRole("navigation");
+
+    expect(dotPagination).toBeInTheDocument();
+
+    // Check if all buttons are present, have the right aria label and get their reference
+    const radioButton1 = getByLabelText("first page button aria-label");
+    const radioButton2 = getByLabelText("2 page aria-label");
+    const radioButton3 = getByLabelText("last page button aria-label");
+
+    expect(radioButton1).toBeInTheDocument();
+    expect(radioButton2).toBeInTheDocument();
+    expect(radioButton3).toBeInTheDocument();
+
+    expect(radioButton1).not.toBeChecked();
+    expect(radioButton2).not.toBeChecked();
+    expect(radioButton3).toBeChecked();
+  });
+
+  it("should have dot navigation on all pages", async () => {
+    const { getByLabelText, findByRole, findByText } = render(
+      <PaginationWithState />
+    );
+
+    const dotPagination = await findByRole("navigation");
+
+    expect(dotPagination).toBeInTheDocument();
+
+    // Check if all buttons are present, have the right aria label and get their reference
+    const radioButton1 = getByLabelText("first page button aria-label");
+    const radioButton2 = getByLabelText("2 page aria-label");
+    const radioButton3 = getByLabelText("3 page aria-label");
+    const radioButton4 = getByLabelText("4 page aria-label");
+    const radioButton5 = getByLabelText("last page button aria-label");
+
+    expect(radioButton1).toBeInTheDocument();
+    expect(radioButton2).toBeInTheDocument();
+    expect(radioButton3).toBeInTheDocument();
+    expect(radioButton4).toBeInTheDocument();
+    expect(radioButton5).toBeInTheDocument();
+
+    await userEvent.click(radioButton1);
+    await findByText("Page 1");
+
+    expect(radioButton1).toBeChecked();
+    expect(radioButton2).not.toBeChecked();
+    expect(radioButton3).not.toBeChecked();
+    expect(radioButton4).not.toBeChecked();
+    expect(radioButton5).not.toBeChecked();
+
+    await userEvent.click(radioButton2);
+    await findByText("Page 2");
+
+    expect(radioButton1).not.toBeChecked();
+    expect(radioButton2).toBeChecked();
+    expect(radioButton3).not.toBeChecked();
+    expect(radioButton4).not.toBeChecked();
+    expect(radioButton5).not.toBeChecked();
+
+    await userEvent.click(radioButton3);
+    await findByText("Page 3");
+
+    expect(radioButton1).not.toBeChecked();
+    expect(radioButton2).not.toBeChecked();
+    expect(radioButton3).toBeChecked();
+    expect(radioButton4).not.toBeChecked();
+    expect(radioButton5).not.toBeChecked();
+
+    await userEvent.click(radioButton4);
+    await findByText("Page 4");
+
+    expect(radioButton1).not.toBeChecked();
+    expect(radioButton2).not.toBeChecked();
+    expect(radioButton3).not.toBeChecked();
+    expect(radioButton4).toBeChecked();
+    expect(radioButton5).not.toBeChecked();
+
+    await userEvent.click(radioButton5);
+    await findByText("Page 5");
+
+    expect(radioButton1).not.toBeChecked();
+    expect(radioButton2).not.toBeChecked();
+    expect(radioButton3).not.toBeChecked();
+    expect(radioButton4).not.toBeChecked();
+    expect(radioButton5).toBeChecked();
+  });
+});

--- a/packages/core/src/components/DotPagination/DotPagination.tsx
+++ b/packages/core/src/components/DotPagination/DotPagination.tsx
@@ -1,0 +1,115 @@
+import clsx from "clsx";
+import { HvRadioGroupProps } from "../RadioGroup";
+import dotPaginationClasses, {
+  HvDotPaginationClasses,
+} from "./dotPaginationClasses";
+import {
+  StyledCurrentStep,
+  StyledOtherStep,
+  StyledRadio,
+  StyledRadioGroup,
+} from "./DotPagination.styles";
+import { cloneElement } from "react";
+
+export type HvDotPaginationProps = HvRadioGroupProps & {
+  /**
+   * Icon to override the default one used for the unselected state.
+   *
+   * The default icon is `OtherStep`.
+   */
+  unselectedIcon?: React.ReactElement;
+  /**
+   * Icon to override the default one used for the selected state.
+   *
+   * The default icon is `CurrentStep`.
+   */
+  selectedIcon?: React.ReactElement;
+  /**
+   *  The number of pages the component has.
+   */
+  pages?: number;
+  /**
+   * The currently selected page.
+   */
+  page?: number;
+  /**
+   * The callback fired when the page value changes.
+   */
+  onPageChange?: (
+    event: React.ChangeEvent<HTMLInputElement>,
+    page: number
+  ) => void;
+  /**
+   * The callback fired to get the page aria label.
+   */
+  getItemAriaLabel?: (page: number) => string;
+  /**
+   * A Jss Object used to override or extend the styles applied.
+   */
+  classes?: HvDotPaginationClasses;
+};
+
+const getSelectorIcons = (
+  radioIcon?: React.ReactElement,
+  radioCheckedIcon?: React.ReactElement,
+  classes?: HvDotPaginationClasses
+) => {
+  return {
+    radio: cloneElement(radioIcon || <StyledOtherStep width={8} height={8} />, {
+      className: clsx(classes?.icon, dotPaginationClasses.icon),
+    }),
+    radioChecked: cloneElement(
+      radioCheckedIcon || <StyledCurrentStep width={8} height={8} />,
+      {
+        className: clsx(classes?.icon, dotPaginationClasses.icon),
+      }
+    ),
+  };
+};
+
+/**
+ * Pagination is the process of dividing a document into discrete pages. It relates to how users interact with structured content on a website or application.
+ * This component uses Radio Buttons to represent each page.
+ */
+export const HvDotPagination = ({
+  className,
+  classes,
+  unselectedIcon,
+  selectedIcon,
+  pages = 1,
+  page = 0,
+  onPageChange,
+  getItemAriaLabel,
+  ...others
+}: HvDotPaginationProps) => {
+  const range = (n: number) => Array.from(Array(n), (_, i) => i);
+
+  const icons = getSelectorIcons(unselectedIcon, selectedIcon, classes);
+
+  return (
+    <StyledRadioGroup
+      className={clsx(className, classes?.root, dotPaginationClasses.root)}
+      classes={{
+        horizontal: clsx(classes?.horizontal, dotPaginationClasses.horizontal),
+      }}
+      orientation="horizontal"
+      {...others}
+    >
+      {range(pages).map((i) => (
+        <StyledRadio
+          classes={{
+            radio: clsx(classes?.radio, dotPaginationClasses.radio),
+            root: clsx(classes?.radioRoot, dotPaginationClasses.radioRoot),
+          }}
+          key={i}
+          value={i}
+          checked={page === i}
+          onChange={(event) => onPageChange?.(event, i)}
+          icon={icons.radio}
+          checkedIcon={icons.radioChecked}
+          aria-label={getItemAriaLabel?.(i)}
+        />
+      ))}
+    </StyledRadioGroup>
+  );
+};

--- a/packages/core/src/components/DotPagination/__snapshots__/DotPagination.test.tsx.snap
+++ b/packages/core/src/components/DotPagination/__snapshots__/DotPagination.test.tsx.snap
@@ -1,0 +1,118 @@
+// Vitest Snapshot v1
+
+exports[`DotPagination > should render correctly 1`] = `
+<div>
+  <div
+    class="HvDotPagination-root e1jtaca23 HvRadioGroup-root css-w7urnl-StyledFormElement-StyledRadioGroup e3r04jq2 HvFormElement-root"
+  >
+    <div
+      class="HvRadioGroup-group HvDotPagination-horizontal HvRadioGroup-horizontal css-li4s69-StyledGroup e3r04jq0"
+      role="navigation"
+    >
+      <div
+        class="e1jtaca22 HvRadio-root HvDotPagination-radioRoot css-esudyc-StyledHvFormElement-StyledRadio e1h80t9i2 HvFormElement-root"
+      >
+        <span
+          class="MuiButtonBase-root MuiRadio-root MuiRadio-colorDefault PrivateSwitchBase-root MuiRadio-root MuiRadio-colorDefault Mui-checked MuiRadio-root MuiRadio-colorDefault HvRadio-radio HvDotPagination-radio e1h80t9i3 HvBaseRadio-root e1v341dn0 css-1t388db-MuiButtonBase-root-MuiRadio-root-StyledRadio-StyledHvBaseRadio"
+        >
+          <input
+            aria-label="first page button aria-label"
+            checked=""
+            class="PrivateSwitchBase-input css-1m9pwf3"
+            name="hvradiogroup9"
+            type="radio"
+            value="0"
+          />
+          <div
+            class="HvDotPagination-icon css-10burq8-StyledCurrentStep e1jtaca20 css-du18qm"
+            font-size="medium"
+            name="CurrentStep"
+          >
+            <svg
+              focusable="false"
+              height="8"
+              viewBox="0 0 16 16"
+              width="8"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                class="color0"
+                d="M16 8a8.024 8.024 0 0 1-8 8 8.023 8.023 0 0 1-8-8 8.023 8.023 0 0 1 8-8 8.024 8.024 0 0 1 8 8z"
+                fill="var(--colors-acce1)"
+              />
+            </svg>
+          </div>
+        </span>
+      </div>
+      <div
+        class="e1jtaca22 HvRadio-root HvDotPagination-radioRoot css-esudyc-StyledHvFormElement-StyledRadio e1h80t9i2 HvFormElement-root"
+      >
+        <span
+          class="MuiButtonBase-root MuiRadio-root MuiRadio-colorDefault PrivateSwitchBase-root MuiRadio-root MuiRadio-colorDefault MuiRadio-root MuiRadio-colorDefault HvRadio-radio HvDotPagination-radio e1h80t9i3 HvBaseRadio-root e1v341dn0 css-1t388db-MuiButtonBase-root-MuiRadio-root-StyledRadio-StyledHvBaseRadio"
+        >
+          <input
+            aria-label="2 page aria-label"
+            class="PrivateSwitchBase-input css-1m9pwf3"
+            name="hvradiogroup9"
+            type="radio"
+            value="1"
+          />
+          <div
+            class="HvDotPagination-icon css-1tb1fcm-StyledOtherStep e1jtaca21 css-du18qm"
+            font-size="medium"
+            name="OtherStep"
+          >
+            <svg
+              focusable="false"
+              height="8"
+              viewBox="0 0 16 16"
+              width="8"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                class="color0"
+                d="M12 8a4.012 4.012 0 0 1-4 4 4.012 4.012 0 0 1-4-4 4.012 4.012 0 0 1 4-4 4.012 4.012 0 0 1 4 4z"
+                fill="var(--colors-acce1)"
+              />
+            </svg>
+          </div>
+        </span>
+      </div>
+      <div
+        class="e1jtaca22 HvRadio-root HvDotPagination-radioRoot css-esudyc-StyledHvFormElement-StyledRadio e1h80t9i2 HvFormElement-root"
+      >
+        <span
+          class="MuiButtonBase-root MuiRadio-root MuiRadio-colorDefault PrivateSwitchBase-root MuiRadio-root MuiRadio-colorDefault MuiRadio-root MuiRadio-colorDefault HvRadio-radio HvDotPagination-radio e1h80t9i3 HvBaseRadio-root e1v341dn0 css-1t388db-MuiButtonBase-root-MuiRadio-root-StyledRadio-StyledHvBaseRadio"
+        >
+          <input
+            aria-label="last page button aria-label"
+            class="PrivateSwitchBase-input css-1m9pwf3"
+            name="hvradiogroup9"
+            type="radio"
+            value="2"
+          />
+          <div
+            class="HvDotPagination-icon css-1tb1fcm-StyledOtherStep e1jtaca21 css-du18qm"
+            font-size="medium"
+            name="OtherStep"
+          >
+            <svg
+              focusable="false"
+              height="8"
+              viewBox="0 0 16 16"
+              width="8"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                class="color0"
+                d="M12 8a4.012 4.012 0 0 1-4 4 4.012 4.012 0 0 1-4-4 4.012 4.012 0 0 1 4-4 4.012 4.012 0 0 1 4 4z"
+                fill="var(--colors-acce1)"
+              />
+            </svg>
+          </div>
+        </span>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/packages/core/src/components/DotPagination/dotPaginationClasses.ts
+++ b/packages/core/src/components/DotPagination/dotPaginationClasses.ts
@@ -1,0 +1,24 @@
+import { getClasses } from "utils";
+
+export type HvDotPaginationClasses = {
+  root?: string;
+  horizontal?: string;
+  radioRoot?: string;
+  radio?: string;
+  icon?: string;
+};
+
+const classKeys: string[] = [
+  "root",
+  "horizontal",
+  "radioRoot",
+  "radio",
+  "icon",
+];
+
+const dotPaginationClasses = getClasses<HvDotPaginationClasses>(
+  classKeys,
+  "HvDotPagination"
+);
+
+export default dotPaginationClasses;

--- a/packages/core/src/components/DotPagination/index.ts
+++ b/packages/core/src/components/DotPagination/index.ts
@@ -1,0 +1,3 @@
+export { default as dotPaginationClasses } from "./dotPaginationClasses";
+export * from "./dotPaginationClasses";
+export * from "./DotPagination";

--- a/packages/core/src/components/DropDownMenu/__snapshots__/DropDownMenu.test.tsx.snap
+++ b/packages/core/src/components/DropDownMenu/__snapshots__/DropDownMenu.test.tsx.snap
@@ -20,8 +20,6 @@ exports[`DropDownMenu > should render correctly 1`] = `
           aria-label="Dropdown menu"
           class="HvDropDownMenu-icon e1y5ntva1 css-ubhy60-StyledButton-StyledButton egl9i9v0"
           id="-2-icon-button"
-          radius="base"
-          variant="secondaryGhost"
         >
           <div
             class="css-1nxr552-StyledContentDiv egl9i9v3"

--- a/packages/core/src/components/FileUploader/DropZone/DropZone.styles.tsx
+++ b/packages/core/src/components/FileUploader/DropZone/DropZone.styles.tsx
@@ -96,7 +96,7 @@ export const StyledInput = styled("input")({
 
 export const StyledDropArea = styled("div")({
   display: "flex",
-  margin: "30px auto",
+  margin: `${theme.spacing(3.75)} auto`,
   minHeight: 48,
 });
 
@@ -112,7 +112,7 @@ export const StyledDragText = styled(HvTypography)({
 
 export const StyledDropAreaIcon = styled(Doc)({
   margin: "auto",
-  marginRight: "10px",
+  marginRight: theme.spacing(1.25),
 });
 
 export const StyledDropAreaLabels = styled("div")({

--- a/packages/core/src/components/FileUploader/DropZone/__snapshots__/DropZone.test.tsx.snap
+++ b/packages/core/src/components/FileUploader/DropZone/__snapshots__/DropZone.test.tsx.snap
@@ -40,10 +40,10 @@ exports[`DropZone > should render correctly 1`] = `
       type="file"
     />
     <div
-      class="HvDropZone-dropArea css-7a01xx-StyledDropArea e1exqe5d5"
+      class="HvDropZone-dropArea css-1gwzdkt-StyledDropArea e1exqe5d5"
     >
       <div
-        class="HvDropZone-dropZoneAreaIcon css-unhwub-StyledDropAreaIcon e1exqe5d2 css-xq48n2"
+        class="HvDropZone-dropZoneAreaIcon css-e01vc1-StyledDropAreaIcon e1exqe5d2 css-xq48n2"
         name="Doc"
       >
         <svg
@@ -121,10 +121,10 @@ exports[`DropZone > should render correctly when disabled 1`] = `
       type="file"
     />
     <div
-      class="HvDropZone-dropArea css-7a01xx-StyledDropArea e1exqe5d5"
+      class="HvDropZone-dropArea css-1gwzdkt-StyledDropArea e1exqe5d5"
     >
       <div
-        class="HvDropZone-dropZoneAreaIcon css-unhwub-StyledDropAreaIcon e1exqe5d2 css-xq48n2"
+        class="HvDropZone-dropZoneAreaIcon css-e01vc1-StyledDropAreaIcon e1exqe5d2 css-xq48n2"
         name="Doc"
       >
         <svg

--- a/packages/core/src/components/FileUploader/File/File.styles.tsx
+++ b/packages/core/src/components/FileUploader/File/File.styles.tsx
@@ -3,7 +3,11 @@ import { Fail, Success } from "@hitachivantara/uikit-icons";
 import { theme } from "@hitachivantara/uikit-styles";
 import { HvButton, HvTypography } from "components";
 
-const iconStyles = { width: 32, height: 32, margin: "0px 10px" };
+const iconStyles = {
+  width: 32,
+  height: 32,
+  margin: `0px ${theme.spacing(1.25)}`,
+};
 
 export const StyledSuccess = styled(Success)({
   ...iconStyles,
@@ -54,7 +58,7 @@ export const StyledProgressTextContainer = styled("span")({
 
 export const StyledPreviewContainer = styled("div")({
   display: "flex",
-  margin: "0px 10px",
+  margin: `0px ${theme.spacing(1.25)}`,
   width: theme.fileUploader.file.previewContainerSize,
   height: theme.fileUploader.file.previewContainerSize,
   justifyContent: "center",
@@ -78,5 +82,5 @@ export const StyledPreviewContainer = styled("div")({
 });
 
 export const StyledIconButton = styled(HvButton)({
-  margin: "0px 10px",
+  margin: `0px ${theme.spacing(1.25)}`,
 });

--- a/packages/core/src/components/FileUploader/File/__snapshots__/File.test.tsx.snap
+++ b/packages/core/src/components/FileUploader/File/__snapshots__/File.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`File > should render correctly fail status 1`] = `
   class="HvFile-root"
 >
   <div
-    class="HvFile-icon css-mych0h-StyledFail e11o985j8 css-du18qm"
+    class="HvFile-icon css-xinaoy-StyledFail e11o985j8 css-du18qm"
     name="Fail"
   >
     <svg
@@ -41,9 +41,7 @@ exports[`File > should render correctly fail status 1`] = `
   </span>
   <button
     aria-label="removeFileButtonLabel"
-    class="HvFile-removeButton e11o985j0 css-7nz3sy-StyledButton-StyledIconButton egl9i9v0"
-    radius="base"
-    variant="secondaryGhost"
+    class="HvFile-removeButton e11o985j0 css-17wdxfh-StyledButton-StyledIconButton egl9i9v0"
   >
     <div
       class="css-1nxr552-StyledContentDiv egl9i9v3"
@@ -80,7 +78,7 @@ exports[`File > should render correctly success status 1`] = `
   class="HvFile-root"
 >
   <div
-    class="HvFile-icon css-18h216t-StyledSuccess e11o985j9 css-du18qm"
+    class="HvFile-icon css-1guhon3-StyledSuccess e11o985j9 css-du18qm"
     name="Success"
   >
     <svg
@@ -116,9 +114,7 @@ exports[`File > should render correctly success status 1`] = `
   </span>
   <button
     aria-label="removeFileButtonLabel"
-    class="HvFile-removeButton e11o985j0 css-7nz3sy-StyledButton-StyledIconButton egl9i9v0"
-    radius="base"
-    variant="secondaryGhost"
+    class="HvFile-removeButton e11o985j0 css-17wdxfh-StyledButton-StyledIconButton egl9i9v0"
   >
     <div
       class="css-1nxr552-StyledContentDiv egl9i9v3"

--- a/packages/core/src/components/FileUploader/FileList/FileList.styles.tsx
+++ b/packages/core/src/components/FileUploader/FileList/FileList.styles.tsx
@@ -5,10 +5,10 @@ import fileListClasses from "./fileListClasses";
 export const StyledList = styled("ul")({
   display: "flex",
   flexDirection: "column",
-  gap: "10px",
+  gap: theme.spacing(1.25),
   margin: 0,
   padding: 0,
-  marginTop: "20px",
+  marginTop: theme.spacing(2.5),
   listStyle: "none",
 
   [`& .${fileListClasses.listItem}`]: {
@@ -16,7 +16,7 @@ export const StyledList = styled("ul")({
     display: "flex",
     alignItems: "center",
     background: theme.colors.atmo1,
-    padding: "10px 0px",
+    padding: `${theme.spacing(1.25)} 0px`,
     border: theme.fileUploader.fileList.itemBorder,
     borderRadius: theme.fileUploader.fileList.itemBorderRadius,
   },

--- a/packages/core/src/components/FileUploader/FileList/__snapshots__/FileList.test.tsx.snap
+++ b/packages/core/src/components/FileUploader/FileList/__snapshots__/FileList.test.tsx.snap
@@ -3,14 +3,14 @@
 exports[`FileList > should render correctly 1`] = `
 <div>
   <ul
-    class="HvFileList-list css-12tzpa8-StyledList e1ybz4wc0"
+    class="HvFileList-list css-1bo3zqs-StyledList e1ybz4wc0"
     id="list-list"
   >
     <li
       class="HvFileList-listItem HvFile-root"
     >
       <div
-        class="HvFile-icon css-mych0h-StyledFail e11o985j8 css-du18qm"
+        class="HvFile-icon css-xinaoy-StyledFail e11o985j8 css-du18qm"
         name="Fail"
       >
         <svg
@@ -46,10 +46,8 @@ exports[`FileList > should render correctly 1`] = `
       </span>
       <button
         aria-label="removeFileButtonLabel"
-        class="HvFile-removeButton e11o985j0 css-7nz3sy-StyledButton-StyledIconButton egl9i9v0"
+        class="HvFile-removeButton e11o985j0 css-17wdxfh-StyledButton-StyledIconButton egl9i9v0"
         id="list-values-remove-button"
-        radius="base"
-        variant="secondaryGhost"
       >
         <div
           class="css-1nxr552-StyledContentDiv egl9i9v3"
@@ -83,7 +81,7 @@ exports[`FileList > should render correctly 1`] = `
       class="HvFileList-listItem HvFile-root"
     >
       <div
-        class="HvFile-icon css-mych0h-StyledFail e11o985j8 css-du18qm"
+        class="HvFile-icon css-xinaoy-StyledFail e11o985j8 css-du18qm"
         name="Fail"
       >
         <svg
@@ -119,10 +117,8 @@ exports[`FileList > should render correctly 1`] = `
       </span>
       <button
         aria-label="removeFileButtonLabel"
-        class="HvFile-removeButton e11o985j0 css-7nz3sy-StyledButton-StyledIconButton egl9i9v0"
+        class="HvFile-removeButton e11o985j0 css-17wdxfh-StyledButton-StyledIconButton egl9i9v0"
         id="list-values-remove-button"
-        radius="base"
-        variant="secondaryGhost"
       >
         <div
           class="css-1nxr552-StyledContentDiv egl9i9v3"

--- a/packages/core/src/components/FileUploader/__snapshots__/FileUploader.test.tsx.snap
+++ b/packages/core/src/components/FileUploader/__snapshots__/FileUploader.test.tsx.snap
@@ -41,10 +41,10 @@ exports[`FileUploader > should render correctly 1`] = `
         type="file"
       />
       <div
-        class="HvDropZone-dropArea css-7a01xx-StyledDropArea e1exqe5d5"
+        class="HvDropZone-dropArea css-1gwzdkt-StyledDropArea e1exqe5d5"
       >
         <div
-          class="HvDropZone-dropZoneAreaIcon css-unhwub-StyledDropAreaIcon e1exqe5d2 css-xq48n2"
+          class="HvDropZone-dropZoneAreaIcon css-e01vc1-StyledDropAreaIcon e1exqe5d2 css-xq48n2"
           name="Doc"
         >
           <svg
@@ -79,13 +79,13 @@ exports[`FileUploader > should render correctly 1`] = `
       </div>
     </div>
     <ul
-      class="HvFileList-list css-12tzpa8-StyledList e1ybz4wc0"
+      class="HvFileList-list css-1bo3zqs-StyledList e1ybz4wc0"
     >
       <li
         class="HvFileList-listItem HvFile-root"
       >
         <div
-          class="HvFile-icon css-ww6rg5-StyledEmptyIcon e11o985j7"
+          class="HvFile-icon css-11wunl3-StyledEmptyIcon e11o985j7"
         />
         <p
           class="HvFile-nameText e11o985j3 css-1rntirt-getStyledComponent-StyledNameText e1te0rfk0"
@@ -106,10 +106,8 @@ exports[`FileUploader > should render correctly 1`] = `
         </span>
         <button
           aria-label="Remove File"
-          class="HvFile-removeButton e11o985j0 css-7nz3sy-StyledButton-StyledIconButton egl9i9v0"
+          class="HvFile-removeButton e11o985j0 css-17wdxfh-StyledButton-StyledIconButton egl9i9v0"
           id="hvfilelist4-values-remove-button"
-          radius="base"
-          variant="secondaryGhost"
         >
           <div
             class="css-1nxr552-StyledContentDiv egl9i9v3"
@@ -143,7 +141,7 @@ exports[`FileUploader > should render correctly 1`] = `
         class="HvFileList-listItem HvFile-root"
       >
         <div
-          class="HvFile-icon css-ww6rg5-StyledEmptyIcon e11o985j7"
+          class="HvFile-icon css-11wunl3-StyledEmptyIcon e11o985j7"
         />
         <p
           class="HvFile-nameText e11o985j3 css-1rntirt-getStyledComponent-StyledNameText e1te0rfk0"
@@ -164,10 +162,8 @@ exports[`FileUploader > should render correctly 1`] = `
         </span>
         <button
           aria-label="Remove File"
-          class="HvFile-removeButton e11o985j0 css-7nz3sy-StyledButton-StyledIconButton egl9i9v0"
+          class="HvFile-removeButton e11o985j0 css-17wdxfh-StyledButton-StyledIconButton egl9i9v0"
           id="hvfilelist4-values-remove-button"
-          radius="base"
-          variant="secondaryGhost"
         >
           <div
             class="css-1nxr552-StyledContentDiv egl9i9v3"

--- a/packages/core/src/components/Input/Input.styles.tsx
+++ b/packages/core/src/components/Input/Input.styles.tsx
@@ -31,7 +31,9 @@ export const StyledSuccess = styled(Success)({
   height: "30px",
 });
 
-export const StyledSuggestions = styled(HvSuggestions)({
+export const StyledSuggestions = styled((props) => (
+  <HvSuggestions {...props} />
+))({
   width: "100%",
   position: "relative",
   [`& .${suggestionsClasses.root} .${suggestionsClasses.list} &`]: {

--- a/packages/core/src/components/Pagination/Pagination.tsx
+++ b/packages/core/src/components/Pagination/Pagination.tsx
@@ -193,7 +193,6 @@ export const HvPagination = ({
     </StyledPageJump>
   );
 
-  console.log(`canPrevious: ${canPrevious}, canNext: ${canNext}`);
   return (
     <StyledRoot
       id={id}

--- a/packages/core/src/components/Pagination/__snapshots__/Pagination.test.tsx.snap
+++ b/packages/core/src/components/Pagination/__snapshots__/Pagination.test.tsx.snap
@@ -28,7 +28,7 @@ exports[`Pagination > should render correctly 1`] = `
               tabindex="0"
             >
               <div
-                class="HvBaseDropdown-selection css-1c8fpra-StyledSelection e1xgfj1t6"
+                class="HvBaseDropdown-selection css-1n3tnd9-StyledSelection e1xgfj1t6"
               >
                 <p
                   class="css-1mchk7j-getStyledComponent e1te0rfk0"
@@ -71,8 +71,6 @@ exports[`Pagination > should render correctly 1`] = `
           aria-label="First Page"
           class="HvPagination-iconContainer en2ju172 css-12i0xb-StyledButton-StyledButtonIconTooltip egl9i9v0"
           disabled=""
-          radius="base"
-          variant="secondaryGhost"
         >
           <div
             class="css-1nxr552-StyledContentDiv egl9i9v3"
@@ -109,8 +107,6 @@ exports[`Pagination > should render correctly 1`] = `
         <button
           class="HvPagination-iconContainer en2ju172 css-12i0xb-StyledButton-StyledButtonIconTooltip egl9i9v0"
           disabled=""
-          radius="base"
-          variant="secondaryGhost"
         >
           <div
             class="css-1nxr552-StyledContentDiv egl9i9v3"
@@ -153,7 +149,7 @@ exports[`Pagination > should render correctly 1`] = `
               class="HvBaseInput-root ep58gjf0 css-cpmv9g-StyledRoot-StyledBaseInput e1wsukd12"
             >
               <div
-                class="MuiInputBase-root MuiInput-root HvBaseInput-inputRoot HvInput-inputRoot HvPagination-pageSizeInputRoot MuiInput-underline MuiInputBase-colorPrimary  e1wsukd10 css-qhl3bu-MuiInputBase-root-MuiInput-root-StyledInput"
+                class="MuiInputBase-root MuiInput-root HvBaseInput-inputRoot HvInput-inputRoot HvPagination-pageSizeInputRoot MuiInput-underline MuiInputBase-colorPrimary  e1wsukd10 css-1veljhk-MuiInputBase-root-MuiInput-root-StyledInput"
               >
                 <input
                   aria-label="Current page"
@@ -220,8 +216,6 @@ exports[`Pagination > should render correctly 1`] = `
           aria-label="Next Page"
           class="HvPagination-iconContainer en2ju172 css-12i0xb-StyledButton-StyledButtonIconTooltip egl9i9v0"
           disabled=""
-          radius="base"
-          variant="secondaryGhost"
         >
           <div
             class="css-1nxr552-StyledContentDiv egl9i9v3"
@@ -259,8 +253,6 @@ exports[`Pagination > should render correctly 1`] = `
           aria-label="Last Page"
           class="HvPagination-iconContainer en2ju172 css-12i0xb-StyledButton-StyledButtonIconTooltip egl9i9v0"
           disabled=""
-          radius="base"
-          variant="secondaryGhost"
         >
           <div
             class="css-1nxr552-StyledContentDiv egl9i9v3"

--- a/packages/core/src/components/Radio/Radio.styles.tsx
+++ b/packages/core/src/components/Radio/Radio.styles.tsx
@@ -82,7 +82,7 @@ export const StyledHvLabel = styled(
   overflow: "hidden",
   textOverflow: "ellipsis",
   verticalAlign: "middle",
-  paddingRight: "10px",
+  paddingRight: theme.spacing(1.25),
   whiteSpace: "nowrap",
   ...theme.typography.body,
   cursor: "pointer",

--- a/packages/core/src/components/RadioGroup/RadioGroup.styles.tsx
+++ b/packages/core/src/components/RadioGroup/RadioGroup.styles.tsx
@@ -12,7 +12,7 @@ export const StyledFormElement = styled(HvFormElement)({
 });
 
 export const StyledLabel = styled(HvLabel)({
-  marginBottom: "10px",
+  marginBottom: theme.spacing(1.25),
 });
 
 export const StyledGroup = styled(
@@ -49,15 +49,15 @@ export const StyledGroup = styled(
     ...($horizontal && {
       flexDirection: "row",
       flexWrap: "wrap",
-      marginLeft: "-20px",
+      marginLeft: `-${theme.spacing(2.5)}`,
       "&>*": {
-        marginLeft: "20px",
+        marginLeft: theme.spacing(2.5),
       },
-      width: "calc(100% + 20px)", // Compensate the negative margin left which increases the width
+      width: `calc(100% + ${theme.spacing(2.5)})`, // Compensate the negative margin left which increases the width
     }),
 
     ...($invalid && {
-      paddingBottom: "10px",
+      paddingBottom: theme.spacing(1.25),
       borderBottom: `1px solid ${theme.colors.sema4}`,
     }),
   })

--- a/packages/core/src/components/RadioGroup/__snapshots__/RadioGroup.test.tsx.snap
+++ b/packages/core/src/components/RadioGroup/__snapshots__/RadioGroup.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`RadioGroup > general > should render correctly 1`] = `
     class="HvRadioGroup-root css-whistd-StyledFormElement e3r04jq2 HvFormElement-root"
   >
     <label
-      class="HvRadioGroup-label e3r04jq1 HvLabel-root e1injmq50 css-d8fglj-getStyledComponent-StyledTypography-StyledLabel e1te0rfk0"
+      class="HvRadioGroup-label e3r04jq1 HvLabel-root e1injmq50 css-1gjgsi2-getStyledComponent-StyledTypography-StyledLabel e1te0rfk0"
       id="hvradiogroup9-label"
       variant="label"
     >
@@ -59,7 +59,7 @@ exports[`RadioGroup > general > should render correctly 1`] = `
             </div>
           </span>
           <label
-            class="HvRadio-label e1h80t9i0 HvLabel-root e1injmq50 css-ivfvh3-getStyledComponent-StyledTypography-StyledHvLabel e1te0rfk0"
+            class="HvRadio-label e1h80t9i0 HvLabel-root e1injmq50 css-czzja4-getStyledComponent-StyledTypography-StyledHvLabel e1te0rfk0"
             for="hvradio11-input"
             id="hvradio11-label"
             variant="label"
@@ -116,7 +116,7 @@ exports[`RadioGroup > general > should render correctly 1`] = `
             </div>
           </span>
           <label
-            class="HvRadio-label e1h80t9i0 HvLabel-root e1injmq50 css-ivfvh3-getStyledComponent-StyledTypography-StyledHvLabel e1te0rfk0"
+            class="HvRadio-label e1h80t9i0 HvLabel-root e1injmq50 css-czzja4-getStyledComponent-StyledTypography-StyledHvLabel e1te0rfk0"
             for="hvradio13-input"
             id="hvradio13-label"
             variant="label"
@@ -167,7 +167,7 @@ exports[`RadioGroup > general > should render correctly 1`] = `
             </div>
           </span>
           <label
-            class="HvRadio-label e1h80t9i0 HvLabel-root e1injmq50 css-ivfvh3-getStyledComponent-StyledTypography-StyledHvLabel e1te0rfk0"
+            class="HvRadio-label e1h80t9i0 HvLabel-root e1injmq50 css-czzja4-getStyledComponent-StyledTypography-StyledHvLabel e1te0rfk0"
             for="hvradio15-input"
             id="hvradio15-label"
             variant="label"

--- a/packages/core/src/components/TagsInput/TagsInput.test.tsx
+++ b/packages/core/src/components/TagsInput/TagsInput.test.tsx
@@ -1,6 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
 import { fireEvent, render } from "@testing-library/react";
-import {} from "@storybook/react";
 import { HvTagsInput } from "components";
 import { ControlledTagArray } from "./TagsInput.stories";
 import { ThemeProvider } from "providers";

--- a/packages/core/src/components/TextArea/__snapshots__/TextArea.test.tsx.snap
+++ b/packages/core/src/components/TextArea/__snapshots__/TextArea.test.tsx.snap
@@ -42,7 +42,7 @@ exports[`TextArea > should render correctly 1`] = `
       class="HvBaseInput-root HvTextArea-baseInput e1f8on4z0 css-1pj9pub-StyledRoot-StyledBaseInput e1wsukd12"
     >
       <div
-        class="MuiInputBase-root MuiInput-root HvBaseInput-inputRoot MuiInput-underline MuiInputBase-colorPrimary MuiInputBase-multiline HvBaseInput-inputRootMultiline  e1wsukd10 css-1wb3arn-MuiInputBase-root-MuiInput-root-StyledInput"
+        class="MuiInputBase-root MuiInput-root HvBaseInput-inputRoot MuiInput-underline MuiInputBase-colorPrimary MuiInputBase-multiline HvBaseInput-inputRootMultiline  e1wsukd10 css-jmrod1-MuiInputBase-root-MuiInput-root-StyledInput"
       >
         <textarea
           aria-controls="hvtextarea3-charCounter"

--- a/packages/core/src/components/index.ts
+++ b/packages/core/src/components/index.ts
@@ -61,3 +61,4 @@ export * from "./DropDownMenu";
 export * from "./Pagination";
 export * from "./ActionsGeneric";
 export * from "./BreadCrumb";
+export * from "./DotPagination";

--- a/packages/styles/src/themes/ds3Theme.ts
+++ b/packages/styles/src/themes/ds3Theme.ts
@@ -291,7 +291,7 @@ const ds3Theme = makeTheme((theme) => ({
       borderRadius: "0px",
       hoverColor: theme.colors.atmo3,
       borderColor: "transparent",
-      extensionHeight: "10px",
+      extensionHeight: theme.spacing(1.25),
       extensionBorderColor: "transparent",
     },
     pagination: {


### PR DESCRIPTION
- **BREAKING CHANGES:** Only the DS5 version was implemented since the icons used are different in DS3. However, as discussed, the user is able to customise the `DotPagination` component to meet the DS3 specifications by providing the `unselectedIcon` and `selectedIcon` properties and overriding the styling. A new story was created to provide an example on how to achieve this.
- Note: A reviewed the components I worked on to start using `theme.spacing` when it was also used in the master branch since I noticed I was not using it as the other components were.