### PR TITLE
fix: load UI Kit styles first to enable styling overrides

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "eslint-config-airbnb-typescript": "^17.0.0",
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-import": "^2.26.0",
+    "react-google-charts": "^4.0.0",
     "formik": "^2.2.9",
     "jsdom": "^20.0.3",
     "lerna": "^6.3.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -36,6 +36,7 @@
   "peerDependencies": {
     "@emotion/react": "^11.10.5",
     "@emotion/styled": "^11.10.5",
+    "@emotion/cache": "^11.10.5",
     "@mui/material": "^5.11.0",
     "react": "^17.0.0 || ^18.0.0",
     "react-dom": "^17.0.0 || ^18.0.0"
@@ -51,7 +52,6 @@
     "hoist-non-react-statics": "^3.3.2",
     "lodash": "^4.17.21",
     "notistack": "^2.0.8",
-    "react-google-charts": "^4.0.0",
     "react-popper": "^2.3.0",
     "react-resize-detector": "^7.1.2",
     "react-table": "^7.8.0",

--- a/packages/core/src/components/BaseDropdown/__snapshots__/BaseDropdown.test.tsx.snap
+++ b/packages/core/src/components/BaseDropdown/__snapshots__/BaseDropdown.test.tsx.snap
@@ -31,7 +31,7 @@ exports[`BaseDropDown > should render correctly 1`] = `
             </p>
           </div>
           <div
-            class="HvBaseDropdown-arrow css-tgcv4t-StyledDropDownXS eapzthe3 css-du18qm"
+            class="HvBaseDropdown-arrow css-tgcv4t-StyledDropDownXS eapzthe3 hv-uikit-css-du18qm"
             name="DropDownXS"
           >
             <svg

--- a/packages/core/src/components/DropDownMenu/__snapshots__/DropDownMenu.test.tsx.snap
+++ b/packages/core/src/components/DropDownMenu/__snapshots__/DropDownMenu.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`DropDownMenu > should render correctly 1`] = `
 <div>
   <div
-    class="HvBaseDropdown-root HvDropDownMenu-root css-uqb84k css-1nukton-StyledRoot eapzthe9"
+    class="HvBaseDropdown-root HvDropDownMenu-root hv-uikit-css-uqb84k css-1nukton-StyledRoot eapzthe9"
   >
     <div
       aria-expanded="false"
@@ -25,7 +25,7 @@ exports[`DropDownMenu > should render correctly 1`] = `
             class="css-1o4qkkz-StyledChildren e138pvrm1"
           >
             <div
-              class="css-du18qm"
+              class="hv-uikit-css-du18qm"
               name="MoreOptionsVertical"
             >
               <svg

--- a/packages/core/src/components/Pagination/__snapshots__/Pagination.test.tsx.snap
+++ b/packages/core/src/components/Pagination/__snapshots__/Pagination.test.tsx.snap
@@ -37,7 +37,7 @@ exports[`Pagination > should render correctly 1`] = `
                 </p>
               </div>
               <div
-                class="HvBaseDropdown-arrow css-tgcv4t-StyledDropDownXS eapzthe3 css-du18qm"
+                class="HvBaseDropdown-arrow css-tgcv4t-StyledDropDownXS eapzthe3 hv-uikit-css-du18qm"
                 name="DropDownXS"
               >
                 <svg
@@ -78,7 +78,7 @@ exports[`Pagination > should render correctly 1`] = `
               class="css-1o4qkkz-StyledChildren e138pvrm1"
             >
               <div
-                class="HvPagination-icon css-du18qm"
+                class="HvPagination-icon hv-uikit-css-du18qm"
                 name="Start"
               >
                 <svg
@@ -115,7 +115,7 @@ exports[`Pagination > should render correctly 1`] = `
               class="css-1o4qkkz-StyledChildren e138pvrm1"
             >
               <div
-                class="HvPagination-icon css-du18qm"
+                class="HvPagination-icon hv-uikit-css-du18qm"
                 name="Backwards"
               >
                 <svg
@@ -168,7 +168,7 @@ exports[`Pagination > should render correctly 1`] = `
               class="HvInput-error HvWarningText-root css-wyhb5v-StyledRoot e1jkc0dp2"
             >
               <div
-                class="HvWarningText-defaultIcon css-184echi-StyledIcon e1jkc0dp0 css-du18qm"
+                class="HvWarningText-defaultIcon css-184echi-StyledIcon e1jkc0dp0 hv-uikit-css-du18qm"
                 name="Fail"
               >
                 <svg
@@ -221,7 +221,7 @@ exports[`Pagination > should render correctly 1`] = `
               class="css-1o4qkkz-StyledChildren e138pvrm1"
             >
               <div
-                class="HvPagination-icon css-du18qm"
+                class="HvPagination-icon hv-uikit-css-du18qm"
                 name="Forwards"
               >
                 <svg
@@ -258,7 +258,7 @@ exports[`Pagination > should render correctly 1`] = `
               class="css-1o4qkkz-StyledChildren e138pvrm1"
             >
               <div
-                class="HvPagination-icon css-du18qm"
+                class="HvPagination-icon hv-uikit-css-du18qm"
                 name="End"
               >
                 <svg

--- a/packages/core/src/providers/Provider.tsx
+++ b/packages/core/src/providers/Provider.tsx
@@ -1,8 +1,9 @@
-import { css, Global } from "@emotion/react";
+import { css, Global, CacheProvider } from "@emotion/react";
 import { CssBaseline, getThemesVars } from "@hitachivantara/uikit-styles";
 import { parseThemes } from "utils";
 import { HvTheme } from "../types/theme";
 import { HvThemeProvider } from "./ThemeProvider";
+import createCache from "@emotion/cache";
 
 // Provider props
 export type HvProviderProps = {
@@ -63,7 +64,16 @@ export const HvProvider = ({
   const themes = parseThemes(baseTheme, name, customizations);
 
   return (
-    <>
+    <CacheProvider
+      /**
+       * Moves UI Kit styles to the top of the <head> so they're loaded first.
+       * This enables users to override the UI Kit styles if necessary.
+       */
+      value={createCache({
+        key: "hv-uikit-css",
+        prepend: true,
+      })}
+    >
       <Global
         styles={css`
           ${enableCssBaseline && CssBaseline}
@@ -78,7 +88,7 @@ export const HvProvider = ({
       >
         {children}
       </HvThemeProvider>
-    </>
+    </CacheProvider>
   );
 };
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,6 +37,7 @@ importers:
       pretty-quick: ^3.1.3
       react: ^18.2.0
       react-dom: ^18.2.0
+      react-google-charts: ^4.0.0
       typescript: ^4.8.4
       vite: ^3.2.4
       vite-plugin-dts: 2.0.0-beta.3
@@ -77,6 +78,7 @@ importers:
       pretty-quick: 3.1.3_prettier@2.8.4
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
+      react-google-charts: 4.0.0_biqbaboplfbrettd7655fr4n2y
       typescript: 4.9.5
       vite: 3.2.5_@types+node@18.14.0
       vite-plugin-dts: 2.0.0-beta.3_mwwey74ihw6cqmenz4ag2bljcy
@@ -123,6 +125,7 @@ importers:
 
   packages/core:
     specifiers:
+      '@emotion/cache': ^11.10.5
       '@emotion/react': ^11.10.5
       '@emotion/styled': ^11.10.5
       '@hitachivantara/uikit-react-icons': workspace:*
@@ -140,13 +143,13 @@ importers:
       notistack: ^2.0.8
       react: ^17.0.0 || ^18.0.0
       react-dom: ^17.0.0 || ^18.0.0
-      react-google-charts: ^4.0.0
       react-popper: ^2.3.0
       react-resize-detector: ^7.1.2
       react-table: ^7.8.0
       react-window: ^1.8.7
       tsc-alias: ^1.8.2
     dependencies:
+      '@emotion/cache': 11.10.5
       '@emotion/react': 11.10.6_pmekkgnqduwlme35zpnqhenc34
       '@emotion/styled': 11.10.6_oouaibmszuch5k64ms7uxp2aia
       '@hitachivantara/uikit-react-icons': link:../icons
@@ -162,7 +165,6 @@ importers:
       notistack: 2.0.8_xi2qqm4afs7e77tnkkiyk5lfne
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
-      react-google-charts: 4.0.0_biqbaboplfbrettd7655fr4n2y
       react-popper: 2.3.0_r6q5zrenym2zg7je7hgi674bti
       react-resize-detector: 7.1.2_biqbaboplfbrettd7655fr4n2y
       react-table: 7.8.0_react@18.2.0
@@ -15424,7 +15426,7 @@ packages:
     dependencies:
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
-    dev: false
+    dev: true
 
   /react-inspector/5.1.1_react@18.2.0:
     resolution: {integrity: sha512-GURDaYzoLbW8pMGXwYPDBIv6nqei4kK7LPRZ9q9HCZF54wqXz/dnylBp/kfE9XmekBhHvLDdcYeyIwSrvtOiWg==}


### PR DESCRIPTION
- `CacheProvider` from emotion is used to prepend the UI Kit styles;
- `react-google-charts` removed from the core package and switched to the project root.