### PR TITLE
chore: replace static references to base radius with the theme value

### DIFF
--- a/app/src/headerTheme.ts
+++ b/app/src/headerTheme.ts
@@ -3,6 +3,9 @@ import { createTheme, theme } from "@hitachivantara/uikit-react-core";
 const headerTheme = createTheme({
   name: "header-theme",
   base: "ds5",
+  radii: {
+    base: "20px",
+  },
   header: {
     color: "#B167EF",
     height: "60px",

--- a/packages/core/src/components/BaseDropdown/BaseDropdown.styles.tsx
+++ b/packages/core/src/components/BaseDropdown/BaseDropdown.styles.tsx
@@ -49,7 +49,7 @@ export const StyledHeaderRoot = styled(
     background: theme.colors.atmo1,
     boxSizing: "border-box",
     border: `1px solid ${theme.baseDropdown.borderColor}`,
-    borderRadius: "2px",
+    borderRadius: theme.radii.base,
     "&:hover": {
       border: `1px solid ${theme.baseDropdown.hoverBorderColor}`,
     },
@@ -93,11 +93,11 @@ export const StyledHeaderRoot = styled(
     }),
 
     ...($openedUp && {
-      borderRadius: "0px 0px 2px 2px",
+      borderRadius: `0px 0px ${theme.radii.base} ${theme.radii.base}`,
     }),
 
     ...($openedDown && {
-      borderRadius: "2px 2px 0px 0px",
+      borderRadius: `${theme.radii.base} ${theme.radii.base} 0px 0px`,
     }),
   })
 );

--- a/packages/core/src/components/BaseDropdown/__snapshots__/BaseDropdown.test.tsx.snap
+++ b/packages/core/src/components/BaseDropdown/__snapshots__/BaseDropdown.test.tsx.snap
@@ -17,7 +17,7 @@ exports[`BaseDropDown > should render correctly 1`] = `
       >
         <div
           aria-label="Main sample"
-          class="HvBaseDropdown-header hv-uikit-style-xmr0xz-StyledHeaderRoot eapzthe7"
+          class="HvBaseDropdown-header hv-uikit-style-4bvoko-StyledHeaderRoot eapzthe7"
           role="textbox"
           tabindex="0"
         >

--- a/packages/core/src/components/BaseInput/BaseInput.styles.tsx
+++ b/packages/core/src/components/BaseInput/BaseInput.styles.tsx
@@ -105,7 +105,7 @@ export const StyledInput = styled(
     [`&.${MuiInputClasses.root}`]: {
       margin: 0,
       width: "100%",
-      borderRadius: "2px",
+      borderRadius: theme.radii.base,
       height: "32px",
       border: `1px solid ${theme.baseInput.borderColor}`,
       boxSizing: "border-box",
@@ -210,7 +210,7 @@ export const StyledInput = styled(
 
       [`& .${baseInputClasses.input}`]: {
         border: `1px solid ${theme.baseInput.multilineBorderColor}`,
-        borderRadius: "2px",
+        borderRadius: theme.radii.base,
         backgroundColor: theme.colors.atmo1,
         height: "auto",
         minHeight: "21px",

--- a/packages/core/src/components/BaseInput/__snapshots__/BaseInput.test.tsx.snap
+++ b/packages/core/src/components/BaseInput/__snapshots__/BaseInput.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`BaseInput > should render correctly 1`] = `
     class="HvBaseInput-root css-1czkd-StyledRoot e8ibl7d2"
   >
     <div
-      class="MuiInputBase-root MuiInput-root HvBaseInput-inputRoot MuiInput-underline MuiInputBase-colorPrimary  css-l9bv42-StyledInput e8ibl7d0 css-q0jhri-MuiInputBase-root-MuiInput-root"
+      class="MuiInputBase-root MuiInput-root HvBaseInput-inputRoot MuiInput-underline MuiInputBase-colorPrimary  css-6atnmb-StyledInput e8ibl7d0 css-q0jhri-MuiInputBase-root-MuiInput-root"
     >
       <input
         class="MuiInputBase-input MuiInput-input HvBaseInput-input css-1x51dt5-MuiInputBase-input-MuiInput-input"

