### PR TITLE
fix: styling fixes

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -37,6 +37,7 @@
     "@emotion/cache": "^11.10.5",
     "@emotion/react": "^11.10.5",
     "@emotion/styled": "^11.10.5",
+    "@emotion/css": "^11.10.6",
     "@mui/material": "^5.11.0",
     "react": "^17.0.0 || ^18.0.0",
     "react-dom": "^17.0.0 || ^18.0.0"

--- a/packages/core/src/components/Accordion/Accordion.tsx
+++ b/packages/core/src/components/Accordion/Accordion.tsx
@@ -134,7 +134,11 @@ export const HvAccordion = ({
         id={accordionHeaderId}
         component="div"
         role="button"
-        className={clsx(accordionClasses.label, classes?.label)}
+        className={clsx(
+          accordionClasses.label,
+          classes?.label,
+          disabled && clsx(accordionClasses.disabled, classes?.disabled)
+        )}
         disabled={disabled}
         tabIndex={0}
         onKeyDown={handleKeyDown}
@@ -178,7 +182,11 @@ export const HvAccordion = ({
         id={accordionContainer}
         role="region"
         aria-labelledby={accordionHeaderId}
-        className={clsx(accordionClasses.container, classes?.container)}
+        className={clsx(
+          accordionClasses.container,
+          classes?.container,
+          !isOpen && clsx(accordionClasses.hidden, classes?.hidden)
+        )}
         hidden={!isOpen}
         {...containerProps}
       >

--- a/packages/core/src/components/Accordion/__snapshots__/Accordion.test.tsx.snap
+++ b/packages/core/src/components/Accordion/__snapshots__/Accordion.test.tsx.snap
@@ -32,7 +32,7 @@ exports[`Accordion > should render correctly 1`] = `
       </div>
     </div>
     <div
-      class="HvAccordion-container css-1av53l8-StyledContainer e86r8k01"
+      class="HvAccordion-container HvAccordion-hidden css-1av53l8-StyledContainer e86r8k01"
       hidden=""
       role="region"
     />

--- a/packages/core/src/components/ActionsGeneric/__snapshots__/ActionsGeneric.test.tsx.snap
+++ b/packages/core/src/components/ActionsGeneric/__snapshots__/ActionsGeneric.test.tsx.snap
@@ -13,7 +13,7 @@ exports[`ActionsGeneric > should render correctly 1`] = `
         class="css-1nxr552-StyledContentDiv e138pvrm3"
       >
         <span
-          class="css-16uosol-StyledIconSpan e138pvrm2"
+          class="HvButton-startIcon css-16uosol-StyledIconSpan e138pvrm2"
         >
           <div
             class="css-du18qm"
@@ -48,7 +48,7 @@ exports[`ActionsGeneric > should render correctly 1`] = `
         class="css-1nxr552-StyledContentDiv e138pvrm3"
       >
         <span
-          class="css-16uosol-StyledIconSpan e138pvrm2"
+          class="HvButton-startIcon css-16uosol-StyledIconSpan e138pvrm2"
         >
           <div
             class="css-du18qm"
@@ -83,7 +83,7 @@ exports[`ActionsGeneric > should render correctly 1`] = `
         class="css-1nxr552-StyledContentDiv e138pvrm3"
       >
         <span
-          class="css-16uosol-StyledIconSpan e138pvrm2"
+          class="HvButton-startIcon css-16uosol-StyledIconSpan e138pvrm2"
         >
           <div
             class="css-du18qm"
@@ -118,7 +118,7 @@ exports[`ActionsGeneric > should render correctly 1`] = `
         class="css-1nxr552-StyledContentDiv e138pvrm3"
       >
         <span
-          class="css-16uosol-StyledIconSpan e138pvrm2"
+          class="HvButton-startIcon css-16uosol-StyledIconSpan e138pvrm2"
         >
           <div
             class="css-du18qm"

--- a/packages/core/src/components/AppSwitcher/AppSwitcher.tsx
+++ b/packages/core/src/components/AppSwitcher/AppSwitcher.tsx
@@ -124,6 +124,8 @@ export const HvAppSwitcher = ({
         className,
         appSwitcherClasses.root,
         classes?.root,
+        appSwitcherClasses[layout],
+        classes?.[layout],
         isOpen && clsx(appSwitcherClasses.open, classes?.open),
         isOpen === false && clsx(appSwitcherClasses.closed, classes?.closed)
       )}

--- a/packages/core/src/components/AppSwitcher/__snapshots__/AppSwitcher.test.tsx.snap
+++ b/packages/core/src/components/AppSwitcher/__snapshots__/AppSwitcher.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`<AppSwitcher /> with minimum configuration > should render correctly 1`] = `
 <div>
   <div
-    class="HvAppSwitcher-root HvAppSwitcher-open css-1obxrpd-StyledRoot e1lxr4i84"
+    class="HvAppSwitcher-root HvAppSwitcher-single HvAppSwitcher-open css-1obxrpd-StyledRoot e1lxr4i84"
   >
     <span
       class="HvAppSwitcher-title e1lxr4i82 HvTypography-root HvTypography-label css-1vsygg1-getStyledComponent-StyledTitleWithTooltip e1tnpalo0"

--- a/packages/core/src/components/AppSwitcher/appSwitcherClasses.ts
+++ b/packages/core/src/components/AppSwitcher/appSwitcherClasses.ts
@@ -14,6 +14,9 @@ export type HvAppSwitcherClasses = {
   open?: string;
   closed?: string;
   title?: string;
+  single?: string;
+  dual?: string;
+  fluid?: string;
 };
 
 const classKeys: string[] = [
@@ -30,6 +33,9 @@ const classKeys: string[] = [
   "open",
   "closed",
   "title",
+  "single",
+  "dual",
+  "fluid",
 ];
 
 const appSwitcherClasses = getClasses<HvAppSwitcherClasses>(

--- a/packages/core/src/components/Avatar/Avatar.tsx
+++ b/packages/core/src/components/Avatar/Avatar.tsx
@@ -154,7 +154,14 @@ export const HvAvatar = ({
       {...others}
     >
       <StyledStatus
-        className={clsx(avatarClasses.status, classes?.status)}
+        className={clsx(
+          avatarClasses.status,
+          classes?.status,
+          avatarClasses[variant],
+          classes?.[variant],
+          avatarClasses[size],
+          classes?.[size]
+        )}
         style={statusInlineStyle}
         $variant={variant}
         $size={size}
@@ -172,7 +179,9 @@ export const HvAvatar = ({
             avatarClasses.root,
             classes?.root,
             avatarClasses.avatar,
-            classes?.avatar
+            classes?.avatar,
+            avatarClasses[size],
+            classes?.[size]
           )}
           style={inlineStyle}
           variant={variant}

--- a/packages/core/src/components/Avatar/__snapshots__/Avatar.test.tsx.snap
+++ b/packages/core/src/components/Avatar/__snapshots__/Avatar.test.tsx.snap
@@ -6,13 +6,13 @@ exports[`Avatar > letter avatar > should render the avatar as text 1`] = `
     class="HvAvatar-container css-1a4hhck-StyledContainer e1sw81qd4"
   >
     <div
-      class="HvAvatar-status css-pfc2yb-StyledStatus e1sw81qd2"
+      class="HvAvatar-status HvAvatar-circular HvAvatar-SM css-pfc2yb-StyledStatus e1sw81qd2"
     >
       <div
         class="HvAvatar-badge css-y4cyfh-StyledBadge e1sw81qd0"
       />
       <div
-        class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault HvAvatar-root HvAvatar-avatar e1sw81qd1 css-rtd540-MuiAvatar-root-StyledAvatar"
+        class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault HvAvatar-root HvAvatar-avatar HvAvatar-SM e1sw81qd1 css-rtd540-MuiAvatar-root-StyledAvatar"
       >
         AB
       </div>
@@ -27,10 +27,10 @@ exports[`Avatar > should render correctly 1`] = `
     class="HvAvatar-container css-1a4hhck-StyledContainer e1sw81qd4"
   >
     <div
-      class="HvAvatar-status css-pfc2yb-StyledStatus e1sw81qd2"
+      class="HvAvatar-status HvAvatar-circular HvAvatar-SM css-pfc2yb-StyledStatus e1sw81qd2"
     >
       <div
-        class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault HvAvatar-root HvAvatar-avatar e1sw81qd1 css-rtd540-MuiAvatar-root-StyledAvatar"
+        class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault HvAvatar-root HvAvatar-avatar HvAvatar-SM e1sw81qd1 css-rtd540-MuiAvatar-root-StyledAvatar"
       >
         <div
           class="HvAvatar-fallback css-du18qm"

--- a/packages/core/src/components/Avatar/avatarClasses.ts
+++ b/packages/core/src/components/Avatar/avatarClasses.ts
@@ -8,6 +8,13 @@ export type HvAvatarClasses = {
   badge?: string;
   avatar?: string;
   status?: string;
+  XS?: string;
+  SM?: string;
+  MD?: string;
+  LG?: string;
+  XL?: string;
+  circular?: string;
+  square?: string;
 };
 
 const classKeys: string[] = [
@@ -18,6 +25,13 @@ const classKeys: string[] = [
   "badge",
   "avatar",
   "status",
+  "XS",
+  "SM",
+  "MD",
+  "LG",
+  "XL",
+  "circular",
+  "square",
 ];
 
 const avatarClasses = getClasses<HvAvatarClasses>(classKeys, "HvAvatar");

--- a/packages/core/src/components/Badge/Badge.tsx
+++ b/packages/core/src/components/Badge/Badge.tsx
@@ -65,7 +65,7 @@ export const HvBadge = (props: HvBadgeProps) => {
   return (
     <StyledRoot
       aria-label={renderedCountOrLabel?.toString()}
-      className={clsx(badgeClasses.root, classes?.root)}
+      className={clsx(className, badgeClasses.root, classes?.root)}
       {...others}
     >
       {Component}
@@ -78,7 +78,18 @@ export const HvBadge = (props: HvBadgeProps) => {
         }
       >
         <StyledBadge
-          className={clsx(badgeClasses.badgePosition, classes?.badgePosition)}
+          className={clsx(
+            badgeClasses.badgePosition,
+            classes?.badgePosition,
+            !!(count > 0 || renderedCountOrLabel) &&
+              clsx(badgeClasses.badge, classes?.badge),
+            !!(!label && renderedCountOrLabel) &&
+              clsx(badgeClasses.showCount, classes?.showCount),
+            !!label && clsx(badgeClasses.showLabel, classes?.showLabel),
+            !!icon && clsx(badgeClasses.badgeIcon, classes?.badgeIcon),
+            String(renderedCountOrLabel).length === 1 &&
+              clsx(badgeClasses.badgeOneDigit, classes?.badgeOneDigit)
+          )}
           $badge={!!(count > 0 || renderedCountOrLabel)}
           $showCount={!!(!label && renderedCountOrLabel)}
           $showLabel={!!label}

--- a/packages/core/src/components/Badge/__snapshots__/Badge.test.tsx.snap
+++ b/packages/core/src/components/Badge/__snapshots__/Badge.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`Badge > should render a small dot when count>0 without showCount 1`] = 
       class=" css-27p99g-StyledContainer e16y1fwq1"
     >
       <div
-        class="HvBadgeClasses-badgePosition css-q9c65s-StyledBadge e16y1fwq0"
+        class="HvBadgeClasses-badgePosition HvBadgeClasses-badge css-q9c65s-StyledBadge e16y1fwq0"
       />
     </div>
   </div>
@@ -26,7 +26,7 @@ exports[`Badge > should render correctly with custom label 1`] = `
       class=" css-27p99g-StyledContainer e16y1fwq1"
     >
       <div
-        class="HvBadgeClasses-badgePosition css-1vsqlrq-StyledBadge e16y1fwq0"
+        class="HvBadgeClasses-badgePosition HvBadgeClasses-badge HvBadgeClasses-showLabel css-1vsqlrq-StyledBadge e16y1fwq0"
       >
         New!
       </div>
@@ -45,7 +45,7 @@ exports[`Badge > should render correctly with custom one-character label 1`] = `
       class=" css-27p99g-StyledContainer e16y1fwq1"
     >
       <div
-        class="HvBadgeClasses-badgePosition css-19po4ur-StyledBadge e16y1fwq0"
+        class="HvBadgeClasses-badgePosition HvBadgeClasses-badge HvBadgeClasses-showLabel HvBadgeClasses-badgeOneDigit css-19po4ur-StyledBadge e16y1fwq0"
       >
         !
       </div>
@@ -64,7 +64,7 @@ exports[`Badge > should render correctly with maxCount 1`] = `
       class=" css-27p99g-StyledContainer e16y1fwq1"
     >
       <div
-        class="HvBadgeClasses-badgePosition css-w9pa41-StyledBadge e16y1fwq0"
+        class="HvBadgeClasses-badgePosition HvBadgeClasses-badge HvBadgeClasses-showCount css-w9pa41-StyledBadge e16y1fwq0"
       >
         99+
       </div>
@@ -83,7 +83,7 @@ exports[`Badge > should render correctly with showCount 1`] = `
       class=" css-27p99g-StyledContainer e16y1fwq1"
     >
       <div
-        class="HvBadgeClasses-badgePosition css-w9pa41-StyledBadge e16y1fwq0"
+        class="HvBadgeClasses-badgePosition HvBadgeClasses-badge HvBadgeClasses-showCount css-w9pa41-StyledBadge e16y1fwq0"
       >
         12
       </div>
@@ -102,7 +102,7 @@ exports[`Badge > should render correctly with showCount and one-digit count 1`] 
       class=" css-27p99g-StyledContainer e16y1fwq1"
     >
       <div
-        class="HvBadgeClasses-badgePosition css-18ngfg2-StyledBadge e16y1fwq0"
+        class="HvBadgeClasses-badgePosition HvBadgeClasses-badge HvBadgeClasses-showCount HvBadgeClasses-badgeOneDigit css-18ngfg2-StyledBadge e16y1fwq0"
       >
         9
       </div>
@@ -139,7 +139,7 @@ exports[`Badge > should render correctly with svg 1`] = `
       class="HvBadgeClasses-badgeContainer css-1ab0lly-StyledContainer e16y1fwq1"
     >
       <div
-        class="HvBadgeClasses-badgePosition css-kg2zaf-StyledBadge e16y1fwq0"
+        class="HvBadgeClasses-badgePosition HvBadgeClasses-badge HvBadgeClasses-showCount HvBadgeClasses-badgeIcon css-kg2zaf-StyledBadge e16y1fwq0"
       >
         99+
       </div>
@@ -163,7 +163,7 @@ exports[`Badge > should render correctly with text 1`] = `
       class="HvBadgeClasses-badgeContainer css-1ab0lly-StyledContainer e16y1fwq1"
     >
       <div
-        class="HvBadgeClasses-badgePosition css-w9pa41-StyledBadge e16y1fwq0"
+        class="HvBadgeClasses-badgePosition HvBadgeClasses-badge HvBadgeClasses-showCount css-w9pa41-StyledBadge e16y1fwq0"
       >
         99+
       </div>
@@ -182,7 +182,7 @@ exports[`Badge > should render custom label but not count when both are specifie
       class=" css-27p99g-StyledContainer e16y1fwq1"
     >
       <div
-        class="HvBadgeClasses-badgePosition css-1vsqlrq-StyledBadge e16y1fwq0"
+        class="HvBadgeClasses-badgePosition HvBadgeClasses-badge HvBadgeClasses-showLabel css-1vsqlrq-StyledBadge e16y1fwq0"
       >
         New!
       </div>

--- a/packages/core/src/components/Badge/badgeClasses.ts
+++ b/packages/core/src/components/Badge/badgeClasses.ts
@@ -4,9 +4,23 @@ export type HvBadgeClasses = {
   root?: string;
   badgeContainer?: string;
   badgePosition?: string;
+  badge?: string;
+  showCount?: string;
+  showLabel?: string;
+  badgeIcon?: string;
+  badgeOneDigit?: string;
 };
 
-const classKeys: string[] = ["root", "badgeContainer", "badgePosition"];
+const classKeys: string[] = [
+  "root",
+  "badgeContainer",
+  "badgePosition",
+  "badge",
+  "showCount",
+  "showLabel",
+  "badgeIcon",
+  "badgeOneDigit",
+];
 
 const badgeClasses = getClasses<HvBadgeClasses>(classKeys, "HvBadgeClasses");
 

--- a/packages/core/src/components/Banner/Banner.tsx
+++ b/packages/core/src/components/Banner/Banner.tsx
@@ -25,7 +25,7 @@ export type HvBannerVariant =
 
 export type HvBannerActionPosition = "auto" | "inline" | "bottom-right";
 
-export type HvBannerProps = Omit<MuiSnackbarProps, "anchorOrigin"> &
+export type HvBannerProps = Omit<MuiSnackbarProps, "anchorOrigin" | "classes"> &
   HvBaseProps & {
     /** If true | Snackbar is open. */
     open: boolean;

--- a/packages/core/src/components/Banner/BannerContent/BannerContent.tsx
+++ b/packages/core/src/components/Banner/BannerContent/BannerContent.tsx
@@ -17,7 +17,10 @@ import { forwardRef } from "react";
 import { iconVariant } from "utils";
 import { HvActionContainerProps } from "./ActionContainer/ActionContainer";
 
-export type HvBannerContentProps = Omit<MuiSnackbarContentProps, "variant"> &
+export type HvBannerContentProps = Omit<
+  MuiSnackbarContentProps,
+  "variant" | "classes"
+> &
   HvBaseProps & {
     /** The message to display. */
     content?: React.ReactNode;
@@ -90,7 +93,9 @@ export const HvBannerContent = forwardRef<HTMLDivElement, HvBannerContentProps>(
           }}
           className={clsx(
             bannerContentClasses.baseVariant,
-            classes?.baseVariant
+            classes?.baseVariant,
+            bannerContentClasses[variant],
+            classes?.[variant]
           )}
           message={
             <HvMessageContainer

--- a/packages/core/src/components/Banner/BannerContent/bannerContentClasses.ts
+++ b/packages/core/src/components/Banner/BannerContent/bannerContentClasses.ts
@@ -6,6 +6,11 @@ export type HvBannerContentClasses = {
   message?: string;
   action?: string;
   baseVariant?: string;
+  success?: string;
+  warning?: string;
+  error?: string;
+  info?: string;
+  default?: string;
 };
 
 const classKeys: string[] = [
@@ -14,6 +19,11 @@ const classKeys: string[] = [
   "message",
   "action",
   "baseVariant",
+  "success",
+  "warning",
+  "error",
+  "info",
+  "default",
 ];
 
 const bannerContentClasses = getClasses<HvBannerContentClasses>(

--- a/packages/core/src/components/Banner/__snapshots__/Banner.test.tsx.snap
+++ b/packages/core/src/components/Banner/__snapshots__/Banner.test.tsx.snap
@@ -11,7 +11,7 @@ exports[`Banner > should render correctly 1`] = `
       class="HvBanner-Content-outContainer css-d89rls-StyledRoot ey1hm771"
     >
       <div
-        class="MuiPaper-root MuiPaper-elevation MuiPaper-elevation6 MuiSnackbarContent-root HvBanner-Content-root HvBanner-Content-baseVariant ey1hm770 css-1fz47rw-MuiPaper-root-MuiSnackbarContent-root-StyledSnackbarContent"
+        class="MuiPaper-root MuiPaper-elevation MuiPaper-elevation6 MuiSnackbarContent-root HvBanner-Content-root HvBanner-Content-baseVariant HvBanner-Content-default ey1hm770 css-1fz47rw-MuiPaper-root-MuiSnackbarContent-root-StyledSnackbarContent"
         role="alert"
         style="webkit-transform: none; transform: none; webkit-transition: -webkit-transform 300ms cubic-bezier(0.0, 0, 0.2, 1) 0ms; transition: transform 300ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;"
       >

--- a/packages/core/src/components/BaseCheckBox/BaseCheckBox.tsx
+++ b/packages/core/src/components/BaseCheckBox/BaseCheckBox.tsx
@@ -12,7 +12,10 @@ import baseCheckBoxClasses, {
   HvBaseCheckBoxClasses,
 } from "./baseCheckBoxClasses";
 
-export type HvBaseCheckBoxProps = Omit<MuiCheckboxProps, "onChange"> &
+export type HvBaseCheckBoxProps = Omit<
+  MuiCheckboxProps,
+  "onChange" | "classes"
+> &
   HvBaseProps<HTMLInputElement, { onChange }> & {
     /**
      * The input name.

--- a/packages/core/src/components/BaseInput/BaseInput.tsx
+++ b/packages/core/src/components/BaseInput/BaseInput.tsx
@@ -50,7 +50,7 @@ const baseInputStyles = css`
   },
 }`;
 
-export type HvBaseInputProps = Omit<MuiInputProps, "onChange"> &
+export type HvBaseInputProps = Omit<MuiInputProps, "onChange" | "classes"> &
   HvBaseProps<HTMLDivElement, { onChange }> & {
     /** The input name. */
     name?: string;
@@ -172,8 +172,16 @@ export const HvBaseInput = ({
           disabled={formElementProps.disabled}
           onChange={onChangeHandler}
           className={clsx(
-            localInvalid && baseInputClasses.inputRootInvalid,
-            readOnly && baseInputClasses.inputRootReadOnly
+            localInvalid &&
+              clsx(
+                baseInputClasses.inputRootInvalid,
+                classes?.inputRootInvalid
+              ),
+            readOnly &&
+              clsx(
+                baseInputClasses.inputRootReadOnly,
+                classes?.inputRootReadOnly
+              )
           )}
           classes={{
             root: clsx(baseInputClasses.inputRoot, classes?.inputRoot),

--- a/packages/core/src/components/BaseRadio/BaseRadio.tsx
+++ b/packages/core/src/components/BaseRadio/BaseRadio.tsx
@@ -5,11 +5,11 @@ import {
   RadioButtonUnselected,
   RadioButtonSelected,
 } from "@hitachivantara/uikit-react-icons";
-import { HvBaseProps, HvExtraProps } from "../../types";
+import { HvBaseProps } from "../../types";
 import { StyledRadio } from "./BaseRadio.styles";
 import baseRadioClasses, { HvBaseRadioClasses } from "./baseRadioClasses";
 
-export type HvBaseRadioProps = Omit<MuiRadioProps, "onChange"> &
+export type HvBaseRadioProps = Omit<MuiRadioProps, "onChange" | "classes"> &
   HvBaseProps<HTMLInputElement, { onChange }> & {
     /**
      * Class names to be applied.
@@ -80,7 +80,7 @@ export type HvBaseRadioProps = Omit<MuiRadioProps, "onChange"> &
      * @ignore
      */
     onBlur?: (event: React.FocusEvent<any>) => void;
-  } & HvExtraProps;
+  };
 
 export const getSelectorIcons = (
   options: { disabled: boolean; semantic: boolean },

--- a/packages/core/src/components/BaseSwitch/BaseSwitch.tsx
+++ b/packages/core/src/components/BaseSwitch/BaseSwitch.tsx
@@ -2,10 +2,10 @@ import React, { useState, useCallback } from "react";
 import clsx from "clsx";
 import { SwitchProps as MuiSwitchProps } from "@mui/material";
 import { StyledSwitch } from "./BaseSwitch.styles";
-import { HvBaseProps, HvExtraProps } from "../../types";
+import { HvBaseProps } from "../../types";
 import baseSwitchClasses, { HvBaseSwitchClasses } from "./baseSwitchClasses";
 
-export type HvBaseSwitchProps = Omit<MuiSwitchProps, "onChange"> &
+export type HvBaseSwitchProps = Omit<MuiSwitchProps, "onChange" | "classes"> &
   HvBaseProps<HTMLInputElement, { onChange }> & {
     /**
      * Class names to be applied.
@@ -71,7 +71,7 @@ export type HvBaseSwitchProps = Omit<MuiSwitchProps, "onChange"> &
      * @ignore
      */
     onBlur?: (event: React.FocusEvent<any>) => void;
-  } & HvExtraProps;
+  };
 
 /**
  * A Switch is <b>binary</b> and work as a digital on/off button.

--- a/packages/core/src/components/BreadCrumb/BreadCrumb.tsx
+++ b/packages/core/src/components/BreadCrumb/BreadCrumb.tsx
@@ -107,11 +107,11 @@ export const HvBreadCrumb = ({
                 classes={{
                   centerContainer: clsx(
                     breadCrumbClasses.centerContainer,
-                    classes?.centerContainer || ""
+                    classes?.centerContainer
                   ),
                   separatorContainer: clsx(
                     breadCrumbClasses.separatorContainer,
-                    classes?.separatorContainer || ""
+                    classes?.separatorContainer
                   ),
                 }}
                 key={key}

--- a/packages/core/src/components/BulkActions/__snapshots__/BulkActions.test.tsx.snap
+++ b/packages/core/src/components/BulkActions/__snapshots__/BulkActions.test.tsx.snap
@@ -77,7 +77,7 @@ exports[`BulkActions > With actions > should render correctly 1`] = `
           class="css-1nxr552-StyledContentDiv e138pvrm3"
         >
           <span
-            class="css-16uosol-StyledIconSpan e138pvrm2"
+            class="HvButton-startIcon css-16uosol-StyledIconSpan e138pvrm2"
           >
             <div
               class="css-du18qm"
@@ -113,7 +113,7 @@ exports[`BulkActions > With actions > should render correctly 1`] = `
           class="css-1nxr552-StyledContentDiv e138pvrm3"
         >
           <span
-            class="css-16uosol-StyledIconSpan e138pvrm2"
+            class="HvButton-startIcon css-16uosol-StyledIconSpan e138pvrm2"
           >
             <div
               class="css-du18qm"

--- a/packages/core/src/components/Button/Button.tsx
+++ b/packages/core/src/components/Button/Button.tsx
@@ -61,14 +61,6 @@ const mapVariant = (variant: HvButtonVariant): HvButtonVariant => {
   return variant;
 };
 
-const onFocusHandler = (event) => {
-  event.target.classList.add("HvIsFocusVisible");
-};
-
-const onBlurHandler = (event) => {
-  event.target.classList.remove("HvIsFocusVisible");
-};
-
 /**
  * Button component is used to trigger an action or event.
  */
@@ -90,10 +82,26 @@ export const HvButton = forwardRef<HTMLButtonElement, HvButtonProps>(
       ...others
     }: HvButtonProps = props;
 
+    const onFocusHandler = (event) => {
+      event.target.classList.add("HvIsFocusVisible");
+      event.target.classList.add(buttonClasses.focusVisible);
+      if (classes?.focusVisible) {
+        event.target.classList.add(classes.focusVisible);
+      }
+    };
+
+    const onBlurHandler = (event) => {
+      event.target.classList.remove("HvIsFocusVisible");
+      event.target.classList.remove(buttonClasses.focusVisible);
+      if (classes?.focusVisible) {
+        event.target.classList.remove(classes.focusVisible);
+      }
+    };
+
     return (
       <StyledButton
         id={id}
-        className={clsx(className, buttonClasses.root)}
+        className={clsx(className, classes?.root, buttonClasses.root)}
         ref={ref}
         onClick={onClick}
         disabled={disabled}
@@ -108,7 +116,13 @@ export const HvButton = forwardRef<HTMLButtonElement, HvButtonProps>(
         {...others}
       >
         <StyledContentDiv>
-          {startIcon && <StyledIconSpan>{startIcon}</StyledIconSpan>}
+          {startIcon && (
+            <StyledIconSpan
+              className={clsx(classes?.startIcon, buttonClasses.startIcon)}
+            >
+              {startIcon}
+            </StyledIconSpan>
+          )}
           {children && <StyledChildren>{children}</StyledChildren>}
         </StyledContentDiv>
       </StyledButton>

--- a/packages/core/src/components/Button/buttonClasses.ts
+++ b/packages/core/src/components/Button/buttonClasses.ts
@@ -2,12 +2,11 @@ import { getClasses } from "utils";
 
 export type HvButtonClasses = {
   root?: string;
-  focusVisible?: string;
   startIcon?: string;
-  primary?: string;
+  focusVisible?: string;
 };
 
-const classKeys: string[] = ["root", "focusVisible", "startIcon", "primary"];
+const classKeys: string[] = ["root", "startIcon", "focusVisible"];
 
 const buttonClasses = getClasses<HvButtonClasses>(classKeys, "HvButton");
 

--- a/packages/core/src/components/Card/Card.styles.tsx
+++ b/packages/core/src/components/Card/Card.styles.tsx
@@ -1,33 +1,21 @@
-import styled from "@emotion/styled";
+import { css } from "@emotion/css";
 import { theme } from "@hitachivantara/uikit-styles";
-import { HvBox } from "components";
 import { outlineStyles } from "utils";
-import { transientOptions } from "utils/transientOptions";
-import cardClasses from "./cardClasses";
 
-const getColor = (c: string): string => theme.colors[c];
-
-export const StyledRoot = styled(
-  HvBox,
-  transientOptions
-)(({ $selectable, $selected, $bgcolor }) => ({
-  overflow: "visible",
-  position: "relative",
-  backgroundColor: getColor($bgcolor),
-  outline: theme.card.outline,
-  borderRadius: theme.card.borderRadius,
-  "&.focus-visible": {
-    ...outlineStyles,
-  },
-  "&:focus": {
-    outline: "none",
-  },
-  ...($selectable && {
-    "&:hover": {
-      outline: `1px solid ${theme.card.hoverColor}`,
+export const styles = {
+  root: css({
+    overflow: "visible",
+    position: "relative",
+    outline: theme.card.outline,
+    borderRadius: theme.card.borderRadius,
+    "&.focus-visible": {
+      ...outlineStyles,
+    },
+    "&:focus": {
+      outline: "none",
     },
   }),
-  ...($selected && {
+  selected: css({
     outline: `1px solid ${theme.colors.acce1}`,
     "&:hover": {
       outline: `1px solid ${theme.colors.acce1}`,
@@ -35,38 +23,26 @@ export const StyledRoot = styled(
     "&:focus": {
       outline: `1px solid ${theme.colors.acce1}`,
     },
-    [`& .${cardClasses.semanticBar}`]: {
-      height: 4,
-    },
-    "& .sema0": {
-      backgroundColor: theme.colors.acce1,
+  }),
+  selectable: css({
+    "&:hover": {
+      outline: `1px solid ${theme.card.hoverColor}`,
     },
   }),
-}));
-
-export const StyledContainer = styled("div")({
-  position: "relative",
-  "& > *": {
-    position: "absolute",
-    zIndex: 1,
-  },
-});
-
-export const StyledBar = styled(
-  "div",
-  transientOptions
-)(({ $barColor }: { $barColor: string }) => ({
-  width: "100%",
-  height: 2,
-  top: -1,
-  right: 0,
-  backgroundColor: theme.colors[$barColor],
-  ...($barColor === "sema0" && {
-    backgroundColor: theme.colors.atmo4,
+  semanticContainer: css({
+    position: "relative",
+    "& > *": {
+      position: "absolute",
+      zIndex: 1,
+    },
   }),
-}));
-
-export const StyledIcon = styled("div")({
-  top: `calc(${theme.card.iconMargin} + ${theme.space.xs})`,
-  right: `calc(${theme.card.iconMargin} + ${theme.space.xs})`,
-});
+  icon: css({
+    top: `calc(${theme.card.iconMargin} + ${theme.space.xs})`,
+    right: `calc(${theme.card.iconMargin} + ${theme.space.xs})`,
+  }),
+  semanticBar: css({
+    width: "100%",
+    top: -1,
+    right: 0,
+  }),
+};

--- a/packages/core/src/components/Card/Card.tsx
+++ b/packages/core/src/components/Card/Card.tsx
@@ -1,12 +1,10 @@
+import { css } from "@emotion/css";
+import { theme } from "@hitachivantara/uikit-styles";
 import clsx from "clsx";
+import { HvBox } from "components";
 import { HvBaseProps } from "../../types";
 import { HvAtmosphereColorKeys, HvSemanticColorKeys } from "../../types/tokens";
-import {
-  StyledRoot,
-  StyledContainer,
-  StyledBar,
-  StyledIcon,
-} from "./Card.styles";
+import { styles } from "./Card.styles";
 import cardClasses, { HvCardClasses } from "./cardClasses";
 
 export type HvCardProps = HvBaseProps & {
@@ -41,33 +39,57 @@ export const HvCard = ({
   selectable = false,
   selected = false,
   statusColor = "sema0",
-  bgcolor = "atmo1",
+  bgcolor,
   ...others
 }: HvCardProps) => {
   return (
-    <StyledRoot
+    <HvBox
       aria-selected={selectable ? selected : undefined}
       className={clsx(
+        styles.root,
+        bgcolor &&
+          css({
+            backgroundColor: theme.colors[bgcolor],
+          }),
         "HvIsCardGridElement",
         cardClasses.root,
         classes?.root,
         className,
-        selectable && clsx(cardClasses.selectable, classes?.selectable),
-        selected && clsx(cardClasses.selected, classes?.selected)
+        selectable &&
+          clsx(styles.selectable, cardClasses.selectable, classes?.selectable),
+        selected &&
+          clsx(styles.selected, cardClasses.selected, classes?.selected)
       )}
-      $selectable={selectable}
-      $selected={selected}
-      $bgcolor={bgcolor}
       {...others}
     >
-      <StyledContainer>
-        <StyledBar
-          className={clsx(cardClasses.semanticBar, classes?.semanticBar)}
-          $barColor={statusColor}
+      <div
+        className={clsx(
+          styles.semanticContainer,
+          cardClasses.semanticContainer,
+          classes?.semanticContainer
+        )}
+      >
+        <div
+          className={clsx(
+            styles.semanticBar,
+            css({
+              height: selected ? 4 : 2,
+              backgroundColor:
+                statusColor === "sema0"
+                  ? selected
+                    ? theme.colors.acce1
+                    : theme.colors.atmo4
+                  : theme.colors[statusColor],
+            }),
+            cardClasses.semanticBar,
+            classes?.semanticBar
+          )}
         />
-        <StyledIcon>{icon}</StyledIcon>
-      </StyledContainer>
+        <div className={clsx(styles.icon, cardClasses.icon, classes?.icon)}>
+          {icon}
+        </div>
+      </div>
       {children}
-    </StyledRoot>
+    </HvBox>
   );
 };

--- a/packages/core/src/components/Card/Content/Content.styles.tsx
+++ b/packages/core/src/components/Card/Content/Content.styles.tsx
@@ -1,10 +1,11 @@
-import styled from "@emotion/styled";
+import { css } from "@emotion/css";
 import { theme } from "@hitachivantara/uikit-styles";
-import CardContent from "@mui/material/CardContent";
 
-export const StyledContent = styled(CardContent)({
-  padding: `0 ${theme.space.sm} 15px ${theme.space.sm}`,
-  "&:last-child": {
-    paddingBottom: theme.space.sm,
-  },
-});
+export const styles = {
+  content: css({
+    padding: `0 ${theme.space.sm} 15px ${theme.space.sm}`,
+    "&:last-child": {
+      paddingBottom: theme.space.sm,
+    },
+  }),
+};

--- a/packages/core/src/components/Card/Content/Content.tsx
+++ b/packages/core/src/components/Card/Content/Content.tsx
@@ -1,10 +1,12 @@
 import clsx from "clsx";
 import { HvBaseProps } from "../../../types";
-import { StyledContent } from "./Content.styles";
-import { CardContentProps as MuiCardContentProps } from "@mui/material/CardContent";
+import { styles } from "./Content.styles";
+import MuiCardContent, {
+  CardContentProps as MuiCardContentProps,
+} from "@mui/material/CardContent";
 import cardContentClasses, { HvCardContentClasses } from "./contentClasses";
 
-export type HvContentProps = MuiCardContentProps &
+export type HvContentProps = Omit<MuiCardContentProps, "classes"> &
   HvBaseProps & {
     /** Id to be applied to the root node. */
     id?: string;
@@ -23,13 +25,18 @@ export const HvContent = ({
   ...others
 }: HvContentProps) => {
   return (
-    <StyledContent
+    <MuiCardContent
       id={id}
-      className={clsx(classes?.content, cardContentClasses.content, className)}
+      className={clsx(
+        styles.content,
+        classes?.content,
+        cardContentClasses.content,
+        className
+      )}
       onClick={onClick}
       {...others}
     >
       {children}
-    </StyledContent>
+    </MuiCardContent>
   );
 };

--- a/packages/core/src/components/Card/Header/Header.styles.tsx
+++ b/packages/core/src/components/Card/Header/Header.styles.tsx
@@ -1,32 +1,24 @@
-import { CSSProperties } from "react";
-import styled from "@emotion/styled";
 import { theme } from "@hitachivantara/uikit-styles";
-import CardHeader from "@mui/material/CardHeader";
-import { transientOptions } from "utils/transientOptions";
+import { css } from "@emotion/css";
 
-export const StyledHeader = styled(
-  CardHeader,
-  transientOptions
-)(({ $short }: { $short?: boolean }) => ({
-  padding: `15px ${theme.space.sm}`,
-  position: "relative",
-
-  // https://mui.com/material-ui/api/card-header/#css
-  "& .MuiCardHeader-title": {
-    ...(theme.typography.title3 as CSSProperties),
+export const styles = {
+  root: css({ padding: `15px ${theme.space.sm}`, position: "relative" }),
+  titleShort: css({
     fontFamily: theme.fontFamily.body,
-    ...($short && { marginRight: "30px" }),
-  },
-  "& .MuiCardHeader-subheader": {
+    marginRight: "30px",
+  }),
+  title: css({
     fontFamily: theme.fontFamily.body,
-    ...(theme.typography.label as CSSProperties),
-  },
-  "& .MuiCardHeader-action": {
+  }),
+  subheader: css({
+    fontFamily: theme.fontFamily.body,
+  }),
+  action: css({
     position: "absolute",
     right: 20,
     marginTop: 0,
     marginRight: "0px",
     paddingLeft: theme.space.xs,
     top: "15px",
-  },
-}));
+  }),
+};

--- a/packages/core/src/components/Card/Header/Header.tsx
+++ b/packages/core/src/components/Card/Header/Header.tsx
@@ -1,10 +1,15 @@
 import clsx from "clsx";
-import { CardHeaderProps as MuiCardHeaderProps } from "@mui/material/CardHeader";
+import MuiCardHeader, {
+  CardHeaderProps as MuiCardHeaderProps,
+} from "@mui/material/CardHeader";
 import { HvBaseProps } from "../../../types";
-import { StyledHeader } from "./Header.styles";
 import cardHeaderClasses, { HvCardHeaderClasses } from "./headerClasses";
+import { styles } from "./Header.styles";
+import { css } from "@emotion/css";
+import { HvThemeContext } from "providers";
+import { useContext } from "react";
 
-export type HvHeaderProps = MuiCardHeaderProps &
+export type HvHeaderProps = Omit<MuiCardHeaderProps, "classes"> &
   HvBaseProps<HTMLDivElement, { title }> & {
     /** The renderable content inside the title slot of the header. */
     title: React.ReactNode;
@@ -27,20 +32,48 @@ export const HvHeader = ({
   onClick,
   ...others
 }: HvHeaderProps) => {
+  const { activeTheme } = useContext(HvThemeContext);
+
   return (
-    <StyledHeader
+    <MuiCardHeader
       title={title}
       subheader={subheader}
       action={icon}
       onClick={onClick}
-      className={clsx(classes?.root, cardHeaderClasses.root, className)}
-      $short={icon ? true : undefined}
+      className={clsx(
+        styles.root,
+        classes?.root,
+        cardHeaderClasses.root,
+        className
+      )}
       classes={{
         title: icon
-          ? clsx(cardHeaderClasses.titleShort, classes?.titleShort)
-          : clsx(cardHeaderClasses.title, classes?.title),
-        subheader: clsx(cardHeaderClasses.subheader, classes?.subheader),
-        action: clsx(cardHeaderClasses.action, classes?.action),
+          ? clsx(
+              styles.titleShort,
+              cardHeaderClasses.titleShort,
+              classes?.titleShort,
+              css({
+                ...activeTheme?.typography[activeTheme?.card.titleVariant],
+              })
+            )
+          : clsx(
+              styles.title,
+              cardHeaderClasses.title,
+              classes?.title,
+              css({
+                ...activeTheme?.typography[activeTheme?.card.titleVariant],
+              })
+            ),
+        subheader: clsx(
+          styles.subheader,
+          cardHeaderClasses.subheader,
+          classes?.subheader,
+          css({
+            ...activeTheme?.typography[activeTheme?.card.subheaderVariant],
+            color: activeTheme?.card.subheaderColor,
+          })
+        ),
+        action: clsx(styles.action, cardHeaderClasses.action, classes?.action),
         content: clsx(cardHeaderClasses.content, classes?.content),
       }}
       {...others}

--- a/packages/core/src/components/Card/Media/Media.styles.tsx
+++ b/packages/core/src/components/Card/Media/Media.styles.tsx
@@ -1,6 +1,5 @@
-import styled from "@emotion/styled";
-import CardMedia from "@mui/material/CardMedia";
+import { css } from "@emotion/css";
 
-export const StyledMedia = styled(CardMedia)({
-  width: "100%",
-});
+export const styles = {
+  root: css({ width: "100%" }),
+};

--- a/packages/core/src/components/Card/Media/Media.tsx
+++ b/packages/core/src/components/Card/Media/Media.tsx
@@ -1,11 +1,13 @@
-import { CardMediaProps as MuiCardMediaProps } from "@mui/material/CardMedia";
-import { StyledMedia } from "./Media.styles";
+import MuiCardMedia, {
+  CardMediaProps as MuiCardMediaProps,
+} from "@mui/material/CardMedia";
+import { styles } from "./Media.styles";
 import { HvBaseProps } from "../../../types";
 import cardMediaClasses, { HvCardMediaClasses } from "./mediaClasses";
 import clsx from "clsx";
 import { ImgHTMLAttributes } from "react";
 
-export type HvMediaProps = MuiCardMediaProps &
+export type HvMediaProps = Omit<MuiCardMediaProps, "classes"> &
   ImgHTMLAttributes<HTMLImageElement> &
   HvBaseProps<HTMLDivElement, { onClick; title }> & {
     /** Id to be applied to the root node. */
@@ -32,10 +34,10 @@ export const HvMedia = ({
   ...others
 }: HvMediaProps) => {
   return (
-    <StyledMedia
+    <MuiCardMedia
       id={id}
       classes={{
-        root: clsx(cardMediaClasses.root, classes?.root),
+        root: clsx(styles.root, cardMediaClasses.root, classes?.root),
         media: clsx(cardMediaClasses.media, classes?.media),
       }}
       className={className}
@@ -45,6 +47,6 @@ export const HvMedia = ({
       {...others}
     >
       {children}
-    </StyledMedia>
+    </MuiCardMedia>
   );
 };

--- a/packages/core/src/components/Card/__snapshots__/Card.test.tsx.snap
+++ b/packages/core/src/components/Card/__snapshots__/Card.test.tsx.snap
@@ -3,31 +3,31 @@
 exports[`Card > should render all the compoents 1`] = `
 <div>
   <div
-    class="HvIsCardGridElement HvCard-root css-m08axw-StyledRoot e5h2ket3"
+    class="css-4fb8k0-root HvIsCardGridElement HvCard-root"
   >
     <div
-      class="css-13ob5sy-StyledContainer e5h2ket2"
+      class="css-1kcigpt-semanticContainer HvCard-semanticContainer"
     >
       <div
-        class="HvCard-semanticBar css-zoemfr-StyledBar e5h2ket1"
+        class="css-1vb6mv5-semanticBar css-sfyg8u-HvCard HvCard-semanticBar"
       />
       <div
-        class="css-117c0kr-StyledIcon e5h2ket0"
+        class="css-6a05hj-icon HvCard-icon"
       />
     </div>
     <div
-      class="MuiCardHeader-root HvCard-Header-root e1xfuyqk0 css-zlagye-MuiCardHeader-root-StyledHeader"
+      class="MuiCardHeader-root css-te5g2l-root HvCard-Header-root css-185gdzj-MuiCardHeader-root"
     >
       <div
         class="MuiCardHeader-content HvCard-Header-content css-1qbkelo-MuiCardHeader-content"
       >
         <span
-          class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title HvCard-Header-title css-1qvr50w-MuiTypography-root"
+          class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title css-1yl86h7-title HvCard-Header-title css-aqxmxp-title css-1qvr50w-MuiTypography-root"
         >
           mockTitle
         </span>
         <span
-          class="MuiTypography-root MuiTypography-body1 MuiCardHeader-subheader HvCard-Header-subheader css-nrdprl-MuiTypography-root"
+          class="MuiTypography-root MuiTypography-body1 MuiCardHeader-subheader css-wobott-subheader HvCard-Header-subheader css-1xilu94-subheader css-nrdprl-MuiTypography-root"
         >
           mockSubtitle
         </span>
@@ -35,11 +35,11 @@ exports[`Card > should render all the compoents 1`] = `
     </div>
     <img
       alt="mockImg"
-      class="MuiCardMedia-root HvCard-Media-root MuiCardMedia-media HvCard-Media-media MuiCardMedia-img e1r97lfn0 css-17tnzdv-MuiCardMedia-root-StyledMedia"
+      class="MuiCardMedia-root css-abc58s-root HvCard-Media-root MuiCardMedia-media HvCard-Media-media MuiCardMedia-img css-o69gx8-MuiCardMedia-root"
       role="img"
     />
     <div
-      class="MuiCardContent-root HvCard-Content-content e12hctsi0 css-v8uagb-MuiCardContent-root-StyledContent"
+      class="MuiCardContent-root css-m6635h-content HvCard-Content-content css-46bh2p-MuiCardContent-root"
     >
       <label
         class="HvTypography-root HvTypography-label css-z0xwjc-getStyledComponent e1tnpalo0"
@@ -54,20 +54,20 @@ exports[`Card > should render all the compoents 1`] = `
 exports[`Card > should render content 1`] = `
 <div>
   <div
-    class="HvIsCardGridElement HvCard-root css-m08axw-StyledRoot e5h2ket3"
+    class="css-4fb8k0-root HvIsCardGridElement HvCard-root"
   >
     <div
-      class="css-13ob5sy-StyledContainer e5h2ket2"
+      class="css-1kcigpt-semanticContainer HvCard-semanticContainer"
     >
       <div
-        class="HvCard-semanticBar css-zoemfr-StyledBar e5h2ket1"
+        class="css-1vb6mv5-semanticBar css-sfyg8u-HvCard HvCard-semanticBar"
       />
       <div
-        class="css-117c0kr-StyledIcon e5h2ket0"
+        class="css-6a05hj-icon HvCard-icon"
       />
     </div>
     <div
-      class="MuiCardContent-root HvCard-Content-content e12hctsi0 css-v8uagb-MuiCardContent-root-StyledContent"
+      class="MuiCardContent-root css-m6635h-content HvCard-Content-content css-46bh2p-MuiCardContent-root"
     >
       <label
         class="HvTypography-root HvTypography-label css-z0xwjc-getStyledComponent e1tnpalo0"
@@ -82,16 +82,16 @@ exports[`Card > should render content 1`] = `
 exports[`Card > should render correctly 1`] = `
 <div>
   <div
-    class="HvIsCardGridElement HvCard-root css-m08axw-StyledRoot e5h2ket3"
+    class="css-4fb8k0-root HvIsCardGridElement HvCard-root"
   >
     <div
-      class="css-13ob5sy-StyledContainer e5h2ket2"
+      class="css-1kcigpt-semanticContainer HvCard-semanticContainer"
     >
       <div
-        class="HvCard-semanticBar css-zoemfr-StyledBar e5h2ket1"
+        class="css-1vb6mv5-semanticBar css-sfyg8u-HvCard HvCard-semanticBar"
       />
       <div
-        class="css-117c0kr-StyledIcon e5h2ket0"
+        class="css-6a05hj-icon HvCard-icon"
       />
     </div>
   </div>
@@ -101,31 +101,31 @@ exports[`Card > should render correctly 1`] = `
 exports[`Card > should render header 1`] = `
 <div>
   <div
-    class="HvIsCardGridElement HvCard-root css-m08axw-StyledRoot e5h2ket3"
+    class="css-4fb8k0-root HvIsCardGridElement HvCard-root"
   >
     <div
-      class="css-13ob5sy-StyledContainer e5h2ket2"
+      class="css-1kcigpt-semanticContainer HvCard-semanticContainer"
     >
       <div
-        class="HvCard-semanticBar css-zoemfr-StyledBar e5h2ket1"
+        class="css-1vb6mv5-semanticBar css-sfyg8u-HvCard HvCard-semanticBar"
       />
       <div
-        class="css-117c0kr-StyledIcon e5h2ket0"
+        class="css-6a05hj-icon HvCard-icon"
       />
     </div>
     <div
-      class="MuiCardHeader-root HvCard-Header-root e1xfuyqk0 css-zlagye-MuiCardHeader-root-StyledHeader"
+      class="MuiCardHeader-root css-te5g2l-root HvCard-Header-root css-185gdzj-MuiCardHeader-root"
     >
       <div
         class="MuiCardHeader-content HvCard-Header-content css-1qbkelo-MuiCardHeader-content"
       >
         <span
-          class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title HvCard-Header-title css-1qvr50w-MuiTypography-root"
+          class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title css-1yl86h7-title HvCard-Header-title css-aqxmxp-title css-1qvr50w-MuiTypography-root"
         >
           mockTitle
         </span>
         <span
-          class="MuiTypography-root MuiTypography-body1 MuiCardHeader-subheader HvCard-Header-subheader css-nrdprl-MuiTypography-root"
+          class="MuiTypography-root MuiTypography-body1 MuiCardHeader-subheader css-wobott-subheader HvCard-Header-subheader css-1xilu94-subheader css-nrdprl-MuiTypography-root"
         >
           mockSubtitle
         </span>
@@ -138,21 +138,21 @@ exports[`Card > should render header 1`] = `
 exports[`Card > should render image 1`] = `
 <div>
   <div
-    class="HvIsCardGridElement HvCard-root css-m08axw-StyledRoot e5h2ket3"
+    class="css-4fb8k0-root HvIsCardGridElement HvCard-root"
   >
     <div
-      class="css-13ob5sy-StyledContainer e5h2ket2"
+      class="css-1kcigpt-semanticContainer HvCard-semanticContainer"
     >
       <div
-        class="HvCard-semanticBar css-zoemfr-StyledBar e5h2ket1"
+        class="css-1vb6mv5-semanticBar css-sfyg8u-HvCard HvCard-semanticBar"
       />
       <div
-        class="css-117c0kr-StyledIcon e5h2ket0"
+        class="css-6a05hj-icon HvCard-icon"
       />
     </div>
     <img
       alt="mockImg"
-      class="MuiCardMedia-root HvCard-Media-root MuiCardMedia-media HvCard-Media-media MuiCardMedia-img e1r97lfn0 css-17tnzdv-MuiCardMedia-root-StyledMedia"
+      class="MuiCardMedia-root css-abc58s-root HvCard-Media-root MuiCardMedia-media HvCard-Media-media MuiCardMedia-img css-o69gx8-MuiCardMedia-root"
       role="img"
     />
   </div>

--- a/packages/core/src/components/Card/cardClasses.ts
+++ b/packages/core/src/components/Card/cardClasses.ts
@@ -5,9 +5,18 @@ export type HvCardClasses = {
   selectable?: string;
   selected?: string;
   semanticBar?: string;
+  semanticContainer?: string;
+  icon?: string;
 };
 
-const classKeys: string[] = ["root", "selectable", "selected", "semanticBar"];
+const classKeys: string[] = [
+  "root",
+  "selectable",
+  "selected",
+  "semanticBar",
+  "semanticContainer",
+  "icon",
+];
 
 const cardClasses = getClasses<HvCardClasses>(classKeys, "HvCard");
 

--- a/packages/core/src/components/Container/Container.tsx
+++ b/packages/core/src/components/Container/Container.tsx
@@ -6,7 +6,7 @@ import { StyledRoot } from "./Container.styles";
 import containerClasses, { HvContainerClasses } from "./containerClasses";
 import clsx from "clsx";
 
-export type HvContainerProps = MuiContainerProps &
+export type HvContainerProps = Omit<MuiContainerProps, "classes"> &
   HvBaseProps & {
     /**
      * The component used for the root node.
@@ -37,7 +37,20 @@ export const HvContainer = forwardRef<HTMLDivElement, HvContainerProps>(
     const muiTheme = useTheme();
     return (
       <StyledRoot
-        className={clsx(className, containerClasses.root, classes?.root)}
+        className={className}
+        classes={{
+          root: clsx(containerClasses.root, classes?.root),
+          disableGutters: clsx(
+            containerClasses.disableGutters,
+            classes?.disableGutters
+          ),
+          fixed: clsx(containerClasses.fixed, classes?.fixed),
+          maxWidthXs: clsx(containerClasses.maxWidthXs, classes?.maxWidthXs),
+          maxWidthSm: clsx(containerClasses.maxWidthSm, classes?.maxWidthSm),
+          maxWidthMd: clsx(containerClasses.maxWidthMd, classes?.maxWidthMd),
+          maxWidthLg: clsx(containerClasses.maxWidthLg, classes?.maxWidthLg),
+          maxWidthXl: clsx(containerClasses.maxWidthXl, classes?.maxWidthXl),
+        }}
         $breakpoints={muiTheme.breakpoints}
         ref={ref}
         maxWidth={maxWidth}

--- a/packages/core/src/components/Container/containerClasses.ts
+++ b/packages/core/src/components/Container/containerClasses.ts
@@ -2,9 +2,25 @@ import { getClasses } from "utils";
 
 export type HvContainerClasses = {
   root?: string;
+  disableGutters?: string;
+  fixed?: string;
+  maxWidthXs?: string;
+  maxWidthSm?: string;
+  maxWidthMd?: string;
+  maxWidthLg?: string;
+  maxWidthXl?: string;
 };
 
-const classKeys: string[] = ["root"];
+const classKeys: string[] = [
+  "root",
+  "disableGutters",
+  "fixed",
+  "maxWidthXs",
+  "maxWidthSm",
+  "maxWidthMd",
+  "maxWidthLg",
+  "maxWidthXl",
+];
 
 const containerClasses = getClasses<HvContainerClasses>(
   classKeys,

--- a/packages/core/src/components/Controls/__snapshots__/Controls.test.tsx.snap
+++ b/packages/core/src/components/Controls/__snapshots__/Controls.test.tsx.snap
@@ -81,7 +81,7 @@ exports[`<HvControls> > sample snapshot testing > Controls 1`] = `
         >
           <div
             aria-controls="cardsGrid itemList"
-            class="HvDropdown-root  e16dy5r70 css-u5677i-StyledHvFormElement-StyledDropdown etta2py4 HvFormElement-root"
+            class=" e16dy5r70 HvDropdown-root css-u5677i-StyledHvFormElement-StyledDropdown etta2py4 HvFormElement-root"
           >
             <div
               class="HvBaseDropdown-root HvDropdown-dropdown css-1nukton-StyledRoot eapzthe9"
@@ -210,400 +210,400 @@ exports[`<HvControls> > sample snapshot testing > Controls 1`] = `
       spacing="sm"
     >
       <div
-        class="HvIsCardGridElement HvCard-root css-m08axw-StyledRoot e5h2ket3"
+        class="css-4fb8k0-root css-1l5xtfm-HvCard HvIsCardGridElement HvCard-root"
         style="width: 100%;"
       >
         <div
-          class="css-13ob5sy-StyledContainer e5h2ket2"
+          class="css-1kcigpt-semanticContainer HvCard-semanticContainer"
         >
           <div
-            class="HvCard-semanticBar css-zoemfr-StyledBar e5h2ket1"
+            class="css-1vb6mv5-semanticBar css-sfyg8u-HvCard HvCard-semanticBar"
           />
           <div
-            class="css-117c0kr-StyledIcon e5h2ket0"
+            class="css-6a05hj-icon HvCard-icon"
           />
         </div>
         <div
-          class="MuiCardHeader-root HvCard-Header-root e1xfuyqk0 css-zlagye-MuiCardHeader-root-StyledHeader"
+          class="MuiCardHeader-root css-te5g2l-root HvCard-Header-root css-185gdzj-MuiCardHeader-root"
         >
           <div
             class="MuiCardHeader-content HvCard-Header-content css-1qbkelo-MuiCardHeader-content"
           >
             <span
-              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title HvCard-Header-title css-1qvr50w-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title css-1yl86h7-title HvCard-Header-title css-aqxmxp-title css-1qvr50w-MuiTypography-root"
             >
               Event 1
             </span>
           </div>
         </div>
         <div
-          class="MuiCardContent-root HvCard-Content-content e12hctsi0 css-v8uagb-MuiCardContent-root-StyledContent"
+          class="MuiCardContent-root css-m6635h-content HvCard-Content-content css-46bh2p-MuiCardContent-root"
         >
           Event: 
           Anomaly detection 0
         </div>
         <div
-          class="MuiCardContent-root HvCard-Content-content e12hctsi0 css-v8uagb-MuiCardContent-root-StyledContent"
+          class="MuiCardContent-root css-m6635h-content HvCard-Content-content css-46bh2p-MuiCardContent-root"
         >
           Severity: 
           Critical
         </div>
       </div>
       <div
-        class="HvIsCardGridElement HvCard-root css-m08axw-StyledRoot e5h2ket3"
+        class="css-4fb8k0-root css-1l5xtfm-HvCard HvIsCardGridElement HvCard-root"
         style="width: 100%;"
       >
         <div
-          class="css-13ob5sy-StyledContainer e5h2ket2"
+          class="css-1kcigpt-semanticContainer HvCard-semanticContainer"
         >
           <div
-            class="HvCard-semanticBar css-zoemfr-StyledBar e5h2ket1"
+            class="css-1vb6mv5-semanticBar css-sfyg8u-HvCard HvCard-semanticBar"
           />
           <div
-            class="css-117c0kr-StyledIcon e5h2ket0"
+            class="css-6a05hj-icon HvCard-icon"
           />
         </div>
         <div
-          class="MuiCardHeader-root HvCard-Header-root e1xfuyqk0 css-zlagye-MuiCardHeader-root-StyledHeader"
+          class="MuiCardHeader-root css-te5g2l-root HvCard-Header-root css-185gdzj-MuiCardHeader-root"
         >
           <div
             class="MuiCardHeader-content HvCard-Header-content css-1qbkelo-MuiCardHeader-content"
           >
             <span
-              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title HvCard-Header-title css-1qvr50w-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title css-1yl86h7-title HvCard-Header-title css-aqxmxp-title css-1qvr50w-MuiTypography-root"
             >
               Event 2
             </span>
           </div>
         </div>
         <div
-          class="MuiCardContent-root HvCard-Content-content e12hctsi0 css-v8uagb-MuiCardContent-root-StyledContent"
+          class="MuiCardContent-root css-m6635h-content HvCard-Content-content css-46bh2p-MuiCardContent-root"
         >
           Event: 
           Anomaly detection 1
         </div>
         <div
-          class="MuiCardContent-root HvCard-Content-content e12hctsi0 css-v8uagb-MuiCardContent-root-StyledContent"
+          class="MuiCardContent-root css-m6635h-content HvCard-Content-content css-46bh2p-MuiCardContent-root"
         >
           Severity: 
           Major
         </div>
       </div>
       <div
-        class="HvIsCardGridElement HvCard-root css-m08axw-StyledRoot e5h2ket3"
+        class="css-4fb8k0-root css-1l5xtfm-HvCard HvIsCardGridElement HvCard-root"
         style="width: 100%;"
       >
         <div
-          class="css-13ob5sy-StyledContainer e5h2ket2"
+          class="css-1kcigpt-semanticContainer HvCard-semanticContainer"
         >
           <div
-            class="HvCard-semanticBar css-zoemfr-StyledBar e5h2ket1"
+            class="css-1vb6mv5-semanticBar css-sfyg8u-HvCard HvCard-semanticBar"
           />
           <div
-            class="css-117c0kr-StyledIcon e5h2ket0"
+            class="css-6a05hj-icon HvCard-icon"
           />
         </div>
         <div
-          class="MuiCardHeader-root HvCard-Header-root e1xfuyqk0 css-zlagye-MuiCardHeader-root-StyledHeader"
+          class="MuiCardHeader-root css-te5g2l-root HvCard-Header-root css-185gdzj-MuiCardHeader-root"
         >
           <div
             class="MuiCardHeader-content HvCard-Header-content css-1qbkelo-MuiCardHeader-content"
           >
             <span
-              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title HvCard-Header-title css-1qvr50w-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title css-1yl86h7-title HvCard-Header-title css-aqxmxp-title css-1qvr50w-MuiTypography-root"
             >
               Event 3
             </span>
           </div>
         </div>
         <div
-          class="MuiCardContent-root HvCard-Content-content e12hctsi0 css-v8uagb-MuiCardContent-root-StyledContent"
+          class="MuiCardContent-root css-m6635h-content HvCard-Content-content css-46bh2p-MuiCardContent-root"
         >
           Event: 
           Anomaly detection 2
         </div>
         <div
-          class="MuiCardContent-root HvCard-Content-content e12hctsi0 css-v8uagb-MuiCardContent-root-StyledContent"
+          class="MuiCardContent-root css-m6635h-content HvCard-Content-content css-46bh2p-MuiCardContent-root"
         >
           Severity: 
           Average
         </div>
       </div>
       <div
-        class="HvIsCardGridElement HvCard-root css-m08axw-StyledRoot e5h2ket3"
+        class="css-4fb8k0-root css-1l5xtfm-HvCard HvIsCardGridElement HvCard-root"
         style="width: 100%;"
       >
         <div
-          class="css-13ob5sy-StyledContainer e5h2ket2"
+          class="css-1kcigpt-semanticContainer HvCard-semanticContainer"
         >
           <div
-            class="HvCard-semanticBar css-zoemfr-StyledBar e5h2ket1"
+            class="css-1vb6mv5-semanticBar css-sfyg8u-HvCard HvCard-semanticBar"
           />
           <div
-            class="css-117c0kr-StyledIcon e5h2ket0"
+            class="css-6a05hj-icon HvCard-icon"
           />
         </div>
         <div
-          class="MuiCardHeader-root HvCard-Header-root e1xfuyqk0 css-zlagye-MuiCardHeader-root-StyledHeader"
+          class="MuiCardHeader-root css-te5g2l-root HvCard-Header-root css-185gdzj-MuiCardHeader-root"
         >
           <div
             class="MuiCardHeader-content HvCard-Header-content css-1qbkelo-MuiCardHeader-content"
           >
             <span
-              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title HvCard-Header-title css-1qvr50w-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title css-1yl86h7-title HvCard-Header-title css-aqxmxp-title css-1qvr50w-MuiTypography-root"
             >
               Event 4
             </span>
           </div>
         </div>
         <div
-          class="MuiCardContent-root HvCard-Content-content e12hctsi0 css-v8uagb-MuiCardContent-root-StyledContent"
+          class="MuiCardContent-root css-m6635h-content HvCard-Content-content css-46bh2p-MuiCardContent-root"
         >
           Event: 
           Anomaly detection 3
         </div>
         <div
-          class="MuiCardContent-root HvCard-Content-content e12hctsi0 css-v8uagb-MuiCardContent-root-StyledContent"
+          class="MuiCardContent-root css-m6635h-content HvCard-Content-content css-46bh2p-MuiCardContent-root"
         >
           Severity: 
           Minor
         </div>
       </div>
       <div
-        class="HvIsCardGridElement HvCard-root css-m08axw-StyledRoot e5h2ket3"
+        class="css-4fb8k0-root css-1l5xtfm-HvCard HvIsCardGridElement HvCard-root"
         style="width: 100%;"
       >
         <div
-          class="css-13ob5sy-StyledContainer e5h2ket2"
+          class="css-1kcigpt-semanticContainer HvCard-semanticContainer"
         >
           <div
-            class="HvCard-semanticBar css-zoemfr-StyledBar e5h2ket1"
+            class="css-1vb6mv5-semanticBar css-sfyg8u-HvCard HvCard-semanticBar"
           />
           <div
-            class="css-117c0kr-StyledIcon e5h2ket0"
+            class="css-6a05hj-icon HvCard-icon"
           />
         </div>
         <div
-          class="MuiCardHeader-root HvCard-Header-root e1xfuyqk0 css-zlagye-MuiCardHeader-root-StyledHeader"
+          class="MuiCardHeader-root css-te5g2l-root HvCard-Header-root css-185gdzj-MuiCardHeader-root"
         >
           <div
             class="MuiCardHeader-content HvCard-Header-content css-1qbkelo-MuiCardHeader-content"
           >
             <span
-              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title HvCard-Header-title css-1qvr50w-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title css-1yl86h7-title HvCard-Header-title css-aqxmxp-title css-1qvr50w-MuiTypography-root"
             >
               Event 5
             </span>
           </div>
         </div>
         <div
-          class="MuiCardContent-root HvCard-Content-content e12hctsi0 css-v8uagb-MuiCardContent-root-StyledContent"
+          class="MuiCardContent-root css-m6635h-content HvCard-Content-content css-46bh2p-MuiCardContent-root"
         >
           Event: 
           Anomaly detection 0
         </div>
         <div
-          class="MuiCardContent-root HvCard-Content-content e12hctsi0 css-v8uagb-MuiCardContent-root-StyledContent"
+          class="MuiCardContent-root css-m6635h-content HvCard-Content-content css-46bh2p-MuiCardContent-root"
         >
           Severity: 
           Critical
         </div>
       </div>
       <div
-        class="HvIsCardGridElement HvCard-root css-m08axw-StyledRoot e5h2ket3"
+        class="css-4fb8k0-root css-1l5xtfm-HvCard HvIsCardGridElement HvCard-root"
         style="width: 100%;"
       >
         <div
-          class="css-13ob5sy-StyledContainer e5h2ket2"
+          class="css-1kcigpt-semanticContainer HvCard-semanticContainer"
         >
           <div
-            class="HvCard-semanticBar css-zoemfr-StyledBar e5h2ket1"
+            class="css-1vb6mv5-semanticBar css-sfyg8u-HvCard HvCard-semanticBar"
           />
           <div
-            class="css-117c0kr-StyledIcon e5h2ket0"
+            class="css-6a05hj-icon HvCard-icon"
           />
         </div>
         <div
-          class="MuiCardHeader-root HvCard-Header-root e1xfuyqk0 css-zlagye-MuiCardHeader-root-StyledHeader"
+          class="MuiCardHeader-root css-te5g2l-root HvCard-Header-root css-185gdzj-MuiCardHeader-root"
         >
           <div
             class="MuiCardHeader-content HvCard-Header-content css-1qbkelo-MuiCardHeader-content"
           >
             <span
-              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title HvCard-Header-title css-1qvr50w-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title css-1yl86h7-title HvCard-Header-title css-aqxmxp-title css-1qvr50w-MuiTypography-root"
             >
               Event 6
             </span>
           </div>
         </div>
         <div
-          class="MuiCardContent-root HvCard-Content-content e12hctsi0 css-v8uagb-MuiCardContent-root-StyledContent"
+          class="MuiCardContent-root css-m6635h-content HvCard-Content-content css-46bh2p-MuiCardContent-root"
         >
           Event: 
           Anomaly detection 1
         </div>
         <div
-          class="MuiCardContent-root HvCard-Content-content e12hctsi0 css-v8uagb-MuiCardContent-root-StyledContent"
+          class="MuiCardContent-root css-m6635h-content HvCard-Content-content css-46bh2p-MuiCardContent-root"
         >
           Severity: 
           Major
         </div>
       </div>
       <div
-        class="HvIsCardGridElement HvCard-root css-m08axw-StyledRoot e5h2ket3"
+        class="css-4fb8k0-root css-1l5xtfm-HvCard HvIsCardGridElement HvCard-root"
         style="width: 100%;"
       >
         <div
-          class="css-13ob5sy-StyledContainer e5h2ket2"
+          class="css-1kcigpt-semanticContainer HvCard-semanticContainer"
         >
           <div
-            class="HvCard-semanticBar css-zoemfr-StyledBar e5h2ket1"
+            class="css-1vb6mv5-semanticBar css-sfyg8u-HvCard HvCard-semanticBar"
           />
           <div
-            class="css-117c0kr-StyledIcon e5h2ket0"
+            class="css-6a05hj-icon HvCard-icon"
           />
         </div>
         <div
-          class="MuiCardHeader-root HvCard-Header-root e1xfuyqk0 css-zlagye-MuiCardHeader-root-StyledHeader"
+          class="MuiCardHeader-root css-te5g2l-root HvCard-Header-root css-185gdzj-MuiCardHeader-root"
         >
           <div
             class="MuiCardHeader-content HvCard-Header-content css-1qbkelo-MuiCardHeader-content"
           >
             <span
-              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title HvCard-Header-title css-1qvr50w-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title css-1yl86h7-title HvCard-Header-title css-aqxmxp-title css-1qvr50w-MuiTypography-root"
             >
               Event 7
             </span>
           </div>
         </div>
         <div
-          class="MuiCardContent-root HvCard-Content-content e12hctsi0 css-v8uagb-MuiCardContent-root-StyledContent"
+          class="MuiCardContent-root css-m6635h-content HvCard-Content-content css-46bh2p-MuiCardContent-root"
         >
           Event: 
           Anomaly detection 2
         </div>
         <div
-          class="MuiCardContent-root HvCard-Content-content e12hctsi0 css-v8uagb-MuiCardContent-root-StyledContent"
+          class="MuiCardContent-root css-m6635h-content HvCard-Content-content css-46bh2p-MuiCardContent-root"
         >
           Severity: 
           Average
         </div>
       </div>
       <div
-        class="HvIsCardGridElement HvCard-root css-m08axw-StyledRoot e5h2ket3"
+        class="css-4fb8k0-root css-1l5xtfm-HvCard HvIsCardGridElement HvCard-root"
         style="width: 100%;"
       >
         <div
-          class="css-13ob5sy-StyledContainer e5h2ket2"
+          class="css-1kcigpt-semanticContainer HvCard-semanticContainer"
         >
           <div
-            class="HvCard-semanticBar css-zoemfr-StyledBar e5h2ket1"
+            class="css-1vb6mv5-semanticBar css-sfyg8u-HvCard HvCard-semanticBar"
           />
           <div
-            class="css-117c0kr-StyledIcon e5h2ket0"
+            class="css-6a05hj-icon HvCard-icon"
           />
         </div>
         <div
-          class="MuiCardHeader-root HvCard-Header-root e1xfuyqk0 css-zlagye-MuiCardHeader-root-StyledHeader"
+          class="MuiCardHeader-root css-te5g2l-root HvCard-Header-root css-185gdzj-MuiCardHeader-root"
         >
           <div
             class="MuiCardHeader-content HvCard-Header-content css-1qbkelo-MuiCardHeader-content"
           >
             <span
-              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title HvCard-Header-title css-1qvr50w-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title css-1yl86h7-title HvCard-Header-title css-aqxmxp-title css-1qvr50w-MuiTypography-root"
             >
               Event 8
             </span>
           </div>
         </div>
         <div
-          class="MuiCardContent-root HvCard-Content-content e12hctsi0 css-v8uagb-MuiCardContent-root-StyledContent"
+          class="MuiCardContent-root css-m6635h-content HvCard-Content-content css-46bh2p-MuiCardContent-root"
         >
           Event: 
           Anomaly detection 3
         </div>
         <div
-          class="MuiCardContent-root HvCard-Content-content e12hctsi0 css-v8uagb-MuiCardContent-root-StyledContent"
+          class="MuiCardContent-root css-m6635h-content HvCard-Content-content css-46bh2p-MuiCardContent-root"
         >
           Severity: 
           Minor
         </div>
       </div>
       <div
-        class="HvIsCardGridElement HvCard-root css-m08axw-StyledRoot e5h2ket3"
+        class="css-4fb8k0-root css-1l5xtfm-HvCard HvIsCardGridElement HvCard-root"
         style="width: 100%;"
       >
         <div
-          class="css-13ob5sy-StyledContainer e5h2ket2"
+          class="css-1kcigpt-semanticContainer HvCard-semanticContainer"
         >
           <div
-            class="HvCard-semanticBar css-zoemfr-StyledBar e5h2ket1"
+            class="css-1vb6mv5-semanticBar css-sfyg8u-HvCard HvCard-semanticBar"
           />
           <div
-            class="css-117c0kr-StyledIcon e5h2ket0"
+            class="css-6a05hj-icon HvCard-icon"
           />
         </div>
         <div
-          class="MuiCardHeader-root HvCard-Header-root e1xfuyqk0 css-zlagye-MuiCardHeader-root-StyledHeader"
+          class="MuiCardHeader-root css-te5g2l-root HvCard-Header-root css-185gdzj-MuiCardHeader-root"
         >
           <div
             class="MuiCardHeader-content HvCard-Header-content css-1qbkelo-MuiCardHeader-content"
           >
             <span
-              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title HvCard-Header-title css-1qvr50w-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title css-1yl86h7-title HvCard-Header-title css-aqxmxp-title css-1qvr50w-MuiTypography-root"
             >
               Event 9
             </span>
           </div>
         </div>
         <div
-          class="MuiCardContent-root HvCard-Content-content e12hctsi0 css-v8uagb-MuiCardContent-root-StyledContent"
+          class="MuiCardContent-root css-m6635h-content HvCard-Content-content css-46bh2p-MuiCardContent-root"
         >
           Event: 
           Anomaly detection 0
         </div>
         <div
-          class="MuiCardContent-root HvCard-Content-content e12hctsi0 css-v8uagb-MuiCardContent-root-StyledContent"
+          class="MuiCardContent-root css-m6635h-content HvCard-Content-content css-46bh2p-MuiCardContent-root"
         >
           Severity: 
           Critical
         </div>
       </div>
       <div
-        class="HvIsCardGridElement HvCard-root css-m08axw-StyledRoot e5h2ket3"
+        class="css-4fb8k0-root css-1l5xtfm-HvCard HvIsCardGridElement HvCard-root"
         style="width: 100%;"
       >
         <div
-          class="css-13ob5sy-StyledContainer e5h2ket2"
+          class="css-1kcigpt-semanticContainer HvCard-semanticContainer"
         >
           <div
-            class="HvCard-semanticBar css-zoemfr-StyledBar e5h2ket1"
+            class="css-1vb6mv5-semanticBar css-sfyg8u-HvCard HvCard-semanticBar"
           />
           <div
-            class="css-117c0kr-StyledIcon e5h2ket0"
+            class="css-6a05hj-icon HvCard-icon"
           />
         </div>
         <div
-          class="MuiCardHeader-root HvCard-Header-root e1xfuyqk0 css-zlagye-MuiCardHeader-root-StyledHeader"
+          class="MuiCardHeader-root css-te5g2l-root HvCard-Header-root css-185gdzj-MuiCardHeader-root"
         >
           <div
             class="MuiCardHeader-content HvCard-Header-content css-1qbkelo-MuiCardHeader-content"
           >
             <span
-              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title HvCard-Header-title css-1qvr50w-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title css-1yl86h7-title HvCard-Header-title css-aqxmxp-title css-1qvr50w-MuiTypography-root"
             >
               Event 10
             </span>
           </div>
         </div>
         <div
-          class="MuiCardContent-root HvCard-Content-content e12hctsi0 css-v8uagb-MuiCardContent-root-StyledContent"
+          class="MuiCardContent-root css-m6635h-content HvCard-Content-content css-46bh2p-MuiCardContent-root"
         >
           Event: 
           Anomaly detection 1
         </div>
         <div
-          class="MuiCardContent-root HvCard-Content-content e12hctsi0 css-v8uagb-MuiCardContent-root-StyledContent"
+          class="MuiCardContent-root css-m6635h-content HvCard-Content-content css-46bh2p-MuiCardContent-root"
         >
           Severity: 
           Major
@@ -695,7 +695,7 @@ exports[`<HvControls> > sample snapshot testing > Controls Controlled 1`] = `
         >
           <div
             aria-controls="controlledCardsGrid controlledItemList"
-            class="HvDropdown-root  e16dy5r70 css-u5677i-StyledHvFormElement-StyledDropdown etta2py4 HvFormElement-root"
+            class=" e16dy5r70 HvDropdown-root css-u5677i-StyledHvFormElement-StyledDropdown etta2py4 HvFormElement-root"
           >
             <div
               class="HvBaseDropdown-root HvDropdown-dropdown css-1nukton-StyledRoot eapzthe9"
@@ -823,340 +823,340 @@ exports[`<HvControls> > sample snapshot testing > Controls Controlled 1`] = `
       spacing="sm"
     >
       <div
-        class="HvIsCardGridElement HvCard-root css-m08axw-StyledRoot e5h2ket3"
+        class="css-4fb8k0-root css-1l5xtfm-HvCard HvIsCardGridElement HvCard-root"
         style="width: 100%;"
       >
         <div
-          class="css-13ob5sy-StyledContainer e5h2ket2"
+          class="css-1kcigpt-semanticContainer HvCard-semanticContainer"
         >
           <div
-            class="HvCard-semanticBar css-zoemfr-StyledBar e5h2ket1"
+            class="css-1vb6mv5-semanticBar css-sfyg8u-HvCard HvCard-semanticBar"
           />
           <div
-            class="css-117c0kr-StyledIcon e5h2ket0"
+            class="css-6a05hj-icon HvCard-icon"
           />
         </div>
         <div
-          class="MuiCardHeader-root HvCard-Header-root e1xfuyqk0 css-zlagye-MuiCardHeader-root-StyledHeader"
+          class="MuiCardHeader-root css-te5g2l-root HvCard-Header-root css-185gdzj-MuiCardHeader-root"
         >
           <div
             class="MuiCardHeader-content HvCard-Header-content css-1qbkelo-MuiCardHeader-content"
           >
             <span
-              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title HvCard-Header-title css-1qvr50w-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title css-1yl86h7-title HvCard-Header-title css-aqxmxp-title css-1qvr50w-MuiTypography-root"
             >
               Event 1
             </span>
           </div>
         </div>
         <div
-          class="MuiCardContent-root HvCard-Content-content e12hctsi0 css-v8uagb-MuiCardContent-root-StyledContent"
+          class="MuiCardContent-root css-m6635h-content HvCard-Content-content css-46bh2p-MuiCardContent-root"
         >
           Severity: 
           Critical
         </div>
       </div>
       <div
-        class="HvIsCardGridElement HvCard-root css-m08axw-StyledRoot e5h2ket3"
+        class="css-4fb8k0-root css-1l5xtfm-HvCard HvIsCardGridElement HvCard-root"
         style="width: 100%;"
       >
         <div
-          class="css-13ob5sy-StyledContainer e5h2ket2"
+          class="css-1kcigpt-semanticContainer HvCard-semanticContainer"
         >
           <div
-            class="HvCard-semanticBar css-zoemfr-StyledBar e5h2ket1"
+            class="css-1vb6mv5-semanticBar css-sfyg8u-HvCard HvCard-semanticBar"
           />
           <div
-            class="css-117c0kr-StyledIcon e5h2ket0"
+            class="css-6a05hj-icon HvCard-icon"
           />
         </div>
         <div
-          class="MuiCardHeader-root HvCard-Header-root e1xfuyqk0 css-zlagye-MuiCardHeader-root-StyledHeader"
+          class="MuiCardHeader-root css-te5g2l-root HvCard-Header-root css-185gdzj-MuiCardHeader-root"
         >
           <div
             class="MuiCardHeader-content HvCard-Header-content css-1qbkelo-MuiCardHeader-content"
           >
             <span
-              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title HvCard-Header-title css-1qvr50w-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title css-1yl86h7-title HvCard-Header-title css-aqxmxp-title css-1qvr50w-MuiTypography-root"
             >
               Event 2
             </span>
           </div>
         </div>
         <div
-          class="MuiCardContent-root HvCard-Content-content e12hctsi0 css-v8uagb-MuiCardContent-root-StyledContent"
+          class="MuiCardContent-root css-m6635h-content HvCard-Content-content css-46bh2p-MuiCardContent-root"
         >
           Severity: 
           Major
         </div>
       </div>
       <div
-        class="HvIsCardGridElement HvCard-root css-m08axw-StyledRoot e5h2ket3"
+        class="css-4fb8k0-root css-1l5xtfm-HvCard HvIsCardGridElement HvCard-root"
         style="width: 100%;"
       >
         <div
-          class="css-13ob5sy-StyledContainer e5h2ket2"
+          class="css-1kcigpt-semanticContainer HvCard-semanticContainer"
         >
           <div
-            class="HvCard-semanticBar css-zoemfr-StyledBar e5h2ket1"
+            class="css-1vb6mv5-semanticBar css-sfyg8u-HvCard HvCard-semanticBar"
           />
           <div
-            class="css-117c0kr-StyledIcon e5h2ket0"
+            class="css-6a05hj-icon HvCard-icon"
           />
         </div>
         <div
-          class="MuiCardHeader-root HvCard-Header-root e1xfuyqk0 css-zlagye-MuiCardHeader-root-StyledHeader"
+          class="MuiCardHeader-root css-te5g2l-root HvCard-Header-root css-185gdzj-MuiCardHeader-root"
         >
           <div
             class="MuiCardHeader-content HvCard-Header-content css-1qbkelo-MuiCardHeader-content"
           >
             <span
-              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title HvCard-Header-title css-1qvr50w-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title css-1yl86h7-title HvCard-Header-title css-aqxmxp-title css-1qvr50w-MuiTypography-root"
             >
               Event 3
             </span>
           </div>
         </div>
         <div
-          class="MuiCardContent-root HvCard-Content-content e12hctsi0 css-v8uagb-MuiCardContent-root-StyledContent"
+          class="MuiCardContent-root css-m6635h-content HvCard-Content-content css-46bh2p-MuiCardContent-root"
         >
           Severity: 
           Average
         </div>
       </div>
       <div
-        class="HvIsCardGridElement HvCard-root css-m08axw-StyledRoot e5h2ket3"
+        class="css-4fb8k0-root css-1l5xtfm-HvCard HvIsCardGridElement HvCard-root"
         style="width: 100%;"
       >
         <div
-          class="css-13ob5sy-StyledContainer e5h2ket2"
+          class="css-1kcigpt-semanticContainer HvCard-semanticContainer"
         >
           <div
-            class="HvCard-semanticBar css-zoemfr-StyledBar e5h2ket1"
+            class="css-1vb6mv5-semanticBar css-sfyg8u-HvCard HvCard-semanticBar"
           />
           <div
-            class="css-117c0kr-StyledIcon e5h2ket0"
+            class="css-6a05hj-icon HvCard-icon"
           />
         </div>
         <div
-          class="MuiCardHeader-root HvCard-Header-root e1xfuyqk0 css-zlagye-MuiCardHeader-root-StyledHeader"
+          class="MuiCardHeader-root css-te5g2l-root HvCard-Header-root css-185gdzj-MuiCardHeader-root"
         >
           <div
             class="MuiCardHeader-content HvCard-Header-content css-1qbkelo-MuiCardHeader-content"
           >
             <span
-              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title HvCard-Header-title css-1qvr50w-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title css-1yl86h7-title HvCard-Header-title css-aqxmxp-title css-1qvr50w-MuiTypography-root"
             >
               Event 4
             </span>
           </div>
         </div>
         <div
-          class="MuiCardContent-root HvCard-Content-content e12hctsi0 css-v8uagb-MuiCardContent-root-StyledContent"
+          class="MuiCardContent-root css-m6635h-content HvCard-Content-content css-46bh2p-MuiCardContent-root"
         >
           Severity: 
           Minor
         </div>
       </div>
       <div
-        class="HvIsCardGridElement HvCard-root css-m08axw-StyledRoot e5h2ket3"
+        class="css-4fb8k0-root css-1l5xtfm-HvCard HvIsCardGridElement HvCard-root"
         style="width: 100%;"
       >
         <div
-          class="css-13ob5sy-StyledContainer e5h2ket2"
+          class="css-1kcigpt-semanticContainer HvCard-semanticContainer"
         >
           <div
-            class="HvCard-semanticBar css-zoemfr-StyledBar e5h2ket1"
+            class="css-1vb6mv5-semanticBar css-sfyg8u-HvCard HvCard-semanticBar"
           />
           <div
-            class="css-117c0kr-StyledIcon e5h2ket0"
+            class="css-6a05hj-icon HvCard-icon"
           />
         </div>
         <div
-          class="MuiCardHeader-root HvCard-Header-root e1xfuyqk0 css-zlagye-MuiCardHeader-root-StyledHeader"
+          class="MuiCardHeader-root css-te5g2l-root HvCard-Header-root css-185gdzj-MuiCardHeader-root"
         >
           <div
             class="MuiCardHeader-content HvCard-Header-content css-1qbkelo-MuiCardHeader-content"
           >
             <span
-              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title HvCard-Header-title css-1qvr50w-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title css-1yl86h7-title HvCard-Header-title css-aqxmxp-title css-1qvr50w-MuiTypography-root"
             >
               Event 5
             </span>
           </div>
         </div>
         <div
-          class="MuiCardContent-root HvCard-Content-content e12hctsi0 css-v8uagb-MuiCardContent-root-StyledContent"
+          class="MuiCardContent-root css-m6635h-content HvCard-Content-content css-46bh2p-MuiCardContent-root"
         >
           Severity: 
           Critical
         </div>
       </div>
       <div
-        class="HvIsCardGridElement HvCard-root css-m08axw-StyledRoot e5h2ket3"
+        class="css-4fb8k0-root css-1l5xtfm-HvCard HvIsCardGridElement HvCard-root"
         style="width: 100%;"
       >
         <div
-          class="css-13ob5sy-StyledContainer e5h2ket2"
+          class="css-1kcigpt-semanticContainer HvCard-semanticContainer"
         >
           <div
-            class="HvCard-semanticBar css-zoemfr-StyledBar e5h2ket1"
+            class="css-1vb6mv5-semanticBar css-sfyg8u-HvCard HvCard-semanticBar"
           />
           <div
-            class="css-117c0kr-StyledIcon e5h2ket0"
+            class="css-6a05hj-icon HvCard-icon"
           />
         </div>
         <div
-          class="MuiCardHeader-root HvCard-Header-root e1xfuyqk0 css-zlagye-MuiCardHeader-root-StyledHeader"
+          class="MuiCardHeader-root css-te5g2l-root HvCard-Header-root css-185gdzj-MuiCardHeader-root"
         >
           <div
             class="MuiCardHeader-content HvCard-Header-content css-1qbkelo-MuiCardHeader-content"
           >
             <span
-              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title HvCard-Header-title css-1qvr50w-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title css-1yl86h7-title HvCard-Header-title css-aqxmxp-title css-1qvr50w-MuiTypography-root"
             >
               Event 6
             </span>
           </div>
         </div>
         <div
-          class="MuiCardContent-root HvCard-Content-content e12hctsi0 css-v8uagb-MuiCardContent-root-StyledContent"
+          class="MuiCardContent-root css-m6635h-content HvCard-Content-content css-46bh2p-MuiCardContent-root"
         >
           Severity: 
           Major
         </div>
       </div>
       <div
-        class="HvIsCardGridElement HvCard-root css-m08axw-StyledRoot e5h2ket3"
+        class="css-4fb8k0-root css-1l5xtfm-HvCard HvIsCardGridElement HvCard-root"
         style="width: 100%;"
       >
         <div
-          class="css-13ob5sy-StyledContainer e5h2ket2"
+          class="css-1kcigpt-semanticContainer HvCard-semanticContainer"
         >
           <div
-            class="HvCard-semanticBar css-zoemfr-StyledBar e5h2ket1"
+            class="css-1vb6mv5-semanticBar css-sfyg8u-HvCard HvCard-semanticBar"
           />
           <div
-            class="css-117c0kr-StyledIcon e5h2ket0"
+            class="css-6a05hj-icon HvCard-icon"
           />
         </div>
         <div
-          class="MuiCardHeader-root HvCard-Header-root e1xfuyqk0 css-zlagye-MuiCardHeader-root-StyledHeader"
+          class="MuiCardHeader-root css-te5g2l-root HvCard-Header-root css-185gdzj-MuiCardHeader-root"
         >
           <div
             class="MuiCardHeader-content HvCard-Header-content css-1qbkelo-MuiCardHeader-content"
           >
             <span
-              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title HvCard-Header-title css-1qvr50w-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title css-1yl86h7-title HvCard-Header-title css-aqxmxp-title css-1qvr50w-MuiTypography-root"
             >
               Event 7
             </span>
           </div>
         </div>
         <div
-          class="MuiCardContent-root HvCard-Content-content e12hctsi0 css-v8uagb-MuiCardContent-root-StyledContent"
+          class="MuiCardContent-root css-m6635h-content HvCard-Content-content css-46bh2p-MuiCardContent-root"
         >
           Severity: 
           Average
         </div>
       </div>
       <div
-        class="HvIsCardGridElement HvCard-root css-m08axw-StyledRoot e5h2ket3"
+        class="css-4fb8k0-root css-1l5xtfm-HvCard HvIsCardGridElement HvCard-root"
         style="width: 100%;"
       >
         <div
-          class="css-13ob5sy-StyledContainer e5h2ket2"
+          class="css-1kcigpt-semanticContainer HvCard-semanticContainer"
         >
           <div
-            class="HvCard-semanticBar css-zoemfr-StyledBar e5h2ket1"
+            class="css-1vb6mv5-semanticBar css-sfyg8u-HvCard HvCard-semanticBar"
           />
           <div
-            class="css-117c0kr-StyledIcon e5h2ket0"
+            class="css-6a05hj-icon HvCard-icon"
           />
         </div>
         <div
-          class="MuiCardHeader-root HvCard-Header-root e1xfuyqk0 css-zlagye-MuiCardHeader-root-StyledHeader"
+          class="MuiCardHeader-root css-te5g2l-root HvCard-Header-root css-185gdzj-MuiCardHeader-root"
         >
           <div
             class="MuiCardHeader-content HvCard-Header-content css-1qbkelo-MuiCardHeader-content"
           >
             <span
-              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title HvCard-Header-title css-1qvr50w-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title css-1yl86h7-title HvCard-Header-title css-aqxmxp-title css-1qvr50w-MuiTypography-root"
             >
               Event 8
             </span>
           </div>
         </div>
         <div
-          class="MuiCardContent-root HvCard-Content-content e12hctsi0 css-v8uagb-MuiCardContent-root-StyledContent"
+          class="MuiCardContent-root css-m6635h-content HvCard-Content-content css-46bh2p-MuiCardContent-root"
         >
           Severity: 
           Minor
         </div>
       </div>
       <div
-        class="HvIsCardGridElement HvCard-root css-m08axw-StyledRoot e5h2ket3"
+        class="css-4fb8k0-root css-1l5xtfm-HvCard HvIsCardGridElement HvCard-root"
         style="width: 100%;"
       >
         <div
-          class="css-13ob5sy-StyledContainer e5h2ket2"
+          class="css-1kcigpt-semanticContainer HvCard-semanticContainer"
         >
           <div
-            class="HvCard-semanticBar css-zoemfr-StyledBar e5h2ket1"
+            class="css-1vb6mv5-semanticBar css-sfyg8u-HvCard HvCard-semanticBar"
           />
           <div
-            class="css-117c0kr-StyledIcon e5h2ket0"
+            class="css-6a05hj-icon HvCard-icon"
           />
         </div>
         <div
-          class="MuiCardHeader-root HvCard-Header-root e1xfuyqk0 css-zlagye-MuiCardHeader-root-StyledHeader"
+          class="MuiCardHeader-root css-te5g2l-root HvCard-Header-root css-185gdzj-MuiCardHeader-root"
         >
           <div
             class="MuiCardHeader-content HvCard-Header-content css-1qbkelo-MuiCardHeader-content"
           >
             <span
-              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title HvCard-Header-title css-1qvr50w-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title css-1yl86h7-title HvCard-Header-title css-aqxmxp-title css-1qvr50w-MuiTypography-root"
             >
               Event 9
             </span>
           </div>
         </div>
         <div
-          class="MuiCardContent-root HvCard-Content-content e12hctsi0 css-v8uagb-MuiCardContent-root-StyledContent"
+          class="MuiCardContent-root css-m6635h-content HvCard-Content-content css-46bh2p-MuiCardContent-root"
         >
           Severity: 
           Critical
         </div>
       </div>
       <div
-        class="HvIsCardGridElement HvCard-root css-m08axw-StyledRoot e5h2ket3"
+        class="css-4fb8k0-root css-1l5xtfm-HvCard HvIsCardGridElement HvCard-root"
         style="width: 100%;"
       >
         <div
-          class="css-13ob5sy-StyledContainer e5h2ket2"
+          class="css-1kcigpt-semanticContainer HvCard-semanticContainer"
         >
           <div
-            class="HvCard-semanticBar css-zoemfr-StyledBar e5h2ket1"
+            class="css-1vb6mv5-semanticBar css-sfyg8u-HvCard HvCard-semanticBar"
           />
           <div
-            class="css-117c0kr-StyledIcon e5h2ket0"
+            class="css-6a05hj-icon HvCard-icon"
           />
         </div>
         <div
-          class="MuiCardHeader-root HvCard-Header-root e1xfuyqk0 css-zlagye-MuiCardHeader-root-StyledHeader"
+          class="MuiCardHeader-root css-te5g2l-root HvCard-Header-root css-185gdzj-MuiCardHeader-root"
         >
           <div
             class="MuiCardHeader-content HvCard-Header-content css-1qbkelo-MuiCardHeader-content"
           >
             <span
-              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title HvCard-Header-title css-1qvr50w-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title css-1yl86h7-title HvCard-Header-title css-aqxmxp-title css-1qvr50w-MuiTypography-root"
             >
               Event 10
             </span>
           </div>
         </div>
         <div
-          class="MuiCardContent-root HvCard-Content-content e12hctsi0 css-v8uagb-MuiCardContent-root-StyledContent"
+          class="MuiCardContent-root css-m6635h-content HvCard-Content-content css-46bh2p-MuiCardContent-root"
         >
           Severity: 
           Major
@@ -1284,690 +1284,690 @@ exports[`<HvControls> > sample snapshot testing > Custom Controls 1`] = `
       spacing="sm"
     >
       <div
-        class="HvIsCardGridElement HvCard-root css-m08axw-StyledRoot e5h2ket3"
+        class="css-4fb8k0-root css-1l5xtfm-HvCard HvIsCardGridElement HvCard-root"
         style="width: 100%;"
       >
         <div
-          class="css-13ob5sy-StyledContainer e5h2ket2"
+          class="css-1kcigpt-semanticContainer HvCard-semanticContainer"
         >
           <div
-            class="HvCard-semanticBar css-zoemfr-StyledBar e5h2ket1"
+            class="css-1vb6mv5-semanticBar css-sfyg8u-HvCard HvCard-semanticBar"
           />
           <div
-            class="css-117c0kr-StyledIcon e5h2ket0"
+            class="css-6a05hj-icon HvCard-icon"
           />
         </div>
         <div
-          class="MuiCardHeader-root HvCard-Header-root e1xfuyqk0 css-zlagye-MuiCardHeader-root-StyledHeader"
+          class="MuiCardHeader-root css-te5g2l-root HvCard-Header-root css-185gdzj-MuiCardHeader-root"
         >
           <div
             class="MuiCardHeader-content HvCard-Header-content css-1qbkelo-MuiCardHeader-content"
           >
             <span
-              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title HvCard-Header-title css-1qvr50w-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title css-1yl86h7-title HvCard-Header-title css-aqxmxp-title css-1qvr50w-MuiTypography-root"
             >
               Event 1
             </span>
           </div>
         </div>
         <div
-          class="MuiCardContent-root HvCard-Content-content e12hctsi0 css-v8uagb-MuiCardContent-root-StyledContent"
+          class="MuiCardContent-root css-m6635h-content HvCard-Content-content css-46bh2p-MuiCardContent-root"
         >
           Event: 
           Anomaly detection 0
         </div>
         <div
-          class="MuiCardContent-root HvCard-Content-content e12hctsi0 css-v8uagb-MuiCardContent-root-StyledContent"
+          class="MuiCardContent-root css-m6635h-content HvCard-Content-content css-46bh2p-MuiCardContent-root"
         >
           Severity: 
           Critical
         </div>
         <div
-          class="MuiCardContent-root HvCard-Content-content e12hctsi0 css-v8uagb-MuiCardContent-root-StyledContent"
+          class="MuiCardContent-root css-m6635h-content HvCard-Content-content css-46bh2p-MuiCardContent-root"
         >
           Temperature: 
           35
         </div>
       </div>
       <div
-        class="HvIsCardGridElement HvCard-root css-m08axw-StyledRoot e5h2ket3"
+        class="css-4fb8k0-root css-1l5xtfm-HvCard HvIsCardGridElement HvCard-root"
         style="width: 100%;"
       >
         <div
-          class="css-13ob5sy-StyledContainer e5h2ket2"
+          class="css-1kcigpt-semanticContainer HvCard-semanticContainer"
         >
           <div
-            class="HvCard-semanticBar css-zoemfr-StyledBar e5h2ket1"
+            class="css-1vb6mv5-semanticBar css-sfyg8u-HvCard HvCard-semanticBar"
           />
           <div
-            class="css-117c0kr-StyledIcon e5h2ket0"
+            class="css-6a05hj-icon HvCard-icon"
           />
         </div>
         <div
-          class="MuiCardHeader-root HvCard-Header-root e1xfuyqk0 css-zlagye-MuiCardHeader-root-StyledHeader"
+          class="MuiCardHeader-root css-te5g2l-root HvCard-Header-root css-185gdzj-MuiCardHeader-root"
         >
           <div
             class="MuiCardHeader-content HvCard-Header-content css-1qbkelo-MuiCardHeader-content"
           >
             <span
-              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title HvCard-Header-title css-1qvr50w-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title css-1yl86h7-title HvCard-Header-title css-aqxmxp-title css-1qvr50w-MuiTypography-root"
             >
               Event 2
             </span>
           </div>
         </div>
         <div
-          class="MuiCardContent-root HvCard-Content-content e12hctsi0 css-v8uagb-MuiCardContent-root-StyledContent"
+          class="MuiCardContent-root css-m6635h-content HvCard-Content-content css-46bh2p-MuiCardContent-root"
         >
           Event: 
           Anomaly detection 1
         </div>
         <div
-          class="MuiCardContent-root HvCard-Content-content e12hctsi0 css-v8uagb-MuiCardContent-root-StyledContent"
+          class="MuiCardContent-root css-m6635h-content HvCard-Content-content css-46bh2p-MuiCardContent-root"
         >
           Severity: 
           Major
         </div>
         <div
-          class="MuiCardContent-root HvCard-Content-content e12hctsi0 css-v8uagb-MuiCardContent-root-StyledContent"
+          class="MuiCardContent-root css-m6635h-content HvCard-Content-content css-46bh2p-MuiCardContent-root"
         >
           Temperature: 
           36
         </div>
       </div>
       <div
-        class="HvIsCardGridElement HvCard-root css-m08axw-StyledRoot e5h2ket3"
+        class="css-4fb8k0-root css-1l5xtfm-HvCard HvIsCardGridElement HvCard-root"
         style="width: 100%;"
       >
         <div
-          class="css-13ob5sy-StyledContainer e5h2ket2"
+          class="css-1kcigpt-semanticContainer HvCard-semanticContainer"
         >
           <div
-            class="HvCard-semanticBar css-zoemfr-StyledBar e5h2ket1"
+            class="css-1vb6mv5-semanticBar css-sfyg8u-HvCard HvCard-semanticBar"
           />
           <div
-            class="css-117c0kr-StyledIcon e5h2ket0"
+            class="css-6a05hj-icon HvCard-icon"
           />
         </div>
         <div
-          class="MuiCardHeader-root HvCard-Header-root e1xfuyqk0 css-zlagye-MuiCardHeader-root-StyledHeader"
+          class="MuiCardHeader-root css-te5g2l-root HvCard-Header-root css-185gdzj-MuiCardHeader-root"
         >
           <div
             class="MuiCardHeader-content HvCard-Header-content css-1qbkelo-MuiCardHeader-content"
           >
             <span
-              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title HvCard-Header-title css-1qvr50w-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title css-1yl86h7-title HvCard-Header-title css-aqxmxp-title css-1qvr50w-MuiTypography-root"
             >
               Event 3
             </span>
           </div>
         </div>
         <div
-          class="MuiCardContent-root HvCard-Content-content e12hctsi0 css-v8uagb-MuiCardContent-root-StyledContent"
+          class="MuiCardContent-root css-m6635h-content HvCard-Content-content css-46bh2p-MuiCardContent-root"
         >
           Event: 
           Anomaly detection 2
         </div>
         <div
-          class="MuiCardContent-root HvCard-Content-content e12hctsi0 css-v8uagb-MuiCardContent-root-StyledContent"
+          class="MuiCardContent-root css-m6635h-content HvCard-Content-content css-46bh2p-MuiCardContent-root"
         >
           Severity: 
           Average
         </div>
         <div
-          class="MuiCardContent-root HvCard-Content-content e12hctsi0 css-v8uagb-MuiCardContent-root-StyledContent"
+          class="MuiCardContent-root css-m6635h-content HvCard-Content-content css-46bh2p-MuiCardContent-root"
         >
           Temperature: 
           37
         </div>
       </div>
       <div
-        class="HvIsCardGridElement HvCard-root css-m08axw-StyledRoot e5h2ket3"
+        class="css-4fb8k0-root css-1l5xtfm-HvCard HvIsCardGridElement HvCard-root"
         style="width: 100%;"
       >
         <div
-          class="css-13ob5sy-StyledContainer e5h2ket2"
+          class="css-1kcigpt-semanticContainer HvCard-semanticContainer"
         >
           <div
-            class="HvCard-semanticBar css-zoemfr-StyledBar e5h2ket1"
+            class="css-1vb6mv5-semanticBar css-sfyg8u-HvCard HvCard-semanticBar"
           />
           <div
-            class="css-117c0kr-StyledIcon e5h2ket0"
+            class="css-6a05hj-icon HvCard-icon"
           />
         </div>
         <div
-          class="MuiCardHeader-root HvCard-Header-root e1xfuyqk0 css-zlagye-MuiCardHeader-root-StyledHeader"
+          class="MuiCardHeader-root css-te5g2l-root HvCard-Header-root css-185gdzj-MuiCardHeader-root"
         >
           <div
             class="MuiCardHeader-content HvCard-Header-content css-1qbkelo-MuiCardHeader-content"
           >
             <span
-              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title HvCard-Header-title css-1qvr50w-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title css-1yl86h7-title HvCard-Header-title css-aqxmxp-title css-1qvr50w-MuiTypography-root"
             >
               Event 4
             </span>
           </div>
         </div>
         <div
-          class="MuiCardContent-root HvCard-Content-content e12hctsi0 css-v8uagb-MuiCardContent-root-StyledContent"
+          class="MuiCardContent-root css-m6635h-content HvCard-Content-content css-46bh2p-MuiCardContent-root"
         >
           Event: 
           Anomaly detection 3
         </div>
         <div
-          class="MuiCardContent-root HvCard-Content-content e12hctsi0 css-v8uagb-MuiCardContent-root-StyledContent"
+          class="MuiCardContent-root css-m6635h-content HvCard-Content-content css-46bh2p-MuiCardContent-root"
         >
           Severity: 
           Minor
         </div>
         <div
-          class="MuiCardContent-root HvCard-Content-content e12hctsi0 css-v8uagb-MuiCardContent-root-StyledContent"
+          class="MuiCardContent-root css-m6635h-content HvCard-Content-content css-46bh2p-MuiCardContent-root"
         >
           Temperature: 
           38
         </div>
       </div>
       <div
-        class="HvIsCardGridElement HvCard-root css-m08axw-StyledRoot e5h2ket3"
+        class="css-4fb8k0-root css-1l5xtfm-HvCard HvIsCardGridElement HvCard-root"
         style="width: 100%;"
       >
         <div
-          class="css-13ob5sy-StyledContainer e5h2ket2"
+          class="css-1kcigpt-semanticContainer HvCard-semanticContainer"
         >
           <div
-            class="HvCard-semanticBar css-zoemfr-StyledBar e5h2ket1"
+            class="css-1vb6mv5-semanticBar css-sfyg8u-HvCard HvCard-semanticBar"
           />
           <div
-            class="css-117c0kr-StyledIcon e5h2ket0"
+            class="css-6a05hj-icon HvCard-icon"
           />
         </div>
         <div
-          class="MuiCardHeader-root HvCard-Header-root e1xfuyqk0 css-zlagye-MuiCardHeader-root-StyledHeader"
+          class="MuiCardHeader-root css-te5g2l-root HvCard-Header-root css-185gdzj-MuiCardHeader-root"
         >
           <div
             class="MuiCardHeader-content HvCard-Header-content css-1qbkelo-MuiCardHeader-content"
           >
             <span
-              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title HvCard-Header-title css-1qvr50w-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title css-1yl86h7-title HvCard-Header-title css-aqxmxp-title css-1qvr50w-MuiTypography-root"
             >
               Event 5
             </span>
           </div>
         </div>
         <div
-          class="MuiCardContent-root HvCard-Content-content e12hctsi0 css-v8uagb-MuiCardContent-root-StyledContent"
+          class="MuiCardContent-root css-m6635h-content HvCard-Content-content css-46bh2p-MuiCardContent-root"
         >
           Event: 
           Anomaly detection 0
         </div>
         <div
-          class="MuiCardContent-root HvCard-Content-content e12hctsi0 css-v8uagb-MuiCardContent-root-StyledContent"
+          class="MuiCardContent-root css-m6635h-content HvCard-Content-content css-46bh2p-MuiCardContent-root"
         >
           Severity: 
           Critical
         </div>
         <div
-          class="MuiCardContent-root HvCard-Content-content e12hctsi0 css-v8uagb-MuiCardContent-root-StyledContent"
+          class="MuiCardContent-root css-m6635h-content HvCard-Content-content css-46bh2p-MuiCardContent-root"
         >
           Temperature: 
           39
         </div>
       </div>
       <div
-        class="HvIsCardGridElement HvCard-root css-m08axw-StyledRoot e5h2ket3"
+        class="css-4fb8k0-root css-1l5xtfm-HvCard HvIsCardGridElement HvCard-root"
         style="width: 100%;"
       >
         <div
-          class="css-13ob5sy-StyledContainer e5h2ket2"
+          class="css-1kcigpt-semanticContainer HvCard-semanticContainer"
         >
           <div
-            class="HvCard-semanticBar css-zoemfr-StyledBar e5h2ket1"
+            class="css-1vb6mv5-semanticBar css-sfyg8u-HvCard HvCard-semanticBar"
           />
           <div
-            class="css-117c0kr-StyledIcon e5h2ket0"
+            class="css-6a05hj-icon HvCard-icon"
           />
         </div>
         <div
-          class="MuiCardHeader-root HvCard-Header-root e1xfuyqk0 css-zlagye-MuiCardHeader-root-StyledHeader"
+          class="MuiCardHeader-root css-te5g2l-root HvCard-Header-root css-185gdzj-MuiCardHeader-root"
         >
           <div
             class="MuiCardHeader-content HvCard-Header-content css-1qbkelo-MuiCardHeader-content"
           >
             <span
-              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title HvCard-Header-title css-1qvr50w-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title css-1yl86h7-title HvCard-Header-title css-aqxmxp-title css-1qvr50w-MuiTypography-root"
             >
               Event 6
             </span>
           </div>
         </div>
         <div
-          class="MuiCardContent-root HvCard-Content-content e12hctsi0 css-v8uagb-MuiCardContent-root-StyledContent"
+          class="MuiCardContent-root css-m6635h-content HvCard-Content-content css-46bh2p-MuiCardContent-root"
         >
           Event: 
           Anomaly detection 1
         </div>
         <div
-          class="MuiCardContent-root HvCard-Content-content e12hctsi0 css-v8uagb-MuiCardContent-root-StyledContent"
+          class="MuiCardContent-root css-m6635h-content HvCard-Content-content css-46bh2p-MuiCardContent-root"
         >
           Severity: 
           Major
         </div>
         <div
-          class="MuiCardContent-root HvCard-Content-content e12hctsi0 css-v8uagb-MuiCardContent-root-StyledContent"
+          class="MuiCardContent-root css-m6635h-content HvCard-Content-content css-46bh2p-MuiCardContent-root"
         >
           Temperature: 
           40
         </div>
       </div>
       <div
-        class="HvIsCardGridElement HvCard-root css-m08axw-StyledRoot e5h2ket3"
+        class="css-4fb8k0-root css-1l5xtfm-HvCard HvIsCardGridElement HvCard-root"
         style="width: 100%;"
       >
         <div
-          class="css-13ob5sy-StyledContainer e5h2ket2"
+          class="css-1kcigpt-semanticContainer HvCard-semanticContainer"
         >
           <div
-            class="HvCard-semanticBar css-zoemfr-StyledBar e5h2ket1"
+            class="css-1vb6mv5-semanticBar css-sfyg8u-HvCard HvCard-semanticBar"
           />
           <div
-            class="css-117c0kr-StyledIcon e5h2ket0"
+            class="css-6a05hj-icon HvCard-icon"
           />
         </div>
         <div
-          class="MuiCardHeader-root HvCard-Header-root e1xfuyqk0 css-zlagye-MuiCardHeader-root-StyledHeader"
+          class="MuiCardHeader-root css-te5g2l-root HvCard-Header-root css-185gdzj-MuiCardHeader-root"
         >
           <div
             class="MuiCardHeader-content HvCard-Header-content css-1qbkelo-MuiCardHeader-content"
           >
             <span
-              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title HvCard-Header-title css-1qvr50w-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title css-1yl86h7-title HvCard-Header-title css-aqxmxp-title css-1qvr50w-MuiTypography-root"
             >
               Event 7
             </span>
           </div>
         </div>
         <div
-          class="MuiCardContent-root HvCard-Content-content e12hctsi0 css-v8uagb-MuiCardContent-root-StyledContent"
+          class="MuiCardContent-root css-m6635h-content HvCard-Content-content css-46bh2p-MuiCardContent-root"
         >
           Event: 
           Anomaly detection 2
         </div>
         <div
-          class="MuiCardContent-root HvCard-Content-content e12hctsi0 css-v8uagb-MuiCardContent-root-StyledContent"
+          class="MuiCardContent-root css-m6635h-content HvCard-Content-content css-46bh2p-MuiCardContent-root"
         >
           Severity: 
           Average
         </div>
         <div
-          class="MuiCardContent-root HvCard-Content-content e12hctsi0 css-v8uagb-MuiCardContent-root-StyledContent"
+          class="MuiCardContent-root css-m6635h-content HvCard-Content-content css-46bh2p-MuiCardContent-root"
         >
           Temperature: 
           41
         </div>
       </div>
       <div
-        class="HvIsCardGridElement HvCard-root css-m08axw-StyledRoot e5h2ket3"
+        class="css-4fb8k0-root css-1l5xtfm-HvCard HvIsCardGridElement HvCard-root"
         style="width: 100%;"
       >
         <div
-          class="css-13ob5sy-StyledContainer e5h2ket2"
+          class="css-1kcigpt-semanticContainer HvCard-semanticContainer"
         >
           <div
-            class="HvCard-semanticBar css-zoemfr-StyledBar e5h2ket1"
+            class="css-1vb6mv5-semanticBar css-sfyg8u-HvCard HvCard-semanticBar"
           />
           <div
-            class="css-117c0kr-StyledIcon e5h2ket0"
+            class="css-6a05hj-icon HvCard-icon"
           />
         </div>
         <div
-          class="MuiCardHeader-root HvCard-Header-root e1xfuyqk0 css-zlagye-MuiCardHeader-root-StyledHeader"
+          class="MuiCardHeader-root css-te5g2l-root HvCard-Header-root css-185gdzj-MuiCardHeader-root"
         >
           <div
             class="MuiCardHeader-content HvCard-Header-content css-1qbkelo-MuiCardHeader-content"
           >
             <span
-              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title HvCard-Header-title css-1qvr50w-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title css-1yl86h7-title HvCard-Header-title css-aqxmxp-title css-1qvr50w-MuiTypography-root"
             >
               Event 8
             </span>
           </div>
         </div>
         <div
-          class="MuiCardContent-root HvCard-Content-content e12hctsi0 css-v8uagb-MuiCardContent-root-StyledContent"
+          class="MuiCardContent-root css-m6635h-content HvCard-Content-content css-46bh2p-MuiCardContent-root"
         >
           Event: 
           Anomaly detection 3
         </div>
         <div
-          class="MuiCardContent-root HvCard-Content-content e12hctsi0 css-v8uagb-MuiCardContent-root-StyledContent"
+          class="MuiCardContent-root css-m6635h-content HvCard-Content-content css-46bh2p-MuiCardContent-root"
         >
           Severity: 
           Minor
         </div>
         <div
-          class="MuiCardContent-root HvCard-Content-content e12hctsi0 css-v8uagb-MuiCardContent-root-StyledContent"
+          class="MuiCardContent-root css-m6635h-content HvCard-Content-content css-46bh2p-MuiCardContent-root"
         >
           Temperature: 
           42
         </div>
       </div>
       <div
-        class="HvIsCardGridElement HvCard-root css-m08axw-StyledRoot e5h2ket3"
+        class="css-4fb8k0-root css-1l5xtfm-HvCard HvIsCardGridElement HvCard-root"
         style="width: 100%;"
       >
         <div
-          class="css-13ob5sy-StyledContainer e5h2ket2"
+          class="css-1kcigpt-semanticContainer HvCard-semanticContainer"
         >
           <div
-            class="HvCard-semanticBar css-zoemfr-StyledBar e5h2ket1"
+            class="css-1vb6mv5-semanticBar css-sfyg8u-HvCard HvCard-semanticBar"
           />
           <div
-            class="css-117c0kr-StyledIcon e5h2ket0"
+            class="css-6a05hj-icon HvCard-icon"
           />
         </div>
         <div
-          class="MuiCardHeader-root HvCard-Header-root e1xfuyqk0 css-zlagye-MuiCardHeader-root-StyledHeader"
+          class="MuiCardHeader-root css-te5g2l-root HvCard-Header-root css-185gdzj-MuiCardHeader-root"
         >
           <div
             class="MuiCardHeader-content HvCard-Header-content css-1qbkelo-MuiCardHeader-content"
           >
             <span
-              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title HvCard-Header-title css-1qvr50w-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title css-1yl86h7-title HvCard-Header-title css-aqxmxp-title css-1qvr50w-MuiTypography-root"
             >
               Event 9
             </span>
           </div>
         </div>
         <div
-          class="MuiCardContent-root HvCard-Content-content e12hctsi0 css-v8uagb-MuiCardContent-root-StyledContent"
+          class="MuiCardContent-root css-m6635h-content HvCard-Content-content css-46bh2p-MuiCardContent-root"
         >
           Event: 
           Anomaly detection 0
         </div>
         <div
-          class="MuiCardContent-root HvCard-Content-content e12hctsi0 css-v8uagb-MuiCardContent-root-StyledContent"
+          class="MuiCardContent-root css-m6635h-content HvCard-Content-content css-46bh2p-MuiCardContent-root"
         >
           Severity: 
           Critical
         </div>
         <div
-          class="MuiCardContent-root HvCard-Content-content e12hctsi0 css-v8uagb-MuiCardContent-root-StyledContent"
+          class="MuiCardContent-root css-m6635h-content HvCard-Content-content css-46bh2p-MuiCardContent-root"
         >
           Temperature: 
           43
         </div>
       </div>
       <div
-        class="HvIsCardGridElement HvCard-root css-m08axw-StyledRoot e5h2ket3"
+        class="css-4fb8k0-root css-1l5xtfm-HvCard HvIsCardGridElement HvCard-root"
         style="width: 100%;"
       >
         <div
-          class="css-13ob5sy-StyledContainer e5h2ket2"
+          class="css-1kcigpt-semanticContainer HvCard-semanticContainer"
         >
           <div
-            class="HvCard-semanticBar css-zoemfr-StyledBar e5h2ket1"
+            class="css-1vb6mv5-semanticBar css-sfyg8u-HvCard HvCard-semanticBar"
           />
           <div
-            class="css-117c0kr-StyledIcon e5h2ket0"
+            class="css-6a05hj-icon HvCard-icon"
           />
         </div>
         <div
-          class="MuiCardHeader-root HvCard-Header-root e1xfuyqk0 css-zlagye-MuiCardHeader-root-StyledHeader"
+          class="MuiCardHeader-root css-te5g2l-root HvCard-Header-root css-185gdzj-MuiCardHeader-root"
         >
           <div
             class="MuiCardHeader-content HvCard-Header-content css-1qbkelo-MuiCardHeader-content"
           >
             <span
-              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title HvCard-Header-title css-1qvr50w-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title css-1yl86h7-title HvCard-Header-title css-aqxmxp-title css-1qvr50w-MuiTypography-root"
             >
               Event 10
             </span>
           </div>
         </div>
         <div
-          class="MuiCardContent-root HvCard-Content-content e12hctsi0 css-v8uagb-MuiCardContent-root-StyledContent"
+          class="MuiCardContent-root css-m6635h-content HvCard-Content-content css-46bh2p-MuiCardContent-root"
         >
           Event: 
           Anomaly detection 1
         </div>
         <div
-          class="MuiCardContent-root HvCard-Content-content e12hctsi0 css-v8uagb-MuiCardContent-root-StyledContent"
+          class="MuiCardContent-root css-m6635h-content HvCard-Content-content css-46bh2p-MuiCardContent-root"
         >
           Severity: 
           Major
         </div>
         <div
-          class="MuiCardContent-root HvCard-Content-content e12hctsi0 css-v8uagb-MuiCardContent-root-StyledContent"
+          class="MuiCardContent-root css-m6635h-content HvCard-Content-content css-46bh2p-MuiCardContent-root"
         >
           Temperature: 
           44
         </div>
       </div>
       <div
-        class="HvIsCardGridElement HvCard-root css-m08axw-StyledRoot e5h2ket3"
+        class="css-4fb8k0-root css-1l5xtfm-HvCard HvIsCardGridElement HvCard-root"
         style="width: 100%;"
       >
         <div
-          class="css-13ob5sy-StyledContainer e5h2ket2"
+          class="css-1kcigpt-semanticContainer HvCard-semanticContainer"
         >
           <div
-            class="HvCard-semanticBar css-zoemfr-StyledBar e5h2ket1"
+            class="css-1vb6mv5-semanticBar css-sfyg8u-HvCard HvCard-semanticBar"
           />
           <div
-            class="css-117c0kr-StyledIcon e5h2ket0"
+            class="css-6a05hj-icon HvCard-icon"
           />
         </div>
         <div
-          class="MuiCardHeader-root HvCard-Header-root e1xfuyqk0 css-zlagye-MuiCardHeader-root-StyledHeader"
+          class="MuiCardHeader-root css-te5g2l-root HvCard-Header-root css-185gdzj-MuiCardHeader-root"
         >
           <div
             class="MuiCardHeader-content HvCard-Header-content css-1qbkelo-MuiCardHeader-content"
           >
             <span
-              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title HvCard-Header-title css-1qvr50w-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title css-1yl86h7-title HvCard-Header-title css-aqxmxp-title css-1qvr50w-MuiTypography-root"
             >
               Event 11
             </span>
           </div>
         </div>
         <div
-          class="MuiCardContent-root HvCard-Content-content e12hctsi0 css-v8uagb-MuiCardContent-root-StyledContent"
+          class="MuiCardContent-root css-m6635h-content HvCard-Content-content css-46bh2p-MuiCardContent-root"
         >
           Event: 
           Anomaly detection 2
         </div>
         <div
-          class="MuiCardContent-root HvCard-Content-content e12hctsi0 css-v8uagb-MuiCardContent-root-StyledContent"
+          class="MuiCardContent-root css-m6635h-content HvCard-Content-content css-46bh2p-MuiCardContent-root"
         >
           Severity: 
           Average
         </div>
         <div
-          class="MuiCardContent-root HvCard-Content-content e12hctsi0 css-v8uagb-MuiCardContent-root-StyledContent"
+          class="MuiCardContent-root css-m6635h-content HvCard-Content-content css-46bh2p-MuiCardContent-root"
         >
           Temperature: 
           45
         </div>
       </div>
       <div
-        class="HvIsCardGridElement HvCard-root css-m08axw-StyledRoot e5h2ket3"
+        class="css-4fb8k0-root css-1l5xtfm-HvCard HvIsCardGridElement HvCard-root"
         style="width: 100%;"
       >
         <div
-          class="css-13ob5sy-StyledContainer e5h2ket2"
+          class="css-1kcigpt-semanticContainer HvCard-semanticContainer"
         >
           <div
-            class="HvCard-semanticBar css-zoemfr-StyledBar e5h2ket1"
+            class="css-1vb6mv5-semanticBar css-sfyg8u-HvCard HvCard-semanticBar"
           />
           <div
-            class="css-117c0kr-StyledIcon e5h2ket0"
+            class="css-6a05hj-icon HvCard-icon"
           />
         </div>
         <div
-          class="MuiCardHeader-root HvCard-Header-root e1xfuyqk0 css-zlagye-MuiCardHeader-root-StyledHeader"
+          class="MuiCardHeader-root css-te5g2l-root HvCard-Header-root css-185gdzj-MuiCardHeader-root"
         >
           <div
             class="MuiCardHeader-content HvCard-Header-content css-1qbkelo-MuiCardHeader-content"
           >
             <span
-              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title HvCard-Header-title css-1qvr50w-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title css-1yl86h7-title HvCard-Header-title css-aqxmxp-title css-1qvr50w-MuiTypography-root"
             >
               Event 12
             </span>
           </div>
         </div>
         <div
-          class="MuiCardContent-root HvCard-Content-content e12hctsi0 css-v8uagb-MuiCardContent-root-StyledContent"
+          class="MuiCardContent-root css-m6635h-content HvCard-Content-content css-46bh2p-MuiCardContent-root"
         >
           Event: 
           Anomaly detection 3
         </div>
         <div
-          class="MuiCardContent-root HvCard-Content-content e12hctsi0 css-v8uagb-MuiCardContent-root-StyledContent"
+          class="MuiCardContent-root css-m6635h-content HvCard-Content-content css-46bh2p-MuiCardContent-root"
         >
           Severity: 
           Minor
         </div>
         <div
-          class="MuiCardContent-root HvCard-Content-content e12hctsi0 css-v8uagb-MuiCardContent-root-StyledContent"
+          class="MuiCardContent-root css-m6635h-content HvCard-Content-content css-46bh2p-MuiCardContent-root"
         >
           Temperature: 
           46
         </div>
       </div>
       <div
-        class="HvIsCardGridElement HvCard-root css-m08axw-StyledRoot e5h2ket3"
+        class="css-4fb8k0-root css-1l5xtfm-HvCard HvIsCardGridElement HvCard-root"
         style="width: 100%;"
       >
         <div
-          class="css-13ob5sy-StyledContainer e5h2ket2"
+          class="css-1kcigpt-semanticContainer HvCard-semanticContainer"
         >
           <div
-            class="HvCard-semanticBar css-zoemfr-StyledBar e5h2ket1"
+            class="css-1vb6mv5-semanticBar css-sfyg8u-HvCard HvCard-semanticBar"
           />
           <div
-            class="css-117c0kr-StyledIcon e5h2ket0"
+            class="css-6a05hj-icon HvCard-icon"
           />
         </div>
         <div
-          class="MuiCardHeader-root HvCard-Header-root e1xfuyqk0 css-zlagye-MuiCardHeader-root-StyledHeader"
+          class="MuiCardHeader-root css-te5g2l-root HvCard-Header-root css-185gdzj-MuiCardHeader-root"
         >
           <div
             class="MuiCardHeader-content HvCard-Header-content css-1qbkelo-MuiCardHeader-content"
           >
             <span
-              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title HvCard-Header-title css-1qvr50w-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title css-1yl86h7-title HvCard-Header-title css-aqxmxp-title css-1qvr50w-MuiTypography-root"
             >
               Event 13
             </span>
           </div>
         </div>
         <div
-          class="MuiCardContent-root HvCard-Content-content e12hctsi0 css-v8uagb-MuiCardContent-root-StyledContent"
+          class="MuiCardContent-root css-m6635h-content HvCard-Content-content css-46bh2p-MuiCardContent-root"
         >
           Event: 
           Anomaly detection 0
         </div>
         <div
-          class="MuiCardContent-root HvCard-Content-content e12hctsi0 css-v8uagb-MuiCardContent-root-StyledContent"
+          class="MuiCardContent-root css-m6635h-content HvCard-Content-content css-46bh2p-MuiCardContent-root"
         >
           Severity: 
           Critical
         </div>
         <div
-          class="MuiCardContent-root HvCard-Content-content e12hctsi0 css-v8uagb-MuiCardContent-root-StyledContent"
+          class="MuiCardContent-root css-m6635h-content HvCard-Content-content css-46bh2p-MuiCardContent-root"
         >
           Temperature: 
           47
         </div>
       </div>
       <div
-        class="HvIsCardGridElement HvCard-root css-m08axw-StyledRoot e5h2ket3"
+        class="css-4fb8k0-root css-1l5xtfm-HvCard HvIsCardGridElement HvCard-root"
         style="width: 100%;"
       >
         <div
-          class="css-13ob5sy-StyledContainer e5h2ket2"
+          class="css-1kcigpt-semanticContainer HvCard-semanticContainer"
         >
           <div
-            class="HvCard-semanticBar css-zoemfr-StyledBar e5h2ket1"
+            class="css-1vb6mv5-semanticBar css-sfyg8u-HvCard HvCard-semanticBar"
           />
           <div
-            class="css-117c0kr-StyledIcon e5h2ket0"
+            class="css-6a05hj-icon HvCard-icon"
           />
         </div>
         <div
-          class="MuiCardHeader-root HvCard-Header-root e1xfuyqk0 css-zlagye-MuiCardHeader-root-StyledHeader"
+          class="MuiCardHeader-root css-te5g2l-root HvCard-Header-root css-185gdzj-MuiCardHeader-root"
         >
           <div
             class="MuiCardHeader-content HvCard-Header-content css-1qbkelo-MuiCardHeader-content"
           >
             <span
-              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title HvCard-Header-title css-1qvr50w-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title css-1yl86h7-title HvCard-Header-title css-aqxmxp-title css-1qvr50w-MuiTypography-root"
             >
               Event 14
             </span>
           </div>
         </div>
         <div
-          class="MuiCardContent-root HvCard-Content-content e12hctsi0 css-v8uagb-MuiCardContent-root-StyledContent"
+          class="MuiCardContent-root css-m6635h-content HvCard-Content-content css-46bh2p-MuiCardContent-root"
         >
           Event: 
           Anomaly detection 1
         </div>
         <div
-          class="MuiCardContent-root HvCard-Content-content e12hctsi0 css-v8uagb-MuiCardContent-root-StyledContent"
+          class="MuiCardContent-root css-m6635h-content HvCard-Content-content css-46bh2p-MuiCardContent-root"
         >
           Severity: 
           Major
         </div>
         <div
-          class="MuiCardContent-root HvCard-Content-content e12hctsi0 css-v8uagb-MuiCardContent-root-StyledContent"
+          class="MuiCardContent-root css-m6635h-content HvCard-Content-content css-46bh2p-MuiCardContent-root"
         >
           Temperature: 
           48
         </div>
       </div>
       <div
-        class="HvIsCardGridElement HvCard-root css-m08axw-StyledRoot e5h2ket3"
+        class="css-4fb8k0-root css-1l5xtfm-HvCard HvIsCardGridElement HvCard-root"
         style="width: 100%;"
       >
         <div
-          class="css-13ob5sy-StyledContainer e5h2ket2"
+          class="css-1kcigpt-semanticContainer HvCard-semanticContainer"
         >
           <div
-            class="HvCard-semanticBar css-zoemfr-StyledBar e5h2ket1"
+            class="css-1vb6mv5-semanticBar css-sfyg8u-HvCard HvCard-semanticBar"
           />
           <div
-            class="css-117c0kr-StyledIcon e5h2ket0"
+            class="css-6a05hj-icon HvCard-icon"
           />
         </div>
         <div
-          class="MuiCardHeader-root HvCard-Header-root e1xfuyqk0 css-zlagye-MuiCardHeader-root-StyledHeader"
+          class="MuiCardHeader-root css-te5g2l-root HvCard-Header-root css-185gdzj-MuiCardHeader-root"
         >
           <div
             class="MuiCardHeader-content HvCard-Header-content css-1qbkelo-MuiCardHeader-content"
           >
             <span
-              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title HvCard-Header-title css-1qvr50w-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title css-1yl86h7-title HvCard-Header-title css-aqxmxp-title css-1qvr50w-MuiTypography-root"
             >
               Event 15
             </span>
           </div>
         </div>
         <div
-          class="MuiCardContent-root HvCard-Content-content e12hctsi0 css-v8uagb-MuiCardContent-root-StyledContent"
+          class="MuiCardContent-root css-m6635h-content HvCard-Content-content css-46bh2p-MuiCardContent-root"
         >
           Event: 
           Anomaly detection 2
         </div>
         <div
-          class="MuiCardContent-root HvCard-Content-content e12hctsi0 css-v8uagb-MuiCardContent-root-StyledContent"
+          class="MuiCardContent-root css-m6635h-content HvCard-Content-content css-46bh2p-MuiCardContent-root"
         >
           Severity: 
           Average
         </div>
         <div
-          class="MuiCardContent-root HvCard-Content-content e12hctsi0 css-v8uagb-MuiCardContent-root-StyledContent"
+          class="MuiCardContent-root css-m6635h-content HvCard-Content-content css-46bh2p-MuiCardContent-root"
         >
           Temperature: 
           49
@@ -2153,690 +2153,690 @@ exports[`<HvControls> > sample snapshot testing > Mixed Controls 1`] = `
       spacing="sm"
     >
       <div
-        class="HvIsCardGridElement HvCard-root css-m08axw-StyledRoot e5h2ket3"
+        class="css-4fb8k0-root css-1l5xtfm-HvCard HvIsCardGridElement HvCard-root"
         style="width: 100%;"
       >
         <div
-          class="css-13ob5sy-StyledContainer e5h2ket2"
+          class="css-1kcigpt-semanticContainer HvCard-semanticContainer"
         >
           <div
-            class="HvCard-semanticBar css-zoemfr-StyledBar e5h2ket1"
+            class="css-1vb6mv5-semanticBar css-sfyg8u-HvCard HvCard-semanticBar"
           />
           <div
-            class="css-117c0kr-StyledIcon e5h2ket0"
+            class="css-6a05hj-icon HvCard-icon"
           />
         </div>
         <div
-          class="MuiCardHeader-root HvCard-Header-root e1xfuyqk0 css-zlagye-MuiCardHeader-root-StyledHeader"
+          class="MuiCardHeader-root css-te5g2l-root HvCard-Header-root css-185gdzj-MuiCardHeader-root"
         >
           <div
             class="MuiCardHeader-content HvCard-Header-content css-1qbkelo-MuiCardHeader-content"
           >
             <span
-              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title HvCard-Header-title css-1qvr50w-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title css-1yl86h7-title HvCard-Header-title css-aqxmxp-title css-1qvr50w-MuiTypography-root"
             >
               Event 1
             </span>
           </div>
         </div>
         <div
-          class="MuiCardContent-root HvCard-Content-content e12hctsi0 css-v8uagb-MuiCardContent-root-StyledContent"
+          class="MuiCardContent-root css-m6635h-content HvCard-Content-content css-46bh2p-MuiCardContent-root"
         >
           Event: 
           Anomaly detection 0
         </div>
         <div
-          class="MuiCardContent-root HvCard-Content-content e12hctsi0 css-v8uagb-MuiCardContent-root-StyledContent"
+          class="MuiCardContent-root css-m6635h-content HvCard-Content-content css-46bh2p-MuiCardContent-root"
         >
           Severity: 
           Critical
         </div>
         <div
-          class="MuiCardContent-root HvCard-Content-content e12hctsi0 css-v8uagb-MuiCardContent-root-StyledContent"
+          class="MuiCardContent-root css-m6635h-content HvCard-Content-content css-46bh2p-MuiCardContent-root"
         >
           Temperature: 
           35
         </div>
       </div>
       <div
-        class="HvIsCardGridElement HvCard-root css-m08axw-StyledRoot e5h2ket3"
+        class="css-4fb8k0-root css-1l5xtfm-HvCard HvIsCardGridElement HvCard-root"
         style="width: 100%;"
       >
         <div
-          class="css-13ob5sy-StyledContainer e5h2ket2"
+          class="css-1kcigpt-semanticContainer HvCard-semanticContainer"
         >
           <div
-            class="HvCard-semanticBar css-zoemfr-StyledBar e5h2ket1"
+            class="css-1vb6mv5-semanticBar css-sfyg8u-HvCard HvCard-semanticBar"
           />
           <div
-            class="css-117c0kr-StyledIcon e5h2ket0"
+            class="css-6a05hj-icon HvCard-icon"
           />
         </div>
         <div
-          class="MuiCardHeader-root HvCard-Header-root e1xfuyqk0 css-zlagye-MuiCardHeader-root-StyledHeader"
+          class="MuiCardHeader-root css-te5g2l-root HvCard-Header-root css-185gdzj-MuiCardHeader-root"
         >
           <div
             class="MuiCardHeader-content HvCard-Header-content css-1qbkelo-MuiCardHeader-content"
           >
             <span
-              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title HvCard-Header-title css-1qvr50w-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title css-1yl86h7-title HvCard-Header-title css-aqxmxp-title css-1qvr50w-MuiTypography-root"
             >
               Event 2
             </span>
           </div>
         </div>
         <div
-          class="MuiCardContent-root HvCard-Content-content e12hctsi0 css-v8uagb-MuiCardContent-root-StyledContent"
+          class="MuiCardContent-root css-m6635h-content HvCard-Content-content css-46bh2p-MuiCardContent-root"
         >
           Event: 
           Anomaly detection 1
         </div>
         <div
-          class="MuiCardContent-root HvCard-Content-content e12hctsi0 css-v8uagb-MuiCardContent-root-StyledContent"
+          class="MuiCardContent-root css-m6635h-content HvCard-Content-content css-46bh2p-MuiCardContent-root"
         >
           Severity: 
           Major
         </div>
         <div
-          class="MuiCardContent-root HvCard-Content-content e12hctsi0 css-v8uagb-MuiCardContent-root-StyledContent"
+          class="MuiCardContent-root css-m6635h-content HvCard-Content-content css-46bh2p-MuiCardContent-root"
         >
           Temperature: 
           36
         </div>
       </div>
       <div
-        class="HvIsCardGridElement HvCard-root css-m08axw-StyledRoot e5h2ket3"
+        class="css-4fb8k0-root css-1l5xtfm-HvCard HvIsCardGridElement HvCard-root"
         style="width: 100%;"
       >
         <div
-          class="css-13ob5sy-StyledContainer e5h2ket2"
+          class="css-1kcigpt-semanticContainer HvCard-semanticContainer"
         >
           <div
-            class="HvCard-semanticBar css-zoemfr-StyledBar e5h2ket1"
+            class="css-1vb6mv5-semanticBar css-sfyg8u-HvCard HvCard-semanticBar"
           />
           <div
-            class="css-117c0kr-StyledIcon e5h2ket0"
+            class="css-6a05hj-icon HvCard-icon"
           />
         </div>
         <div
-          class="MuiCardHeader-root HvCard-Header-root e1xfuyqk0 css-zlagye-MuiCardHeader-root-StyledHeader"
+          class="MuiCardHeader-root css-te5g2l-root HvCard-Header-root css-185gdzj-MuiCardHeader-root"
         >
           <div
             class="MuiCardHeader-content HvCard-Header-content css-1qbkelo-MuiCardHeader-content"
           >
             <span
-              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title HvCard-Header-title css-1qvr50w-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title css-1yl86h7-title HvCard-Header-title css-aqxmxp-title css-1qvr50w-MuiTypography-root"
             >
               Event 3
             </span>
           </div>
         </div>
         <div
-          class="MuiCardContent-root HvCard-Content-content e12hctsi0 css-v8uagb-MuiCardContent-root-StyledContent"
+          class="MuiCardContent-root css-m6635h-content HvCard-Content-content css-46bh2p-MuiCardContent-root"
         >
           Event: 
           Anomaly detection 2
         </div>
         <div
-          class="MuiCardContent-root HvCard-Content-content e12hctsi0 css-v8uagb-MuiCardContent-root-StyledContent"
+          class="MuiCardContent-root css-m6635h-content HvCard-Content-content css-46bh2p-MuiCardContent-root"
         >
           Severity: 
           Average
         </div>
         <div
-          class="MuiCardContent-root HvCard-Content-content e12hctsi0 css-v8uagb-MuiCardContent-root-StyledContent"
+          class="MuiCardContent-root css-m6635h-content HvCard-Content-content css-46bh2p-MuiCardContent-root"
         >
           Temperature: 
           37
         </div>
       </div>
       <div
-        class="HvIsCardGridElement HvCard-root css-m08axw-StyledRoot e5h2ket3"
+        class="css-4fb8k0-root css-1l5xtfm-HvCard HvIsCardGridElement HvCard-root"
         style="width: 100%;"
       >
         <div
-          class="css-13ob5sy-StyledContainer e5h2ket2"
+          class="css-1kcigpt-semanticContainer HvCard-semanticContainer"
         >
           <div
-            class="HvCard-semanticBar css-zoemfr-StyledBar e5h2ket1"
+            class="css-1vb6mv5-semanticBar css-sfyg8u-HvCard HvCard-semanticBar"
           />
           <div
-            class="css-117c0kr-StyledIcon e5h2ket0"
+            class="css-6a05hj-icon HvCard-icon"
           />
         </div>
         <div
-          class="MuiCardHeader-root HvCard-Header-root e1xfuyqk0 css-zlagye-MuiCardHeader-root-StyledHeader"
+          class="MuiCardHeader-root css-te5g2l-root HvCard-Header-root css-185gdzj-MuiCardHeader-root"
         >
           <div
             class="MuiCardHeader-content HvCard-Header-content css-1qbkelo-MuiCardHeader-content"
           >
             <span
-              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title HvCard-Header-title css-1qvr50w-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title css-1yl86h7-title HvCard-Header-title css-aqxmxp-title css-1qvr50w-MuiTypography-root"
             >
               Event 4
             </span>
           </div>
         </div>
         <div
-          class="MuiCardContent-root HvCard-Content-content e12hctsi0 css-v8uagb-MuiCardContent-root-StyledContent"
+          class="MuiCardContent-root css-m6635h-content HvCard-Content-content css-46bh2p-MuiCardContent-root"
         >
           Event: 
           Anomaly detection 3
         </div>
         <div
-          class="MuiCardContent-root HvCard-Content-content e12hctsi0 css-v8uagb-MuiCardContent-root-StyledContent"
+          class="MuiCardContent-root css-m6635h-content HvCard-Content-content css-46bh2p-MuiCardContent-root"
         >
           Severity: 
           Minor
         </div>
         <div
-          class="MuiCardContent-root HvCard-Content-content e12hctsi0 css-v8uagb-MuiCardContent-root-StyledContent"
+          class="MuiCardContent-root css-m6635h-content HvCard-Content-content css-46bh2p-MuiCardContent-root"
         >
           Temperature: 
           38
         </div>
       </div>
       <div
-        class="HvIsCardGridElement HvCard-root css-m08axw-StyledRoot e5h2ket3"
+        class="css-4fb8k0-root css-1l5xtfm-HvCard HvIsCardGridElement HvCard-root"
         style="width: 100%;"
       >
         <div
-          class="css-13ob5sy-StyledContainer e5h2ket2"
+          class="css-1kcigpt-semanticContainer HvCard-semanticContainer"
         >
           <div
-            class="HvCard-semanticBar css-zoemfr-StyledBar e5h2ket1"
+            class="css-1vb6mv5-semanticBar css-sfyg8u-HvCard HvCard-semanticBar"
           />
           <div
-            class="css-117c0kr-StyledIcon e5h2ket0"
+            class="css-6a05hj-icon HvCard-icon"
           />
         </div>
         <div
-          class="MuiCardHeader-root HvCard-Header-root e1xfuyqk0 css-zlagye-MuiCardHeader-root-StyledHeader"
+          class="MuiCardHeader-root css-te5g2l-root HvCard-Header-root css-185gdzj-MuiCardHeader-root"
         >
           <div
             class="MuiCardHeader-content HvCard-Header-content css-1qbkelo-MuiCardHeader-content"
           >
             <span
-              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title HvCard-Header-title css-1qvr50w-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title css-1yl86h7-title HvCard-Header-title css-aqxmxp-title css-1qvr50w-MuiTypography-root"
             >
               Event 5
             </span>
           </div>
         </div>
         <div
-          class="MuiCardContent-root HvCard-Content-content e12hctsi0 css-v8uagb-MuiCardContent-root-StyledContent"
+          class="MuiCardContent-root css-m6635h-content HvCard-Content-content css-46bh2p-MuiCardContent-root"
         >
           Event: 
           Anomaly detection 0
         </div>
         <div
-          class="MuiCardContent-root HvCard-Content-content e12hctsi0 css-v8uagb-MuiCardContent-root-StyledContent"
+          class="MuiCardContent-root css-m6635h-content HvCard-Content-content css-46bh2p-MuiCardContent-root"
         >
           Severity: 
           Critical
         </div>
         <div
-          class="MuiCardContent-root HvCard-Content-content e12hctsi0 css-v8uagb-MuiCardContent-root-StyledContent"
+          class="MuiCardContent-root css-m6635h-content HvCard-Content-content css-46bh2p-MuiCardContent-root"
         >
           Temperature: 
           39
         </div>
       </div>
       <div
-        class="HvIsCardGridElement HvCard-root css-m08axw-StyledRoot e5h2ket3"
+        class="css-4fb8k0-root css-1l5xtfm-HvCard HvIsCardGridElement HvCard-root"
         style="width: 100%;"
       >
         <div
-          class="css-13ob5sy-StyledContainer e5h2ket2"
+          class="css-1kcigpt-semanticContainer HvCard-semanticContainer"
         >
           <div
-            class="HvCard-semanticBar css-zoemfr-StyledBar e5h2ket1"
+            class="css-1vb6mv5-semanticBar css-sfyg8u-HvCard HvCard-semanticBar"
           />
           <div
-            class="css-117c0kr-StyledIcon e5h2ket0"
+            class="css-6a05hj-icon HvCard-icon"
           />
         </div>
         <div
-          class="MuiCardHeader-root HvCard-Header-root e1xfuyqk0 css-zlagye-MuiCardHeader-root-StyledHeader"
+          class="MuiCardHeader-root css-te5g2l-root HvCard-Header-root css-185gdzj-MuiCardHeader-root"
         >
           <div
             class="MuiCardHeader-content HvCard-Header-content css-1qbkelo-MuiCardHeader-content"
           >
             <span
-              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title HvCard-Header-title css-1qvr50w-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title css-1yl86h7-title HvCard-Header-title css-aqxmxp-title css-1qvr50w-MuiTypography-root"
             >
               Event 6
             </span>
           </div>
         </div>
         <div
-          class="MuiCardContent-root HvCard-Content-content e12hctsi0 css-v8uagb-MuiCardContent-root-StyledContent"
+          class="MuiCardContent-root css-m6635h-content HvCard-Content-content css-46bh2p-MuiCardContent-root"
         >
           Event: 
           Anomaly detection 1
         </div>
         <div
-          class="MuiCardContent-root HvCard-Content-content e12hctsi0 css-v8uagb-MuiCardContent-root-StyledContent"
+          class="MuiCardContent-root css-m6635h-content HvCard-Content-content css-46bh2p-MuiCardContent-root"
         >
           Severity: 
           Major
         </div>
         <div
-          class="MuiCardContent-root HvCard-Content-content e12hctsi0 css-v8uagb-MuiCardContent-root-StyledContent"
+          class="MuiCardContent-root css-m6635h-content HvCard-Content-content css-46bh2p-MuiCardContent-root"
         >
           Temperature: 
           40
         </div>
       </div>
       <div
-        class="HvIsCardGridElement HvCard-root css-m08axw-StyledRoot e5h2ket3"
+        class="css-4fb8k0-root css-1l5xtfm-HvCard HvIsCardGridElement HvCard-root"
         style="width: 100%;"
       >
         <div
-          class="css-13ob5sy-StyledContainer e5h2ket2"
+          class="css-1kcigpt-semanticContainer HvCard-semanticContainer"
         >
           <div
-            class="HvCard-semanticBar css-zoemfr-StyledBar e5h2ket1"
+            class="css-1vb6mv5-semanticBar css-sfyg8u-HvCard HvCard-semanticBar"
           />
           <div
-            class="css-117c0kr-StyledIcon e5h2ket0"
+            class="css-6a05hj-icon HvCard-icon"
           />
         </div>
         <div
-          class="MuiCardHeader-root HvCard-Header-root e1xfuyqk0 css-zlagye-MuiCardHeader-root-StyledHeader"
+          class="MuiCardHeader-root css-te5g2l-root HvCard-Header-root css-185gdzj-MuiCardHeader-root"
         >
           <div
             class="MuiCardHeader-content HvCard-Header-content css-1qbkelo-MuiCardHeader-content"
           >
             <span
-              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title HvCard-Header-title css-1qvr50w-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title css-1yl86h7-title HvCard-Header-title css-aqxmxp-title css-1qvr50w-MuiTypography-root"
             >
               Event 7
             </span>
           </div>
         </div>
         <div
-          class="MuiCardContent-root HvCard-Content-content e12hctsi0 css-v8uagb-MuiCardContent-root-StyledContent"
+          class="MuiCardContent-root css-m6635h-content HvCard-Content-content css-46bh2p-MuiCardContent-root"
         >
           Event: 
           Anomaly detection 2
         </div>
         <div
-          class="MuiCardContent-root HvCard-Content-content e12hctsi0 css-v8uagb-MuiCardContent-root-StyledContent"
+          class="MuiCardContent-root css-m6635h-content HvCard-Content-content css-46bh2p-MuiCardContent-root"
         >
           Severity: 
           Average
         </div>
         <div
-          class="MuiCardContent-root HvCard-Content-content e12hctsi0 css-v8uagb-MuiCardContent-root-StyledContent"
+          class="MuiCardContent-root css-m6635h-content HvCard-Content-content css-46bh2p-MuiCardContent-root"
         >
           Temperature: 
           41
         </div>
       </div>
       <div
-        class="HvIsCardGridElement HvCard-root css-m08axw-StyledRoot e5h2ket3"
+        class="css-4fb8k0-root css-1l5xtfm-HvCard HvIsCardGridElement HvCard-root"
         style="width: 100%;"
       >
         <div
-          class="css-13ob5sy-StyledContainer e5h2ket2"
+          class="css-1kcigpt-semanticContainer HvCard-semanticContainer"
         >
           <div
-            class="HvCard-semanticBar css-zoemfr-StyledBar e5h2ket1"
+            class="css-1vb6mv5-semanticBar css-sfyg8u-HvCard HvCard-semanticBar"
           />
           <div
-            class="css-117c0kr-StyledIcon e5h2ket0"
+            class="css-6a05hj-icon HvCard-icon"
           />
         </div>
         <div
-          class="MuiCardHeader-root HvCard-Header-root e1xfuyqk0 css-zlagye-MuiCardHeader-root-StyledHeader"
+          class="MuiCardHeader-root css-te5g2l-root HvCard-Header-root css-185gdzj-MuiCardHeader-root"
         >
           <div
             class="MuiCardHeader-content HvCard-Header-content css-1qbkelo-MuiCardHeader-content"
           >
             <span
-              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title HvCard-Header-title css-1qvr50w-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title css-1yl86h7-title HvCard-Header-title css-aqxmxp-title css-1qvr50w-MuiTypography-root"
             >
               Event 8
             </span>
           </div>
         </div>
         <div
-          class="MuiCardContent-root HvCard-Content-content e12hctsi0 css-v8uagb-MuiCardContent-root-StyledContent"
+          class="MuiCardContent-root css-m6635h-content HvCard-Content-content css-46bh2p-MuiCardContent-root"
         >
           Event: 
           Anomaly detection 3
         </div>
         <div
-          class="MuiCardContent-root HvCard-Content-content e12hctsi0 css-v8uagb-MuiCardContent-root-StyledContent"
+          class="MuiCardContent-root css-m6635h-content HvCard-Content-content css-46bh2p-MuiCardContent-root"
         >
           Severity: 
           Minor
         </div>
         <div
-          class="MuiCardContent-root HvCard-Content-content e12hctsi0 css-v8uagb-MuiCardContent-root-StyledContent"
+          class="MuiCardContent-root css-m6635h-content HvCard-Content-content css-46bh2p-MuiCardContent-root"
         >
           Temperature: 
           42
         </div>
       </div>
       <div
-        class="HvIsCardGridElement HvCard-root css-m08axw-StyledRoot e5h2ket3"
+        class="css-4fb8k0-root css-1l5xtfm-HvCard HvIsCardGridElement HvCard-root"
         style="width: 100%;"
       >
         <div
-          class="css-13ob5sy-StyledContainer e5h2ket2"
+          class="css-1kcigpt-semanticContainer HvCard-semanticContainer"
         >
           <div
-            class="HvCard-semanticBar css-zoemfr-StyledBar e5h2ket1"
+            class="css-1vb6mv5-semanticBar css-sfyg8u-HvCard HvCard-semanticBar"
           />
           <div
-            class="css-117c0kr-StyledIcon e5h2ket0"
+            class="css-6a05hj-icon HvCard-icon"
           />
         </div>
         <div
-          class="MuiCardHeader-root HvCard-Header-root e1xfuyqk0 css-zlagye-MuiCardHeader-root-StyledHeader"
+          class="MuiCardHeader-root css-te5g2l-root HvCard-Header-root css-185gdzj-MuiCardHeader-root"
         >
           <div
             class="MuiCardHeader-content HvCard-Header-content css-1qbkelo-MuiCardHeader-content"
           >
             <span
-              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title HvCard-Header-title css-1qvr50w-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title css-1yl86h7-title HvCard-Header-title css-aqxmxp-title css-1qvr50w-MuiTypography-root"
             >
               Event 9
             </span>
           </div>
         </div>
         <div
-          class="MuiCardContent-root HvCard-Content-content e12hctsi0 css-v8uagb-MuiCardContent-root-StyledContent"
+          class="MuiCardContent-root css-m6635h-content HvCard-Content-content css-46bh2p-MuiCardContent-root"
         >
           Event: 
           Anomaly detection 0
         </div>
         <div
-          class="MuiCardContent-root HvCard-Content-content e12hctsi0 css-v8uagb-MuiCardContent-root-StyledContent"
+          class="MuiCardContent-root css-m6635h-content HvCard-Content-content css-46bh2p-MuiCardContent-root"
         >
           Severity: 
           Critical
         </div>
         <div
-          class="MuiCardContent-root HvCard-Content-content e12hctsi0 css-v8uagb-MuiCardContent-root-StyledContent"
+          class="MuiCardContent-root css-m6635h-content HvCard-Content-content css-46bh2p-MuiCardContent-root"
         >
           Temperature: 
           43
         </div>
       </div>
       <div
-        class="HvIsCardGridElement HvCard-root css-m08axw-StyledRoot e5h2ket3"
+        class="css-4fb8k0-root css-1l5xtfm-HvCard HvIsCardGridElement HvCard-root"
         style="width: 100%;"
       >
         <div
-          class="css-13ob5sy-StyledContainer e5h2ket2"
+          class="css-1kcigpt-semanticContainer HvCard-semanticContainer"
         >
           <div
-            class="HvCard-semanticBar css-zoemfr-StyledBar e5h2ket1"
+            class="css-1vb6mv5-semanticBar css-sfyg8u-HvCard HvCard-semanticBar"
           />
           <div
-            class="css-117c0kr-StyledIcon e5h2ket0"
+            class="css-6a05hj-icon HvCard-icon"
           />
         </div>
         <div
-          class="MuiCardHeader-root HvCard-Header-root e1xfuyqk0 css-zlagye-MuiCardHeader-root-StyledHeader"
+          class="MuiCardHeader-root css-te5g2l-root HvCard-Header-root css-185gdzj-MuiCardHeader-root"
         >
           <div
             class="MuiCardHeader-content HvCard-Header-content css-1qbkelo-MuiCardHeader-content"
           >
             <span
-              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title HvCard-Header-title css-1qvr50w-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title css-1yl86h7-title HvCard-Header-title css-aqxmxp-title css-1qvr50w-MuiTypography-root"
             >
               Event 10
             </span>
           </div>
         </div>
         <div
-          class="MuiCardContent-root HvCard-Content-content e12hctsi0 css-v8uagb-MuiCardContent-root-StyledContent"
+          class="MuiCardContent-root css-m6635h-content HvCard-Content-content css-46bh2p-MuiCardContent-root"
         >
           Event: 
           Anomaly detection 1
         </div>
         <div
-          class="MuiCardContent-root HvCard-Content-content e12hctsi0 css-v8uagb-MuiCardContent-root-StyledContent"
+          class="MuiCardContent-root css-m6635h-content HvCard-Content-content css-46bh2p-MuiCardContent-root"
         >
           Severity: 
           Major
         </div>
         <div
-          class="MuiCardContent-root HvCard-Content-content e12hctsi0 css-v8uagb-MuiCardContent-root-StyledContent"
+          class="MuiCardContent-root css-m6635h-content HvCard-Content-content css-46bh2p-MuiCardContent-root"
         >
           Temperature: 
           44
         </div>
       </div>
       <div
-        class="HvIsCardGridElement HvCard-root css-m08axw-StyledRoot e5h2ket3"
+        class="css-4fb8k0-root css-1l5xtfm-HvCard HvIsCardGridElement HvCard-root"
         style="width: 100%;"
       >
         <div
-          class="css-13ob5sy-StyledContainer e5h2ket2"
+          class="css-1kcigpt-semanticContainer HvCard-semanticContainer"
         >
           <div
-            class="HvCard-semanticBar css-zoemfr-StyledBar e5h2ket1"
+            class="css-1vb6mv5-semanticBar css-sfyg8u-HvCard HvCard-semanticBar"
           />
           <div
-            class="css-117c0kr-StyledIcon e5h2ket0"
+            class="css-6a05hj-icon HvCard-icon"
           />
         </div>
         <div
-          class="MuiCardHeader-root HvCard-Header-root e1xfuyqk0 css-zlagye-MuiCardHeader-root-StyledHeader"
+          class="MuiCardHeader-root css-te5g2l-root HvCard-Header-root css-185gdzj-MuiCardHeader-root"
         >
           <div
             class="MuiCardHeader-content HvCard-Header-content css-1qbkelo-MuiCardHeader-content"
           >
             <span
-              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title HvCard-Header-title css-1qvr50w-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title css-1yl86h7-title HvCard-Header-title css-aqxmxp-title css-1qvr50w-MuiTypography-root"
             >
               Event 11
             </span>
           </div>
         </div>
         <div
-          class="MuiCardContent-root HvCard-Content-content e12hctsi0 css-v8uagb-MuiCardContent-root-StyledContent"
+          class="MuiCardContent-root css-m6635h-content HvCard-Content-content css-46bh2p-MuiCardContent-root"
         >
           Event: 
           Anomaly detection 2
         </div>
         <div
-          class="MuiCardContent-root HvCard-Content-content e12hctsi0 css-v8uagb-MuiCardContent-root-StyledContent"
+          class="MuiCardContent-root css-m6635h-content HvCard-Content-content css-46bh2p-MuiCardContent-root"
         >
           Severity: 
           Average
         </div>
         <div
-          class="MuiCardContent-root HvCard-Content-content e12hctsi0 css-v8uagb-MuiCardContent-root-StyledContent"
+          class="MuiCardContent-root css-m6635h-content HvCard-Content-content css-46bh2p-MuiCardContent-root"
         >
           Temperature: 
           45
         </div>
       </div>
       <div
-        class="HvIsCardGridElement HvCard-root css-m08axw-StyledRoot e5h2ket3"
+        class="css-4fb8k0-root css-1l5xtfm-HvCard HvIsCardGridElement HvCard-root"
         style="width: 100%;"
       >
         <div
-          class="css-13ob5sy-StyledContainer e5h2ket2"
+          class="css-1kcigpt-semanticContainer HvCard-semanticContainer"
         >
           <div
-            class="HvCard-semanticBar css-zoemfr-StyledBar e5h2ket1"
+            class="css-1vb6mv5-semanticBar css-sfyg8u-HvCard HvCard-semanticBar"
           />
           <div
-            class="css-117c0kr-StyledIcon e5h2ket0"
+            class="css-6a05hj-icon HvCard-icon"
           />
         </div>
         <div
-          class="MuiCardHeader-root HvCard-Header-root e1xfuyqk0 css-zlagye-MuiCardHeader-root-StyledHeader"
+          class="MuiCardHeader-root css-te5g2l-root HvCard-Header-root css-185gdzj-MuiCardHeader-root"
         >
           <div
             class="MuiCardHeader-content HvCard-Header-content css-1qbkelo-MuiCardHeader-content"
           >
             <span
-              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title HvCard-Header-title css-1qvr50w-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title css-1yl86h7-title HvCard-Header-title css-aqxmxp-title css-1qvr50w-MuiTypography-root"
             >
               Event 12
             </span>
           </div>
         </div>
         <div
-          class="MuiCardContent-root HvCard-Content-content e12hctsi0 css-v8uagb-MuiCardContent-root-StyledContent"
+          class="MuiCardContent-root css-m6635h-content HvCard-Content-content css-46bh2p-MuiCardContent-root"
         >
           Event: 
           Anomaly detection 3
         </div>
         <div
-          class="MuiCardContent-root HvCard-Content-content e12hctsi0 css-v8uagb-MuiCardContent-root-StyledContent"
+          class="MuiCardContent-root css-m6635h-content HvCard-Content-content css-46bh2p-MuiCardContent-root"
         >
           Severity: 
           Minor
         </div>
         <div
-          class="MuiCardContent-root HvCard-Content-content e12hctsi0 css-v8uagb-MuiCardContent-root-StyledContent"
+          class="MuiCardContent-root css-m6635h-content HvCard-Content-content css-46bh2p-MuiCardContent-root"
         >
           Temperature: 
           46
         </div>
       </div>
       <div
-        class="HvIsCardGridElement HvCard-root css-m08axw-StyledRoot e5h2ket3"
+        class="css-4fb8k0-root css-1l5xtfm-HvCard HvIsCardGridElement HvCard-root"
         style="width: 100%;"
       >
         <div
-          class="css-13ob5sy-StyledContainer e5h2ket2"
+          class="css-1kcigpt-semanticContainer HvCard-semanticContainer"
         >
           <div
-            class="HvCard-semanticBar css-zoemfr-StyledBar e5h2ket1"
+            class="css-1vb6mv5-semanticBar css-sfyg8u-HvCard HvCard-semanticBar"
           />
           <div
-            class="css-117c0kr-StyledIcon e5h2ket0"
+            class="css-6a05hj-icon HvCard-icon"
           />
         </div>
         <div
-          class="MuiCardHeader-root HvCard-Header-root e1xfuyqk0 css-zlagye-MuiCardHeader-root-StyledHeader"
+          class="MuiCardHeader-root css-te5g2l-root HvCard-Header-root css-185gdzj-MuiCardHeader-root"
         >
           <div
             class="MuiCardHeader-content HvCard-Header-content css-1qbkelo-MuiCardHeader-content"
           >
             <span
-              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title HvCard-Header-title css-1qvr50w-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title css-1yl86h7-title HvCard-Header-title css-aqxmxp-title css-1qvr50w-MuiTypography-root"
             >
               Event 13
             </span>
           </div>
         </div>
         <div
-          class="MuiCardContent-root HvCard-Content-content e12hctsi0 css-v8uagb-MuiCardContent-root-StyledContent"
+          class="MuiCardContent-root css-m6635h-content HvCard-Content-content css-46bh2p-MuiCardContent-root"
         >
           Event: 
           Anomaly detection 0
         </div>
         <div
-          class="MuiCardContent-root HvCard-Content-content e12hctsi0 css-v8uagb-MuiCardContent-root-StyledContent"
+          class="MuiCardContent-root css-m6635h-content HvCard-Content-content css-46bh2p-MuiCardContent-root"
         >
           Severity: 
           Critical
         </div>
         <div
-          class="MuiCardContent-root HvCard-Content-content e12hctsi0 css-v8uagb-MuiCardContent-root-StyledContent"
+          class="MuiCardContent-root css-m6635h-content HvCard-Content-content css-46bh2p-MuiCardContent-root"
         >
           Temperature: 
           47
         </div>
       </div>
       <div
-        class="HvIsCardGridElement HvCard-root css-m08axw-StyledRoot e5h2ket3"
+        class="css-4fb8k0-root css-1l5xtfm-HvCard HvIsCardGridElement HvCard-root"
         style="width: 100%;"
       >
         <div
-          class="css-13ob5sy-StyledContainer e5h2ket2"
+          class="css-1kcigpt-semanticContainer HvCard-semanticContainer"
         >
           <div
-            class="HvCard-semanticBar css-zoemfr-StyledBar e5h2ket1"
+            class="css-1vb6mv5-semanticBar css-sfyg8u-HvCard HvCard-semanticBar"
           />
           <div
-            class="css-117c0kr-StyledIcon e5h2ket0"
+            class="css-6a05hj-icon HvCard-icon"
           />
         </div>
         <div
-          class="MuiCardHeader-root HvCard-Header-root e1xfuyqk0 css-zlagye-MuiCardHeader-root-StyledHeader"
+          class="MuiCardHeader-root css-te5g2l-root HvCard-Header-root css-185gdzj-MuiCardHeader-root"
         >
           <div
             class="MuiCardHeader-content HvCard-Header-content css-1qbkelo-MuiCardHeader-content"
           >
             <span
-              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title HvCard-Header-title css-1qvr50w-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title css-1yl86h7-title HvCard-Header-title css-aqxmxp-title css-1qvr50w-MuiTypography-root"
             >
               Event 14
             </span>
           </div>
         </div>
         <div
-          class="MuiCardContent-root HvCard-Content-content e12hctsi0 css-v8uagb-MuiCardContent-root-StyledContent"
+          class="MuiCardContent-root css-m6635h-content HvCard-Content-content css-46bh2p-MuiCardContent-root"
         >
           Event: 
           Anomaly detection 1
         </div>
         <div
-          class="MuiCardContent-root HvCard-Content-content e12hctsi0 css-v8uagb-MuiCardContent-root-StyledContent"
+          class="MuiCardContent-root css-m6635h-content HvCard-Content-content css-46bh2p-MuiCardContent-root"
         >
           Severity: 
           Major
         </div>
         <div
-          class="MuiCardContent-root HvCard-Content-content e12hctsi0 css-v8uagb-MuiCardContent-root-StyledContent"
+          class="MuiCardContent-root css-m6635h-content HvCard-Content-content css-46bh2p-MuiCardContent-root"
         >
           Temperature: 
           48
         </div>
       </div>
       <div
-        class="HvIsCardGridElement HvCard-root css-m08axw-StyledRoot e5h2ket3"
+        class="css-4fb8k0-root css-1l5xtfm-HvCard HvIsCardGridElement HvCard-root"
         style="width: 100%;"
       >
         <div
-          class="css-13ob5sy-StyledContainer e5h2ket2"
+          class="css-1kcigpt-semanticContainer HvCard-semanticContainer"
         >
           <div
-            class="HvCard-semanticBar css-zoemfr-StyledBar e5h2ket1"
+            class="css-1vb6mv5-semanticBar css-sfyg8u-HvCard HvCard-semanticBar"
           />
           <div
-            class="css-117c0kr-StyledIcon e5h2ket0"
+            class="css-6a05hj-icon HvCard-icon"
           />
         </div>
         <div
-          class="MuiCardHeader-root HvCard-Header-root e1xfuyqk0 css-zlagye-MuiCardHeader-root-StyledHeader"
+          class="MuiCardHeader-root css-te5g2l-root HvCard-Header-root css-185gdzj-MuiCardHeader-root"
         >
           <div
             class="MuiCardHeader-content HvCard-Header-content css-1qbkelo-MuiCardHeader-content"
           >
             <span
-              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title HvCard-Header-title css-1qvr50w-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title css-1yl86h7-title HvCard-Header-title css-aqxmxp-title css-1qvr50w-MuiTypography-root"
             >
               Event 15
             </span>
           </div>
         </div>
         <div
-          class="MuiCardContent-root HvCard-Content-content e12hctsi0 css-v8uagb-MuiCardContent-root-StyledContent"
+          class="MuiCardContent-root css-m6635h-content HvCard-Content-content css-46bh2p-MuiCardContent-root"
         >
           Event: 
           Anomaly detection 2
         </div>
         <div
-          class="MuiCardContent-root HvCard-Content-content e12hctsi0 css-v8uagb-MuiCardContent-root-StyledContent"
+          class="MuiCardContent-root css-m6635h-content HvCard-Content-content css-46bh2p-MuiCardContent-root"
         >
           Severity: 
           Average
         </div>
         <div
-          class="MuiCardContent-root HvCard-Content-content e12hctsi0 css-v8uagb-MuiCardContent-root-StyledContent"
+          class="MuiCardContent-root css-m6635h-content HvCard-Content-content css-46bh2p-MuiCardContent-root"
         >
           Temperature: 
           49

--- a/packages/core/src/components/Controls/controlClasses.ts
+++ b/packages/core/src/components/Controls/controlClasses.ts
@@ -1,0 +1,14 @@
+import { getClasses } from "utils";
+
+export type HvControlsClasses = {
+  root: string;
+  section: string;
+  rightSection: string;
+  leftSection: string;
+};
+
+const classKeys: string[] = ["root", "section", "rightSection", "leftSection"];
+
+const controlsClasses = getClasses<HvControlsClasses>(classKeys, "HvControls");
+
+export default controlsClasses;

--- a/packages/core/src/components/Controls/index.ts
+++ b/packages/core/src/components/Controls/index.ts
@@ -1,19 +1,5 @@
-import { getClasses } from "utils";
-
-export type HvControlsClasses = {
-  root: string;
-  section: string;
-  rightSection: string;
-  leftSection: string;
-};
-
-const classKeys: string[] = ["root", "section", "rightSection", "leftSection"];
-
-export const controlsClasses = getClasses<HvControlsClasses>(
-  classKeys,
-  "HvControls"
-);
-
+export { default as controlsClasses } from "./controlClasses";
+export * from "./controlClasses";
 export * from "./Controls";
 export * from "./LeftControl";
 export * from "./RightControl";

--- a/packages/core/src/components/Dialog/Actions/Actions.tsx
+++ b/packages/core/src/components/Dialog/Actions/Actions.tsx
@@ -4,7 +4,7 @@ import { HvBaseProps } from "../../../types";
 import { StyledActions } from "./Actions.styles";
 import dialogActionClasses, { HvDialogActionClasses } from "./actionsClasses";
 
-export type HvActionsProps = MuiDialogActionsProps &
+export type HvActionsProps = Omit<MuiDialogActionsProps, "classes"> &
   HvBaseProps & {
     /** Set the dialog to fullscreen mode. */
     fullscreen?: boolean;

--- a/packages/core/src/components/Dialog/Content/Content.styles.tsx
+++ b/packages/core/src/components/Dialog/Content/Content.styles.tsx
@@ -1,10 +1,7 @@
 import styled from "@emotion/styled";
 import { theme } from "@hitachivantara/uikit-styles";
-import DialogContent from "@mui/material/DialogContent";
 import { HvTypography } from "components";
 import { transientOptions } from "utils/transientOptions";
-
-export const StyledContent = styled(DialogContent)({});
 
 export const StyledTypography = styled(
   HvTypography,

--- a/packages/core/src/components/Dialog/Content/Content.tsx
+++ b/packages/core/src/components/Dialog/Content/Content.tsx
@@ -1,10 +1,12 @@
-import { DialogContentProps as MuiDialogContentProps } from "@mui/material/DialogContent";
+import MuiDialogContent, {
+  DialogContentProps as MuiDialogContentProps,
+} from "@mui/material/DialogContent";
 import clsx from "clsx";
 import { HvBaseProps } from "../../../types";
-import { StyledContent, StyledTypography } from "./Content.styles";
+import { StyledTypography } from "./Content.styles";
 import dialogContentClasses, { HvDialogContentClasses } from "./contentClasses";
 
-export type HvContentProps = MuiDialogContentProps &
+export type HvContentProps = Omit<MuiDialogContentProps, "classes"> &
   HvBaseProps & {
     /** Content should be indented in relationship to the Dialog title. */
     indentContent?: boolean;
@@ -19,8 +21,14 @@ export const HvContent = ({
 }: HvContentProps) => {
   return (
     <StyledTypography
-      component={StyledContent}
-      className={clsx(className, dialogContentClasses.root, classes?.root)}
+      component={MuiDialogContent}
+      className={clsx(
+        className,
+        dialogContentClasses.root,
+        classes?.root,
+        !!indentContent &&
+          clsx(dialogContentClasses.textContent, classes?.textContent)
+      )}
       $indentContent={indentContent}
     >
       {children}

--- a/packages/core/src/components/Dialog/Content/contentClasses.ts
+++ b/packages/core/src/components/Dialog/Content/contentClasses.ts
@@ -2,9 +2,10 @@ import { getClasses } from "utils";
 
 export type HvDialogContentClasses = {
   root?: string;
+  textContent?: string;
 };
 
-const classKeys: string[] = ["root"];
+const classKeys: string[] = ["root", "textContent"];
 
 const dialogContentClasses = getClasses<HvDialogContentClasses>(
   classKeys,

--- a/packages/core/src/components/Dialog/Dialog.styles.tsx
+++ b/packages/core/src/components/Dialog/Dialog.styles.tsx
@@ -1,16 +1,12 @@
 import styled from "@emotion/styled";
-import Backdrop from "@mui/material/Backdrop";
-import Dialog from "@mui/material/Dialog";
-import Paper from "@mui/material/Paper";
+import { Paper as MuiPaper, Backdrop as MuiBackdrop } from "@mui/material";
 import { theme } from "@hitachivantara/uikit-styles";
 import { transientOptions } from "utils/transientOptions";
 import fade from "utils/hexToRgbA";
 import { HvButton } from "components";
 
-export const StyledDialog = styled(Dialog)({});
-
 export const StyledPaper = styled(
-  Paper,
+  MuiPaper,
   transientOptions
 )(({ $fullscreen }: { $fullscreen: boolean }) => ({
   color: theme.colors.acce1,
@@ -32,7 +28,7 @@ export const StyledPaper = styled(
 }));
 
 export const StyledBackdrop = styled(
-  Backdrop,
+  MuiBackdrop,
   transientOptions
 )(({ $backColor }: { $backColor: string }) => ({
   background: fade($backColor, 0.8),

--- a/packages/core/src/components/Dialog/Title/Title.tsx
+++ b/packages/core/src/components/Dialog/Title/Title.tsx
@@ -1,7 +1,7 @@
 import { DialogTitleProps as MuiDialogTitleProps } from "@mui/material/DialogTitle";
 import clsx from "clsx";
 import { HvTypography } from "components";
-import { HvBaseProps, HvExtraProps } from "../../../types";
+import { HvBaseProps } from "../../../types";
 import { iconVariant } from "utils";
 import {
   StyledTitle,
@@ -9,6 +9,8 @@ import {
   StyledTextWithIcon,
 } from "./Title.styles";
 import dialogTitleClasses, { HvDialogTitleClasses } from "./titleClasses";
+import { useContext } from "react";
+import { HvThemeContext } from "providers";
 
 export type HvDialogTitleVariant =
   | "success"
@@ -17,7 +19,7 @@ export type HvDialogTitleVariant =
   | "info"
   | "default";
 
-export type HvTitleProps = Omit<MuiDialogTitleProps, "variant"> &
+export type HvTitleProps = Omit<MuiDialogTitleProps, "variant" | "classes"> &
   HvBaseProps & {
     /** Variant of the Dialog. */
     variant?: HvDialogTitleVariant;
@@ -26,7 +28,7 @@ export type HvTitleProps = Omit<MuiDialogTitleProps, "variant"> &
     /** Custom icon to replace the variant default. */
     customIcon?: React.ReactNode;
     classes?: HvDialogTitleClasses;
-  } & HvExtraProps;
+  };
 
 export const HvTitle = ({
   classes,
@@ -37,9 +39,12 @@ export const HvTitle = ({
   customIcon = null,
   ...others
 }: HvTitleProps) => {
+  const { activeTheme } = useContext(HvThemeContext);
+
   const isString = typeof children === "string";
-  const { fullscreen } = others;
-  delete others.fullscreen;
+
+  const { fullscreen } = others as any;
+  delete (others as any).fullscreen;
 
   const icon = customIcon || (showIcon && iconVariant(variant, "", ""));
 
@@ -49,19 +54,32 @@ export const HvTitle = ({
         dialogTitleClasses.root,
         classes?.root,
         className,
-        fullscreen
-          ? clsx(dialogTitleClasses.fullscreen, classes?.fullscreen)
-          : ""
+        fullscreen && clsx(dialogTitleClasses.fullscreen, classes?.fullscreen)
       )}
       $fullscreen={fullscreen}
       {...others}
     >
-      <StyledMessageContainer>
+      <StyledMessageContainer
+        className={clsx(
+          dialogTitleClasses.messageContainer,
+          classes?.messageContainer
+        )}
+      >
         {icon}
-
-        <StyledTextWithIcon $hasIcon={!!icon}>
+        <StyledTextWithIcon
+          className={
+            !!icon
+              ? clsx(dialogTitleClasses.textWithIcon, classes?.textWithIcon)
+              : undefined
+          }
+          $hasIcon={!!icon}
+        >
           {!isString && children}
-          {isString && <HvTypography variant="title4">{children}</HvTypography>}
+          {isString && (
+            <HvTypography variant={activeTheme?.dialog.titleVariant}>
+              {children}
+            </HvTypography>
+          )}
         </StyledTextWithIcon>
       </StyledMessageContainer>
     </StyledTitle>

--- a/packages/core/src/components/Dialog/Title/titleClasses.ts
+++ b/packages/core/src/components/Dialog/Title/titleClasses.ts
@@ -3,9 +3,16 @@ import { getClasses } from "utils";
 export type HvDialogTitleClasses = {
   root?: string;
   fullscreen?: string;
+  messageContainer?: string;
+  textWithIcon?: string;
 };
 
-const classKeys: string[] = ["root", "fullscreen"];
+const classKeys: string[] = [
+  "root",
+  "fullscreen",
+  "messageContainer",
+  "textWithIcon",
+];
 
 const dialogTitleClasses = getClasses<HvDialogTitleClasses>(
   classKeys,

--- a/packages/core/src/components/Dialog/dialogClasses.ts
+++ b/packages/core/src/components/Dialog/dialogClasses.ts
@@ -4,9 +4,17 @@ export type HvDialogClasses = {
   root?: string;
   closeButton?: string;
   fullscreen?: string;
+  background?: string;
+  paper?: string;
 };
 
-const classKeys: string[] = ["root", "closeButton", "fullscreen"];
+const classKeys: string[] = [
+  "root",
+  "closeButton",
+  "fullscreen",
+  "background",
+  "paper",
+];
 
 const dialogClasses = getClasses<HvDialogClasses>(classKeys, "HvDialog");
 

--- a/packages/core/src/components/DotPagination/DotPagination.tsx
+++ b/packages/core/src/components/DotPagination/DotPagination.tsx
@@ -11,7 +11,7 @@ import {
 } from "./DotPagination.styles";
 import { cloneElement } from "react";
 
-export type HvDotPaginationProps = HvRadioGroupProps & {
+export type HvDotPaginationProps = Omit<HvRadioGroupProps, "classes"> & {
   /**
    * Icon to override the default one used for the unselected state.
    *

--- a/packages/core/src/components/Dropdown/Dropdown.tsx
+++ b/packages/core/src/components/Dropdown/Dropdown.tsx
@@ -506,7 +506,7 @@ export const HvDropdown = (props: HvDropdownProps) => {
       disabled={disabled}
       readOnly={readOnly}
       required={required}
-      className={clsx(dropdownClasses.root, className, classes?.root)}
+      className={clsx(className, dropdownClasses.root, classes?.root)}
       $selectionDisabled={disabled}
       {...others}
     >

--- a/packages/core/src/components/EmptyState/EmptyState.styles.tsx
+++ b/packages/core/src/components/EmptyState/EmptyState.styles.tsx
@@ -42,8 +42,6 @@ export const StyledContainer = styled(
   })
 );
 
-export const StyledIconContainer = styled("div")({});
-
 export const StyledTextContainer = styled(
   "div",
   transientOptions
@@ -64,33 +62,12 @@ export const StyledTextContainer = styled(
 export const StyledTypography = styled(
   HvTypography,
   transientOptions
-)(
-  ({
-    $type,
-    $breakpoints,
-  }: {
-    $type: string;
-    $breakpoints: MuiBreakpoints;
-  }) => ({
-    ...($type === "title" && {
-      marginTop: 4,
-      marginBottom: theme.space.xs,
-    }),
-    ...($type === "text" && {
-      background: "transparent",
-      maxWidth: "510px",
-      overflow: "hidden",
-      fontFamily: theme.fontFamily.body,
-      [$breakpoints.up("sm")]: {
-        marginLeft: theme.space.xs,
-      },
-      "& a": {
-        color: theme.colors.acce2,
-        textDecoration: "none",
-      },
-    }),
-    ...($type === "action" && {
-      marginTop: theme.space.xs,
-    }),
-  })
-);
+)(({ $type }: { $type: "title" | "message" | "action" }) => ({
+  ...($type === "title" && {
+    marginTop: theme.emptyState.titleMarginTop,
+    marginBottom: theme.space.sm,
+  }),
+  ...($type === "action" && {
+    marginTop: theme.space.sm,
+  }),
+}));

--- a/packages/core/src/components/EmptyState/EmptyState.tsx
+++ b/packages/core/src/components/EmptyState/EmptyState.tsx
@@ -1,15 +1,16 @@
 import { useTheme } from "@mui/material/styles";
 import clsx from "clsx";
-import React from "react";
+import React, { useContext } from "react";
 import { HvBaseProps } from "../../types";
 import emptyStateClasses, { HvEmptyStateClasses } from "./emptyStateClasses";
 import {
   StyledContainer,
-  StyledIconContainer,
   StyledRoot,
   StyledTextContainer,
   StyledTypography,
 } from "./EmptyState.styles";
+import { HvTypographyProps } from "components";
+import { HvThemeContext } from "index";
 
 export type HvEmptyStateProps = HvBaseProps<HTMLDivElement, { title }> & {
   /** Icon to be presented. */
@@ -28,16 +29,18 @@ export type HvEmptyStateProps = HvBaseProps<HTMLDivElement, { title }> & {
  * Empty states communicate that there’s no information, data or values to display in a given context.
  */
 export const HvEmptyState = (props: HvEmptyStateProps) => {
+  const { activeTheme } = useContext(HvThemeContext);
+
   const muiTheme = useTheme();
 
-  const renderNode = (node, className, type, variant) =>
+  const renderNode = (
+    type: "action" | "message" | "title",
+    variant?: HvTypographyProps["variant"],
+    node?: string | React.ReactNode,
+    className?: string
+  ) =>
     node && (
-      <StyledTypography
-        $breakpoints={muiTheme.breakpoints}
-        $type={type}
-        variant={variant}
-        className={className}
-      >
+      <StyledTypography $type={type} variant={variant} className={className}>
         {node}
       </StyledTypography>
     );
@@ -50,17 +53,26 @@ export const HvEmptyState = (props: HvEmptyStateProps) => {
       {...others}
     >
       <StyledContainer
+        className={clsx(
+          emptyStateClasses.container,
+          classes?.container,
+          !!(message && !(title || action)) &&
+            clsx(
+              emptyStateClasses.containerMessageOnly,
+              classes?.containerMessageOnly
+            )
+        )}
         $breakpoints={muiTheme.breakpoints}
         $messageOnly={!!(message && !(title || action))}
       >
-        <StyledIconContainer
+        <div
           className={clsx(
             emptyStateClasses.iconContainer,
             classes?.iconContainer
           )}
         >
           {icon}
-        </StyledIconContainer>
+        </div>
         <StyledTextContainer
           $breakpoints={muiTheme.breakpoints}
           className={clsx(
@@ -69,22 +81,22 @@ export const HvEmptyState = (props: HvEmptyStateProps) => {
           )}
         >
           {renderNode(
-            title,
-            clsx(emptyStateClasses.titleContainer, classes?.titleContainer),
             "title",
-            "title4"
+            activeTheme?.emptyState.titleVariant,
+            title,
+            clsx(emptyStateClasses.titleContainer, classes?.titleContainer)
           )}
           {renderNode(
-            message,
-            clsx(emptyStateClasses.messageContainer, classes?.messageContainer),
             "message",
-            "body"
+            "body",
+            message,
+            clsx(emptyStateClasses.messageContainer, classes?.messageContainer)
           )}
           {renderNode(
-            action,
-            clsx(emptyStateClasses.actionContainer, classes?.actionContainer),
             "action",
-            "body"
+            "body",
+            action,
+            clsx(emptyStateClasses.actionContainer, classes?.actionContainer)
           )}
         </StyledTextContainer>
       </StyledContainer>

--- a/packages/core/src/components/FileUploader/Preview/Preview.tsx
+++ b/packages/core/src/components/FileUploader/Preview/Preview.tsx
@@ -10,7 +10,10 @@ import {
   StyledPreviewIcon,
 } from "./Preview.styles";
 
-export type HvFileUploaderPreviewProps = Omit<HvButtonProps, "children"> & {
+export type HvFileUploaderPreviewProps = Omit<
+  HvButtonProps,
+  "children" | "classes"
+> & {
   /**
    * Content that represents the preview of an uploaded file.
    */
@@ -38,6 +41,7 @@ export type HvFileUploaderPreviewProps = Omit<HvButtonProps, "children"> & {
  * of the button (when clickable) and the detection of image unloading.
  */
 export const HvFileUploaderPreview = ({
+  className,
   children,
   classes,
   disableOverlay = false,
@@ -56,6 +60,7 @@ export const HvFileUploaderPreview = ({
       <StyledButton
         icon
         className={clsx(
+          className,
           classes?.previewButton,
           fileUploaderPreviewClasses.previewButton
         )}

--- a/packages/core/src/components/Focus/Focus.tsx
+++ b/packages/core/src/components/Focus/Focus.tsx
@@ -95,7 +95,7 @@ export const HvFocus = ({
     const focuses = rootRef?.current
       ? Array.from(
           rootRef.current.getElementsByClassName(
-            filterClass || focusClasses.root || "root"
+            filterClass || focusClasses.root || classes?.root || "root"
           )
         )
       : [];
@@ -115,7 +115,9 @@ export const HvFocus = ({
   const setSelectedTabIndex = () => {
     const focuses = getFocuses();
     const firstSelected = focuses.find((focus) =>
-      focus.classList.contains(focusClasses.selected || "selected")
+      focus.classList.contains(
+        focusClasses.selected || classes?.selected || "selected"
+      )
     );
 
     if (!firstSelected) return;
@@ -172,6 +174,9 @@ export const HvFocus = ({
   const addFocusClass = (evt) => {
     if (!useFalseFocus) {
       evt.currentTarget.classList.add(focusClasses.focused);
+      if (classes?.focused) {
+        evt.currentTarget.classList.add(classes.focused);
+      }
       // add global class HvIsFocused as a marker
       // not to be styled directly, only as helper in specific css queries
       evt.currentTarget.classList.add("HvIsFocused");
@@ -186,6 +191,9 @@ export const HvFocus = ({
       getFocuses().forEach((element) => {
         if (focusClasses.focused) {
           element.classList.remove(focusClasses.focused);
+        }
+        if (classes?.focused) {
+          element.classList.remove(classes.focused);
         }
         // remove the global class HvIsFocused
         element.classList.remove("HvIsFocused");

--- a/packages/core/src/components/Footer/Footer.tsx
+++ b/packages/core/src/components/Footer/Footer.tsx
@@ -45,7 +45,10 @@ export const HvFooter = (props: HvFooterProps) => {
       >
         {name}
       </StyledName>
-      <StyledRightContainer $breakpoints={muiTheme.breakpoints}>
+      <StyledRightContainer
+        className={clsx(footerClasses.rightContainer, classes?.rightContainer)}
+        $breakpoints={muiTheme.breakpoints}
+      >
         <StyledCopyright
           $breakpoints={muiTheme.breakpoints}
           className={clsx(footerClasses.copyright, classes?.copyright)}

--- a/packages/core/src/components/Footer/footerClasses.ts
+++ b/packages/core/src/components/Footer/footerClasses.ts
@@ -5,9 +5,16 @@ export type HvFooterClasses = {
   name?: string;
   copyright?: string;
   separator?: string;
+  rightContainer?: string;
 };
 
-const classKeys: string[] = ["root", "name", "copyright", "separator"];
+const classKeys: string[] = [
+  "root",
+  "name",
+  "copyright",
+  "separator",
+  "rightContainer",
+];
 
 const footerClasses = getClasses<HvFooterClasses>(classKeys, "HvFooter");
 

--- a/packages/core/src/components/GlobalActions/GlobalActions.tsx
+++ b/packages/core/src/components/GlobalActions/GlobalActions.tsx
@@ -12,6 +12,8 @@ import {
 import globalActionsClasses, {
   HvGlobalActionsClasses,
 } from "./globalActionsClasses";
+import { useContext } from "react";
+import { HvThemeContext } from "providers";
 
 export type HvGlobalActionsVariant = "global" | "section";
 
@@ -52,7 +54,10 @@ export const HvGlobalActions = ({
   position: positionProp,
   ...others
 }: HvGlobalActionsProps) => {
+  const { activeTheme } = useContext(HvThemeContext);
+
   const muiTheme = useTheme();
+
   const headingLevelToApply = headingLevel || (variant === "global" ? 1 : 2);
 
   const backButtonRenderer = () => {
@@ -110,7 +115,11 @@ export const HvGlobalActions = ({
           title
         ) : (
           <HvTypography
-            variant={variant === "global" ? "title3" : "title4"}
+            variant={
+              variant === "global"
+                ? "title3"
+                : activeTheme?.globalActions.sectionVariant
+            }
             component={`h${headingLevelToApply}`}
             className={clsx(globalActionsClasses.name, classes?.name)}
           >

--- a/packages/core/src/components/Grid/Grid.tsx
+++ b/packages/core/src/components/Grid/Grid.tsx
@@ -3,6 +3,7 @@ import { isString } from "lodash";
 import { forwardRef } from "react";
 import { useWidth } from "hooks";
 import { HvBaseProps } from "../../types";
+import { HvGridClasses } from "./gridClasses";
 
 const BREAKPOINT_GUTTERS = {
   xs: 2,
@@ -105,6 +106,8 @@ export type HvGridProps = MuiGridProps &
      * Refer to the limitations section of the documentation to better understand the use case.
      */
     zeroMinWidth?: boolean;
+    /** A Jss Object used to override or extend the styles applied to the component. */
+    classes?: HvGridClasses;
   };
 
 /**

--- a/packages/core/src/components/Grid/gridClasses.ts
+++ b/packages/core/src/components/Grid/gridClasses.ts
@@ -1,0 +1,77 @@
+import { getClasses } from "utils";
+
+export type HvGridClasses = {
+  root?: string;
+  container?: string;
+  item?: string;
+  zeroMinWidth?: string;
+  "direction-xs-column"?: string;
+  "direction-xs-reverse"?: string;
+  "direction-xs-row-reverse"?: string;
+  "wrap-xs-nowrap"?: string;
+  "wrap-xs-wrap-reverse"?: string;
+  "spacing-xs-1"?: string;
+  "spacing-xs-2"?: string;
+  "spacing-xs-3"?: string;
+  "spacing-xs-4"?: string;
+  "spacing-xs-5"?: string;
+  "spacing-xs-6"?: string;
+  "spacing-xs-7"?: string;
+  "spacing-xs-8"?: string;
+  "spacing-xs-9"?: string;
+  "spacing-xs-10"?: string;
+  "grid-xs-auto"?: string;
+  "grid-xs-true"?: string;
+  "grid-xs-1"?: string;
+  "grid-xs-2"?: string;
+  "grid-xs-3"?: string;
+  "grid-xs-4"?: string;
+  "grid-xs-5"?: string;
+  "grid-xs-6"?: string;
+  "grid-xs-7"?: string;
+  "grid-xs-8"?: string;
+  "grid-xs-9"?: string;
+  "grid-xs-10"?: string;
+  "grid-xs-11"?: string;
+  "grid-xs-12"?: string;
+};
+
+const classKeys: string[] = [
+  "root",
+  "container",
+  "item",
+  "zeroMinWidth",
+  "direction-xs-column",
+  "direction-xs-reverse",
+  "direction-xs-row-reverse",
+  "wrap-xs-nowrap",
+  "wrap-xs-wrap-reverse",
+  "spacing-xs-1",
+  "spacing-xs-2",
+  "spacing-xs-3",
+  "spacing-xs-4",
+  "spacing-xs-5",
+  "spacing-xs-6",
+  "spacing-xs-7",
+  "spacing-xs-8",
+  "spacing-xs-9",
+  "spacing-xs-10",
+  "grid-xs-auto",
+  "grid-xs-true",
+  "grid-xs-1",
+  "grid-xs-2",
+  "grid-xs-3",
+  "grid-xs-4",
+  "grid-xs-5",
+  "grid-xs-6",
+  "grid-xs-7",
+  "grid-xs-8",
+  "grid-xs-9",
+  "grid-xs-10",
+  "grid-xs-11",
+  "grid-xs-12",
+];
+
+const gridClasses = getClasses<HvGridClasses>(classKeys, "HvGrid");
+
+export default gridClasses;

--- a/packages/core/src/components/Grid/index.ts
+++ b/packages/core/src/components/Grid/index.ts
@@ -1,1 +1,3 @@
+export { default as gridClasses } from "./gridClasses";
+export * from "./gridClasses";
 export * from "./Grid";

--- a/packages/core/src/components/Header/Brand/Brand.tsx
+++ b/packages/core/src/components/Header/Brand/Brand.tsx
@@ -13,13 +13,24 @@ export type HvBrandProps = HvBaseProps & {
 /**
  * Header component is used to render a header bar with logo and brand name, navigation and actions.
  */
-export const HvBrand = ({ classes, logo, name, className }: HvBrandProps) => {
+export const HvBrand = ({
+  classes,
+  logo,
+  name,
+  className,
+  ...others
+}: HvBrandProps) => {
   return (
     <BrandRoot
       className={clsx(classes?.root, headerBrandClasses.root, className)}
+      {...others}
     >
       {logo}
-      {logo && name && <BrandSeparator />}
+      {logo && name && (
+        <BrandSeparator
+          className={clsx(classes?.separator, headerBrandClasses.separator)}
+        />
+      )}
       {name && <HvTypography variant="label">{name}</HvTypography>}
     </BrandRoot>
   );

--- a/packages/core/src/components/Header/Brand/brandClasses.ts
+++ b/packages/core/src/components/Header/Brand/brandClasses.ts
@@ -2,9 +2,10 @@ import { getClasses } from "utils";
 
 export type HvHeaderBrandClasses = {
   root?: string;
+  separator?: string;
 };
 
-const classKeys: string[] = ["root"];
+const classKeys: string[] = ["root", "separator"];
 
 const headerBrandClasses = getClasses<HvHeaderBrandClasses>(
   classKeys,

--- a/packages/core/src/components/Header/Header.styles.tsx
+++ b/packages/core/src/components/Header/Header.styles.tsx
@@ -30,7 +30,7 @@ export const StyledAppBar = styled(
   ...($position === "sticky" && { position: "sticky" }),
 }));
 
-export const HeaderRoot = styled("div")({
+export const StyledHeaderRoot = styled("div")({
   display: "flex",
   alignItems: "center",
   width: "100%",

--- a/packages/core/src/components/Header/Header.tsx
+++ b/packages/core/src/components/Header/Header.tsx
@@ -1,5 +1,7 @@
+import clsx from "clsx";
 import { HvBaseProps } from "../../types";
-import { HeaderRoot, StyledAppBar } from "./Header.styles";
+import { StyledHeaderRoot, StyledAppBar } from "./Header.styles";
+import headerClasses, { HvHeaderClasses } from "./headerClasses";
 
 export type HvHeaderPosition =
   | "fixed"
@@ -11,16 +13,31 @@ export type HvHeaderPosition =
 export type HvHeaderProps = HvBaseProps & {
   /** The position of the header bar */
   position?: HvHeaderPosition;
+  /** A Jss Object used to override or extend the styles applied to the component. */
+  classes?: HvHeaderClasses;
 };
 
 /**
  * Header component is used to render a header bar with logo and brand name, navigation and actions.
  */
 export const HvHeader = (props: HvHeaderProps) => {
-  const { children, position = "fixed" } = props;
+  const { className, classes, children, position = "fixed", ...others } = props;
+
   return (
-    <StyledAppBar $position={position}>
-      <HeaderRoot>{children}</HeaderRoot>
+    <StyledAppBar
+      className={clsx(
+        className,
+        classes?.root,
+        headerClasses.root,
+        classes?.backgroundColor,
+        headerClasses.backgroundColor
+      )}
+      $position={position}
+      {...others}
+    >
+      <StyledHeaderRoot className={clsx(classes?.header, headerClasses.header)}>
+        {children}
+      </StyledHeaderRoot>
     </StyledAppBar>
   );
 };

--- a/packages/core/src/components/Header/Navigation/Navigation.tsx
+++ b/packages/core/src/components/Header/Navigation/Navigation.tsx
@@ -31,7 +31,8 @@ export const HvNavigation = ({
   selected,
   onClick,
   className,
-  classes = {},
+  classes,
+  ...others
 }: HvNavigationProps) => {
   const selectionPath = useSelectionPath(data, selected);
 
@@ -48,6 +49,7 @@ export const HvNavigation = ({
             headerNavigationClasses.root,
             classes?.root
           )}
+          {...others}
         >
           <HvMenuBar data={data} type="menubar" onClick={handleClick} />
         </StyledNav>

--- a/packages/core/src/components/Header/headerClasses.ts
+++ b/packages/core/src/components/Header/headerClasses.ts
@@ -1,0 +1,13 @@
+import { getClasses } from "utils";
+
+export type HvHeaderClasses = {
+  root?: string;
+  header?: string;
+  backgroundColor?: string;
+};
+
+const classKeys: string[] = ["root", "header", "backgroundColor"];
+
+const headerClasses = getClasses<HvHeaderClasses>(classKeys, "HvHeader");
+
+export default headerClasses;

--- a/packages/core/src/components/Header/index.ts
+++ b/packages/core/src/components/Header/index.ts
@@ -1,3 +1,5 @@
+export { default as headerClasses } from "./headerClasses";
+export * from "./headerClasses";
 export * from "./Header";
 export * from "./Actions";
 export * from "./Brand";

--- a/packages/core/src/components/List/List.tsx
+++ b/packages/core/src/components/List/List.tsx
@@ -295,7 +295,10 @@ export const HvList = ({
         disabled={item.disabled || undefined}
         className={clsx(listClasses.item, classes?.item)}
         classes={{
-          selected: clsx(listClasses.itemSelector, classes?.itemSelector),
+          selected:
+            useSelector || multiSelect
+              ? clsx(listClasses.itemSelector, classes?.itemSelector)
+              : undefined,
         }}
         selected={multiSelect || selected ? selected : undefined}
         onClick={(evt) => handleSelect(evt, item)}

--- a/packages/core/src/components/ListContainer/ListItem/ListItem.tsx
+++ b/packages/core/src/components/ListContainer/ListItem/ListItem.tsx
@@ -137,7 +137,7 @@ export const HvListItem = ({
           listItemClasses.startAdornment,
           disabled && listItemClasses.disabled
         ),
-        classes?.startAdornment
+        clsx(classes?.startAdornment, disabled && classes?.disabled)
       ),
     [classes?.startAdornment, disabled, handleOnClick, selected, startAdornment]
   );
@@ -149,7 +149,7 @@ export const HvListItem = ({
           listItemClasses.endAdornment,
           disabled && listItemClasses.disabled
         ),
-        classes?.endAdornment
+        clsx(classes?.endAdornment, disabled && classes?.disabled)
       ),
     [classes?.endAdornment, endAdornment]
   );

--- a/packages/core/src/components/Loading/Loading.tsx
+++ b/packages/core/src/components/Loading/Loading.tsx
@@ -58,7 +58,8 @@ export const HvLoading = (props: HvLoadingProps) => {
             className={clsx(
               loadingClasses.loadingBar,
               classes?.loadingBar,
-              variant
+              loadingClasses[variant],
+              classes?.[variant]
             )}
             $variant={variant}
           ></StyledBar>

--- a/packages/core/src/components/Loading/loadingClasses.ts
+++ b/packages/core/src/components/Loading/loadingClasses.ts
@@ -8,6 +8,10 @@ export type HvLoadingClasses = {
   overlay?: string;
   blur?: string;
   hidden?: string;
+  small?: string;
+  regular?: string;
+  smallColor?: string;
+  regularColor?: string;
 };
 
 const classKeys: string[] = [
@@ -18,6 +22,10 @@ const classKeys: string[] = [
   "overlay",
   "blur",
   "hidden",
+  "small",
+  "regular",
+  "smallColor",
+  "regularColor",
 ];
 
 const loadingClasses = getClasses<HvLoadingClasses>(classKeys, "HvLoading");

--- a/packages/core/src/components/Login/Login.tsx
+++ b/packages/core/src/components/Login/Login.tsx
@@ -1,6 +1,7 @@
 import clsx from "clsx";
 import { HvBaseProps } from "../../types";
 import { StyledFormContainer, StyledRoot } from "./Login.styles";
+import loginClasses, { HvLoginClasses } from "./loginClasses";
 
 export type HvLoginProps = HvBaseProps & {
   /**
@@ -10,16 +11,7 @@ export type HvLoginProps = HvBaseProps & {
   /**
    * Class names to be applied.
    */
-  classes?: {
-    /**
-     * Styles applied to root.
-     */
-    root?: string;
-    /**
-     * Styles applied to the form container.
-     */
-    formContainer?: string;
-  };
+  classes?: HvLoginClasses;
 };
 
 /**
@@ -36,13 +28,15 @@ export const HvLogin = ({
   return (
     <StyledRoot
       id={id}
-      className={clsx(className, classes?.root)}
+      className={clsx(className, loginClasses.root, classes?.root)}
       style={{
         backgroundImage: background && `url(${background})`,
       }}
       {...others}
     >
-      <StyledFormContainer className={classes?.formContainer}>
+      <StyledFormContainer
+        className={clsx(loginClasses.formContainer, classes?.formContainer)}
+      >
         {children}
       </StyledFormContainer>
     </StyledRoot>

--- a/packages/core/src/components/Login/__snapshots__/Login.test.tsx.snap
+++ b/packages/core/src/components/Login/__snapshots__/Login.test.tsx.snap
@@ -3,10 +3,10 @@
 exports[`Login > should render correctly 1`] = `
 <div>
   <div
-    class=" css-v05m5x-StyledRoot e1jay62a1"
+    class="HvLogin-root css-v05m5x-StyledRoot e1jay62a1"
   >
     <div
-      class="css-81tf3b-StyledFormContainer e1jay62a0"
+      class="HvLogin-formContainer css-81tf3b-StyledFormContainer e1jay62a0"
     >
       Login content
     </div>

--- a/packages/core/src/components/Login/index.ts
+++ b/packages/core/src/components/Login/index.ts
@@ -1,1 +1,3 @@
+export { default as loginClasses } from "./loginClasses";
+export * from "./loginClasses";
 export * from "./Login";

--- a/packages/core/src/components/Login/loginClasses.ts
+++ b/packages/core/src/components/Login/loginClasses.ts
@@ -1,0 +1,12 @@
+import { getClasses } from "utils";
+
+export type HvLoginClasses = {
+  root?: string;
+  formContainer?: string;
+};
+
+const classKeys: string[] = ["root", "formContainer"];
+
+const loginClasses = getClasses<HvLoginClasses>(classKeys, "HvLogin");
+
+export default loginClasses;

--- a/packages/core/src/components/MultiButton/MultiButton.tsx
+++ b/packages/core/src/components/MultiButton/MultiButton.tsx
@@ -27,19 +27,34 @@ export const HvMultiButton = ({
 }: HvMultiButtonProps) => {
   return (
     <StyledRoot
-      className={clsx(className, multiButtonClasses.root, classes?.root)}
+      className={clsx(
+        className,
+        multiButtonClasses.root,
+        classes?.root,
+        vertical && clsx(classes?.vertical, multiButtonClasses.vertical)
+      )}
       $vertical={vertical}
       {...others}
     >
       {React.Children.map(children, (child) => {
         if (React.isValidElement(child)) {
           const childIsSelected = !!child.props.selected;
+
           const btn = cloneElement(child as React.ReactElement, {
             variant,
             disabled: disabled || child.props.disabled,
             "aria-pressed": childIsSelected,
+            className: clsx(
+              child.props.className,
+              multiButtonClasses.button,
+              classes?.button,
+              childIsSelected &&
+                clsx(multiButtonClasses.selected, classes?.selected)
+            ),
           });
+
           const StyledBtn = StyledButton(btn);
+
           return React.createElement(StyledBtn);
         }
       })}

--- a/packages/core/src/components/MultiButton/multiButtonClasses.ts
+++ b/packages/core/src/components/MultiButton/multiButtonClasses.ts
@@ -3,9 +3,11 @@ import { getClasses } from "utils";
 export type HvMultiButtonClasses = {
   root?: string;
   button?: string;
+  vertical?: string;
+  selected?: string;
 };
 
-const classKeys: string[] = ["root", "button"];
+const classKeys: string[] = ["root", "button", "vertical", "selected"];
 
 const multiButtonClasses = getClasses<HvMultiButtonClasses>(
   classKeys,

--- a/packages/core/src/components/ProgressBar/ProgressBar.tsx
+++ b/packages/core/src/components/ProgressBar/ProgressBar.tsx
@@ -60,11 +60,18 @@ export const HvProgressBar = (props: HvProgressBarProps) => {
       aria-valuenow={clampedValue}
       {...others}
     >
-      <StyledProgressContainer>
+      <StyledProgressContainer
+        className={clsx(
+          classes?.progressContainer,
+          progressBarClasses.progressContainer
+        )}
+      >
         <StyledValue
           className={clsx(
             progressBarClasses.progressBarLabel,
-            classes?.progressBarLabel
+            classes?.progressBarLabel,
+            status === "completed" &&
+              clsx(progressBarClasses.progressDone, classes?.progressDone)
           )}
           variant="caption2"
           style={{ width: `${clampedValue}%` }}
@@ -72,12 +79,21 @@ export const HvProgressBar = (props: HvProgressBarProps) => {
         >
           {`${clampedValue}%`}
         </StyledValue>
-        <StyledProgressBarContainer>
+        <StyledProgressBarContainer
+          className={clsx(
+            classes?.progressBarContainer,
+            progressBarClasses.progressBarContainer
+          )}
+        >
           <StyledProgressBar
             style={{ width: `${clampedValue}%` }}
             className={clsx(
               progressBarClasses.progressBar,
-              classes?.progressBar
+              classes?.progressBar,
+              status === "completed" &&
+                clsx(classes?.progressDone, progressBarClasses.progressDone),
+              status === "error" &&
+                clsx(classes?.progressError, progressBarClasses.progressError)
             )}
             $status={status}
           />

--- a/packages/core/src/components/ProgressBar/__snapshots__/ProgressBar.test.tsx.snap
+++ b/packages/core/src/components/ProgressBar/__snapshots__/ProgressBar.test.tsx.snap
@@ -10,7 +10,7 @@ exports[`ProgressBar > should render correctly 1`] = `
     role="progressbar"
   >
     <div
-      class="css-1ezqlcy-StyledProgressContainer e1eucrrc3"
+      class="HvProgressBar-progressContainer css-1ezqlcy-StyledProgressContainer e1eucrrc3"
     >
       <p
         class="HvProgressBar-progressBarLabel e1eucrrc2 HvTypography-root HvTypography-caption2 css-1cy1v53-getStyledComponent-StyledValue e1tnpalo0"
@@ -19,7 +19,7 @@ exports[`ProgressBar > should render correctly 1`] = `
         0%
       </p>
       <div
-        class="css-1baf8nw-StyledProgressBarContainer e1eucrrc1"
+        class="HvProgressBar-progressBarContainer css-1baf8nw-StyledProgressBarContainer e1eucrrc1"
       >
         <div
           class="HvProgressBar-progressBar css-1q42i5j-StyledProgressBar e1eucrrc0"

--- a/packages/core/src/components/ProgressBar/progressBarClasses.ts
+++ b/packages/core/src/components/ProgressBar/progressBarClasses.ts
@@ -5,6 +5,10 @@ export type HvProgressBarClasses = {
   progress?: string;
   progressBar?: string;
   progressBarLabel?: string;
+  progressContainer?: string;
+  progressDone?: string;
+  progressBarContainer?: string;
+  progressError?: string;
 };
 
 const classKeys: string[] = [
@@ -12,6 +16,10 @@ const classKeys: string[] = [
   "progress",
   "progressBar",
   "progressBarLabel",
+  "progressContainer",
+  "progressDone",
+  "progressBarContainer",
+  "progressError",
 ];
 
 const progressBarClasses = getClasses<HvProgressBarClasses>(

--- a/packages/core/src/components/Radio/Radio.tsx
+++ b/packages/core/src/components/Radio/Radio.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useState } from "react";
 import clsx from "clsx";
 import { RadioProps as MuiRadioProps } from "@mui/material";
-import { HvBaseProps, HvExtraProps } from "../../types";
+import { HvBaseProps } from "../../types";
 import { HvWarningText } from "components";
 import { isInvalid } from "../Forms/FormElement/validationStates";
 import { useControlled, useUniqueId } from "hooks";
@@ -16,7 +16,7 @@ import radioClasses, { HvRadioClasses } from "./radioClasses";
 
 export type HvRadioStatus = "standBy" | "valid" | "invalid";
 
-export type HvRadioProps = Omit<MuiRadioProps, "onChange"> &
+export type HvRadioProps = Omit<MuiRadioProps, "onChange" | "classes"> &
   HvBaseProps<HTMLInputElement, { onChange }> & {
     /**
      * Class names to be applied.
@@ -132,7 +132,7 @@ export type HvRadioProps = Omit<MuiRadioProps, "onChange"> &
      * @ignore
      */
     onBlur?: (event: React.FocusEvent<any>) => void;
-  } & HvExtraProps;
+  };
 
 /**
  * A Radio Button is a mechanism that allows user to select just an option from a group of options.

--- a/packages/core/src/components/SimpleGrid/SimpleGrid.tsx
+++ b/packages/core/src/components/SimpleGrid/SimpleGrid.tsx
@@ -1,25 +1,6 @@
 import { HvBaseProps } from "index";
 import { StyledContainer } from "./SimpleGrid.styles";
 
-export const HvSimpleGrid = ({
-  children,
-  breakpoints,
-  spacing = "sm",
-  cols,
-  ...others
-}: HvSimpleGridProps) => {
-  return (
-    <StyledContainer
-      spacing={spacing}
-      cols={cols}
-      breakpoints={breakpoints}
-      {...others}
-    >
-      {children}
-    </StyledContainer>
-  );
-};
-
 export type Spacing = "sm" | "md" | "lg" | "xl";
 
 export type Breakpoint = {
@@ -52,4 +33,23 @@ export type HvSimpleGridProps = HvBaseProps & {
    * Number of how many columns the content will be displayed
    */
   cols?: number;
+};
+
+export const HvSimpleGrid = ({
+  children,
+  breakpoints,
+  spacing = "sm",
+  cols,
+  ...others
+}: HvSimpleGridProps) => {
+  return (
+    <StyledContainer
+      spacing={spacing}
+      cols={cols}
+      breakpoints={breakpoints}
+      {...others}
+    >
+      {children}
+    </StyledContainer>
+  );
 };

--- a/packages/core/src/components/Snackbar/Snackbar.tsx
+++ b/packages/core/src/components/Snackbar/Snackbar.tsx
@@ -6,17 +6,18 @@ import {
 } from "@mui/material/Snackbar";
 import { HvBaseProps } from "../../types";
 import { StyledSnackbar } from "./Snackbar.styles";
-import { HvSnackbarClasses } from "./snackbarClasses";
+import { HvSnackbarClasses, snackbarClasses } from "./snackbarClasses";
 import { capitalize } from "lodash";
 import { SyntheticEvent } from "react";
 import HvSnackBarContentWrapper from "./SnackbarContentWrapper";
 import { setId } from "utils";
 import { HvActionGeneric } from "components";
 import { HvSnackbarContentWrapperProps } from "./SnackbarContentWrapper/SnackbarContentWrapper";
+import clsx from "clsx";
 
 export type HvSnackbarVariant = "default" | "success" | "warning" | "error";
 
-export type HvSnackbarProps = Omit<MuiSnackbarProps, "action"> &
+export type HvSnackbarProps = Omit<MuiSnackbarProps, "action" | "classes"> &
   HvBaseProps & {
     /** If true, Snackbar is open. */
     open?: boolean;
@@ -120,7 +121,33 @@ export const HvSnackbar = ({
       style={
         anchorOriginOffset[`anchorOrigin${capitalize(anchorOrigin.vertical)}`]
       }
-      classes={classes}
+      classes={{
+        root: clsx(classes?.root, snackbarClasses.root),
+        anchorOriginBottomCenter: clsx(
+          classes?.anchorOriginBottomCenter,
+          snackbarClasses.anchorOriginBottomCenter
+        ),
+        anchorOriginBottomLeft: clsx(
+          classes?.anchorOriginBottomLeft,
+          snackbarClasses.anchorOriginBottomLeft
+        ),
+        anchorOriginBottomRight: clsx(
+          classes?.anchorOriginBottomRight,
+          snackbarClasses.anchorOriginBottomRight
+        ),
+        anchorOriginTopCenter: clsx(
+          classes?.anchorOriginTopCenter,
+          snackbarClasses.anchorOriginTopCenter
+        ),
+        anchorOriginTopLeft: clsx(
+          classes?.anchorOriginTopLeft,
+          snackbarClasses.anchorOriginTopLeft
+        ),
+        anchorOriginTopRight: clsx(
+          classes?.anchorOriginTopRight,
+          snackbarClasses.anchorOriginTopRight
+        ),
+      }}
       className={className}
       id={id}
       anchorOrigin={anchorOrigin}

--- a/packages/core/src/components/Snackbar/SnackbarContentWrapper/SnackbarContentWrapper.tsx
+++ b/packages/core/src/components/Snackbar/SnackbarContentWrapper/SnackbarContentWrapper.tsx
@@ -18,7 +18,7 @@ import { HvActionsGeneric, HvActionGeneric } from "components";
 
 export type HvSnackbarContentWrapperProps = Omit<
   MuiSnackbarContentProps,
-  "variant" | "action"
+  "variant" | "action" | "classes"
 > &
   HvBaseProps & {
     /** The message to display. */
@@ -47,6 +47,7 @@ const HvSnackbarContentWrapper = forwardRef<
 >(
   (
     {
+      className,
       id,
       classes,
       label,
@@ -74,6 +75,11 @@ const HvSnackbarContentWrapper = forwardRef<
             classes?.message
           ),
         }}
+        className={clsx(
+          className,
+          classes?.[variant],
+          snackbarContentWrapperClasses[variant]
+        )}
         message={
           <StyledMessageSpan
             id={setId(id, "message")}

--- a/packages/core/src/components/Snackbar/SnackbarContentWrapper/snackbarContentWrapperClasses.ts
+++ b/packages/core/src/components/Snackbar/SnackbarContentWrapper/snackbarContentWrapperClasses.ts
@@ -7,6 +7,10 @@ export type HvSnackbarContentWrapperClasses = {
   iconVariant?: string;
   messageText?: string;
   action?: string;
+  default?: string;
+  success?: string;
+  warning?: string;
+  error?: string;
 };
 
 const classKeys: string[] = [
@@ -16,6 +20,10 @@ const classKeys: string[] = [
   "iconVariant",
   "messageText",
   "action",
+  "default",
+  "success",
+  "warning",
+  "error",
 ];
 
 const snackbarContentWrapperClasses =

--- a/packages/core/src/components/Snackbar/snackbarClasses.ts
+++ b/packages/core/src/components/Snackbar/snackbarClasses.ts
@@ -1,6 +1,7 @@
 import { getClasses } from "utils";
 
 export type HvSnackbarClasses = {
+  root?: string;
   /** Styles applied to the component when define as top right.  */
   anchorOriginTopRight?: string;
   /** Styles applied to the component when define as top left.  */
@@ -16,6 +17,7 @@ export type HvSnackbarClasses = {
 };
 
 const classKeys: string[] = [
+  "root",
   "anchorOriginTopRight",
   "anchorOriginTopLeft",
   "anchorOriginTopCenter",

--- a/packages/core/src/components/Stack/Stack.tsx
+++ b/packages/core/src/components/Stack/Stack.tsx
@@ -101,7 +101,7 @@ export const HvStack = ({
   return (
     <StyledRoot
       ref={containerRef}
-      className={clsx(stackClasses.root, classes?.root)}
+      className={clsx(className, stackClasses.root, classes?.root)}
       $direction={processedDirection}
       $breakpoint={spacing}
       {...others}

--- a/packages/core/src/components/Switch/Switch.tsx
+++ b/packages/core/src/components/Switch/Switch.tsx
@@ -15,10 +15,10 @@ import {
   StyledLabel,
   StyledSwitchContainer,
 } from "./Switch.styles";
-import { HvBaseProps, HvExtraProps } from "../../types";
+import { HvBaseProps } from "../../types";
 import switchClasses, { HvSwitchClasses } from "./switchClasses";
 
-export type HvSwitchProps = Omit<MuiSwitchProps, "onChange"> &
+export type HvSwitchProps = Omit<MuiSwitchProps, "onChange" | "classes"> &
   HvBaseProps<HTMLInputElement, { onChange }> & {
     /**
      * Class names to be applied.
@@ -119,7 +119,7 @@ export type HvSwitchProps = Omit<MuiSwitchProps, "onChange"> &
      * Properties passed on to the input element.
      */
     inputProps?: React.InputHTMLAttributes<HTMLInputElement>;
-  } & HvExtraProps;
+  };
 
 /**
  * A Switch is <b>binary</b> and work as a digital on/off button.

--- a/packages/core/src/components/Table/TableBody/TableBody.tsx
+++ b/packages/core/src/components/Table/TableBody/TableBody.tsx
@@ -101,7 +101,6 @@ export const HvTableBody = forwardRef<HTMLElement, HvTableBodyProps>(
                 }
               })
             : children}
-          {/* {children} */}
         </TableBody>
       </TableSectionContext.Provider>
     );

--- a/packages/core/src/components/Table/TableCell/TableCell.tsx
+++ b/packages/core/src/components/Table/TableCell/TableCell.tsx
@@ -307,8 +307,7 @@ export const HvTableCell = forwardRef<HTMLElement, HvTableCellProps>(
           tableCellClasses.root,
           classes?.root,
           tableCellClasses[type],
-          classes && classes[type],
-
+          classes?.[type],
           align !== "inherit" &&
             clsx(
               tableCellClasses[`align${capitalize(align)}`],
@@ -319,14 +318,12 @@ export const HvTableCell = forwardRef<HTMLElement, HvTableCellProps>(
               tableCellClasses[`variant${capitalize(variant)}`],
               classes?.[`variant${capitalize(variant)}`]
             ),
-
           tableContext.variant === "listrow" &&
             clsx(tableCellClasses.variantList, classes?.variantList),
           tableContext.variant === "listrow" &&
             type !== "body" &&
             clsx(tableCellClasses.variantListHead, classes?.variantListHead),
           sorted && clsx(tableCellClasses.sorted, classes?.sorted),
-
           stickyColumn &&
             clsx(tableCellClasses.stickyColumn, classes?.stickyColumn),
           stickyColumnMostLeft &&
@@ -339,7 +336,6 @@ export const HvTableCell = forwardRef<HTMLElement, HvTableCellProps>(
               tableCellClasses.stickyColumnLeastRight,
               classes?.stickyColumnLeastRight
             ),
-
           groupColumnMostLeft &&
             clsx(
               tableCellClasses.groupColumnMostLeft,
@@ -350,7 +346,6 @@ export const HvTableCell = forwardRef<HTMLElement, HvTableCellProps>(
               tableCellClasses.groupColumnMostRight,
               classes?.groupColumnMostRight
             ),
-
           resizable && clsx(tableCellClasses.resizable, classes?.resizable),
           resizing && clsx(tableCellClasses.resizing, classes?.resizing)
         )}

--- a/packages/core/src/components/Table/TableHead/TableHead.tsx
+++ b/packages/core/src/components/Table/TableHead/TableHead.tsx
@@ -59,7 +59,13 @@ export const HvTableHead = forwardRef<HTMLElement, HvTableHeadProps>(
     return (
       <TableSectionContext.Provider value={tableSectionContext}>
         <TableHead
-          className={clsx(tableHeadClasses.root, classes?.root, className)}
+          className={clsx(
+            tableHeadClasses.root,
+            classes?.root,
+            className,
+            stickyHeader &&
+              clsx(classes?.stickyHeader, tableHeadClasses.stickyHeader)
+          )}
           ref={externalRef}
           role={Component === defaultComponent ? null : "rowgroup"}
           $stickyHeader={stickyHeader}

--- a/packages/core/src/components/Table/TableHeader/TableHeader.tsx
+++ b/packages/core/src/components/Table/TableHeader/TableHeader.tsx
@@ -336,8 +336,7 @@ export const HvTableHeader = forwardRef<HTMLElement, HvTableHeaderProps>(
           tableHeaderClasses.root,
           classes?.root,
           tableHeaderClasses[type],
-          classes && classes[type],
-
+          classes?.[type],
           groupColumnMostLeft &&
             clsx(
               tableHeaderClasses.groupColumnMostLeft,

--- a/packages/core/src/components/Table/TableRow/TableRow.tsx
+++ b/packages/core/src/components/Table/TableRow/TableRow.tsx
@@ -167,8 +167,7 @@ export const HvTableRow = forwardRef<HTMLElement, HvTableRowProps>(
           tableRowClasses.root,
           classes?.root,
           tableRowClasses[type],
-          classes && classes[type],
-
+          classes?.[type],
           hover && clsx(tableRowClasses.hover, classes?.hover),
           selected && clsx(tableRowClasses.selected, classes?.selected),
           expanded && clsx(tableRowClasses.expanded, classes?.expanded),

--- a/packages/core/src/components/Tag/Tag.tsx
+++ b/packages/core/src/components/Tag/Tag.tsx
@@ -10,7 +10,7 @@ import { HvThemeContext } from "../../providers";
 import { HvButtonProps } from "../Button";
 import tagClasses, { HvTagClasses } from "./tagClasses";
 
-export type HvTagProps = Omit<MuiChipProps, "color"> &
+export type HvTagProps = Omit<MuiChipProps, "color" | "classes"> &
   HvBaseProps<HTMLDivElement, { children }> & {
     /** Inline styles to be applied to the root element. */
     style?: CSSProperties;
@@ -93,7 +93,7 @@ export const HvTag = ({
         classes={{
           startIcon: clsx(tagClasses.tagButton, classes?.tagButton),
           focusVisible: clsx(tagClasses.focusVisible, classes?.focusVisible),
-          primary: clsx(tagClasses.primaryButton, classes?.primaryButton),
+          root: clsx(tagClasses.button, classes?.button),
         }}
         aria-label={deleteButtonArialLabel}
         tabIndex={tabIndex}

--- a/packages/core/src/components/Tag/tagClasses.ts
+++ b/packages/core/src/components/Tag/tagClasses.ts
@@ -4,7 +4,7 @@ export type HvTagClasses = {
   root?: string;
   tagButton?: string;
   focusVisible?: string;
-  primaryButton?: string;
+  button?: string;
   label?: string;
   chipRoot?: string;
   categorical?: string;
@@ -20,7 +20,7 @@ const classKeys: string[] = [
   "root",
   "tagButton",
   "focusVisible",
-  "primaryButton",
+  "button",
   "label",
   "chipRoot",
   "categorical",

--- a/packages/core/src/components/TagsInput/TagsInput.tsx
+++ b/packages/core/src/components/TagsInput/TagsInput.tsx
@@ -651,8 +651,11 @@ export const HvTagsInput = ({
                 clsx(
                   tagsInputClasses.singleLine,
                   classes?.singleLine,
-                  value.length === 0 && tagsInputClasses.tagInputRootEmpty,
-                  value.length === 0 && classes?.tagInputRootEmpty
+                  value.length === 0 &&
+                    clsx(
+                      tagsInputClasses.tagInputRootEmpty,
+                      classes?.tagInputRootEmpty
+                    )
                 )
             )}
             classes={{

--- a/packages/core/src/components/Tooltip/Tooltip.tsx
+++ b/packages/core/src/components/Tooltip/Tooltip.tsx
@@ -24,7 +24,7 @@ export type HvTooltipPlacementType =
   | "top-start"
   | "top";
 
-export type HvTooltipProps = MuiTooltipProps & {
+export type HvTooltipProps = Omit<MuiTooltipProps, "classes"> & {
   /**
    * Class names to be applied.
    */

--- a/packages/core/src/providers/ThemeProvider.tsx
+++ b/packages/core/src/providers/ThemeProvider.tsx
@@ -71,7 +71,7 @@ export const HvThemeProvider = ({
     setElementAttrs(
       pTheme.selected,
       pTheme.selectedMode,
-      pTheme.bgColor,
+      pTheme.styles,
       rootId
     );
   };

--- a/packages/core/src/utils/theme.ts
+++ b/packages/core/src/utils/theme.ts
@@ -3,6 +3,7 @@ import {
   HvBaseTheme,
   colors,
   HvThemeColorModeStructure,
+  HvParsedThemeStyles,
 } from "@hitachivantara/uikit-styles";
 import { HvThemeCustomizationProps, HvCustomizedTheme } from "types/theme";
 
@@ -12,7 +13,7 @@ import { HvThemeCustomizationProps, HvCustomizedTheme } from "types/theme";
 export const setElementAttrs = (
   theme: string,
   mode: string,
-  bgColor: string,
+  styles: HvParsedThemeStyles,
   elementId?: string
 ) => {
   const element =
@@ -20,7 +21,16 @@ export const setElementAttrs = (
 
   element.setAttribute(`data-theme`, theme);
   element.setAttribute(`data-color-mode`, mode);
-  element.style.backgroundColor = bgColor;
+
+  // Set default properties for all components to inherit
+  element.style.backgroundColor = styles.bgColor;
+  element.style.colorScheme = styles.colorScheme;
+  element.style.accentColor = styles.accentColor;
+  element.style.color = styles.color;
+  element.style.fontSize = styles.fontSize;
+  element.style.fontWeight = styles.fontWeight;
+  element.style.lineHeight = styles.lineHeight;
+  element.style.letterSpacing = styles.letterSpacing;
 };
 
 /**

--- a/packages/styles/src/CssBaseline.ts
+++ b/packages/styles/src/CssBaseline.ts
@@ -1,4 +1,16 @@
 export const CssBaseline = {
+  /* Clears input's clear and reveal buttons from IE */
+  "input[type=search]::-ms-clear": { display: "none", width: 0, height: 0 },
+  "input[type=search]::-ms-reveal": { display: "none", width: 0, height: 0 },
+
+  /* Clears input's clear button from Chrome */
+  'input[type="search"]::-webkit-search-decoration': { display: "none" },
+  'input[type="search"]::-webkit-search-cancel-button': { display: "none" },
+  'input[type="search"]::-webkit-search-results-button': { display: "none" },
+  'input[type="search"]::-webkit-search-results-decoration': {
+    display: "none",
+  },
+
   "*, ::before, ::after": {
     boxSizing: "border-box",
     borderWidth: "0",

--- a/packages/styles/src/theme.ts
+++ b/packages/styles/src/theme.ts
@@ -55,6 +55,9 @@ const componentsSpec: DeepString<HvThemeComponents> = {
     outline: "string",
     borderRadius: "string",
     hoverColor: "string",
+    titleVariant: "string",
+    subheaderVariant: "string",
+    subheaderColor: "string",
   },
   tab: {
     padding: "string",
@@ -69,6 +72,7 @@ const componentsSpec: DeepString<HvThemeComponents> = {
   dialog: {
     borderRadius: "string",
     margin: "string",
+    titleVariant: "string",
   },
   baseCheckBox: {
     hoverColor: "string",
@@ -217,6 +221,13 @@ const componentsSpec: DeepString<HvThemeComponents> = {
     rowHoverColor: "string",
     rowHoverBorderColor: "string",
   },
+  globalActions: {
+    sectionVariant: "string",
+  },
+  emptyState: {
+    titleVariant: "string",
+    titleMarginTop: "string",
+  },
 };
 
 const typographyProps: DeepString<HvTypographyProps> = {
@@ -254,6 +265,7 @@ const typographySpec: DeepString<HvThemeTypography> = {
 const themeVars: HvThemeVars = mapCSSVars({
   ...tokens,
   colors: {
+    type: "light",
     backgroundColor: tokens.colors.light.atmo2,
     ...tokens.colors.common,
     ...tokens.colors.light,

--- a/packages/styles/src/themes/ds3.ts
+++ b/packages/styles/src/themes/ds3.ts
@@ -8,7 +8,7 @@ const ds3 = makeTheme((theme: HvTheme) => ({
     modes: {
       dawn: {
         type: "light",
-        backgroundColor: colors.light.atmo2,
+        backgroundColor: "#F0F0F0",
         ...colors.common,
         ...colors.light,
         acce2h: "#477DBD",
@@ -235,6 +235,9 @@ const ds3 = makeTheme((theme: HvTheme) => ({
     outline: "none",
     borderRadius: "0px",
     hoverColor: theme.colors.atmo4,
+    titleVariant: "title3",
+    subheaderVariant: "body",
+    subheaderColor: theme.colors.acce1,
   },
   tab: {
     padding: "0 20px",
@@ -249,6 +252,7 @@ const ds3 = makeTheme((theme: HvTheme) => ({
   dialog: {
     borderRadius: "0",
     margin: "100px",
+    titleVariant: "xxsTitle",
   },
   baseCheckBox: {
     hoverColor: theme.colors.atmo3,
@@ -396,6 +400,13 @@ const ds3 = makeTheme((theme: HvTheme) => ({
     rowExpandBackgroundColor: theme.colors.atmo1,
     rowHoverColor: theme.colors.atmo1,
     rowHoverBorderColor: theme.colors.atmo4,
+  },
+  globalActions: {
+    sectionVariant: "sectionTitle",
+  },
+  emptyState: {
+    titleVariant: "xxsTitle",
+    titleMarginTop: "2px",
   },
 }));
 

--- a/packages/styles/src/themes/ds5.ts
+++ b/packages/styles/src/themes/ds5.ts
@@ -177,6 +177,9 @@ const ds5 = makeTheme((theme: HvTheme) => ({
     outline: `1px solid ${theme.colors.atmo4}`,
     borderRadius: "0px 0px 6px 6px",
     hoverColor: theme.colors.acce2,
+    titleVariant: "label",
+    subheaderVariant: "caption1",
+    subheaderColor: theme.colors.acce4,
   },
   tab: {
     padding: "0 16px",
@@ -191,6 +194,7 @@ const ds5 = makeTheme((theme: HvTheme) => ({
   dialog: {
     borderRadius: "6px",
     margin: "80px",
+    titleVariant: "title4",
   },
   baseCheckBox: {
     hoverColor: theme.colors.acce2s,
@@ -338,6 +342,13 @@ const ds5 = makeTheme((theme: HvTheme) => ({
     rowExpandBackgroundColor: theme.colors.atmo2,
     rowHoverColor: theme.colors.acce2s,
     rowHoverBorderColor: theme.colors.atmo4,
+  },
+  globalActions: {
+    sectionVariant: "title4",
+  },
+  emptyState: {
+    titleVariant: "title4",
+    titleMarginTop: "4px",
   },
 }));
 

--- a/packages/styles/src/types.ts
+++ b/packages/styles/src/types.ts
@@ -7,6 +7,7 @@ import { CSSProperties } from "react";
 const flattenTokens = {
   ...tokens,
   colors: {
+    type: "light",
     backgroundColor: tokens.colors.light.atmo2,
     ...tokens.colors.common,
     ...tokens.colors.light,
@@ -61,6 +62,9 @@ export type HvThemeComponents = {
     outline: string;
     borderRadius: string;
     hoverColor: string;
+    titleVariant: keyof HvThemeTypography["typography"];
+    subheaderVariant: keyof HvThemeTypography["typography"];
+    subheaderColor: string;
   };
   tab: {
     padding: string;
@@ -75,6 +79,7 @@ export type HvThemeComponents = {
   dialog: {
     borderRadius: string;
     margin: string;
+    titleVariant: keyof HvThemeTypography["typography"];
   };
   baseCheckBox: {
     hoverColor: string;
@@ -222,6 +227,13 @@ export type HvThemeComponents = {
     rowExpandBackgroundColor: string;
     rowHoverColor: string;
     rowHoverBorderColor: string;
+  };
+  globalActions: {
+    sectionVariant: keyof HvThemeTypography["typography"];
+  };
+  emptyState: {
+    titleVariant: keyof HvThemeTypography["typography"];
+    titleMarginTop: string;
   };
 };
 

--- a/packages/styles/src/utils.ts
+++ b/packages/styles/src/utils.ts
@@ -54,6 +54,17 @@ export const mergeTheme = (...objects) => {
   }, {});
 };
 
+export type HvParsedThemeStyles = {
+  bgColor: string;
+  color: string;
+  accentColor: string;
+  colorScheme: string;
+  fontSize: string;
+  letterSpacing: string;
+  lineHeight: string;
+  fontWeight: string;
+};
+
 export const parseTheme = (
   themes: { [key: string]: HvThemeStructure },
   theme: string = "",
@@ -62,7 +73,7 @@ export const parseTheme = (
   selected: string;
   selectedMode: string;
   colorModes: string[];
-  bgColor: string;
+  styles: HvParsedThemeStyles;
 } => {
   const names = Object.keys(themes);
   const selected = names.includes(theme) ? theme : names[0];
@@ -70,9 +81,27 @@ export const parseTheme = (
   const selectedMode = colorModes.includes(colorMode)
     ? colorMode
     : colorModes[0];
-  const bgColor = themes[selected].colors.modes[selectedMode].backgroundColor;
+  const styles: HvParsedThemeStyles = {
+    bgColor: themes[selected].colors.modes[selectedMode].backgroundColor,
+    color: themes[selected].colors.modes[selectedMode].acce1,
+    accentColor: themes[selected].colors.modes[selectedMode].acce1,
+    colorScheme: themes[selected].colors.modes[selectedMode].type,
+    fontSize: (typeof themes[selected].typography.body.fontSize === "string"
+      ? themes[selected].typography.body.fontSize
+      : `${themes[selected].typography.body.fontSize}px`) as string,
+    letterSpacing: (typeof themes[selected].typography.body.letterSpacing ===
+    "string"
+      ? themes[selected].typography.body.letterSpacing
+      : `${themes[selected].typography.body.letterSpacing}px`) as string,
+    lineHeight: (typeof themes[selected].typography.body.lineHeight === "string"
+      ? themes[selected].typography.body.lineHeight
+      : `${themes[selected].typography.body.lineHeight}px`) as string,
+    fontWeight: (typeof themes[selected].typography.body.fontWeight === "string"
+      ? themes[selected].typography.body.fontWeight
+      : `${themes[selected].typography.body.fontWeight}`) as string,
+  };
 
-  return { selected, selectedMode, colorModes, bgColor };
+  return { selected, selectedMode, colorModes, styles };
 };
 
 export const getThemesList = (themes: object) => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -126,6 +126,7 @@ importers:
   packages/core:
     specifiers:
       '@emotion/cache': ^11.10.5
+      '@emotion/css': ^11.10.6
       '@emotion/react': ^11.10.5
       '@emotion/styled': ^11.10.5
       '@hitachivantara/uikit-react-icons': workspace:*
@@ -150,6 +151,7 @@ importers:
       tsc-alias: ^1.8.2
     dependencies:
       '@emotion/cache': 11.10.5
+      '@emotion/css': 11.10.6
       '@emotion/react': 11.10.6_pmekkgnqduwlme35zpnqhenc34
       '@emotion/styled': 11.10.6_oouaibmszuch5k64ms7uxp2aia
       '@hitachivantara/uikit-react-icons': link:../icons
@@ -2294,6 +2296,16 @@ packages:
   /@emotion/core/11.0.0:
     resolution: {integrity: sha512-w4sE3AmHmyG6RDKf6mIbtHpgJUSJ2uGvPQb8VXFL7hFjMPibE8IiehG8cMX3Ztm4svfCQV6KqusQbeIOkurBcA==}
     dev: true
+
+  /@emotion/css/11.10.6:
+    resolution: {integrity: sha512-88Sr+3heKAKpj9PCqq5A1hAmAkoSIvwEq1O2TwDij7fUtsJpdkV4jMTISSTouFeRvsGvXIpuSuDQ4C1YdfNGXw==}
+    dependencies:
+      '@emotion/babel-plugin': 11.10.6
+      '@emotion/cache': 11.10.5
+      '@emotion/serialize': 1.1.1
+      '@emotion/sheet': 1.2.1
+      '@emotion/utils': 1.2.0
+    dev: false
 
   /@emotion/hash/0.9.0:
     resolution: {integrity: sha512-14FtKiHhy2QoPIzdTcvh//8OyBlknNs2nXRwIhG904opCby3l+9Xaf/wuPvICBF0rc1ZCNBd3nKe9cd2mecVkQ==}


### PR DESCRIPTION
- Default clear button removed from inputs: missing CSS was added to the CSS baseline;
- `HvExtraProps` removed from components' props because this was enabling users to pass any property to a component without showing an error;
- All components were reviewed in order to add missing classes since some applications may be using these classes to override some styles;
- `HvCard` was reviewed to fix the styling and because some classes were not being overwritten (emotion `css` was used instead of `styled`);
- `classes` prop omitted from MUI props to use the one defined by us;
- Missing default font properties added to the root component. Since the components were not inheriting from the root as before, in some cases the font was not the right color or size (for example, dark font on dark background when the theme was wicked);
- DS3 background color for light mode fixed;
- Typography changes according to the DS for `HvGlobalActions`, `HvEmptyState`, `HvDialog`, and `HvCard` since the wrong typographies were being used.