### PR TITLE
fix: fix Dialog firstFocusable property not working properly. #HVUIKIT-6609

### DIFF
--- a/packages/core/src/components/Dialog/Dialog.stories.tsx
+++ b/packages/core/src/components/Dialog/Dialog.stories.tsx
@@ -261,7 +261,7 @@ export const LongContent: StoryObj<HvDialogProps> = {
           id="test"
           open={open}
           onClose={() => setOpen(false)}
-          firstFocusable="test-close"
+          firstFocusable="accept"
         >
           <HvDialogTitle variant="warning">Terms and Conditions</HvDialogTitle>
           <HvDialogContent indentContent>
@@ -338,7 +338,11 @@ export const LongContent: StoryObj<HvDialogProps> = {
             venenatis mi et dapibus.
           </HvDialogContent>
           <HvDialogActions>
-            <HvButton variant="secondaryGhost" onClick={() => setOpen(false)}>
+            <HvButton
+              id="accept"
+              variant="secondaryGhost"
+              onClick={() => setOpen(false)}
+            >
               I Accept
             </HvButton>
           </HvDialogActions>

--- a/packages/core/src/components/Dialog/Dialog.tsx
+++ b/packages/core/src/components/Dialog/Dialog.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useContext, useState } from "react";
+import React, { useCallback, useContext, useRef } from "react";
 import clsx from "clsx";
 import { DialogProps as MuiDialogProps } from "@mui/material/Dialog";
 import { Close } from "@hitachivantara/uikit-react-icons";
@@ -54,7 +54,7 @@ export const HvDialog = ({
 
   const { activeTheme, selectedMode, rootId } = useContext(HvThemeContext);
 
-  const [focusableQueue, setFocusableQueue] = useState<{
+  const focusableQueue = useRef<{
     first?: HTMLElement;
     last?: HTMLElement;
   }>({ first: undefined, last: undefined });
@@ -74,10 +74,10 @@ export const HvDialog = ({
     (node) => {
       if (node) {
         const focusableList = getFocusableList(node);
-        setFocusableQueue({
+        focusableQueue.current = {
           first: focusableList[1],
           last: focusableList[focusableList.length - 2],
-        });
+        };
         if (isNil(firstFocusable)) focusableList[1].focus();
         else {
           const element =
@@ -100,12 +100,12 @@ export const HvDialog = ({
       !isNil(event.target) &&
       !isNil(focusableQueue)
     ) {
-      if (event.shiftKey && event.target === focusableQueue.first) {
-        focusableQueue.last?.focus();
+      if (event.shiftKey && event.target === focusableQueue.current.first) {
+        focusableQueue.current.last?.focus();
         event.preventDefault();
       }
-      if (!event.shiftKey && event.target === focusableQueue.last) {
-        focusableQueue.first?.focus();
+      if (!event.shiftKey && event.target === focusableQueue.current.last) {
+        focusableQueue.current.first?.focus();
         event.preventDefault();
       }
     }


### PR DESCRIPTION
- the code that sets the `focusableQueue` was causing a re-render of the `Dialog` component because of the `useState` hook and this re-render was removing the focus of the intended element. 
- updated the code to the `useRef` hook to prevent the re-render.