### PR TITLE
fix: default transparent background color for HvCard

### DIFF
--- a/packages/core/src/providers/ThemeProvider.tsx
+++ b/packages/core/src/providers/ThemeProvider.tsx
@@ -9,7 +9,7 @@ import {
   ThemeProvider as MuiThemeProvider,
 } from "@mui/material/styles";
 import { setElementAttrs } from "utils";
-import { HvCustomizedTheme } from "types/theme";
+import { HvCustomizedTheme } from "../types/theme";
 
 interface HvThemeContextValue {
   themes: (HvBaseTheme | string)[];

--- a/packages/styles/src/themes/ds3.ts
+++ b/packages/styles/src/themes/ds3.ts
@@ -235,7 +235,7 @@ const ds3 = makeTheme((theme: HvTheme) => ({
     outline: "none",
     borderRadius: "0px",
     hoverColor: theme.colors.atmo4,
-    backgroundColor: theme.colors.atmo1,
+    backgroundColor: "transparent",
     titleVariant: "title3",
     subheaderVariant: "body",
     subheaderColor: theme.colors.acce1,

--- a/packages/styles/src/themes/ds5.ts
+++ b/packages/styles/src/themes/ds5.ts
@@ -177,7 +177,7 @@ const ds5 = makeTheme((theme: HvTheme) => ({
     outline: `1px solid ${theme.colors.atmo4}`,
     borderRadius: "0px 0px 6px 6px",
     hoverColor: theme.colors.acce2,
-    backgroundColor: theme.colors.atmo1,
+    backgroundColor: "transparent",
     titleVariant: "label",
     subheaderVariant: "caption1",
     subheaderColor: theme.colors.acce4,


### PR DESCRIPTION
- In the master branch, if no `bgcolor` was provided to the `HvCard`, the card would have a transparent background color. This was fixed in this PR since the applications that are currently using the UI Kit are expecting to have this transparent background color.