### PR TITLE
chore: update types for the Radio component

### DIFF
--- a/packages/core/src/components/Radio/Radio.tsx
+++ b/packages/core/src/components/Radio/Radio.tsx
@@ -3,6 +3,7 @@ import clsx from "clsx";
 import { RadioProps as MuiRadioProps } from "@mui/material";
 import { HvBaseProps } from "../../types";
 import { HvWarningText } from "components";
+import { HvLabelProps } from "../Forms/Label";
 import { isInvalid } from "../Forms/FormElement/validationStates";
 import { useControlled, useUniqueId } from "hooks";
 import { setId } from "utils";
@@ -62,7 +63,7 @@ export type HvRadioProps = Omit<MuiRadioProps, "onChange" | "classes"> &
     /**
      * Properties passed on to the label element.
      */
-    labelProps?: any;
+    labelProps?: HvLabelProps;
     /**
      * Indicates that user input is required on the form element.
      *


### PR DESCRIPTION
I opted to leave the `value` prop typed as `any` because MUI's `Radio` component which we are using also types it as `any`: https://mui.com/material-ui/api/radio/