### PR TITLE
fix: update themes when themes list changes

### DIFF
--- a/packages/core/src/providers/ThemeProvider.tsx
+++ b/packages/core/src/providers/ThemeProvider.tsx
@@ -38,7 +38,11 @@ export const HvThemeProvider = ({
   );
   const [selectedMode, setThemeMode] = useState<string>(pTheme.selectedMode);
   const [colorModes, setColorModes] = useState<string[]>(pTheme.colorModes);
-  const [themes] = useState<string[]>(themesList.map((t) => t.name));
+  const [themes, setThemes] = useState<string[]>(themesList.map((t) => t.name));
+
+  useEffect(() => {
+    setThemes(themesList.map((t) => t.name));
+  }, [themesList]);
 
   const changeTheme = (newTheme = selectedTheme, newMode = selectedMode) => {
     pTheme = parseTheme(themesList, newTheme, newMode);


### PR DESCRIPTION
I noticed that the themes list on the `ThemeSwitcher` was not updating when I updated the themes on the code. From what I understand the themes variable that we're setting on the `ThemeContext` is not getting updated so the `ThemeSwitcher`was not reflecting that change.