### PR TITLE
fix: remove console warnings, deprecated props and small fix on the TagsInput component

### DIFF
--- a/packages/core/src/components/Accordion/Accordion.stories.tsx
+++ b/packages/core/src/components/Accordion/Accordion.stories.tsx
@@ -107,21 +107,27 @@ export const Controlled: StoryObj<HvAccordionProps> = {
           breakpoints={brk}
         >
           <HvButton
-            variant="secondary"
+            variant="secondarySubtle"
             onClick={() => handleToggle("analytics")}
           >
             Toggle Analytics
           </HvButton>
-          <HvButton variant="secondary" onClick={() => handleToggle("system")}>
+          <HvButton
+            variant="secondarySubtle"
+            onClick={() => handleToggle("system")}
+          >
             Toggle System
           </HvButton>
-          <HvButton variant="secondary" onClick={() => handleToggle("data")}>
+          <HvButton
+            variant="secondarySubtle"
+            onClick={() => handleToggle("data")}
+          >
             Toggle Data
           </HvButton>
-          <HvButton variant="secondary" onClick={() => handleAll(false)}>
+          <HvButton variant="secondarySubtle" onClick={() => handleAll(false)}>
             Close all
           </HvButton>
-          <HvButton variant="secondary" onClick={() => handleAll(true)}>
+          <HvButton variant="secondarySubtle" onClick={() => handleAll(true)}>
             Expand all
           </HvButton>
         </HvSimpleGrid>

--- a/packages/core/src/components/BaseCheckBox/BaseCheckBox.styles.ts
+++ b/packages/core/src/components/BaseCheckBox/BaseCheckBox.styles.ts
@@ -33,7 +33,7 @@ export const StyledCheckedBox = styled(
     },
 
     "& svg": {
-      "& path:nth-child(2)": {
+      "& path:nth-of-type(2)": {
         fill: theme.colors.atmo5,
       },
     },

--- a/packages/core/src/components/BaseCheckBox/__snapshots__/BaseCheckBox.test.tsx.snap
+++ b/packages/core/src/components/BaseCheckBox/__snapshots__/BaseCheckBox.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`BaseCheckBox > checked > should render correctly 1`] = `
 <div>
   <span
-    class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorDefault PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorDefault Mui-checked MuiCheckbox-root MuiCheckbox-colorDefault HvBaseCheckBox-root edk6te40 css-z4tg9a-MuiButtonBase-root-MuiCheckbox-root-StyledCheckedBox"
+    class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorDefault PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorDefault Mui-checked MuiCheckbox-root MuiCheckbox-colorDefault HvBaseCheckBox-root edk6te40 css-1e3uo5y-MuiButtonBase-root-MuiCheckbox-root-StyledCheckedBox"
   >
     <input
       checked=""
@@ -49,7 +49,7 @@ exports[`BaseCheckBox > disabled > should render correctly 1`] = `
 <div>
   <span
     aria-disabled="true"
-    class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorDefault Mui-disabled PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorDefault Mui-disabled MuiCheckbox-root MuiCheckbox-colorDefault HvBaseCheckBox-root HvBaseCheckBox-disabled edk6te40 css-z4tg9a-MuiButtonBase-root-MuiCheckbox-root-StyledCheckedBox"
+    class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorDefault Mui-disabled PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorDefault Mui-disabled MuiCheckbox-root MuiCheckbox-colorDefault HvBaseCheckBox-root HvBaseCheckBox-disabled edk6te40 css-1e3uo5y-MuiButtonBase-root-MuiCheckbox-root-StyledCheckedBox"
     tabindex="-1"
   >
     <input
@@ -90,7 +90,7 @@ exports[`BaseCheckBox > disabled > should render correctly 1`] = `
 exports[`BaseCheckBox > indeterminate > should render correctly 1`] = `
 <div>
   <span
-    class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-indeterminate MuiCheckbox-colorDefault PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-indeterminate MuiCheckbox-colorDefault MuiCheckbox-root MuiCheckbox-indeterminate MuiCheckbox-colorDefault HvBaseCheckBox-root edk6te40 css-z4tg9a-MuiButtonBase-root-MuiCheckbox-root-StyledCheckedBox"
+    class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-indeterminate MuiCheckbox-colorDefault PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-indeterminate MuiCheckbox-colorDefault MuiCheckbox-root MuiCheckbox-indeterminate MuiCheckbox-colorDefault HvBaseCheckBox-root edk6te40 css-1e3uo5y-MuiButtonBase-root-MuiCheckbox-root-StyledCheckedBox"
   >
     <input
       class="PrivateSwitchBase-input css-1m9pwf3"
@@ -129,7 +129,7 @@ exports[`BaseCheckBox > indeterminate > should render correctly 1`] = `
 exports[`BaseCheckBox > read only > should render correctly 1`] = `
 <div>
   <span
-    class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorDefault PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-root MuiCheckbox-colorDefault HvBaseCheckBox-root edk6te40 css-z4tg9a-MuiButtonBase-root-MuiCheckbox-root-StyledCheckedBox"
+    class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorDefault PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-root MuiCheckbox-colorDefault HvBaseCheckBox-root edk6te40 css-1e3uo5y-MuiButtonBase-root-MuiCheckbox-root-StyledCheckedBox"
   >
     <input
       class="PrivateSwitchBase-input css-1m9pwf3"
@@ -169,7 +169,7 @@ exports[`BaseCheckBox > read only > should render correctly 1`] = `
 exports[`BaseCheckBox > required > should render correctly 1`] = `
 <div>
   <span
-    class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorDefault PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-root MuiCheckbox-colorDefault HvBaseCheckBox-root edk6te40 css-z4tg9a-MuiButtonBase-root-MuiCheckbox-root-StyledCheckedBox"
+    class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorDefault PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-root MuiCheckbox-colorDefault HvBaseCheckBox-root edk6te40 css-1e3uo5y-MuiButtonBase-root-MuiCheckbox-root-StyledCheckedBox"
   >
     <input
       class="PrivateSwitchBase-input css-1m9pwf3"
@@ -209,7 +209,7 @@ exports[`BaseCheckBox > required > should render correctly 1`] = `
 exports[`BaseCheckBox > should render correctly 1`] = `
 <div>
   <span
-    class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorDefault PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-root MuiCheckbox-colorDefault HvBaseCheckBox-root edk6te40 css-z4tg9a-MuiButtonBase-root-MuiCheckbox-root-StyledCheckedBox"
+    class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorDefault PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-root MuiCheckbox-colorDefault HvBaseCheckBox-root edk6te40 css-1e3uo5y-MuiButtonBase-root-MuiCheckbox-root-StyledCheckedBox"
   >
     <input
       class="PrivateSwitchBase-input css-1m9pwf3"

--- a/packages/core/src/components/BaseRadio/BaseRadio.styles.tsx
+++ b/packages/core/src/components/BaseRadio/BaseRadio.styles.tsx
@@ -23,7 +23,7 @@ export const StyledRadio = styled(
     cursor: "not-allowed",
     pointerEvents: "initial",
     "& svg": {
-      "& path:nth-child(2)": {
+      "& path:nth-of-type(2)": {
         fill: theme.colors.atmo5,
       },
     },

--- a/packages/core/src/components/BulkActions/__snapshots__/BulkActions.test.tsx.snap
+++ b/packages/core/src/components/BulkActions/__snapshots__/BulkActions.test.tsx.snap
@@ -15,7 +15,7 @@ exports[`BulkActions > With actions > should render correctly 1`] = `
           class="HvCheckBox-container css-j79apy-StyledLabelContainer ezlsftu2"
         >
           <span
-            class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorDefault PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-root MuiCheckbox-colorDefault HvCheckBox-checkbox ezlsftu0 HvBaseCheckBox-root edk6te40 css-1gqbdie-MuiButtonBase-root-MuiCheckbox-root-StyledCheckedBox-StyledBaseCheckBox"
+            class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorDefault PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-root MuiCheckbox-colorDefault HvCheckBox-checkbox ezlsftu0 HvBaseCheckBox-root edk6te40 css-1q24rar-MuiButtonBase-root-MuiCheckbox-root-StyledCheckedBox-StyledBaseCheckBox"
           >
             <input
               class="PrivateSwitchBase-input css-1m9pwf3"
@@ -207,7 +207,7 @@ exports[`BulkActions > Without actions > should render correctly 1`] = `
           class="HvCheckBox-container css-j79apy-StyledLabelContainer ezlsftu2"
         >
           <span
-            class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorDefault PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-root MuiCheckbox-colorDefault HvCheckBox-checkbox ezlsftu0 HvBaseCheckBox-root edk6te40 css-1gqbdie-MuiButtonBase-root-MuiCheckbox-root-StyledCheckedBox-StyledBaseCheckBox"
+            class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorDefault PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-root MuiCheckbox-colorDefault HvCheckBox-checkbox ezlsftu0 HvBaseCheckBox-root edk6te40 css-1q24rar-MuiButtonBase-root-MuiCheckbox-root-StyledCheckedBox-StyledBaseCheckBox"
           >
             <input
               class="PrivateSwitchBase-input css-1m9pwf3"

--- a/packages/core/src/components/CheckBox/__snapshots__/CheckBox.test.tsx.snap
+++ b/packages/core/src/components/CheckBox/__snapshots__/CheckBox.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`CheckBox > general > should render correctly 1`] = `
       class="HvCheckBox-container css-j79apy-StyledLabelContainer ezlsftu2"
     >
       <span
-        class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorDefault PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-root MuiCheckbox-colorDefault HvCheckBox-checkbox ezlsftu0 HvBaseCheckBox-root edk6te40 css-1gqbdie-MuiButtonBase-root-MuiCheckbox-root-StyledCheckedBox-StyledBaseCheckBox"
+        class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorDefault PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-root MuiCheckbox-colorDefault HvCheckBox-checkbox ezlsftu0 HvBaseCheckBox-root edk6te40 css-1q24rar-MuiButtonBase-root-MuiCheckbox-root-StyledCheckedBox-StyledBaseCheckBox"
       >
         <input
           class="PrivateSwitchBase-input css-1m9pwf3"

--- a/packages/core/src/components/CheckBoxGroup/CheckBoxGroup.styles.tsx
+++ b/packages/core/src/components/CheckBoxGroup/CheckBoxGroup.styles.tsx
@@ -50,7 +50,7 @@ export const StyledGroupContainer = styled(
       flexDirection: "row",
       flexWrap: "wrap",
 
-      "&>*:not(:first-child)": {
+      "&>*:not(:first-of-type)": {
         marginLeft: theme.space.sm,
       },
     }),

--- a/packages/core/src/components/CheckBoxGroup/__snapshots__/CheckBoxGroup.test.tsx.snap
+++ b/packages/core/src/components/CheckBoxGroup/__snapshots__/CheckBoxGroup.test.tsx.snap
@@ -23,7 +23,7 @@ exports[`CheckBoxGroup > general > should render correctly 1`] = `
           class="HvCheckBox-container css-j79apy-StyledLabelContainer ezlsftu2"
         >
           <span
-            class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorDefault PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-root MuiCheckbox-colorDefault HvCheckBox-checkbox ezlsftu0 HvBaseCheckBox-root edk6te40 css-1gqbdie-MuiButtonBase-root-MuiCheckbox-root-StyledCheckedBox-StyledBaseCheckBox"
+            class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorDefault PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-root MuiCheckbox-colorDefault HvCheckBox-checkbox ezlsftu0 HvBaseCheckBox-root edk6te40 css-1q24rar-MuiButtonBase-root-MuiCheckbox-root-StyledCheckedBox-StyledBaseCheckBox"
           >
             <input
               class="PrivateSwitchBase-input css-1m9pwf3"
@@ -73,7 +73,7 @@ exports[`CheckBoxGroup > general > should render correctly 1`] = `
           class="HvCheckBox-container css-j79apy-StyledLabelContainer ezlsftu2"
         >
           <span
-            class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorDefault PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-root MuiCheckbox-colorDefault HvCheckBox-checkbox ezlsftu0 HvBaseCheckBox-root edk6te40 css-1gqbdie-MuiButtonBase-root-MuiCheckbox-root-StyledCheckedBox-StyledBaseCheckBox"
+            class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorDefault PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-root MuiCheckbox-colorDefault HvCheckBox-checkbox ezlsftu0 HvBaseCheckBox-root edk6te40 css-1q24rar-MuiButtonBase-root-MuiCheckbox-root-StyledCheckedBox-StyledBaseCheckBox"
           >
             <input
               class="PrivateSwitchBase-input css-1m9pwf3"
@@ -123,7 +123,7 @@ exports[`CheckBoxGroup > general > should render correctly 1`] = `
           class="HvCheckBox-container css-j79apy-StyledLabelContainer ezlsftu2"
         >
           <span
-            class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorDefault PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-root MuiCheckbox-colorDefault HvCheckBox-checkbox ezlsftu0 HvBaseCheckBox-root edk6te40 css-1gqbdie-MuiButtonBase-root-MuiCheckbox-root-StyledCheckedBox-StyledBaseCheckBox"
+            class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorDefault PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-root MuiCheckbox-colorDefault HvCheckBox-checkbox ezlsftu0 HvBaseCheckBox-root edk6te40 css-1q24rar-MuiButtonBase-root-MuiCheckbox-root-StyledCheckedBox-StyledBaseCheckBox"
           >
             <input
               class="PrivateSwitchBase-input css-1m9pwf3"

--- a/packages/core/src/components/Controls/__snapshots__/Controls.test.tsx.snap
+++ b/packages/core/src/components/Controls/__snapshots__/Controls.test.tsx.snap
@@ -135,7 +135,7 @@ exports[`<HvControls> > sample snapshot testing > Controls 1`] = `
           <button
             aria-label="Select card view"
             aria-pressed="true"
-            class="button selected e17vrbb40 css-l7jzt6-StyledButton-StyledButton e138pvrm0"
+            class="button selected e17vrbb40 css-3vtsx1-StyledButton-StyledButton e138pvrm0"
             id="card"
             label="Select card view"
           >
@@ -169,7 +169,7 @@ exports[`<HvControls> > sample snapshot testing > Controls 1`] = `
           <button
             aria-label="Select list view"
             aria-pressed="false"
-            class="button e17vrbb40 css-l7jzt6-StyledButton-StyledButton e138pvrm0"
+            class="button e17vrbb40 css-3vtsx1-StyledButton-StyledButton e138pvrm0"
             id="list"
             label="Select list view"
           >
@@ -749,7 +749,7 @@ exports[`<HvControls> > sample snapshot testing > Controls Controlled 1`] = `
           <button
             aria-label="Select card view"
             aria-pressed="true"
-            class="button selected e17vrbb40 css-l7jzt6-StyledButton-StyledButton e138pvrm0"
+            class="button selected e17vrbb40 css-3vtsx1-StyledButton-StyledButton e138pvrm0"
             id="card"
             label="Select card view"
           >
@@ -783,7 +783,7 @@ exports[`<HvControls> > sample snapshot testing > Controls Controlled 1`] = `
           <button
             aria-label="Select list view"
             aria-pressed="false"
-            class="button e17vrbb40 css-l7jzt6-StyledButton-StyledButton e138pvrm0"
+            class="button e17vrbb40 css-3vtsx1-StyledButton-StyledButton e138pvrm0"
             id="list"
             label="Select list view"
           >
@@ -1189,7 +1189,7 @@ exports[`<HvControls> > sample snapshot testing > Custom Controls 1`] = `
             <button
               aria-controls="CustomControlsCardsId"
               aria-pressed="true"
-              class="button selected e17vrbb40 css-1o3odqw-StyledButton-StyledButton e138pvrm0"
+              class="button selected e17vrbb40 css-szeboj-StyledButton-StyledButton e138pvrm0"
               id="all"
             >
               <div
@@ -1205,7 +1205,7 @@ exports[`<HvControls> > sample snapshot testing > Custom Controls 1`] = `
             <button
               aria-controls="CustomControlsCardsId"
               aria-pressed="false"
-              class="button e17vrbb40 css-1o3odqw-StyledButton-StyledButton e138pvrm0"
+              class="button e17vrbb40 css-szeboj-StyledButton-StyledButton e138pvrm0"
               id="critical"
             >
               <div
@@ -1221,7 +1221,7 @@ exports[`<HvControls> > sample snapshot testing > Custom Controls 1`] = `
             <button
               aria-controls="CustomControlsCardsId"
               aria-pressed="false"
-              class="button e17vrbb40 css-1o3odqw-StyledButton-StyledButton e138pvrm0"
+              class="button e17vrbb40 css-szeboj-StyledButton-StyledButton e138pvrm0"
               id="major"
             >
               <div
@@ -1237,7 +1237,7 @@ exports[`<HvControls> > sample snapshot testing > Custom Controls 1`] = `
             <button
               aria-controls="CustomControlsCardsId"
               aria-pressed="false"
-              class="button e17vrbb40 css-1o3odqw-StyledButton-StyledButton e138pvrm0"
+              class="button e17vrbb40 css-szeboj-StyledButton-StyledButton e138pvrm0"
               id="average"
             >
               <div
@@ -1253,7 +1253,7 @@ exports[`<HvControls> > sample snapshot testing > Custom Controls 1`] = `
             <button
               aria-controls="CustomControlsCardsId"
               aria-pressed="false"
-              class="button e17vrbb40 css-1o3odqw-StyledButton-StyledButton e138pvrm0"
+              class="button e17vrbb40 css-szeboj-StyledButton-StyledButton e138pvrm0"
               id="minor"
             >
               <div
@@ -2058,7 +2058,7 @@ exports[`<HvControls> > sample snapshot testing > Mixed Controls 1`] = `
             <button
               aria-controls="mixedControlsCardsId"
               aria-pressed="true"
-              class="button selected e17vrbb40 css-1o3odqw-StyledButton-StyledButton e138pvrm0"
+              class="button selected e17vrbb40 css-szeboj-StyledButton-StyledButton e138pvrm0"
               id="all"
             >
               <div
@@ -2074,7 +2074,7 @@ exports[`<HvControls> > sample snapshot testing > Mixed Controls 1`] = `
             <button
               aria-controls="mixedControlsCardsId"
               aria-pressed="false"
-              class="button e17vrbb40 css-1o3odqw-StyledButton-StyledButton e138pvrm0"
+              class="button e17vrbb40 css-szeboj-StyledButton-StyledButton e138pvrm0"
               id="critical"
             >
               <div
@@ -2090,7 +2090,7 @@ exports[`<HvControls> > sample snapshot testing > Mixed Controls 1`] = `
             <button
               aria-controls="mixedControlsCardsId"
               aria-pressed="false"
-              class="button e17vrbb40 css-1o3odqw-StyledButton-StyledButton e138pvrm0"
+              class="button e17vrbb40 css-szeboj-StyledButton-StyledButton e138pvrm0"
               id="major"
             >
               <div
@@ -2106,7 +2106,7 @@ exports[`<HvControls> > sample snapshot testing > Mixed Controls 1`] = `
             <button
               aria-controls="mixedControlsCardsId"
               aria-pressed="false"
-              class="button e17vrbb40 css-1o3odqw-StyledButton-StyledButton e138pvrm0"
+              class="button e17vrbb40 css-szeboj-StyledButton-StyledButton e138pvrm0"
               id="average"
             >
               <div
@@ -2122,7 +2122,7 @@ exports[`<HvControls> > sample snapshot testing > Mixed Controls 1`] = `
             <button
               aria-controls="mixedControlsCardsId"
               aria-pressed="false"
-              class="button e17vrbb40 css-1o3odqw-StyledButton-StyledButton e138pvrm0"
+              class="button e17vrbb40 css-szeboj-StyledButton-StyledButton e138pvrm0"
               id="minor"
             >
               <div

--- a/packages/core/src/components/DotPagination/DotPagination.styles.tsx
+++ b/packages/core/src/components/DotPagination/DotPagination.styles.tsx
@@ -4,7 +4,7 @@ import { theme } from "@hitachivantara/uikit-styles";
 import dotPaginationClasses from "./dotPaginationClasses";
 import { CurrentStep, OtherStep } from "@hitachivantara/uikit-react-icons";
 
-export const StyledRadioGroup = styled(HvRadioGroup)({
+export const StyledRadioGroup = styled((props) => <HvRadioGroup {...props} />)({
   display: "flex",
   justifyContent: "center",
 

--- a/packages/core/src/components/DotPagination/__snapshots__/DotPagination.test.tsx.snap
+++ b/packages/core/src/components/DotPagination/__snapshots__/DotPagination.test.tsx.snap
@@ -6,14 +6,14 @@ exports[`DotPagination > should render correctly 1`] = `
     class="HvDotPagination-root e1buriah3 HvRadioGroup-root css-w7urnl-StyledFormElement-StyledRadioGroup e1qvmihv2 HvFormElement-root"
   >
     <div
-      class="HvRadioGroup-group HvDotPagination-horizontal HvRadioGroup-horizontal css-374br7-StyledGroup e1qvmihv0"
+      class="HvRadioGroup-group HvDotPagination-horizontal HvRadioGroup-horizontal css-16xh4vj-StyledGroup e1qvmihv0"
       role="navigation"
     >
       <div
         class="e1buriah2 HvRadio-root HvDotPagination-radioRoot css-esudyc-StyledHvFormElement-StyledRadio e11n8xyl2 HvFormElement-root"
       >
         <span
-          class="MuiButtonBase-root MuiRadio-root MuiRadio-colorDefault PrivateSwitchBase-root MuiRadio-root MuiRadio-colorDefault Mui-checked MuiRadio-root MuiRadio-colorDefault HvRadio-radio HvDotPagination-radio e11n8xyl3 HvBaseRadio-root e1sbb5xr0 css-1t388db-MuiButtonBase-root-MuiRadio-root-StyledRadio-StyledHvBaseRadio"
+          class="MuiButtonBase-root MuiRadio-root MuiRadio-colorDefault PrivateSwitchBase-root MuiRadio-root MuiRadio-colorDefault Mui-checked MuiRadio-root MuiRadio-colorDefault HvRadio-radio HvDotPagination-radio e11n8xyl3 HvBaseRadio-root e1sbb5xr0 css-p364vd-MuiButtonBase-root-MuiRadio-root-StyledRadio-StyledHvBaseRadio"
         >
           <input
             aria-label="first page button aria-label"
@@ -48,7 +48,7 @@ exports[`DotPagination > should render correctly 1`] = `
         class="e1buriah2 HvRadio-root HvDotPagination-radioRoot css-esudyc-StyledHvFormElement-StyledRadio e11n8xyl2 HvFormElement-root"
       >
         <span
-          class="MuiButtonBase-root MuiRadio-root MuiRadio-colorDefault PrivateSwitchBase-root MuiRadio-root MuiRadio-colorDefault MuiRadio-root MuiRadio-colorDefault HvRadio-radio HvDotPagination-radio e11n8xyl3 HvBaseRadio-root e1sbb5xr0 css-1t388db-MuiButtonBase-root-MuiRadio-root-StyledRadio-StyledHvBaseRadio"
+          class="MuiButtonBase-root MuiRadio-root MuiRadio-colorDefault PrivateSwitchBase-root MuiRadio-root MuiRadio-colorDefault MuiRadio-root MuiRadio-colorDefault HvRadio-radio HvDotPagination-radio e11n8xyl3 HvBaseRadio-root e1sbb5xr0 css-p364vd-MuiButtonBase-root-MuiRadio-root-StyledRadio-StyledHvBaseRadio"
         >
           <input
             aria-label="2 page aria-label"
@@ -82,7 +82,7 @@ exports[`DotPagination > should render correctly 1`] = `
         class="e1buriah2 HvRadio-root HvDotPagination-radioRoot css-esudyc-StyledHvFormElement-StyledRadio e11n8xyl2 HvFormElement-root"
       >
         <span
-          class="MuiButtonBase-root MuiRadio-root MuiRadio-colorDefault PrivateSwitchBase-root MuiRadio-root MuiRadio-colorDefault MuiRadio-root MuiRadio-colorDefault HvRadio-radio HvDotPagination-radio e11n8xyl3 HvBaseRadio-root e1sbb5xr0 css-1t388db-MuiButtonBase-root-MuiRadio-root-StyledRadio-StyledHvBaseRadio"
+          class="MuiButtonBase-root MuiRadio-root MuiRadio-colorDefault PrivateSwitchBase-root MuiRadio-root MuiRadio-colorDefault MuiRadio-root MuiRadio-colorDefault HvRadio-radio HvDotPagination-radio e11n8xyl3 HvBaseRadio-root e1sbb5xr0 css-p364vd-MuiButtonBase-root-MuiRadio-root-StyledRadio-StyledHvBaseRadio"
         >
           <input
             aria-label="last page button aria-label"

--- a/packages/core/src/components/FileUploader/DropZone/DropZone.styles.tsx
+++ b/packages/core/src/components/FileUploader/DropZone/DropZone.styles.tsx
@@ -11,9 +11,9 @@ export const StyledDropZoneLabelsGroup = styled("div")({
   display: "flex",
   justifyContent: "start",
 
-  "& label:nth-child(1)": {},
+  "& label:nth-of-type(1)": {},
 
-  "& p:nth-child(2)": {
+  "& p:nth-of-type(2)": {
     marginLeft: "auto",
   },
 });

--- a/packages/core/src/components/FileUploader/DropZone/__snapshots__/DropZone.test.tsx.snap
+++ b/packages/core/src/components/FileUploader/DropZone/__snapshots__/DropZone.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`DropZone > should render correctly 1`] = `
 <div>
   <div
     aria-label="File Dropzone"
-    class="HvDropZone-dropZoneLabelsGroup css-qn1o70-StyledDropZoneLabelsGroup e1r4xwg210"
+    class="HvDropZone-dropZoneLabelsGroup css-713atf-StyledDropZoneLabelsGroup e1r4xwg210"
     id="dropzone-test"
   >
     <label
@@ -81,7 +81,7 @@ exports[`DropZone > should render correctly when disabled 1`] = `
 <div>
   <div
     aria-label="File Dropzone"
-    class="HvDropZone-dropZoneLabelsGroup css-qn1o70-StyledDropZoneLabelsGroup e1r4xwg210"
+    class="HvDropZone-dropZoneLabelsGroup css-713atf-StyledDropZoneLabelsGroup e1r4xwg210"
     id="dropzone-test"
   >
     <label

--- a/packages/core/src/components/FileUploader/__snapshots__/FileUploader.test.tsx.snap
+++ b/packages/core/src/components/FileUploader/__snapshots__/FileUploader.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`FileUploader > should render correctly 1`] = `
   <div>
     <div
       aria-label="File Dropzone"
-      class="HvDropZone-dropZoneLabelsGroup css-qn1o70-StyledDropZoneLabelsGroup e1r4xwg210"
+      class="HvDropZone-dropZoneLabelsGroup css-713atf-StyledDropZoneLabelsGroup e1r4xwg210"
       id="-3"
     >
       <label

--- a/packages/core/src/components/Forms/WarningText/WarningText.styles.tsx
+++ b/packages/core/src/components/Forms/WarningText/WarningText.styles.tsx
@@ -23,7 +23,7 @@ export const StyledTypography = styled(
 )(({ $topGutter, $hideText }: { $topGutter: boolean; $hideText: boolean }) => ({
   color: theme.colors.sema4,
   paddingRight: theme.space.xs,
-  "&:first-child": {
+  "&:first-of-type": {
     paddingLeft: theme.space.xs,
   },
   ...($topGutter && {

--- a/packages/core/src/components/Forms/WarningText/__snapshots__/WarningText.test.tsx.snap
+++ b/packages/core/src/components/Forms/WarningText/__snapshots__/WarningText.test.tsx.snap
@@ -25,7 +25,7 @@ exports[`WarningText > should render correctly 1`] = `
     </div>
     <p
       aria-relevant="additions text"
-      class="HvWarningText-warningText HvWarningText-topGutter e1jkc0dp1 css-19k789t-getStyledComponent-StyledTypography e1tnpalo0"
+      class="HvWarningText-warningText HvWarningText-topGutter e1jkc0dp1 css-x9czmt-getStyledComponent-StyledTypography e1tnpalo0"
       role="status"
     />
   </div>

--- a/packages/core/src/components/GlobalActions/GlobalActions.styles.tsx
+++ b/packages/core/src/components/GlobalActions/GlobalActions.styles.tsx
@@ -88,7 +88,7 @@ export const StyledActions = styled("div")({
   alignItems: "center",
   justifyContent: "flex-end",
   marginLeft: "auto",
-  "& > *:not(:first-child) ": {
+  "& > *:not(:first-of-type) ": {
     marginLeft: theme.space.xs,
   },
 });

--- a/packages/core/src/components/Input/Input.stories.tsx
+++ b/packages/core/src/components/Input/Input.stories.tsx
@@ -613,7 +613,7 @@ export const PrefixAndSuffix: StoryObj<HvInputProps> = {
       "& > *": {
         marginLeft: theme.space.xs,
       },
-      "& > *:first-child": {
+      "& > *:first-of-type": {
         marginLeft: 0,
       },
     });

--- a/packages/core/src/components/MultiButton/MultiButton.styles.tsx
+++ b/packages/core/src/components/MultiButton/MultiButton.styles.tsx
@@ -46,7 +46,7 @@ export const StyledRoot = styled(
           borderBottom: "solid 1px transparent",
         },
       },
-      "&:first-child": {
+      "&:first-of-type": {
         borderTop: `solid 1px ${theme.colors.atmo4}`,
         borderTopLeftRadius: "2px",
         borderTopRightRadius: "2px",
@@ -59,7 +59,7 @@ export const StyledRoot = styled(
           borderBottom: `solid 1px ${theme.colors.atmo4} !important`,
         },
       },
-      "&:not(:first-child)": {
+      "&:not(:first-of-type)": {
         marginLeft: 0,
         marginTop: -1,
       },
@@ -123,7 +123,7 @@ export const StyledButton = (Element) =>
         borderRight: "solid 1px transparent",
       },
     },
-    "&:first-child": {
+    "&:first-of-type": {
       borderLeft: `solid 1px ${theme.colors.atmo4}`,
       borderTopLeftRadius: "2px",
       borderBottomLeftRadius: "2px",
@@ -136,7 +136,7 @@ export const StyledButton = (Element) =>
         borderRight: `solid 1px ${theme.colors.atmo4} !important`,
       },
     },
-    "&:not(:first-child)": {
+    "&:not(:first-of-type)": {
       marginLeft: "-1px",
     },
     "&.selected": {
@@ -155,7 +155,7 @@ export const StyledButton = (Element) =>
           border: `solid 1px ${theme.colors.atmo4}`,
         },
       },
-      "&:first-child, &:last-child": {
+      "&:first-of-type, &:last-child": {
         border: `solid 1px ${theme.colors.acce1}`,
       },
 

--- a/packages/core/src/components/Pagination/__snapshots__/Pagination.test.tsx.snap
+++ b/packages/core/src/components/Pagination/__snapshots__/Pagination.test.tsx.snap
@@ -187,7 +187,7 @@ exports[`Pagination > should render correctly 1`] = `
               </div>
               <p
                 aria-relevant="additions text"
-                class="HvWarningText-warningText HvWarningText-topGutter e1jkc0dp1 css-19k789t-getStyledComponent-StyledTypography e1tnpalo0"
+                class="HvWarningText-warningText HvWarningText-topGutter e1jkc0dp1 css-x9czmt-getStyledComponent-StyledTypography e1tnpalo0"
                 id="hvinput9-error"
                 role="status"
               />

--- a/packages/core/src/components/Radio/__snapshots__/Radio.test.tsx.snap
+++ b/packages/core/src/components/Radio/__snapshots__/Radio.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`HvRadio > sample snapshot testing > should match the snapshot 1`] = `
     class="HvRadio-root css-1rzqrp5-StyledHvFormElement e11n8xyl2 HvFormElement-root"
   >
     <span
-      class="MuiButtonBase-root MuiRadio-root MuiRadio-colorDefault PrivateSwitchBase-root MuiRadio-root MuiRadio-colorDefault MuiRadio-root MuiRadio-colorDefault HvRadio-radio e11n8xyl3 HvBaseRadio-root e1sbb5xr0 css-1t388db-MuiButtonBase-root-MuiRadio-root-StyledRadio-StyledHvBaseRadio"
+      class="MuiButtonBase-root MuiRadio-root MuiRadio-colorDefault PrivateSwitchBase-root MuiRadio-root MuiRadio-colorDefault MuiRadio-root MuiRadio-colorDefault HvRadio-radio e11n8xyl3 HvBaseRadio-root e1sbb5xr0 css-p364vd-MuiButtonBase-root-MuiRadio-root-StyledRadio-StyledHvBaseRadio"
     >
       <input
         class="PrivateSwitchBase-input css-1m9pwf3"

--- a/packages/core/src/components/RadioGroup/RadioGroup.styles.tsx
+++ b/packages/core/src/components/RadioGroup/RadioGroup.styles.tsx
@@ -49,7 +49,7 @@ export const StyledGroup = styled(
     ...($horizontal && {
       flexDirection: "row",
       flexWrap: "wrap",
-      "&>*:not(:first-child)": {
+      "&>*:not(:first-of-type)": {
         marginLeft: theme.space.sm,
       },
       width: `calc(100% + ${theme.space.sm})`, // Compensate the negative margin left which increases the width

--- a/packages/core/src/components/RadioGroup/__snapshots__/RadioGroup.test.tsx.snap
+++ b/packages/core/src/components/RadioGroup/__snapshots__/RadioGroup.test.tsx.snap
@@ -23,7 +23,7 @@ exports[`RadioGroup > general > should render correctly 1`] = `
           class="HvRadio-container css-kflfdh-StyledDivContainer e11n8xyl1"
         >
           <span
-            class="MuiButtonBase-root MuiRadio-root MuiRadio-colorDefault PrivateSwitchBase-root MuiRadio-root MuiRadio-colorDefault MuiRadio-root MuiRadio-colorDefault HvRadio-radio e11n8xyl3 HvBaseRadio-root e1sbb5xr0 css-1t388db-MuiButtonBase-root-MuiRadio-root-StyledRadio-StyledHvBaseRadio"
+            class="MuiButtonBase-root MuiRadio-root MuiRadio-colorDefault PrivateSwitchBase-root MuiRadio-root MuiRadio-colorDefault MuiRadio-root MuiRadio-colorDefault HvRadio-radio e11n8xyl3 HvBaseRadio-root e1sbb5xr0 css-p364vd-MuiButtonBase-root-MuiRadio-root-StyledRadio-StyledHvBaseRadio"
           >
             <input
               class="PrivateSwitchBase-input css-1m9pwf3"
@@ -73,7 +73,7 @@ exports[`RadioGroup > general > should render correctly 1`] = `
           class="HvRadio-container css-kflfdh-StyledDivContainer e11n8xyl1"
         >
           <span
-            class="MuiButtonBase-root MuiRadio-root MuiRadio-colorDefault PrivateSwitchBase-root MuiRadio-root MuiRadio-colorDefault Mui-checked MuiRadio-root MuiRadio-colorDefault HvRadio-radio e11n8xyl3 HvBaseRadio-root e1sbb5xr0 css-1t388db-MuiButtonBase-root-MuiRadio-root-StyledRadio-StyledHvBaseRadio"
+            class="MuiButtonBase-root MuiRadio-root MuiRadio-colorDefault PrivateSwitchBase-root MuiRadio-root MuiRadio-colorDefault Mui-checked MuiRadio-root MuiRadio-colorDefault HvRadio-radio e11n8xyl3 HvBaseRadio-root e1sbb5xr0 css-p364vd-MuiButtonBase-root-MuiRadio-root-StyledRadio-StyledHvBaseRadio"
           >
             <input
               checked=""
@@ -129,7 +129,7 @@ exports[`RadioGroup > general > should render correctly 1`] = `
           class="HvRadio-container css-kflfdh-StyledDivContainer e11n8xyl1"
         >
           <span
-            class="MuiButtonBase-root MuiRadio-root MuiRadio-colorDefault PrivateSwitchBase-root MuiRadio-root MuiRadio-colorDefault MuiRadio-root MuiRadio-colorDefault HvRadio-radio e11n8xyl3 HvBaseRadio-root e1sbb5xr0 css-1t388db-MuiButtonBase-root-MuiRadio-root-StyledRadio-StyledHvBaseRadio"
+            class="MuiButtonBase-root MuiRadio-root MuiRadio-colorDefault PrivateSwitchBase-root MuiRadio-root MuiRadio-colorDefault MuiRadio-root MuiRadio-colorDefault HvRadio-radio e11n8xyl3 HvBaseRadio-root e1sbb5xr0 css-p364vd-MuiButtonBase-root-MuiRadio-root-StyledRadio-StyledHvBaseRadio"
           >
             <input
               class="PrivateSwitchBase-input css-1m9pwf3"

--- a/packages/core/src/components/Switch/Switch.stories.tsx
+++ b/packages/core/src/components/Switch/Switch.stories.tsx
@@ -175,7 +175,7 @@ const StyledSwitchContainer = styled("div")({
   "& > *": {
     marginLeft: theme.space.xs,
   },
-  "& > *:first-child": {
+  "& > *:first-of-type": {
     marginLeft: 0,
   },
 });

--- a/packages/core/src/components/Table/TableCell/TableCell.tsx
+++ b/packages/core/src/components/Table/TableCell/TableCell.tsx
@@ -114,7 +114,7 @@ const StyledTableCell = (c: any) =>
       ...($groupColumnMostLeft && {
         borderLeft: `solid 1px ${theme.colors.atmo4}`,
 
-        "&:first-child": {
+        "&:first-of-type": {
           borderLeft: 0,
         },
       }),

--- a/packages/core/src/components/Table/TableHeader/TableHeader.tsx
+++ b/packages/core/src/components/Table/TableHeader/TableHeader.tsx
@@ -195,7 +195,7 @@ const StyledTableHeader = (c: any) =>
       }),
       // type
       ...($type === "head" && {
-        // ":first-child": {
+        // ":first-of-type": {
         height: "var(--first-row-cell-height)",
         borderTop: $variantList
           ? 0
@@ -249,7 +249,7 @@ const StyledTableHeader = (c: any) =>
         backgroundColor: "inherit",
         borderBottom: 0,
         height: 16,
-        ":first-child > &": {
+        ":first-of-type > &": {
           borderTop: 0,
           height: 16,
         },

--- a/packages/core/src/components/Table/TableRow/TableRow.tsx
+++ b/packages/core/src/components/Table/TableRow/TableRow.tsx
@@ -78,7 +78,7 @@ const StyledTableRow = (c: any) =>
         },
       }),
       ...($striped && {
-        "&:nth-child(even)": {
+        "&:nth-of-type(even)": {
           backgroundColor: $stripedColor,
           "&:hover": {
             backgroundColor: theme.table.rowHoverColor,
@@ -89,11 +89,11 @@ const StyledTableRow = (c: any) =>
       // type
       ...($type === "head" && {
         backgroundColor: "transparent",
-        "&:first-child": {
+        "&:first-of-type": {
           height: 52,
         },
 
-        "tr&:first-child": {
+        "tr&:first-of-type": {
           height: 52,
         },
       }),
@@ -117,11 +117,11 @@ const StyledTableRow = (c: any) =>
       }),
       ...($variantListHead && {
         height: 16,
-        "&:first-child": {
+        "&:first-of-type": {
           height: 16,
         },
 
-        "tr&:first-child": {
+        "tr&:first-of-type": {
           height: 16,
         },
       }),

--- a/packages/core/src/components/Table/__snapshots__/Table.test.tsx.snap
+++ b/packages/core/src/components/Table/__snapshots__/Table.test.tsx.snap
@@ -12,10 +12,10 @@ exports[`List Row > should be defined 1`] = `
         class="HvTableHead-root css-1c8o9gy-StyledTableHead e122w5bu0"
       >
         <tr
-          class="HvTableRow-root HvTableRow-head HvTableRow-variantListHead css-6swmnd-StyledTableRow e1cjstvf0"
+          class="HvTableRow-root HvTableRow-head HvTableRow-variantListHead css-1882nl0-StyledTableRow e1cjstvf0"
         >
           <th
-            class="HvTableHeader-root HvTableHeader-head HvTableHeader-variantList css-13fqqed-StyledTableHeader eopmu0i1"
+            class="HvTableHeader-root HvTableHeader-head HvTableHeader-variantList css-db45kb-StyledTableHeader eopmu0i1"
             scope="col"
           >
             <div
@@ -29,7 +29,7 @@ exports[`List Row > should be defined 1`] = `
             </div>
           </th>
           <th
-            class="HvTableHeader-root HvTableHeader-head HvTableHeader-variantList css-13fqqed-StyledTableHeader eopmu0i1"
+            class="HvTableHeader-root HvTableHeader-head HvTableHeader-variantList css-db45kb-StyledTableHeader eopmu0i1"
             scope="col"
           >
             <div
@@ -43,7 +43,7 @@ exports[`List Row > should be defined 1`] = `
             </div>
           </th>
           <th
-            class="HvTableHeader-root HvTableHeader-head HvTableHeader-variantList css-13fqqed-StyledTableHeader eopmu0i1"
+            class="HvTableHeader-root HvTableHeader-head HvTableHeader-variantList css-db45kb-StyledTableHeader eopmu0i1"
             scope="col"
           >
             <div
@@ -62,115 +62,115 @@ exports[`List Row > should be defined 1`] = `
         class="HvTableBody-root css-1uj09q8-StyledTableBody e1i1hapa0"
       >
         <tr
-          class="HvFocus-root grid grid HvTableRow-root HvTableRow-body HvTableRow-variantList css-mnswpx-StyledTableRow e1cjstvf0"
+          class="HvFocus-root grid grid HvTableRow-root HvTableRow-body HvTableRow-variantList css-1y8u7tj-StyledTableRow e1cjstvf0"
         >
           <td
-            class="HvTableCell-root HvTableCell-body HvTableCell-variantList css-1uw2fch-StyledTableCell e8848lx0"
+            class="HvTableCell-root HvTableCell-body HvTableCell-variantList css-qbp0nu-StyledTableCell e8848lx0"
           >
             Sample Cell 0
           </td>
           <td
-            class="HvTableCell-root HvTableCell-body HvTableCell-variantList css-1uw2fch-StyledTableCell e8848lx0"
+            class="HvTableCell-root HvTableCell-body HvTableCell-variantList css-qbp0nu-StyledTableCell e8848lx0"
           >
             Sample Cell 1
           </td>
           <td
-            class="HvTableCell-root HvTableCell-body HvTableCell-variantList css-1uw2fch-StyledTableCell e8848lx0"
+            class="HvTableCell-root HvTableCell-body HvTableCell-variantList css-qbp0nu-StyledTableCell e8848lx0"
           >
             Sample Cell 2
           </td>
         </tr>
         <tr
-          class="HvFocus-root grid grid HvTableRow-root HvTableRow-body HvTableRow-variantList css-mnswpx-StyledTableRow e1cjstvf0"
+          class="HvFocus-root grid grid HvTableRow-root HvTableRow-body HvTableRow-variantList css-1y8u7tj-StyledTableRow e1cjstvf0"
         >
           <td
-            class="HvTableCell-root HvTableCell-body HvTableCell-variantList css-1uw2fch-StyledTableCell e8848lx0"
+            class="HvTableCell-root HvTableCell-body HvTableCell-variantList css-qbp0nu-StyledTableCell e8848lx0"
           >
             Sample Cell 0
           </td>
           <td
-            class="HvTableCell-root HvTableCell-body HvTableCell-variantList css-1uw2fch-StyledTableCell e8848lx0"
+            class="HvTableCell-root HvTableCell-body HvTableCell-variantList css-qbp0nu-StyledTableCell e8848lx0"
           >
             Sample Cell 1
           </td>
           <td
-            class="HvTableCell-root HvTableCell-body HvTableCell-variantList css-1uw2fch-StyledTableCell e8848lx0"
+            class="HvTableCell-root HvTableCell-body HvTableCell-variantList css-qbp0nu-StyledTableCell e8848lx0"
           >
             Sample Cell 2
           </td>
         </tr>
         <tr
-          class="HvFocus-root grid grid HvTableRow-root HvTableRow-body HvTableRow-variantList css-mnswpx-StyledTableRow e1cjstvf0"
+          class="HvFocus-root grid grid HvTableRow-root HvTableRow-body HvTableRow-variantList css-1y8u7tj-StyledTableRow e1cjstvf0"
         >
           <td
-            class="HvTableCell-root HvTableCell-body HvTableCell-variantList css-1uw2fch-StyledTableCell e8848lx0"
+            class="HvTableCell-root HvTableCell-body HvTableCell-variantList css-qbp0nu-StyledTableCell e8848lx0"
           >
             Sample Cell 0
           </td>
           <td
-            class="HvTableCell-root HvTableCell-body HvTableCell-variantList css-1uw2fch-StyledTableCell e8848lx0"
+            class="HvTableCell-root HvTableCell-body HvTableCell-variantList css-qbp0nu-StyledTableCell e8848lx0"
           >
             Sample Cell 1
           </td>
           <td
-            class="HvTableCell-root HvTableCell-body HvTableCell-variantList css-1uw2fch-StyledTableCell e8848lx0"
+            class="HvTableCell-root HvTableCell-body HvTableCell-variantList css-qbp0nu-StyledTableCell e8848lx0"
           >
             Sample Cell 2
           </td>
         </tr>
         <tr
-          class="HvFocus-root grid grid HvTableRow-root HvTableRow-body HvTableRow-variantList css-mnswpx-StyledTableRow e1cjstvf0"
+          class="HvFocus-root grid grid HvTableRow-root HvTableRow-body HvTableRow-variantList css-1y8u7tj-StyledTableRow e1cjstvf0"
         >
           <td
-            class="HvTableCell-root HvTableCell-body HvTableCell-variantList css-1uw2fch-StyledTableCell e8848lx0"
+            class="HvTableCell-root HvTableCell-body HvTableCell-variantList css-qbp0nu-StyledTableCell e8848lx0"
           >
             Sample Cell 0
           </td>
           <td
-            class="HvTableCell-root HvTableCell-body HvTableCell-variantList css-1uw2fch-StyledTableCell e8848lx0"
+            class="HvTableCell-root HvTableCell-body HvTableCell-variantList css-qbp0nu-StyledTableCell e8848lx0"
           >
             Sample Cell 1
           </td>
           <td
-            class="HvTableCell-root HvTableCell-body HvTableCell-variantList css-1uw2fch-StyledTableCell e8848lx0"
+            class="HvTableCell-root HvTableCell-body HvTableCell-variantList css-qbp0nu-StyledTableCell e8848lx0"
           >
             Sample Cell 2
           </td>
         </tr>
         <tr
-          class="HvFocus-root grid grid HvTableRow-root HvTableRow-body HvTableRow-variantList css-mnswpx-StyledTableRow e1cjstvf0"
+          class="HvFocus-root grid grid HvTableRow-root HvTableRow-body HvTableRow-variantList css-1y8u7tj-StyledTableRow e1cjstvf0"
         >
           <td
-            class="HvTableCell-root HvTableCell-body HvTableCell-variantList css-1uw2fch-StyledTableCell e8848lx0"
+            class="HvTableCell-root HvTableCell-body HvTableCell-variantList css-qbp0nu-StyledTableCell e8848lx0"
           >
             Sample Cell 0
           </td>
           <td
-            class="HvTableCell-root HvTableCell-body HvTableCell-variantList css-1uw2fch-StyledTableCell e8848lx0"
+            class="HvTableCell-root HvTableCell-body HvTableCell-variantList css-qbp0nu-StyledTableCell e8848lx0"
           >
             Sample Cell 1
           </td>
           <td
-            class="HvTableCell-root HvTableCell-body HvTableCell-variantList css-1uw2fch-StyledTableCell e8848lx0"
+            class="HvTableCell-root HvTableCell-body HvTableCell-variantList css-qbp0nu-StyledTableCell e8848lx0"
           >
             Sample Cell 2
           </td>
         </tr>
         <tr
-          class="HvFocus-root grid grid HvTableRow-root HvTableRow-body HvTableRow-variantList css-mnswpx-StyledTableRow e1cjstvf0"
+          class="HvFocus-root grid grid HvTableRow-root HvTableRow-body HvTableRow-variantList css-1y8u7tj-StyledTableRow e1cjstvf0"
         >
           <td
-            class="HvTableCell-root HvTableCell-body HvTableCell-variantList css-1uw2fch-StyledTableCell e8848lx0"
+            class="HvTableCell-root HvTableCell-body HvTableCell-variantList css-qbp0nu-StyledTableCell e8848lx0"
           >
             Sample Cell 0
           </td>
           <td
-            class="HvTableCell-root HvTableCell-body HvTableCell-variantList css-1uw2fch-StyledTableCell e8848lx0"
+            class="HvTableCell-root HvTableCell-body HvTableCell-variantList css-qbp0nu-StyledTableCell e8848lx0"
           >
             Sample Cell 1
           </td>
           <td
-            class="HvTableCell-root HvTableCell-body HvTableCell-variantList css-1uw2fch-StyledTableCell e8848lx0"
+            class="HvTableCell-root HvTableCell-body HvTableCell-variantList css-qbp0nu-StyledTableCell e8848lx0"
           >
             Sample Cell 2
           </td>
@@ -193,7 +193,7 @@ exports[`Simple Table > should be defined 1`] = `
         class="HvTableHead-root css-1c8o9gy-StyledTableHead e122w5bu0"
       >
         <tr
-          class="HvTableRow-root HvTableRow-head css-8grsxm-StyledTableRow e1cjstvf0"
+          class="HvTableRow-root HvTableRow-head css-1hgvxfz-StyledTableRow e1cjstvf0"
         >
           <th
             class="HvTableHeader-root HvTableHeader-head css-1j8mvy9-StyledTableHeader eopmu0i1"

--- a/packages/core/src/components/Table/utils/utils.ts
+++ b/packages/core/src/components/Table/utils/utils.ts
@@ -3,7 +3,7 @@ import { theme } from "@hitachivantara/uikit-styles";
 export const getBorderStyles = (type: string, color: string) => {
   if (type === "row") {
     return {
-      "& td:first-child": {
+      "& td:first-of-type": {
         borderLeft: `1px solid ${color}`,
         borderTop: `1px solid ${color}`,
         borderBottom: `1px solid ${color}`,
@@ -15,14 +15,14 @@ export const getBorderStyles = (type: string, color: string) => {
         borderBottom: `1px solid ${color}`,
         borderRadius: `0 ${theme.table.rowBorderRadius} ${theme.table.rowBorderRadius} 0`,
       },
-      "& td:not(:first-child):not(:last-child)": {
+      "& td:not(:first-of-type):not(:last-child)": {
         borderTop: `1px solid ${color}`,
         borderBottom: `1px solid ${color}`,
       },
     };
   } else if (type === "cell") {
     return {
-      ":first-child&": {
+      ":first-of-type&": {
         borderLeft: `1px solid ${theme.table.rowBorderColor}`,
         borderTop: `1px solid ${theme.table.rowBorderColor}`,
         borderBottom: `1px solid ${theme.table.rowBorderColor}`,
@@ -34,7 +34,7 @@ export const getBorderStyles = (type: string, color: string) => {
         borderBottom: `1px solid ${theme.table.rowBorderColor}`,
         borderRadius: `0 ${theme.table.rowBorderRadius} ${theme.table.rowBorderRadius} 0`,
       },
-      ":not(:first-child):not(:last-child)&": {
+      ":not(:first-of-type):not(:last-child)&": {
         borderTop: `1px solid ${theme.table.rowBorderColor}`,
         borderBottom: `1px solid ${theme.table.rowBorderColor}`,
       },

--- a/packages/core/src/components/Tabs/Tabs.styles.tsx
+++ b/packages/core/src/components/Tabs/Tabs.styles.tsx
@@ -22,7 +22,7 @@ export const StyledTabs = styled(MuiTabs)({
     overflow: "visible !important",
   },
   "& .MuiTabs-flexContainer": {
-    "& button:first-child": {
+    "& button:first-of-type": {
       marginLeft: "3px",
     },
   },

--- a/packages/core/src/components/Tabs/__snapshots__/Tabs.test.tsx.snap
+++ b/packages/core/src/components/Tabs/__snapshots__/Tabs.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Tabs > should render correctly 1`] = `
 <div>
   <div
-    class="MuiTabs-root HvTabs-root ex13pr80 css-mlk5wh-MuiTabs-root-StyledTabs"
+    class="MuiTabs-root HvTabs-root ex13pr80 css-7dmw98-MuiTabs-root-StyledTabs"
   >
     <div
       class="MuiTabs-scroller HvTabs-scroller MuiTabs-fixed css-jpln7h-MuiTabs-scroller"
@@ -27,7 +27,7 @@ exports[`Tabs > should render correctly 1`] = `
 exports[`Tabs > should render correctly all components 1`] = `
 <div>
   <div
-    class="MuiTabs-root HvTabs-root ex13pr80 css-mlk5wh-MuiTabs-root-StyledTabs"
+    class="MuiTabs-root HvTabs-root ex13pr80 css-7dmw98-MuiTabs-root-StyledTabs"
   >
     <div
       class="MuiTabs-scroller HvTabs-scroller MuiTabs-fixed css-jpln7h-MuiTabs-scroller"

--- a/packages/core/src/components/TagsInput/TagsInput.stories.tsx
+++ b/packages/core/src/components/TagsInput/TagsInput.stories.tsx
@@ -40,6 +40,7 @@ export const Main: StoryObj<HvTagsInputProps> = {
   args: {
     label: "Enter your tags",
     description: "This is where you enter your tags",
+    placeholder: "Enter value",
     disabled: false,
     readOnly: false,
     required: false,

--- a/packages/core/src/components/TagsInput/TagsInput.styles.tsx
+++ b/packages/core/src/components/TagsInput/TagsInput.styles.tsx
@@ -54,7 +54,7 @@ export const StyledCharCounter = styled((props) => (
 }));
 
 export const StyledTagsList = styled(
-  (props) => <HvListContainer {...props} />,
+  HvListContainer,
   transientOptions
 )(
   ({
@@ -232,6 +232,7 @@ export const StyledInput = styled(
 )(({ $singleLine }: { $singleLine: boolean }) => ({
   [`& .${baseInputClasses.root}`]: {
     width: "100%",
+    border: "none",
     [`&:hover .${tagsInputClasses.tagInputBorderContainer}`]: {
       background: "none",
     },
@@ -239,15 +240,15 @@ export const StyledInput = styled(
       background: "none",
     },
   },
-  [`& .${baseInputClasses.inputRoot}`]: {
+  [`&& .${baseInputClasses.inputRoot}`]: {
     marginLeft: 0,
     marginRight: 0,
-    width: 0,
     flex: "1 1 auto",
     minWidth: 48,
     height: 24,
     lineHeight: "24px",
     padding: 0,
+    border: "none",
   },
   [`& .${baseInputClasses.inputBorderContainer}`]: {
     border: "none",

--- a/packages/core/src/components/TagsInput/TagsInput.tsx
+++ b/packages/core/src/components/TagsInput/TagsInput.tsx
@@ -622,13 +622,12 @@ export const HvTagsInput = ({
           <StyledInputListItem
             className={clsx(
               !multiline &&
-                clsx(tagsInputClasses.singleLine, classes?.singleLine),
-              value.length === 0
-                ? clsx(
-                    tagsInputClasses.tagInputRootEmpty,
-                    classes?.tagInputRootEmpty
-                  )
-                : ""
+                clsx(
+                  tagsInputClasses.singleLine,
+                  classes?.singleLine,
+                  value.length === 0 && tagsInputClasses.tagInputRootEmpty,
+                  value.length === 0 && classes?.tagInputRootEmpty
+                )
             )}
             classes={{
               root: clsx(

--- a/packages/core/src/components/TagsInput/tagsInputClasses.ts
+++ b/packages/core/src/components/TagsInput/tagsInputClasses.ts
@@ -70,6 +70,7 @@ const classKeys: string[] = [
   "tagSelected",
   "tagInputBorderContainer",
   "tagInputRootFocused",
+  "tagInputRootEmpty",
   "singleLine",
   "error",
   "inputExtension",

--- a/packages/core/src/components/TextArea/__snapshots__/TextArea.test.tsx.snap
+++ b/packages/core/src/components/TextArea/__snapshots__/TextArea.test.tsx.snap
@@ -81,7 +81,7 @@ exports[`TextArea > should render correctly 1`] = `
       </div>
       <p
         aria-relevant="additions text"
-        class="HvWarningText-warningText HvWarningText-topGutter e1jkc0dp1 css-19k789t-getStyledComponent-StyledTypography e1tnpalo0"
+        class="HvWarningText-warningText HvWarningText-topGutter e1jkc0dp1 css-x9czmt-getStyledComponent-StyledTypography e1tnpalo0"
         id="hvtextarea3-error"
         role="status"
       />


### PR DESCRIPTION
- updated styles to not use insecure pseudo-selectors (`nth-child` > `nth-of-type`, `first-child` > `first-of-type`)
- fixed incorrect style on the `TagsInput` component
- updated use of deprecated button variants