### PR TITLE
fix: border radius added to table outline focus

### DIFF
--- a/packages/core/src/components/Table/TableRow/TableRow.tsx
+++ b/packages/core/src/components/Table/TableRow/TableRow.tsx
@@ -133,6 +133,10 @@ const StyledTableRow = (c: any) =>
           height: 16,
         },
       }),
+
+      "&.HvIsFocused": {
+        borderRadius: theme.table.rowBorderRadius,
+      },
     })
   );
 

--- a/packages/core/src/components/Table/__snapshots__/Table.test.tsx.snap
+++ b/packages/core/src/components/Table/__snapshots__/Table.test.tsx.snap
@@ -12,7 +12,7 @@ exports[`List Row > should be defined 1`] = `
         class="HvTableHead-root css-1c8o9gy-StyledTableHead e122w5bu0"
       >
         <tr
-          class="HvTableRow-root HvTableRow-head HvTableRow-variantListHead css-10h476g-StyledTableRow e1cjstvf0"
+          class="HvTableRow-root HvTableRow-head HvTableRow-variantListHead css-1nsmz1t-StyledTableRow e1cjstvf0"
         >
           <th
             class="HvTableHeader-root HvTableHeader-head HvTableHeader-variantList css-1j2ycju-StyledTableHeader eopmu0i1"
@@ -62,7 +62,7 @@ exports[`List Row > should be defined 1`] = `
         class="HvTableBody-root css-1uj09q8-StyledTableBody e1i1hapa0"
       >
         <tr
-          class="HvFocus-root grid grid HvTableRow-root HvTableRow-body HvTableRow-variantList css-lb1wd-StyledTableRow e1cjstvf0"
+          class="HvFocus-root grid grid HvTableRow-root HvTableRow-body HvTableRow-variantList css-12tuxlz-StyledTableRow e1cjstvf0"
         >
           <td
             class="HvTableCell-root HvTableCell-body HvTableCell-variantList css-1jqgxep-StyledTableCell e8848lx0"
@@ -81,7 +81,7 @@ exports[`List Row > should be defined 1`] = `
           </td>
         </tr>
         <tr
-          class="HvFocus-root grid grid HvTableRow-root HvTableRow-body HvTableRow-variantList css-lb1wd-StyledTableRow e1cjstvf0"
+          class="HvFocus-root grid grid HvTableRow-root HvTableRow-body HvTableRow-variantList css-12tuxlz-StyledTableRow e1cjstvf0"
         >
           <td
             class="HvTableCell-root HvTableCell-body HvTableCell-variantList css-1jqgxep-StyledTableCell e8848lx0"
@@ -100,7 +100,7 @@ exports[`List Row > should be defined 1`] = `
           </td>
         </tr>
         <tr
-          class="HvFocus-root grid grid HvTableRow-root HvTableRow-body HvTableRow-variantList css-lb1wd-StyledTableRow e1cjstvf0"
+          class="HvFocus-root grid grid HvTableRow-root HvTableRow-body HvTableRow-variantList css-12tuxlz-StyledTableRow e1cjstvf0"
         >
           <td
             class="HvTableCell-root HvTableCell-body HvTableCell-variantList css-1jqgxep-StyledTableCell e8848lx0"
@@ -119,7 +119,7 @@ exports[`List Row > should be defined 1`] = `
           </td>
         </tr>
         <tr
-          class="HvFocus-root grid grid HvTableRow-root HvTableRow-body HvTableRow-variantList css-lb1wd-StyledTableRow e1cjstvf0"
+          class="HvFocus-root grid grid HvTableRow-root HvTableRow-body HvTableRow-variantList css-12tuxlz-StyledTableRow e1cjstvf0"
         >
           <td
             class="HvTableCell-root HvTableCell-body HvTableCell-variantList css-1jqgxep-StyledTableCell e8848lx0"
@@ -138,7 +138,7 @@ exports[`List Row > should be defined 1`] = `
           </td>
         </tr>
         <tr
-          class="HvFocus-root grid grid HvTableRow-root HvTableRow-body HvTableRow-variantList css-lb1wd-StyledTableRow e1cjstvf0"
+          class="HvFocus-root grid grid HvTableRow-root HvTableRow-body HvTableRow-variantList css-12tuxlz-StyledTableRow e1cjstvf0"
         >
           <td
             class="HvTableCell-root HvTableCell-body HvTableCell-variantList css-1jqgxep-StyledTableCell e8848lx0"
