### PR TITLE
fix(Badge): constrain badge size to specs

### DIFF
--- a/packages/core/src/components/Badge/Badge.styles.tsx
+++ b/packages/core/src/components/Badge/Badge.styles.tsx
@@ -3,10 +3,11 @@ import { theme } from "@hitachivantara/uikit-styles";
 import { CSSProperties } from "react";
 import { transientOptions } from "utils/transientOptions";
 
-const labelBaseStyle = {
+const labelBaseStyle: CSSProperties = {
   ...theme.typography.label,
   padding: "0 5px",
   color: theme.colors.atmo1,
+  lineHeight: "16px",
 };
 
 export const StyledRoot = styled("div")({

--- a/packages/core/src/components/Badge/__snapshots__/Badge.test.tsx.snap
+++ b/packages/core/src/components/Badge/__snapshots__/Badge.test.tsx.snap
@@ -26,7 +26,7 @@ exports[`Badge > should render correctly with custom label 1`] = `
       class=" css-27p99g-StyledContainer e16y1fwq1"
     >
       <div
-        class="HvBadgeClasses-badgePosition HvBadgeClasses-badge HvBadgeClasses-showLabel css-o4zazf-StyledBadge e16y1fwq0"
+        class="HvBadgeClasses-badgePosition HvBadgeClasses-badge HvBadgeClasses-showLabel css-aqzyiy-StyledBadge e16y1fwq0"
       >
         New!
       </div>
@@ -45,7 +45,7 @@ exports[`Badge > should render correctly with custom one-character label 1`] = `
       class=" css-27p99g-StyledContainer e16y1fwq1"
     >
       <div
-        class="HvBadgeClasses-badgePosition HvBadgeClasses-badge HvBadgeClasses-showLabel HvBadgeClasses-badgeOneDigit css-19y3sec-StyledBadge e16y1fwq0"
+        class="HvBadgeClasses-badgePosition HvBadgeClasses-badge HvBadgeClasses-showLabel HvBadgeClasses-badgeOneDigit css-1ig4zil-StyledBadge e16y1fwq0"
       >
         !
       </div>
@@ -64,7 +64,7 @@ exports[`Badge > should render correctly with maxCount 1`] = `
       class=" css-27p99g-StyledContainer e16y1fwq1"
     >
       <div
-        class="HvBadgeClasses-badgePosition HvBadgeClasses-badge HvBadgeClasses-showCount css-1vhimo0-StyledBadge e16y1fwq0"
+        class="HvBadgeClasses-badgePosition HvBadgeClasses-badge HvBadgeClasses-showCount css-19arfk9-StyledBadge e16y1fwq0"
       >
         99+
       </div>
@@ -83,7 +83,7 @@ exports[`Badge > should render correctly with showCount 1`] = `
       class=" css-27p99g-StyledContainer e16y1fwq1"
     >
       <div
-        class="HvBadgeClasses-badgePosition HvBadgeClasses-badge HvBadgeClasses-showCount css-1vhimo0-StyledBadge e16y1fwq0"
+        class="HvBadgeClasses-badgePosition HvBadgeClasses-badge HvBadgeClasses-showCount css-19arfk9-StyledBadge e16y1fwq0"
       >
         12
       </div>
@@ -102,7 +102,7 @@ exports[`Badge > should render correctly with showCount and one-digit count 1`] 
       class=" css-27p99g-StyledContainer e16y1fwq1"
     >
       <div
-        class="HvBadgeClasses-badgePosition HvBadgeClasses-badge HvBadgeClasses-showCount HvBadgeClasses-badgeOneDigit css-1wppqwy-StyledBadge e16y1fwq0"
+        class="HvBadgeClasses-badgePosition HvBadgeClasses-badge HvBadgeClasses-showCount HvBadgeClasses-badgeOneDigit css-5egl5s-StyledBadge e16y1fwq0"
       >
         9
       </div>
@@ -139,7 +139,7 @@ exports[`Badge > should render correctly with svg 1`] = `
       class="HvBadgeClasses-badgeContainer css-1ab0lly-StyledContainer e16y1fwq1"
     >
       <div
-        class="HvBadgeClasses-badgePosition HvBadgeClasses-badge HvBadgeClasses-showCount HvBadgeClasses-badgeIcon css-11ie2j7-StyledBadge e16y1fwq0"
+        class="HvBadgeClasses-badgePosition HvBadgeClasses-badge HvBadgeClasses-showCount HvBadgeClasses-badgeIcon css-k85t9q-StyledBadge e16y1fwq0"
       >
         99+
       </div>
@@ -163,7 +163,7 @@ exports[`Badge > should render correctly with text 1`] = `
       class="HvBadgeClasses-badgeContainer css-1ab0lly-StyledContainer e16y1fwq1"
     >
       <div
-        class="HvBadgeClasses-badgePosition HvBadgeClasses-badge HvBadgeClasses-showCount css-1vhimo0-StyledBadge e16y1fwq0"
+        class="HvBadgeClasses-badgePosition HvBadgeClasses-badge HvBadgeClasses-showCount css-19arfk9-StyledBadge e16y1fwq0"
       >
         99+
       </div>
@@ -182,7 +182,7 @@ exports[`Badge > should render custom label but not count when both are specifie
       class=" css-27p99g-StyledContainer e16y1fwq1"
     >
       <div
-        class="HvBadgeClasses-badgePosition HvBadgeClasses-badge HvBadgeClasses-showLabel css-o4zazf-StyledBadge e16y1fwq0"
+        class="HvBadgeClasses-badgePosition HvBadgeClasses-badge HvBadgeClasses-showLabel css-aqzyiy-StyledBadge e16y1fwq0"
       >
         New!
       </div>

--- a/packages/styles/src/types.ts
+++ b/packages/styles/src/types.ts
@@ -241,12 +241,7 @@ export type HvThemeComponents = {
 // Theme typography
 export type HvTypographyProps = Pick<
   CSSProperties,
-  | "color"
-  | "fontSize"
-  | "letterSpacing"
-  | "lineHeight"
-  | "fontWeight"
-  | "textTransform"
+  "color" | "fontSize" | "letterSpacing" | "lineHeight" | "fontWeight"
 >;
 
 export type HvThemeTypography = {


### PR DESCRIPTION
- also removed `textTransform` from the `TypographyProps` type as it's not used. The only typography variant that uses it is the legacy variant `sectionTitle` and that is setting the `textTransform` itself. 