### PR TITLE
fix: generic function types removed

### DIFF
--- a/packages/core/src/components/AppSwitcher/Action/Action.tsx
+++ b/packages/core/src/components/AppSwitcher/Action/Action.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import clsx from "clsx";
 import { theme } from "@hitachivantara/uikit-styles";
 import { HvAvatar, HvTooltip, HvTypography } from "components";
-import { HvApplication } from "..";
+import { HvAppSwitcherActionApplication } from "../AppSwitcher";
 import { HvBaseProps } from "../../../types";
 import TitleWithTooltip from "../TitleWithTooltip";
 import {
@@ -18,11 +18,14 @@ import appSwitcherActionClasses, {
 
 export type HvActionProps = HvBaseProps & {
   /** The application data to be used to render the Action object. */
-  application: HvApplication;
+  application: HvAppSwitcherActionApplication;
   /** Callback triggered when the action is clicked. */
-  onClickCallback?: Function;
+  onClickCallback?: (
+    event: React.MouseEvent,
+    application: HvAppSwitcherActionApplication
+  ) => void;
   /** Must return a boolean stating if the action element is selected or not. */
-  isSelectedCallback?: Function;
+  isSelectedCallback?: (application: HvAppSwitcherActionApplication) => boolean;
   /** A Jss Object used to override or extend the styles applied to the component. */
   classes?: HvAppSwitcherActionClasses;
 };
@@ -45,7 +48,7 @@ export const HvAction = ({
     ? theme.colors.atmo5
     : getColor(application?.color, theme.colors.acce1);
 
-  const [validIconUrl, setValidIconUrl] = useState(true);
+  const [validIconUrl, setValidIconUrl] = useState<boolean>(true);
 
   const renderApplicationIcon = () => {
     if (iconElement) {
@@ -82,7 +85,7 @@ export const HvAction = ({
   /**
    * Handles the onClick event and triggers the appropriate callback if it exists.
    */
-  const handleOnClick = (event) => {
+  const handleOnClick = (event: React.MouseEvent) => {
     if (disabled) {
       event.preventDefault();
       return;

--- a/packages/core/src/components/AppSwitcher/AppSwitcher.stories.tsx
+++ b/packages/core/src/components/AppSwitcher/AppSwitcher.stories.tsx
@@ -3,12 +3,12 @@ import { Meta, StoryObj } from "@storybook/react";
 import {
   HvAppSwitcher,
   HvAppSwitcherProps,
-  HvApplication,
+  HvAppSwitcherActionApplication,
   HvTypography,
 } from "components";
 import { useState } from "react";
 
-const applicationsList: HvApplication[] = [
+const applicationsList: HvAppSwitcherActionApplication[] = [
   {
     name: "UI Kit Storybook",
     color: "#FF4785",
@@ -92,7 +92,7 @@ export const ManyEntries: StoryObj<HvAppSwitcherProps> = {
     };
 
     const getDummyApplicationsList = () => {
-      const dummyApplicationsList: HvApplication[] = [];
+      const dummyApplicationsList: HvAppSwitcherActionApplication[] = [];
 
       for (let index = 1; index <= 100; index += 1) {
         dummyApplicationsList.push({

--- a/packages/core/src/components/AppSwitcher/AppSwitcher.tsx
+++ b/packages/core/src/components/AppSwitcher/AppSwitcher.tsx
@@ -11,7 +11,7 @@ import {
 import TitleWithTooltip from "./TitleWithTooltip";
 import appSwitcherClasses, { HvAppSwitcherClasses } from "./appSwitcherClasses";
 
-export type HvApplication = {
+export type HvAppSwitcherActionApplication = {
   /** Id of the application. */
   id?: string;
   /** Name of the application, this is the value that will be displayed on the component. */
@@ -40,11 +40,16 @@ export type HvAppSwitcherProps = HvBaseProps & {
   /** Title to be displayed on the header of the component. */
   title?: string;
   /** The list of applications to be used to render the actions on the component. */
-  applications?: HvApplication[];
+  applications?: HvAppSwitcherActionApplication[];
   /** Triggered when an action is clicked. */
-  onActionClickedCallback?: Function;
+  onActionClickedCallback?: (
+    event: React.MouseEvent,
+    application: HvAppSwitcherActionApplication
+  ) => void;
   /** Must return a boolean stating if the action element is selected or not. */
-  isActionSelectedCallback?: Function;
+  isActionSelectedCallback?: (
+    application: HvAppSwitcherActionApplication
+  ) => boolean;
   /** Element to be added to the header container, if none is provided a label with the title will be added. */
   header?: React.ReactNode;
   /** Element to be added to the footer container. */
@@ -72,7 +77,10 @@ export const HvAppSwitcher = ({
   footer,
   isOpen,
 }: HvAppSwitcherProps) => {
-  const actionClicked = (event, application) => {
+  const actionClicked = (
+    event: React.MouseEvent,
+    application: HvAppSwitcherActionApplication
+  ) => {
     onActionClickedCallback?.(event, application);
   };
 

--- a/packages/core/src/components/Banner/Banner.stories.tsx
+++ b/packages/core/src/components/Banner/Banner.stories.tsx
@@ -97,8 +97,7 @@ export const BannerController: StoryObj<HvBannerProps> = {
 
       const handleOpen = () => setOpen(true);
 
-      const handleClose = (event, reason) => {
-        if (reason === "clickaway") return;
+      const handleClose = () => {
         setOpen(false);
       };
 

--- a/packages/core/src/components/Banner/Banner.tsx
+++ b/packages/core/src/components/Banner/Banner.tsx
@@ -8,24 +8,27 @@ import {
 import capitalize from "lodash/capitalize";
 import { HvBaseProps } from "../../types";
 import { StyledSnackbar } from "./Banner.styles";
-import { bannerClasses, HvBannerClasses } from ".";
-import { setId } from "utils";
+import bannerClasses, { HvBannerClasses } from "./bannerClasses";
+import { setId } from "../../utils";
 import {
   HvBannerContent,
   HvBannerContentProps,
 } from "./BannerContent/BannerContent";
-import { HvActionGeneric } from "components";
+import { HvActionGeneric } from "../ActionsGeneric";
 
 export type HvBannerVariant = "success" | "warning" | "error" | "default";
 
 export type HvBannerActionPosition = "auto" | "inline" | "bottom-right";
 
-export type HvBannerProps = Omit<MuiSnackbarProps, "anchorOrigin" | "classes"> &
+export type HvBannerProps = Omit<
+  MuiSnackbarProps,
+  "anchorOrigin" | "classes" | "onClose"
+> &
   HvBaseProps & {
     /** If true | Snackbar is open. */
     open: boolean;
     /** Callback fired when the component requests to be closed. Typically onClose is used to set state in the parent component, which is used to control the Snackbar open prop. The reason parameter can optionally be used to control the response to onClose, for example ignoring clickaway. */
-    onClose?: Function;
+    onClose?: (event: React.MouseEvent<HTMLButtonElement>) => void;
     /** The message to display. */
     label?: React.ReactNode;
     /** The anchor of the Snackbar. */

--- a/packages/core/src/components/Banner/BannerContent/ActionContainer/ActionContainer.tsx
+++ b/packages/core/src/components/Banner/BannerContent/ActionContainer/ActionContainer.tsx
@@ -9,13 +9,13 @@ import {
   StyledClose,
   StyledActionsInnerContainer,
 } from "./ActionContainer.styles";
-import { HvActionGeneric, HvActionsGeneric } from "components";
+import { HvActionGeneric, HvActionsGeneric } from "../../../ActionsGeneric";
 import { theme } from "@hitachivantara/uikit-styles";
-import { useTheme } from "hooks";
+import { useTheme } from "../../../../hooks";
 
 export type HvActionContainerProps = HvBaseProps & {
   /** onClose function. */
-  onClose?: Function;
+  onClose?: (event: React.MouseEvent<HTMLButtonElement>) => void;
   /** Actions to display. */
   action?: React.ReactNode | HvActionGeneric[];
   /**  The callback function ran when an action is triggered, receiving `action` as param */

--- a/packages/core/src/components/Banner/BannerContent/BannerContent.tsx
+++ b/packages/core/src/components/Banner/BannerContent/BannerContent.tsx
@@ -1,12 +1,11 @@
 import clsx from "clsx";
 import { SnackbarContentProps as MuiSnackbarContentProps } from "@mui/material/SnackbarContent";
 import { HvBaseProps } from "../../../types";
-import {
-  bannerContentClasses,
+import bannerContentClasses, {
   HvBannerContentClasses,
-  HvMessageContainer,
-  HvActionContainer,
-} from ".";
+} from "./bannerContentClasses";
+import { HvActionContainer } from "./ActionContainer";
+import { HvMessageContainer } from "./MessageContainer";
 import { StyledRoot, StyledSnackbarContent } from "./BannerContent.styles";
 import {
   HvActionGeneric,
@@ -14,12 +13,12 @@ import {
   HvBannerVariant,
 } from "components";
 import { forwardRef } from "react";
-import { iconVariant } from "utils";
+import { iconVariant } from "../../../utils";
 import { HvActionContainerProps } from "./ActionContainer/ActionContainer";
 
 export type HvBannerContentProps = Omit<
   MuiSnackbarContentProps,
-  "variant" | "classes"
+  "variant" | "classes" | "onClose"
 > &
   HvBaseProps & {
     /** The message to display. */
@@ -31,7 +30,7 @@ export type HvBannerContentProps = Omit<
     /** Custom icon to replace the variant default. */
     customIcon?: React.ReactNode;
     /** onClose function. */
-    onClose?: Function;
+    onClose?: (event: React.MouseEvent<HTMLButtonElement>) => void;
     /** Actions to display on the right side. */
     actions?: React.ReactNode | HvActionGeneric[];
     /**  The callback function ran when an action is triggered, receiving `action` as param */

--- a/packages/core/src/components/Forms/FormElement/FormElement.tsx
+++ b/packages/core/src/components/Forms/FormElement/FormElement.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from "react";
 import clsx from "clsx";
-import { HvBaseProps } from "../../../types/index";
-import { useUniqueId } from "hooks";
+import { HvBaseProps } from "../../../types";
+import { useUniqueId } from "../../../hooks";
 import { findDescriptors } from "./utils/FormUtils";
 import { HvFormElementContextProvider } from "./context/FormElementContext";
 import { HvFormElementValueContextProvider } from "./context/FormElementValueContext";
@@ -10,7 +10,7 @@ import formElementClasses, { HvFormElementClasses } from "./formElementClasses";
 
 export type HvFormStatus = "standBy" | "valid" | "invalid" | "empty";
 
-export type HvFormElementProps = HvBaseProps & {
+export type HvFormElementProps = HvBaseProps<HTMLDivElement, { onChange }> & {
   /**
    * Name of the form element.
    *
@@ -50,7 +50,7 @@ export type HvFormElementProps = HvBaseProps & {
   /** The error message to show when `status` is "invalid". */
   statusMessage?: string;
   /** The callback fired when the value changes. */
-  onChange?: Function;
+  onChange?: (event: React.FormEvent<HTMLDivElement>) => void;
   /** A Jss Object used to override or extend the styles applied to the component. */
   classes?: HvFormElementClasses;
 };

--- a/packages/core/src/components/Forms/Suggestions/Suggestions.tsx
+++ b/packages/core/src/components/Forms/Suggestions/Suggestions.tsx
@@ -8,8 +8,8 @@ import {
 } from "./Suggestions.styles";
 import { setId } from "../../../utils";
 import { HvFormElementContext } from "../FormElement";
-import { HvListItem } from "components";
-import { useClickOutside } from "hooks";
+import { HvListItem } from "../../ListContainer/ListItem";
+import { HvClickOutsideEvent, useClickOutside } from "../../../hooks";
 import suggestionsClasses, { HvSuggestionsClasses } from "./suggestionsClasses";
 
 export type HvSuggestion = {
@@ -26,12 +26,10 @@ export type HvSuggestionsProps = HvBaseProps & {
   anchorEl?: HTMLElement | null;
   /** Array of { id, label, ...others } values to display in the suggestion list */
   suggestionValues?: HvSuggestion[] | null;
-  /** Function called when suggestion list is closed */
-  // onClose: Function,
   /** Function called when a suggestion is selected */
-  onSuggestionSelected?: Function;
+  onSuggestionSelected?: (event: React.MouseEvent, value: HvSuggestion) => void;
   /** Function called when suggestion list is closed */
-  onClose?: Function;
+  onClose?: (event: HvClickOutsideEvent) => void;
   /** A Jss Object used to override or extend the styles applied to the component. */
   classes?: HvSuggestionsClasses;
 };
@@ -53,9 +51,9 @@ export const HvSuggestions = ({
   const ref = useRef<HTMLDivElement>(null);
   const [isOpen, setIsOpen] = useState<boolean>(expanded);
 
-  useClickOutside(ref, (e) => {
+  useClickOutside(ref, (event: HvClickOutsideEvent) => {
     setIsOpen(false);
-    onClose?.(e);
+    onClose?.(event);
   });
 
   useEffect(() => {

--- a/packages/core/src/components/Input/Input.stories.tsx
+++ b/packages/core/src/components/Input/Input.stories.tsx
@@ -15,6 +15,7 @@ import {
   HvBaseInput,
 } from "components";
 import countryNamesArray from "./countries";
+import { HvInputSuggestion } from "../../types";
 
 const meta: Meta<typeof HvInput> = {
   title: "Components/Input",
@@ -228,7 +229,7 @@ export const InvalidState: StoryObj<HvInputProps> = {
         defaultValue="Not a name!"
         status={validationState}
         statusMessage={errorMessage}
-        onFocus={(value) => setValidationState(value ? "standBy" : "empty")}
+        onFocus={(_, value) => setValidationState(value ? "standBy" : "empty")}
         onBlur={() => {
           setValidationState("invalid");
           setErrorMessage(
@@ -291,7 +292,7 @@ export const ExternalErrorMessage: StoryObj<HvInputProps> = {
               required
               status={lastNameValidationState}
               aria-errormessage="lastName-error"
-              onFocus={(value) => {
+              onFocus={(_, value) => {
                 setLastNameValidationState(value ? "standBy" : "empty");
               }}
               onBlur={(_e, _value, inputValidity) => {
@@ -486,7 +487,7 @@ export const EventDemonstration: StoryObj<HvInputProps> = {
 
     return (
       <HvInput
-        id="event-demostration-input"
+        id="event-demonstration-input"
         label="Text I will modify"
         description="Look at the browser's developer console to see the event handlers output"
         placeholder="Insert text"
@@ -545,7 +546,7 @@ export const Suggestion: StoryObj<HvInputProps> = {
 
     const countries = countryNamesArray;
 
-    const suggestionHandler = (val) => {
+    const suggestionHandler = (val: string): HvInputSuggestion[] | null => {
       if (typeof val !== "string" || val === "") return null;
       const foundCountries = countries.filter((country) =>
         country.toUpperCase().startsWith(val.toUpperCase())

--- a/packages/core/src/components/Pagination/Pagination.tsx
+++ b/packages/core/src/components/Pagination/Pagination.tsx
@@ -171,7 +171,7 @@ export const HvPagination = ({
         labels={labels}
         inputProps={{
           "aria-label": labels?.paginationInputLabel,
-          // we really want the native number input
+          // We really want the native number input
           type: "number",
         }}
         classes={{
@@ -185,11 +185,11 @@ export const HvPagination = ({
             classes?.pageSizeInputRoot
           ),
         }}
-        onChange={handleInputChange}
+        onChange={(event, value) => handleInputChange(event, Number(value))}
         value={String(pageInput)}
-        onBlur={(evt, value) => changePage(value - 1)}
+        onBlur={(evt, value) => changePage(Number(value) - 1)}
         onKeyDown={(evt, value) =>
-          isKeypress(evt, Enter) && changePage(value - 1)
+          isKeypress(evt, Enter) && changePage(Number(value) - 1)
         }
         disabled={pageSize === 0}
         disableClear

--- a/packages/core/src/components/SelectionList/SelectionList.tsx
+++ b/packages/core/src/components/SelectionList/SelectionList.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useMemo, useRef, useEffect } from "react";
 import clsx from "clsx";
-import { HvBaseProps } from "../../types/index";
+import { HvBaseProps } from "../../types";
 import {
   StyledListContainer,
   StyledFormElement,
@@ -13,9 +13,9 @@ import {
   keyboardCodes,
   setId,
   multiSelectionEventHandler,
-} from "utils";
-import { useControlled, useUniqueId } from "hooks";
-import { HvFormStatus } from "components";
+} from "../../utils";
+import { useControlled, useUniqueId } from "../../hooks";
+import { HvFormStatus } from "../Forms/FormElement";
 import selectionListClasses, {
   HvSelectionListClasses,
 } from "./selectionListClasses";
@@ -74,7 +74,7 @@ export type HvSelectionListProps = HvBaseProps<
   /** Indicates whether the list orientation is horizontal or vertical. Defaults to vertical. */
   orientation?: "vertical" | "horizontal";
   /** The callback fired when the value changes. */
-  onChange?: Function;
+  onChange?: (event: React.MouseEvent, value: any) => void;
   /** A Jss Object used to override or extend the styles applied to the component. */
   classes?: HvSelectionListClasses;
 };
@@ -198,10 +198,15 @@ export const HvSelectionList = ({
   }, [allValues, selectedState, setValue, ArrowUp, ArrowDown]);
 
   const onChildChangeInterceptor = useCallback(
-    (index, childOnClick, evt) => {
+    (
+      index: number,
+      childOnClick: (e: React.MouseEvent) => void,
+      evt: React.MouseEvent
+    ) => {
       childOnClick?.(evt);
+
       if (!readOnly && !disabled) {
-        let newValue;
+        let newValue: any;
         if (multiple) {
           newValue = multiSelectionEventHandler(
             evt,
@@ -221,7 +226,7 @@ export const HvSelectionList = ({
         onChange?.(evt, newValue);
 
         setValue(() => {
-          // this will only run if uncontrolled
+          // This will only run if uncontrolled
 
           if (required && newValue.length === 0) {
             setValidationState("invalid");
@@ -249,7 +254,7 @@ export const HvSelectionList = ({
   );
 
   const modifiedChildren = useMemo(() => {
-    return React.Children.map(children, (child: any, i) => {
+    return React.Children.map(children, (child: any, i: number) => {
       const childIsSelected = selectedState[i];
 
       return React.cloneElement(child, {
@@ -262,7 +267,7 @@ export const HvSelectionList = ({
     });
   }, [children, disabled, onChildChangeInterceptor, selectedState]);
 
-  // the error message area will only be created if:
+  // The error message area will only be created if:
   // - an external element that provides an error message isn't identified via aria-errormessage AND
   //   - both status and statusMessage properties are being controlled OR
   //   - status is uncontrolled and required is true

--- a/packages/core/src/components/TagsInput/TagsInput.tsx
+++ b/packages/core/src/components/TagsInput/TagsInput.tsx
@@ -7,8 +7,11 @@ import React, {
 } from "react";
 import clsx from "clsx";
 import isNil from "lodash/isNil";
-import { HvValidationMessages } from "types/forms";
-import { HvBaseProps } from "../../types";
+import {
+  HvBaseProps,
+  HvTagSuggestion,
+  HvValidationMessages,
+} from "../../types";
 import {
   StyledCharCounter,
   StyledDescription,
@@ -25,9 +28,9 @@ import {
 } from "./TagsInput.styles";
 import validationStates from "../Forms/FormElement/validationStates";
 import { DEFAULT_ERROR_MESSAGES } from "../BaseInput/validations";
-import { useControlled, useIsMounted, useUniqueId } from "hooks";
-import { isKeypress, keyboardCodes, setId } from "utils";
-import { HvTagProps } from "components";
+import { useControlled, useIsMounted, useUniqueId } from "../../hooks";
+import { isKeypress, keyboardCodes, setId } from "../../utils";
+import { HvTagProps } from "../Tag";
 import tagsInputClasses, { HvTagsInputClasses } from "./tagsInputClasses";
 import { HvCharCounterProps, HvFormStatus } from "../Forms";
 import { InputBaseComponentProps as MuiInputBaseComponentProps } from "@mui/material";
@@ -121,7 +124,7 @@ export type HvTagsInputProps = HvBaseProps<
   /** If `true` the tag will be committed when the blur event occurs. */
   commitOnBlur?: boolean;
   /** The function that will be executed to received an array of objects that has a label and id to create list of suggestion */
-  suggestionListCallback?: Function;
+  suggestionListCallback?: (value: string) => HvTagSuggestion[] | null;
   /** A Jss Object used to override or extend the styles applied to the component. */
   classes?: HvTagsInputClasses;
 };
@@ -196,7 +199,9 @@ export const HvTagsInput = ({
   const hasCounter = maxTagsQuantity != null && !hideCounter;
 
   // suggestions related state
-  const [suggestionValues, setSuggestionValues] = useState(null);
+  const [suggestionValues, setSuggestionValues] = useState<
+    HvTagSuggestion[] | null
+  >(null);
 
   const isStateInvalid = useMemo(() => {
     return hasCounter && value.length > maxTagsQuantity;

--- a/packages/core/src/components/ToggleButton/ToggleButton.tsx
+++ b/packages/core/src/components/ToggleButton/ToggleButton.tsx
@@ -1,6 +1,6 @@
 import { forwardRef } from "react";
-import { HvButton } from "components";
-import { useControlled } from "hooks";
+import { HvButton } from "../Button";
+import { useControlled } from "../../hooks";
 import { HvBaseProps } from "../../types";
 
 export type HvToggleButtonProps = HvBaseProps<
@@ -18,7 +18,10 @@ export type HvToggleButtonProps = HvBaseProps<
   /** Icon for when selected. Ignored if the component has children. */
   selectedIcon?: React.ReactNode;
   /** Function called when icon is clicked. */
-  onClick?: Function;
+  onClick?: (
+    event: React.MouseEvent<HTMLButtonElement>,
+    selected: boolean
+  ) => void;
 };
 
 export const HvToggleButton = forwardRef<
@@ -40,9 +43,9 @@ export const HvToggleButton = forwardRef<
     Boolean(defaultSelected)
   );
 
-  const onClickHandler = (e) => {
+  const onClickHandler = (event: React.MouseEvent<HTMLButtonElement>) => {
     setIsSelected(!isSelected);
-    onClick?.(e, !isSelected);
+    onClick?.(event, !isSelected);
   };
 
   return (

--- a/packages/core/src/hooks/useClickOutside.ts
+++ b/packages/core/src/hooks/useClickOutside.ts
@@ -1,13 +1,13 @@
 import { useEffect, RefObject } from "react";
 
-type Event = MouseEvent | KeyboardEvent | TouchEvent;
+export type HvClickOutsideEvent = MouseEvent | KeyboardEvent | TouchEvent;
 
 export const useClickOutside = <T extends HTMLElement = HTMLElement>(
   ref: RefObject<T>,
-  handler: (event: Event) => void
+  handler: (event: HvClickOutsideEvent) => void
 ) => {
   useEffect(() => {
-    const listener = (event: Event) => {
+    const listener = (event: HvClickOutsideEvent) => {
       const el = ref?.current;
       const isKeyUp = event.type === "keyup";
       const isEscape = (event as KeyboardEvent).key === "Escape";

--- a/packages/core/src/types/forms.ts
+++ b/packages/core/src/types/forms.ts
@@ -23,3 +23,11 @@ export type HvInputLabels = {
   /** The label of the search button. */
   searchButtonLabel?: string;
 };
+
+export type HvInputSuggestion = {
+  id: string;
+  label: string;
+  value?: string;
+};
+
+export type HvTagSuggestion = HvInputSuggestion;


### PR DESCRIPTION
The generic function types were removed this was not providing enough context while using the components. 

`HvApplication` was also renamed to `HvAppSwitcherActionApplication`. This is the old name and it seems more specific.