### PR TITLE
feat: package providing shared React context

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -75,8 +75,8 @@
     "types": "dist/types/index.d.ts",
     "exports": {
       ".": {
-        "require": "dist/cjs/index.cjs",
-        "import": "dist/esm/index.js"
+        "require": "./dist/cjs/index.cjs",
+        "import": "./dist/esm/index.js"
       }
     }
   },

--- a/packages/core/src/hocs/withId.tsx
+++ b/packages/core/src/hocs/withId.tsx
@@ -1,14 +1,18 @@
 import { useState } from "react";
 import hoistNonReactStatics from "hoist-non-react-statics";
 import uniqueId from "lodash/uniqueId";
-import { HvExtraProps } from "types";
+import { HvExtraProps } from "../types";
 import { getComponentName } from "utils";
 
 const pascalToKebab = (string = "") =>
   string.replace(/([a-z0-9])([A-Z])/g, "$1-$2").toLowerCase();
 
+export interface WithIdProps extends HvExtraProps {
+  id?: string;
+}
+
 const withId = (Component) => {
-  const WithId = ({ id, ...others }: { id?: string } & HvExtraProps) => {
+  const WithId = ({ id, ...others }: WithIdProps) => {
     const [internalId] = useState(
       id || uniqueId(`${pascalToKebab(getComponentName(Component))}-`)
     );

--- a/packages/core/src/providers/ThemeProvider.tsx
+++ b/packages/core/src/providers/ThemeProvider.tsx
@@ -1,5 +1,7 @@
-import { createContext, useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { parseTheme, HvThemeStructure } from "@hitachivantara/uikit-styles";
+import { HvThemeContext } from "@hitachivantara/uikit-react-shared";
+import type { HvThemeContextValue } from "@hitachivantara/uikit-react-shared";
 import {
   createTheme,
   ThemeProvider as MuiThemeProvider,
@@ -7,15 +9,8 @@ import {
 import { setElementAttrs } from "utils";
 import { HvTheme } from "../types/theme";
 
-export interface HvThemeContextValue {
-  themes: string[];
-  colorModes: string[];
-  activeTheme?: HvTheme | HvThemeStructure;
-  selectedTheme: string;
-  selectedMode: string;
-  changeTheme: (theme?: string, mode?: string) => void;
-  rootId?: string;
-}
+export { HvThemeContext };
+export type { HvThemeContextValue };
 
 interface HvThemeProviderProps {
   children: React.ReactNode;
@@ -24,16 +19,6 @@ interface HvThemeProviderProps {
   colorMode: string;
   rootElementId?: string;
 }
-
-export const HvThemeContext = createContext<HvThemeContextValue>({
-  themes: [],
-  activeTheme: undefined,
-  colorModes: [],
-  selectedTheme: "",
-  selectedMode: "",
-  changeTheme: () => {},
-  rootId: undefined,
-});
 
 export const HvThemeProvider = ({
   children,

--- a/packages/core/src/types/generic.ts
+++ b/packages/core/src/types/generic.ts
@@ -1,5 +1,12 @@
 import { HTMLAttributes } from "react";
 
+import type {
+  HvExtraProps,
+  HvExtraDeepProps,
+} from "@hitachivantara/uikit-react-shared";
+
+export type { HvExtraProps, HvExtraDeepProps };
+
 type AsProp<C extends React.ElementType> = {
   as?: C;
 };
@@ -26,19 +33,11 @@ export type HvBaseProps<E = HTMLDivElement, P = {}> = Omit<
   keyof P
 >;
 
-// This type allows to pass undetermined extra props to components
-export type HvExtraProps = { [key: string]: any };
-
 // This type allows to do a deep partial by applying the Partial type to each key recursively
-export type DeepPartial<T> = Partial<{ [P in keyof T]: DeepPartial<T[P]> }>;
+type DeepPartial<T> = Partial<{ [P in keyof T]: DeepPartial<T[P]> }>;
 
 // This type combines the HvExtraProps and DeepPartial types
 export type HvExtraDeepPartialProps<T> = Partial<{
   [P in keyof T]: DeepPartial<T[P]> & HvExtraProps;
 }> &
   HvExtraProps;
-
-// This type allows to pass undetermined extra props to components recursively
-export type HvExtraDeepProps<T> = {
-  [P in keyof T]: T[P] & HvExtraProps;
-} & HvExtraProps;

--- a/packages/core/src/types/theme.ts
+++ b/packages/core/src/types/theme.ts
@@ -3,18 +3,10 @@ import {
   HvThemeStructure,
   HvThemeColorModeStructure,
 } from "@hitachivantara/uikit-styles";
-import { HvExtraDeepPartialProps, HvExtraDeepProps } from "../types";
+import type { HvTheme } from "@hitachivantara/uikit-react-shared";
+import { HvExtraDeepPartialProps } from "../types";
 
-/**
- * Theme structure
- */
-export type HvTheme = HvExtraDeepProps<Omit<HvThemeStructure, "colors">> & {
-  colors: {
-    modes: {
-      [key: string]: HvThemeColorModeStructure & { [key: string]: string };
-    };
-  };
-};
+export type { HvTheme };
 
 /**
  * Create theme props

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -66,8 +66,8 @@
     "types": "dist/types/index.d.ts",
     "exports": {
       ".": {
-        "require": "dist/cjs/index.cjs",
-        "import": "dist/esm/index.js"
+        "require": "./dist/cjs/index.cjs",
+        "import": "./dist/esm/index.js"
       }
     }
   },

--- a/packages/shared/CHANGELOG.md
+++ b/packages/shared/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.

--- a/packages/shared/README.md
+++ b/packages/shared/README.md
@@ -1,0 +1,7 @@
+# @hitachivantara/uikit-react-shared
+
+The package provides shared React contexts for the Hitachi Vantara UI Kit. It allows UI Kit components to share state (e.g. active theme) even if they are built with different versions of the UI Kit or are not using the same HvProvider instance.
+
+This package is intended to be used in embedded scenarios, particularly when using the Hitachi Vantara App Shell framework. In these cases, declare the @hitachivantara/uikit-react-shared package as external in your bundler configuration. An ESM bundle is provided in the package, which can be deployed, and the importmap can be configured to point to it.
+
+For regular usage of the UI Kit, you don't need to know about this package. All the contexts and types are re-exported from the core package.

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@hitachivantara/uikit-react-core",
-  "version": "5.0.0-next.13",
+  "name": "@hitachivantara/uikit-react-shared",
+  "version": "5.0.0-next.11",
   "private": false,
   "author": "Hitachi Vantara UI Kit Team",
   "description": "UI Kit core React components for the Next Design System.",
@@ -25,44 +25,20 @@
   "scripts": {
     "build": "run-s clean build:*",
     "build:js": "vite build",
-    "test": "vitest run",
-    "test:update": "vitest -u",
-    "test:ui": "vitest --ui",
-    "coverage": "vitest run --coverage",
     "clean": "npx rimraf dist package",
     "typecheck": "tsc --noEmit",
     "prepublishOnly": "pnpm build && npx clean-publish --fields main"
   },
   "peerDependencies": {
-    "@emotion/css": "^11.10.6",
-    "@emotion/react": "^11.10.5",
-    "@emotion/styled": "^11.10.5",
-    "@mui/material": "^5.11.0",
     "react": "^17.0.0 || ^18.0.0",
     "react-dom": "^17.0.0 || ^18.0.0"
   },
   "dependencies": {
-    "@emotion/cache": "^11.10.5",
-    "@hitachivantara/uikit-react-shared": "workspace:*",
-    "@hitachivantara/uikit-react-icons": "workspace:*",
-    "@hitachivantara/uikit-styles": "workspace:*",
-    "@popperjs/core": "^2.11.6",
-    "attr-accept": "^2.2.2",
-    "clsx": "^1.2.1",
-    "dayjs": "^1.11.7",
-    "detect-browser": "^5.3.0",
-    "hoist-non-react-statics": "^3.3.2",
-    "lodash": "^4.17.21",
-    "notistack": "^2.0.8",
-    "react-popper": "^2.3.0",
-    "react-resize-detector": "^8.0.4",
-    "react-table": "^7.8.0",
-    "react-window": "^1.8.8"
+    "@hitachivantara/uikit-styles": "workspace:*"
   },
   "devDependencies": {
     "@types/react": "^18.0.28",
-    "@types/react-dom": "^18.0.11",
-    "tsc-alias": "^1.8.2"
+    "@types/react-dom": "^18.0.11"
   },
   "files": [
     "dist"
@@ -75,9 +51,11 @@
     "types": "dist/types/index.d.ts",
     "exports": {
       ".": {
-        "require": "dist/cjs/index.cjs",
-        "import": "dist/esm/index.js"
-      }
+        "require": "./dist/cjs/index.cjs",
+        "import": "./dist/esm/index.js"
+      },
+      "./package.json": "./package.json",
+      "./bundles/*": "./dist/bundles/*"
     }
   },
   "clean-publish": {

--- a/packages/shared/src/context/ThemeContext.ts
+++ b/packages/shared/src/context/ThemeContext.ts
@@ -1,0 +1,25 @@
+import { createContext } from "react";
+
+import { HvThemeStructure } from "@hitachivantara/uikit-styles";
+
+import { HvTheme } from "../types/theme";
+
+export interface HvThemeContextValue {
+  themes: string[];
+  colorModes: string[];
+  activeTheme?: HvTheme | HvThemeStructure;
+  selectedTheme: string;
+  selectedMode: string;
+  changeTheme: (theme?: string, mode?: string) => void;
+  rootId?: string;
+}
+
+export const HvThemeContext = createContext<HvThemeContextValue>({
+  themes: [],
+  activeTheme: undefined,
+  colorModes: [],
+  selectedTheme: "",
+  selectedMode: "",
+  changeTheme: () => {},
+  rootId: undefined,
+});

--- a/packages/shared/src/context/index.ts
+++ b/packages/shared/src/context/index.ts
@@ -1,0 +1,1 @@
+export * from "./ThemeContext";

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,0 +1,2 @@
+export * from "./context";
+export * from "./types";

--- a/packages/shared/src/types/generic.ts
+++ b/packages/shared/src/types/generic.ts
@@ -1,0 +1,7 @@
+// This type allows to pass undetermined extra props to components
+export type HvExtraProps = { [key: string]: any };
+
+// This type allows to pass undetermined extra props to components recursively
+export type HvExtraDeepProps<T> = {
+  [P in keyof T]: T[P] & HvExtraProps;
+} & HvExtraProps;

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -1,0 +1,2 @@
+export * from "./generic";
+export * from "./theme";

--- a/packages/shared/src/types/theme.ts
+++ b/packages/shared/src/types/theme.ts
@@ -1,0 +1,17 @@
+import {
+  HvThemeStructure,
+  HvThemeColorModeStructure,
+} from "@hitachivantara/uikit-styles";
+
+import { HvExtraDeepProps } from "./generic";
+
+/**
+ * Theme structure
+ */
+export type HvTheme = HvExtraDeepProps<Omit<HvThemeStructure, "colors">> & {
+  colors: {
+    modes: {
+      [key: string]: HvThemeColorModeStructure & { [key: string]: string };
+    };
+  };
+};

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "composite": true,
+    "baseUrl": "src",
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src"],
+  "references": [
+    {
+      "path": "../styles/tsconfig.json"
+    }
+  ]
+}

--- a/packages/shared/vite.config.js
+++ b/packages/shared/vite.config.js
@@ -1,0 +1,17 @@
+import { mergeConfig } from "vite";
+
+import viteConfig from "../../.config/vite.config";
+
+export default mergeConfig(viteConfig, {
+  build: {
+    rollupOptions: {
+      output: [
+        {
+          format: "esm",
+          dir: "dist/bundles",
+          sourcemap: true,
+        },
+      ],
+    },
+  },
+});

--- a/packages/styles/package.json
+++ b/packages/styles/package.json
@@ -34,8 +34,8 @@
     "types": "dist/types/index.d.ts",
     "exports": {
       ".": {
-        "require": "dist/cjs/index.cjs",
-        "import": "dist/esm/index.js"
+        "require": "./dist/cjs/index.cjs",
+        "import": "./dist/esm/index.js"
       }
     }
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -140,6 +140,7 @@ importers:
       '@emotion/react': ^11.10.5
       '@emotion/styled': ^11.10.5
       '@hitachivantara/uikit-react-icons': workspace:*
+      '@hitachivantara/uikit-react-shared': workspace:*
       '@hitachivantara/uikit-styles': workspace:*
       '@mui/material': ^5.11.0
       '@popperjs/core': ^2.11.6
@@ -165,6 +166,7 @@ importers:
       '@emotion/react': 11.10.6_pmekkgnqduwlme35zpnqhenc34
       '@emotion/styled': 11.10.6_oouaibmszuch5k64ms7uxp2aia
       '@hitachivantara/uikit-react-icons': link:../icons
+      '@hitachivantara/uikit-react-shared': link:../shared
       '@hitachivantara/uikit-styles': link:../styles
       '@mui/material': 5.11.12_xqeqsl5kvjjtyxwyi3jhw3yuli
       '@popperjs/core': 2.11.6
@@ -223,6 +225,22 @@ importers:
       ts-node: 10.9.1_alpjt73dvgv6kni625hu7f2l4m
       tsconfig-paths: 4.1.2
       yargs: 17.7.1
+    publishDirectory: package
+
+  packages/shared:
+    specifiers:
+      '@hitachivantara/uikit-styles': workspace:*
+      '@types/react': ^18.0.28
+      '@types/react-dom': ^18.0.11
+      react: ^17.0.0 || ^18.0.0
+      react-dom: ^17.0.0 || ^18.0.0
+    dependencies:
+      '@hitachivantara/uikit-styles': link:../styles
+      react: 18.2.0
+      react-dom: 18.2.0_react@18.2.0
+    devDependencies:
+      '@types/react': 18.0.28
+      '@types/react-dom': 18.0.11
     publishDirectory: package
 
   packages/styles:

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,6 +16,7 @@
     "jsxImportSource": "@emotion/react",
     "baseUrl": ".",
     "paths": {
+      "@hitachivantara/uikit-react-shared": ["packages/shared/src"],
       "@hitachivantara/uikit-react-core": ["packages/core/src"],
       "@hitachivantara/uikit-react-icons": ["packages/icons/bin"],
       "@hitachivantara/uikit-react-icons/dist/*": ["packages/icons/bin/*"],


### PR DESCRIPTION
The package provides shared React contexts for the Hitachi Vantara UI Kit. It allows UI Kit components to share state (e.g. active theme) even if they are built with different versions of the UI Kit or are not using the same HvProvider instance.

This package is intended to be used in embedded scenarios, particularly when using the Hitachi Vantara App Shell framework. In these cases, declare the @hitachivantara/uikit-react-shared package as external in your bundler configuration. An ESM bundle is provided in the package, which can be deployed, and the importmap can be configured to point to it.

For regular usage of the UI Kit, you don't need to know about this package. All the contexts and types are re-exported from the core package.