@@ -157,7 +157,7 @@ exports[`List Row > should be defined 1`] = `
           </td>
         </tr>
         <tr
-          class="HvFocus-root grid grid HvTableRow-root HvTableRow-body HvTableRow-variantList css-lb1wd-StyledTableRow e1cjstvf0"
+          class="HvFocus-root grid grid HvTableRow-root HvTableRow-body HvTableRow-variantList css-12tuxlz-StyledTableRow e1cjstvf0"
         >
           <td
             class="HvTableCell-root HvTableCell-body HvTableCell-variantList css-1jqgxep-StyledTableCell e8848lx0"
@@ -193,7 +193,7 @@ exports[`Simple Table > should be defined 1`] = `
         class="HvTableHead-root css-1c8o9gy-StyledTableHead e122w5bu0"
       >
         <tr
-          class="HvTableRow-root HvTableRow-head css-1okhz2u-StyledTableRow e1cjstvf0"
+          class="HvTableRow-root HvTableRow-head css-1na72p5-StyledTableRow e1cjstvf0"
         >
           <th
             class="HvTableHeader-root HvTableHeader-head css-1wvrgc7-StyledTableHeader eopmu0i1"
@@ -243,7 +243,7 @@ exports[`Simple Table > should be defined 1`] = `
         class="HvTableBody-root css-1uj09q8-StyledTableBody e1i1hapa0"
       >
         <tr
-          class="grid HvTableRow-root HvTableRow-body css-1b550m2-StyledTableRow e1cjstvf0"
+          class="grid HvTableRow-root HvTableRow-body css-1ve2tum-StyledTableRow e1cjstvf0"
         >
           <td
             class="HvTableCell-root HvTableCell-body css-1rfsof4-StyledTableCell e8848lx0"
@@ -262,7 +262,7 @@ exports[`Simple Table > should be defined 1`] = `
           </td>
         </tr>
         <tr
-          class="grid HvTableRow-root HvTableRow-body css-1b550m2-StyledTableRow e1cjstvf0"
+          class="grid HvTableRow-root HvTableRow-body css-1ve2tum-StyledTableRow e1cjstvf0"
         >
           <td
             class="HvTableCell-root HvTableCell-body css-1rfsof4-StyledTableCell e8848lx0"
@@ -281,7 +281,7 @@ exports[`Simple Table > should be defined 1`] = `
           </td>
         </tr>
         <tr
-          class="grid HvTableRow-root HvTableRow-body css-1b550m2-StyledTableRow e1cjstvf0"
+          class="grid HvTableRow-root HvTableRow-body css-1ve2tum-StyledTableRow e1cjstvf0"
         >
           <td
             class="HvTableCell-root HvTableCell-body css-1rfsof4-StyledTableCell e8848lx0"
@@ -300,7 +300,7 @@ exports[`Simple Table > should be defined 1`] = `
           </td>
         </tr>
         <tr
-          class="grid HvTableRow-root HvTableRow-body css-1b550m2-StyledTableRow e1cjstvf0"
+          class="grid HvTableRow-root HvTableRow-body css-1ve2tum-StyledTableRow e1cjstvf0"
         >
           <td
             class="HvTableCell-root HvTableCell-body css-1rfsof4-StyledTableCell e8848lx0"
@@ -319,7 +319,7 @@ exports[`Simple Table > should be defined 1`] = `
           </td>
         </tr>
         <tr
-          class="grid HvTableRow-root HvTableRow-body css-1b550m2-StyledTableRow e1cjstvf0"
+          class="grid HvTableRow-root HvTableRow-body css-1ve2tum-StyledTableRow e1cjstvf0"
         >
           <td
             class="HvTableCell-root HvTableCell-body css-1rfsof4-StyledTableCell e8848lx0"
@@ -338,7 +338,7 @@ exports[`Simple Table > should be defined 1`] = `
           </td>
         </tr>
         <tr
-          class="grid HvTableRow-root HvTableRow-body css-1b550m2-StyledTableRow e1cjstvf0"
+          class="grid HvTableRow-root HvTableRow-body css-1ve2tum-StyledTableRow e1cjstvf0"
         >
           <td
             class="HvTableCell-root HvTableCell-body css-1rfsof4-StyledTableCell e8848lx0"


### PR DESCRIPTION
A border radius was added to the table outline focus.

Note: The table needs to be reviewed later on because in Firefox the background color overflows the outline.
 
<img width="431" alt="Screenshot 2023-03-20 at 10 40 02" src="https://user-images.githubusercontent.com/43220251/226317629-62eb37db-05da-4159-a594-805b5bcd4d07.png">