--- a/packages/core/src/components/BreadCrumb/Page/Page.styles.tsx
+++ b/packages/core/src/components/BreadCrumb/Page/Page.styles.tsx
@@ -5,7 +5,7 @@ import { HvLink, HvTypography } from "components";
 export const StyledLink = styled((props) => <HvLink {...props} />)({
   padding: `8px ${theme.space.xs}`,
   textDecoration: "none",
-  borderRadius: "2px",
+  borderRadius: theme.radii.base,
   "&:hover": {
     backgroundColor: theme.colors.atmo3,
   },

--- a/packages/core/src/components/BreadCrumb/__snapshots__/BreadCrumb.test.tsx.snap
+++ b/packages/core/src/components/BreadCrumb/__snapshots__/BreadCrumb.test.tsx.snap
@@ -12,7 +12,7 @@ exports[`BreadCrumb > should render correctly 1`] = `
         class="HvPathElement-centerContainer HvBreadCrumb-centerContainer css-1sm7i34-StyledLi e14mbcex0"
       >
         <a
-          class="e8ovoy91 HvLink-a HvPage-a HvBreadCrumb-a css-tkb3xd-StyledA-StyledLink e18zed7a0"
+          class="e8ovoy91 HvLink-a HvPage-a HvBreadCrumb-a css-ra1djb-StyledA-StyledLink e18zed7a0"
           href="route1"
         >
           <div
@@ -48,7 +48,7 @@ exports[`BreadCrumb > should render correctly 1`] = `
         class="HvPathElement-centerContainer HvBreadCrumb-centerContainer css-1sm7i34-StyledLi e14mbcex0"
       >
         <a
-          class="e8ovoy91 HvLink-a HvPage-a HvBreadCrumb-a css-tkb3xd-StyledA-StyledLink e18zed7a0"
+          class="e8ovoy91 HvLink-a HvPage-a HvBreadCrumb-a css-ra1djb-StyledA-StyledLink e18zed7a0"
           href="route2"
         >
           <div
@@ -84,7 +84,7 @@ exports[`BreadCrumb > should render correctly 1`] = `
         class="HvPathElement-centerContainer HvBreadCrumb-centerContainer css-1sm7i34-StyledLi e14mbcex0"
       >
         <a
-          class="e8ovoy91 HvLink-a HvPage-a HvBreadCrumb-a css-tkb3xd-StyledA-StyledLink e18zed7a0"
+          class="e8ovoy91 HvLink-a HvPage-a HvBreadCrumb-a css-ra1djb-StyledA-StyledLink e18zed7a0"
           href="route3"
         >
           <div
@@ -120,7 +120,7 @@ exports[`BreadCrumb > should render correctly 1`] = `
         class="HvPathElement-centerContainer HvBreadCrumb-centerContainer css-1sm7i34-StyledLi e14mbcex0"
       >
         <a
-          class="e8ovoy91 HvLink-a HvPage-a HvBreadCrumb-a css-tkb3xd-StyledA-StyledLink e18zed7a0"
+          class="e8ovoy91 HvLink-a HvPage-a HvBreadCrumb-a css-ra1djb-StyledA-StyledLink e18zed7a0"
           href="route4"
         >
           <div
@@ -156,7 +156,7 @@ exports[`BreadCrumb > should render correctly 1`] = `
         class="HvPathElement-centerContainer HvBreadCrumb-centerContainer css-1sm7i34-StyledLi e14mbcex0"
       >
         <a
-          class="e8ovoy91 HvLink-a HvPage-a HvBreadCrumb-a css-tkb3xd-StyledA-StyledLink e18zed7a0"
+          class="e8ovoy91 HvLink-a HvPage-a HvBreadCrumb-a css-ra1djb-StyledA-StyledLink e18zed7a0"
           href="route5"
         >
           <div
@@ -192,7 +192,7 @@ exports[`BreadCrumb > should render correctly 1`] = `
         class="HvPathElement-centerContainer HvBreadCrumb-centerContainer css-1sm7i34-StyledLi e14mbcex0"
       >
         <a
-          class="e8ovoy91 HvLink-a HvPage-a HvBreadCrumb-a css-tkb3xd-StyledA-StyledLink e18zed7a0"
+          class="e8ovoy91 HvLink-a HvPage-a HvBreadCrumb-a css-ra1djb-StyledA-StyledLink e18zed7a0"
           href="route6"
         >
           <div

--- a/packages/core/src/components/Controls/__snapshots__/Controls.test.tsx.snap
+++ b/packages/core/src/components/Controls/__snapshots__/Controls.test.tsx.snap
@@ -21,7 +21,7 @@ exports[`<HvControls> > sample snapshot testing > Controls 1`] = `
               class="HvBaseInput-root eryso6g0 css-1njcp56-StyledRoot-StyledBaseInput e8ibl7d2"
             >
               <div
-                class="MuiInputBase-root MuiInput-root HvBaseInput-inputRoot HvInput-inputRoot MuiInput-underline MuiInputBase-colorPrimary MuiInputBase-adornedEnd  css-l9bv42-StyledInput e8ibl7d0 css-q0jhri-MuiInputBase-root-MuiInput-root"
+                class="MuiInputBase-root MuiInput-root HvBaseInput-inputRoot HvInput-inputRoot MuiInput-underline MuiInputBase-colorPrimary MuiInputBase-adornedEnd  css-6atnmb-StyledInput e8ibl7d0 css-q0jhri-MuiInputBase-root-MuiInput-root"
               >
                 <input
                   aria-controls="cardsGrid itemList"
@@ -93,7 +93,7 @@ exports[`<HvControls> > sample snapshot testing > Controls 1`] = `
                 tabindex="-1"
               >
                 <div
-                  class="HvBaseDropdown-header HvDropdown-dropdownHeader css-xmr0xz-StyledHeaderRoot eapzthe7"
+                  class="HvBaseDropdown-header HvDropdown-dropdownHeader css-4bvoko-StyledHeaderRoot eapzthe7"
                   role="textbox"
                   tabindex="0"
                 >
@@ -135,7 +135,7 @@ exports[`<HvControls> > sample snapshot testing > Controls 1`] = `
           <button
             aria-label="Select card view"
             aria-pressed="true"
-            class="button selected e17vrbb40 HvButton-root css-zklq89-StyledButton-StyledButton e138pvrm0"
+            class="button selected e17vrbb40 HvButton-root css-1x87vjd-StyledButton-StyledButton e138pvrm0"
             id="card"
             label="Select card view"
           >
@@ -169,7 +169,7 @@ exports[`<HvControls> > sample snapshot testing > Controls 1`] = `
           <button
             aria-label="Select list view"
             aria-pressed="false"
-            class="button e17vrbb40 HvButton-root css-zklq89-StyledButton-StyledButton e138pvrm0"
+            class="button e17vrbb40 HvButton-root css-1x87vjd-StyledButton-StyledButton e138pvrm0"
             id="list"
             label="Select list view"
           >
@@ -635,7 +635,7 @@ exports[`<HvControls> > sample snapshot testing > Controls Controlled 1`] = `
               class="HvBaseInput-root eryso6g0 css-1njcp56-StyledRoot-StyledBaseInput e8ibl7d2"
             >
               <div
-                class="MuiInputBase-root MuiInput-root HvBaseInput-inputRoot HvInput-inputRoot MuiInput-underline MuiInputBase-colorPrimary MuiInputBase-adornedEnd  css-l9bv42-StyledInput e8ibl7d0 css-q0jhri-MuiInputBase-root-MuiInput-root"
+                class="MuiInputBase-root MuiInput-root HvBaseInput-inputRoot HvInput-inputRoot MuiInput-underline MuiInputBase-colorPrimary MuiInputBase-adornedEnd  css-6atnmb-StyledInput e8ibl7d0 css-q0jhri-MuiInputBase-root-MuiInput-root"
               >
                 <input
                   aria-controls="controlledCardsGrid controlledItemList"
@@ -707,7 +707,7 @@ exports[`<HvControls> > sample snapshot testing > Controls Controlled 1`] = `
                 tabindex="-1"
               >
                 <div
-                  class="HvBaseDropdown-header HvDropdown-dropdownHeader css-xmr0xz-StyledHeaderRoot eapzthe7"
+                  class="HvBaseDropdown-header HvDropdown-dropdownHeader css-4bvoko-StyledHeaderRoot eapzthe7"
                   role="textbox"
                   tabindex="0"
                 >
@@ -749,7 +749,7 @@ exports[`<HvControls> > sample snapshot testing > Controls Controlled 1`] = `
           <button
             aria-label="Select card view"
             aria-pressed="true"
-            class="button selected e17vrbb40 HvButton-root css-zklq89-StyledButton-StyledButton e138pvrm0"
+            class="button selected e17vrbb40 HvButton-root css-1x87vjd-StyledButton-StyledButton e138pvrm0"
             id="card"
             label="Select card view"
           >
@@ -783,7 +783,7 @@ exports[`<HvControls> > sample snapshot testing > Controls Controlled 1`] = `
           <button
             aria-label="Select list view"
             aria-pressed="false"
-            class="button e17vrbb40 HvButton-root css-zklq89-StyledButton-StyledButton e138pvrm0"
+            class="button e17vrbb40 HvButton-root css-1x87vjd-StyledButton-StyledButton e138pvrm0"
             id="list"
             label="Select list view"
           >
@@ -1189,7 +1189,7 @@ exports[`<HvControls> > sample snapshot testing > Custom Controls 1`] = `
             <button
               aria-controls="CustomControlsCardsId"
               aria-pressed="true"
-              class="button selected e17vrbb40 HvButton-root css-ll89mo-StyledButton-StyledButton e138pvrm0"
+              class="button selected e17vrbb40 HvButton-root css-1fr81co-StyledButton-StyledButton e138pvrm0"
               id="all"
             >
               <div
@@ -1205,7 +1205,7 @@ exports[`<HvControls> > sample snapshot testing > Custom Controls 1`] = `
             <button
               aria-controls="CustomControlsCardsId"
               aria-pressed="false"
-              class="button e17vrbb40 HvButton-root css-ll89mo-StyledButton-StyledButton e138pvrm0"
+              class="button e17vrbb40 HvButton-root css-1fr81co-StyledButton-StyledButton e138pvrm0"
               id="critical"
             >
               <div
@@ -1221,7 +1221,7 @@ exports[`<HvControls> > sample snapshot testing > Custom Controls 1`] = `
             <button
               aria-controls="CustomControlsCardsId"
               aria-pressed="false"
-              class="button e17vrbb40 HvButton-root css-ll89mo-StyledButton-StyledButton e138pvrm0"
+              class="button e17vrbb40 HvButton-root css-1fr81co-StyledButton-StyledButton e138pvrm0"
               id="major"
             >
               <div
@@ -1237,7 +1237,7 @@ exports[`<HvControls> > sample snapshot testing > Custom Controls 1`] = `
             <button
               aria-controls="CustomControlsCardsId"
               aria-pressed="false"
-              class="button e17vrbb40 HvButton-root css-ll89mo-StyledButton-StyledButton e138pvrm0"
+              class="button e17vrbb40 HvButton-root css-1fr81co-StyledButton-StyledButton e138pvrm0"
               id="average"
             >
               <div
@@ -1253,7 +1253,7 @@ exports[`<HvControls> > sample snapshot testing > Custom Controls 1`] = `
             <button
               aria-controls="CustomControlsCardsId"
               aria-pressed="false"
-              class="button e17vrbb40 HvButton-root css-ll89mo-StyledButton-StyledButton e138pvrm0"
+              class="button e17vrbb40 HvButton-root css-1fr81co-StyledButton-StyledButton e138pvrm0"
               id="minor"
             >
               <div
@@ -2001,7 +2001,7 @@ exports[`<HvControls> > sample snapshot testing > Mixed Controls 1`] = `
               class="HvBaseInput-root eryso6g0 css-1njcp56-StyledRoot-StyledBaseInput e8ibl7d2"
             >
               <div
-                class="MuiInputBase-root MuiInput-root HvBaseInput-inputRoot HvInput-inputRoot MuiInput-underline MuiInputBase-colorPrimary MuiInputBase-adornedEnd  css-l9bv42-StyledInput e8ibl7d0 css-q0jhri-MuiInputBase-root-MuiInput-root"
+                class="MuiInputBase-root MuiInput-root HvBaseInput-inputRoot HvInput-inputRoot MuiInput-underline MuiInputBase-colorPrimary MuiInputBase-adornedEnd  css-6atnmb-StyledInput e8ibl7d0 css-q0jhri-MuiInputBase-root-MuiInput-root"
               >
                 <input
                   class="MuiInputBase-input MuiInput-input HvBaseInput-input HvInput-input MuiInputBase-inputTypeSearch MuiInputBase-inputAdornedEnd css-c63i49-MuiInputBase-input-MuiInput-input"
@@ -2058,7 +2058,7 @@ exports[`<HvControls> > sample snapshot testing > Mixed Controls 1`] = `
             <button
               aria-controls="mixedControlsCardsId"
               aria-pressed="true"
-              class="button selected e17vrbb40 HvButton-root css-ll89mo-StyledButton-StyledButton e138pvrm0"
+              class="button selected e17vrbb40 HvButton-root css-1fr81co-StyledButton-StyledButton e138pvrm0"
               id="all"
             >
               <div
@@ -2074,7 +2074,7 @@ exports[`<HvControls> > sample snapshot testing > Mixed Controls 1`] = `
             <button
               aria-controls="mixedControlsCardsId"
               aria-pressed="false"
-              class="button e17vrbb40 HvButton-root css-ll89mo-StyledButton-StyledButton e138pvrm0"
+              class="button e17vrbb40 HvButton-root css-1fr81co-StyledButton-StyledButton e138pvrm0"
               id="critical"
             >
               <div
@@ -2090,7 +2090,7 @@ exports[`<HvControls> > sample snapshot testing > Mixed Controls 1`] = `
             <button
               aria-controls="mixedControlsCardsId"
               aria-pressed="false"
-              class="button e17vrbb40 HvButton-root css-ll89mo-StyledButton-StyledButton e138pvrm0"
+              class="button e17vrbb40 HvButton-root css-1fr81co-StyledButton-StyledButton e138pvrm0"
               id="major"
             >
               <div
@@ -2106,7 +2106,7 @@ exports[`<HvControls> > sample snapshot testing > Mixed Controls 1`] = `
             <button
               aria-controls="mixedControlsCardsId"
               aria-pressed="false"
-              class="button e17vrbb40 HvButton-root css-ll89mo-StyledButton-StyledButton e138pvrm0"
+              class="button e17vrbb40 HvButton-root css-1fr81co-StyledButton-StyledButton e138pvrm0"
               id="average"
             >
               <div
@@ -2122,7 +2122,7 @@ exports[`<HvControls> > sample snapshot testing > Mixed Controls 1`] = `
             <button
               aria-controls="mixedControlsCardsId"
               aria-pressed="false"
-              class="button e17vrbb40 HvButton-root css-ll89mo-StyledButton-StyledButton e138pvrm0"
+              class="button e17vrbb40 HvButton-root css-1fr81co-StyledButton-StyledButton e138pvrm0"
               id="minor"
             >
               <div

--- a/packages/core/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/packages/core/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -20,7 +20,7 @@ exports[`Dropdown > should render correctly 1`] = `
         >
           <div
             aria-label="Main sample"
-            class="HvBaseDropdown-header HvDropdown-dropdownHeader css-xmr0xz-StyledHeaderRoot eapzthe7"
+            class="HvBaseDropdown-header HvDropdown-dropdownHeader css-4bvoko-StyledHeaderRoot eapzthe7"
             role="textbox"
             tabindex="0"
           >

--- a/packages/core/src/components/MultiButton/MultiButton.styles.tsx
+++ b/packages/core/src/components/MultiButton/MultiButton.styles.tsx
@@ -68,7 +68,7 @@ export const StyledRoot = styled(
         width: `calc(100% + 2px) !important`,
         background: theme.colors.atmo1,
         ...(theme.typography.label as CSSProperties),
-        borderRadius: "2px",
+        borderRadius: theme.radii.base,
         border: `solid 1px ${theme.colors.acce1}`,
         zIndex: 2,
         "&:hover, &:focus": {
@@ -125,13 +125,13 @@ export const StyledButton = (Element) =>
     },
     "&:first-of-type": {
       borderLeft: `solid 1px ${theme.colors.atmo4}`,
-      borderTopLeftRadius: "2px",
-      borderBottomLeftRadius: "2px",
+      borderTopLeftRadius: theme.radii.base,
+      borderBottomLeftRadius: theme.radii.base,
     },
     "&:last-child": {
       borderRight: `solid 1px ${theme.colors.atmo4}`,
-      borderTopRightRadius: "2px",
-      borderBottomRightRadius: "2px",
+      borderTopRightRadius: theme.radii.base,
+      borderBottomRightRadius: theme.radii.base,
       "&:disabled:hover": {
         borderRight: `solid 1px ${theme.colors.atmo4} !important`,
       },
@@ -143,7 +143,6 @@ export const StyledButton = (Element) =>
       background: theme.colors.atmo1,
       height: 34,
       ...(theme.typography.label as CSSProperties),
-      borderRadius: "2px",
       border: `solid 1px ${theme.colors.acce1}`,
       zIndex: 2,
       "&:hover": {

--- a/packages/core/src/components/Pagination/Pagination.styles.tsx
+++ b/packages/core/src/components/Pagination/Pagination.styles.tsx
@@ -98,7 +98,7 @@ export const StyledPageJump = styled("div")({
       paddingRight: `4px`,
       margin: 0,
       textAlign: "center",
-      // textAlign: theme.pagination.pageJumpTextAlign, TODO: fix this
+      borderRadius: theme.radii.base,
       MozAppearance: "textfield",
       "&:focus": {
         backgroundColor: hoverColor,

--- a/packages/core/src/components/Pagination/__snapshots__/Pagination.test.tsx.snap
+++ b/packages/core/src/components/Pagination/__snapshots__/Pagination.test.tsx.snap
@@ -23,7 +23,7 @@ exports[`Pagination > should render correctly 1`] = `
           >
             <div
               aria-label="Select how many to display"
-              class="HvBaseDropdown-header hv-uikit-style-xmr0xz-StyledHeaderRoot eapzthe7"
+              class="HvBaseDropdown-header hv-uikit-style-4bvoko-StyledHeaderRoot eapzthe7"
               role="textbox"
               tabindex="0"
             >
@@ -140,7 +140,7 @@ exports[`Pagination > should render correctly 1`] = `
         class="HvPagination-pageInfo hv-uikit-style-1wjzhg6-StyledPageInfo e1tn2n0k1"
       >
         <div
-          class="HvPagination-pageJump hv-uikit-style-m3cag5-StyledPageJump e1tn2n0k0"
+          class="HvPagination-pageJump hv-uikit-style-bz8qz2-StyledPageJump e1tn2n0k0"
         >
           <div
             class="HvInput-root HvPagination-pageSizeInputContainer hv-uikit-style-b8m0re-StyledFormElement eryso6g8 HvFormElement-root"
@@ -149,7 +149,7 @@ exports[`Pagination > should render correctly 1`] = `
               class="HvBaseInput-root eryso6g0 hv-uikit-style-1njcp56-StyledRoot-StyledBaseInput e8ibl7d2"
             >
               <div
-                class="MuiInputBase-root MuiInput-root HvBaseInput-inputRoot HvInput-inputRoot HvPagination-pageSizeInputRoot MuiInput-underline MuiInputBase-colorPrimary  hv-uikit-style-l9bv42-StyledInput e8ibl7d0 css-q0jhri-MuiInputBase-root-MuiInput-root"
+                class="MuiInputBase-root MuiInput-root HvBaseInput-inputRoot HvInput-inputRoot HvPagination-pageSizeInputRoot MuiInput-underline MuiInputBase-colorPrimary  hv-uikit-style-6atnmb-StyledInput e8ibl7d0 css-q0jhri-MuiInputBase-root-MuiInput-root"
               >
                 <input
                   aria-label="Current page"

--- a/packages/core/src/components/TagsInput/TagsInput.styles.tsx
+++ b/packages/core/src/components/TagsInput/TagsInput.styles.tsx
@@ -88,7 +88,7 @@ export const StyledTagsList = styled(
 
     backgroundColor: theme.colors.atmo1,
     border: `1px solid ${theme.tagsInput.borderColor}`,
-    borderRadius: "2px",
+    borderRadius: theme.radii.base,
 
     "&:hover": {
       cursor: "text",

--- a/packages/core/src/components/TextArea/__snapshots__/TextArea.test.tsx.snap
+++ b/packages/core/src/components/TextArea/__snapshots__/TextArea.test.tsx.snap
@@ -39,7 +39,7 @@ exports[`TextArea > should render correctly 1`] = `
       class="HvBaseInput-root HvTextArea-baseInput e1e5t49x0 css-1lzob26-StyledRoot-StyledBaseInput e8ibl7d2"
     >
       <div
-        class="MuiInputBase-root MuiInput-root HvBaseInput-inputRoot MuiInput-underline MuiInputBase-colorPrimary MuiInputBase-multiline HvBaseInput-inputRootMultiline  css-l9bv42-StyledInput e8ibl7d0 css-he3345-MuiInputBase-root-MuiInput-root"
+        class="MuiInputBase-root MuiInput-root HvBaseInput-inputRoot MuiInput-underline MuiInputBase-colorPrimary MuiInputBase-multiline HvBaseInput-inputRootMultiline  css-6atnmb-StyledInput e8ibl7d0 css-he3345-MuiInputBase-root-MuiInput-root"
       >
         <textarea
           aria-controls="hvtextarea3-charCounter"

--- a/packages/styles/src/themes/ds5.ts
+++ b/packages/styles/src/themes/ds5.ts
@@ -142,7 +142,7 @@ const ds5 = makeTheme((theme: HvTheme) => ({
     },
   },
   dropdown: {
-    borderRadius: "2px",
+    borderRadius: theme.radii.base,
     headerBorder: `1px solid ${theme.colors.acce4}`,
     headerBorderHover: `1px solid ${theme.colors.acce4}`,
     disabledColor: theme.colors.atmo5,
@@ -153,7 +153,7 @@ const ds5 = makeTheme((theme: HvTheme) => ({
     dropdownHeaderOpenBorder: `1px solid ${theme.colors.acce1}`,
     listBackgroundColor: theme.colors.atmo1,
     listBorder: `1px solid ${theme.colors.acce1}`,
-    listBorderRadius: `0px 0px ${theme.radii.sm} ${theme.radii.sm}`,
+    listBorderRadius: `0px 0px ${theme.radii.base} ${theme.radii.base}`,
     listContainerPadding: theme.space.sm,
     searchContainerMargin: theme.space.xs,
   },
@@ -197,7 +197,7 @@ const ds5 = makeTheme((theme: HvTheme) => ({
   tab: {
     padding: "0 16px",
     hoverBackgroundColor: theme.colors.acce2s,
-    hoverBackgroundBorderRadius: "2px",
+    hoverBackgroundBorderRadius: theme.radii.base,
     hoverUnderlineBackgroundColor: theme.colors.atmo4,
   },
   list: {
@@ -211,11 +211,11 @@ const ds5 = makeTheme((theme: HvTheme) => ({
   },
   baseCheckBox: {
     hoverColor: theme.colors.acce2s,
-    borderRadius: "2px",
+    borderRadius: theme.radii.base,
   },
   checkbox: {
     hoverColor: theme.colors.acce2s,
-    borderRadius: "2px",
+    borderRadius: theme.radii.base,
   },
   baseDropdown: {
     shadow: "none",
@@ -230,7 +230,7 @@ const ds5 = makeTheme((theme: HvTheme) => ({
   },
   baseRadio: {
     hoverColor: theme.colors.acce2s,
-    hoverBorderRadius: "2px",
+    hoverBorderRadius: theme.radii.base,
   },
   baseSwitch: {
     padding: 0,
@@ -266,7 +266,7 @@ const ds5 = makeTheme((theme: HvTheme) => ({
     hoverBackgroundColor: theme.colors.acce2s,
     hoverBaseBackgroundColor: "transparent",
     checkedOpacity: 1,
-    borderRadius: "2px",
+    borderRadius: theme.radii.base,
     focusBorderRadius: "8px",
   },
   baseInput: {
@@ -285,7 +285,7 @@ const ds5 = makeTheme((theme: HvTheme) => ({
   },
   radio: {
     hoverColor: theme.colors.acce2s,
-    borderRadius: "2px",
+    borderRadius: theme.radii.base,
   },
   tagsInput: {
     borderColor: theme.colors.acce4,
@@ -320,11 +320,11 @@ const ds5 = makeTheme((theme: HvTheme) => ({
       buttonSize: "48px",
       overlayColor: theme.colors.acce2s,
       overlayOpacity: "0.6", // TODO: Change to 1 when acce2s is fixed and has an alpha value
-      overlayBorderRadius: "2px",
+      overlayBorderRadius: theme.radii.base,
     },
   },
   dropDownMenu: {
-    borderRadius: "2px",
+    borderRadius: theme.radii.base,
     hoverColor: theme.colors.acce2s,
     borderOpened: `1px solid ${theme.colors.acce4}`,
     borderClosed: "1px solid transparent",
@@ -333,7 +333,7 @@ const ds5 = makeTheme((theme: HvTheme) => ({
   },
   pagination: {
     pageSizeBorderColor: theme.colors.acce1,
-    pageSizeBorderRadius: "2px",
+    pageSizeBorderRadius: theme.radii.base,
     pageJumpTextAlign: "center",
   },
   actionsGeneric: { buttonSize: "md" },


### PR DESCRIPTION
- Replace occurrences of `borderRadius: "2px"` with the same value but from the theme (`base` value).
- Allows us to customize the theme to change the value of the `base` property and have it reflected everywhere
