### PR TITLE
feat(Theme): add Theme Generator

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -1,21 +1,28 @@
+import { ds3, ds5, HvProvider } from "@hitachivantara/uikit-react-core";
 import "lib/i18n";
-import { BrowserRouter as Router } from "react-router-dom";
-import { HvProvider } from "@hitachivantara/uikit-react-core";
-import { Container } from "components/common";
-import { NavigationProvider } from "lib/context/NavigationContext";
-import navigation from "lib/navigation";
-import Routes from "lib/routes";
+import Content from "generator/Content";
+import { Sidebar } from "generator/Sidebar";
+import GeneratorProvider from "generator/GeneratorContext";
 
-const App = () => (
-  <Router>
-    <HvProvider rootElementId="hv-root">
-      <NavigationProvider navigation={navigation}>
-        <Container maxWidth="xl">
-          <Routes />
-        </Container>
-      </NavigationProvider>
-    </HvProvider>
-  </Router>
-);
+const App = () => {
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "row",
+        marginRight: 390,
+      }}
+    >
+      <HvProvider themes={[ds3, ds5]} theme="ds5">
+        <GeneratorProvider>
+          <div style={{ flexGrow: 1 }}>
+            <Content />
+          </div>
+          <Sidebar />
+        </GeneratorProvider>
+      </HvProvider>
+    </div>
+  );
+};
 
 export default App;

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -1,24 +1,68 @@
-import { ds3, ds5, HvProvider } from "@hitachivantara/uikit-react-core";
+import {
+  ds3,
+  ds5,
+  HvBox,
+  HvButton,
+  HvProvider,
+  HvTooltip,
+  HvTypography,
+  theme,
+} from "@hitachivantara/uikit-react-core";
 import "lib/i18n";
 import Content from "generator/Content";
 import { Sidebar } from "generator/Sidebar";
 import GeneratorProvider from "generator/GeneratorContext";
+import { useState } from "react";
+import { Backwards, Forwards } from "@hitachivantara/uikit-react-icons";
+import { css } from "@emotion/css";
 
 const App = () => {
+  const [open, setOpen] = useState(false);
+
   return (
     <div
       style={{
         display: "flex",
         flexDirection: "row",
-        marginRight: 390,
+        marginRight: open ? 390 : 30,
+        borderRadius: theme.radii.circle,
       }}
     >
+      <HvBox
+        sx={{
+          position: "absolute",
+          top: "calc(50% - 16px)",
+          right: open ? 375 : 14,
+          zIndex: theme.zIndices.tooltip,
+          backgroundColor: theme.colors.atmo1,
+          borderRadius: theme.radii.circle,
+        }}
+      >
+        <HvTooltip
+          title={
+            <HvTypography>
+              {open ? "Close Theme Generator" : "Open Theme Generator"}
+            </HvTypography>
+          }
+        >
+          <HvButton
+            icon
+            variant="secondaryGhost"
+            onClick={() => setOpen((prev) => !prev)}
+            classes={{
+              root: css({ borderRadius: `${theme.radii.circle}!important` }),
+            }}
+          >
+            {open ? <Forwards /> : <Backwards />}
+          </HvButton>
+        </HvTooltip>
+      </HvBox>
       <HvProvider themes={[ds3, ds5]} theme="ds5">
         <GeneratorProvider>
           <div style={{ flexGrow: 1 }}>
             <Content />
           </div>
-          <Sidebar />
+          <Sidebar open={open} />
         </GeneratorProvider>
       </HvProvider>
     </div>

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -30,12 +30,13 @@ const App = () => {
     >
       <HvBox
         sx={{
-          position: "absolute",
+          position: "fixed",
           top: "calc(50% - 16px)",
           right: open ? 375 : 14,
           zIndex: theme.zIndices.tooltip,
           backgroundColor: theme.colors.atmo1,
           borderRadius: theme.radii.circle,
+          boxShadow: "-10px 0px 10px 1px rgba(65,65,65,0.12)",
         }}
       >
         <HvTooltip

--- a/app/src/components/common/Container/styles.ts
+++ b/app/src/components/common/Container/styles.ts
@@ -4,7 +4,7 @@ import { theme } from "@hitachivantara/uikit-styles";
 const styles = {
   root: css({
     display: "flex",
-    paddingTop: `calc(2 * ${theme.header.height} + ${theme.space.lg})`,
+    paddingTop: `calc(${theme.header.height} + ${theme.space.sm})`,
     paddingBottom: theme.space.lg,
     minHeight: "100vh",
   }),

--- a/app/src/components/common/Header/Header.tsx
+++ b/app/src/components/common/Header/Header.tsx
@@ -14,7 +14,7 @@ import {
 import HitachiLogo from "assets/HitachiLogo";
 import { NavigationContext } from "lib/context/NavigationContext";
 import navigation from "lib/navigation";
-import { ThemeSwitcher } from "../../common/ThemeSwitcher";
+// import { ThemeSwitcher } from "../../common/ThemeSwitcher";
 
 export const Header = () => {
   const navigate = useNavigate();
@@ -29,7 +29,7 @@ export const Header = () => {
   };
 
   return (
-    <HvHeader>
+    <HvHeader position="relative">
       {!isMdUp && (
         <div>
           <HvButton variant="primaryGhost" icon>
@@ -60,7 +60,7 @@ export const Header = () => {
             icon={<Alert />}
             style={{ marginRight: 10 }}
           />
-          <ThemeSwitcher />
+          {/* <ThemeSwitcher /> */}
         </HvHeaderActions>
       )}
     </HvHeader>

--- a/app/src/components/components/Buttons/Buttons.tsx
+++ b/app/src/components/components/Buttons/Buttons.tsx
@@ -2,85 +2,124 @@ import {
   HvBox,
   HvButton,
   HvTypography,
+  theme,
 } from "@hitachivantara/uikit-react-core";
 import { Draw, MoreOptionsVertical } from "@hitachivantara/uikit-react-icons";
-import { ButtonConfigurator } from "../ButtonConfigurator";
 
 export const Buttons = () => {
   return (
-    <>
-      <ButtonConfigurator />
-      <HvBox sx={{ display: "flex", gap: 20 }}>
-        <HvButton icon variant="primary">
-          <MoreOptionsVertical />
-        </HvButton>
-        <HvButton icon variant="primarySubtle">
-          <MoreOptionsVertical />
-        </HvButton>
-        <HvButton icon variant="primaryGhost">
-          <MoreOptionsVertical />
-        </HvButton>
-        <HvButton icon variant="secondarySubtle">
-          <MoreOptionsVertical />
-        </HvButton>
-        <HvButton icon variant="secondaryGhost">
-          <MoreOptionsVertical />
-        </HvButton>
+    <HvBox
+      sx={{ display: "flex", flexDirection: "column", gap: theme.space.md }}
+    >
+      <HvBox
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          gap: theme.space.xs,
+        }}
+      >
+        <HvTypography variant="title4">Default</HvTypography>
+        <HvBox sx={{ display: "flex", gap: theme.space.md }}>
+          <HvButton
+            variant="primary"
+            onClick={() => alert("This can be triggered")}
+            startIcon={<Draw />}
+          >
+            Primary
+          </HvButton>
+          <HvButton variant="primarySubtle" startIcon={<Draw />}>
+            Primary Subtle
+          </HvButton>
+          <HvButton variant="primaryGhost" startIcon={<Draw />}>
+            Primary Ghost
+          </HvButton>
+          <HvButton variant="secondarySubtle" startIcon={<Draw />}>
+            Secondary Subtle
+          </HvButton>
+          <HvButton variant="secondaryGhost" startIcon={<Draw />}>
+            Secondary Ghost
+          </HvButton>
+        </HvBox>
       </HvBox>
-      <HvBox sx={{ display: "flex", gap: 20 }}>
-        <HvButton
-          variant="primary"
-          onClick={() => alert("This can be triggered")}
-          startIcon={<Draw />}
+
+      <HvBox
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          gap: theme.space.xs,
+        }}
+      >
+        <HvTypography variant="title4">Disabled</HvTypography>
+        <HvBox sx={{ display: "flex", gap: theme.space.md }}>
+          <HvButton disabled variant="primary" startIcon={<Draw />}>
+            Primary
+          </HvButton>
+          <HvButton disabled variant="primarySubtle" startIcon={<Draw />}>
+            Primary Subtle
+          </HvButton>
+          <HvButton disabled variant="primaryGhost" startIcon={<Draw />}>
+            Primary Ghost
+          </HvButton>
+          <HvButton
+            disabled
+            overrideIconColors={false}
+            variant="secondarySubtle"
+            startIcon={<Draw />}
+          >
+            Secondary Subtle
+          </HvButton>
+          <HvButton
+            disabled
+            overrideIconColors={false}
+            variant="secondaryGhost"
+            startIcon={<Draw />}
+          >
+            Secondary Ghost
+          </HvButton>
+        </HvBox>
+      </HvBox>
+      <HvBox
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          gap: theme.space.xs,
+        }}
+      >
+        <HvTypography variant="title4">Icons</HvTypography>
+        <HvBox
+          sx={{ display: "flex", gap: theme.space.md, alignItems: "center" }}
         >
-          Primary
-        </HvButton>
-        <HvButton variant="primarySubtle" startIcon={<Draw />}>
-          Primary Subtle
-        </HvButton>
-        <HvButton variant="primaryGhost" startIcon={<Draw />}>
-          Primary Ghost
-        </HvButton>
-        <HvButton variant="secondarySubtle" startIcon={<Draw />}>
-          Secondary Subtle
-        </HvButton>
-        <HvButton variant="secondaryGhost" startIcon={<Draw />}>
-          Secondary Ghost
-        </HvButton>
+          <HvButton icon variant="primary">
+            <MoreOptionsVertical />
+          </HvButton>
+          <HvButton icon variant="primarySubtle">
+            <MoreOptionsVertical />
+          </HvButton>
+          <HvButton icon variant="primaryGhost">
+            <MoreOptionsVertical />
+          </HvButton>
+          <HvButton icon variant="secondarySubtle">
+            <MoreOptionsVertical />
+          </HvButton>
+          <HvButton icon variant="secondaryGhost">
+            <MoreOptionsVertical />
+          </HvButton>
+        </HvBox>
       </HvBox>
-      <HvBox sx={{ display: "flex", gap: 20 }}>
-        <HvButton disabled variant="primary" startIcon={<Draw />}>
-          Primary
-        </HvButton>
-        <HvButton disabled variant="primarySubtle" startIcon={<Draw />}>
-          Primary Subtle
-        </HvButton>
-        <HvButton disabled variant="primaryGhost" startIcon={<Draw />}>
-          Primary Ghost
-        </HvButton>
-        <HvButton
-          disabled
-          overrideIconColors={false}
-          variant="secondarySubtle"
-          startIcon={<Draw />}
-        >
-          Secondary Subtle
-        </HvButton>
-        <HvButton
-          disabled
-          overrideIconColors={false}
-          variant="secondaryGhost"
-          startIcon={<Draw />}
-        >
-          Secondary Ghost
-        </HvButton>
+      <HvBox
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          gap: theme.space.xs,
+        }}
+      >
+        <HvTypography variant="title4">Semantic</HvTypography>
+        <HvBox sx={{ backgroundColor: "#D3E3F6" }}>
+          <HvButton variant="semantic" startIcon={<Draw />}>
+            Semantic
+          </HvButton>
+        </HvBox>
       </HvBox>
-      <HvBox sx={{ display: "flex", gap: 20, backgroundColor: "#D3E3F6" }}>
-        <HvTypography variant="title1">Semantic</HvTypography>
-        <HvButton variant="semantic" startIcon={<Draw />}>
-          Primary
-        </HvButton>
-      </HvBox>
-    </>
+    </HvBox>
   );
 };

--- a/app/src/components/components/Cards/Cards.tsx
+++ b/app/src/components/components/Cards/Cards.tsx
@@ -4,38 +4,62 @@ import {
   HvCardContent,
   HvCardMedia,
   HvTypography,
+  theme,
+  HvBox,
 } from "@hitachivantara/uikit-react-core";
 import compressor from "./assets/compressor.png";
 
 export const Cards = () => {
   return (
-    <HvCard
-      bgcolor="atmo1"
-      statusColor="sema4"
-      style={{ width: 360 }}
-      selectable
-    >
-      <HvCardHeader
-        title="Asset Avatar L90"
-        subheader="Compressor"
-        aria-label="Compressor"
-      />
-      <HvCardMedia
-        component="img"
-        alt="Compressor"
-        height={140}
-        image={compressor}
-      />
-      <HvCardContent>
-        <div style={{ paddingTop: "20px" }}>
-          <HvTypography variant="label">ID</HvTypography>
-          <HvTypography>2101cad3-7cd4-1000-bdp95-d8c497176e7c</HvTypography>
-        </div>
-        <div style={{ marginTop: "20px" }}>
-          <HvTypography variant="label">Last connected</HvTypography>
-          <HvTypography>Aug 30, 2017 12:27:53 PM</HvTypography>
-        </div>
-      </HvCardContent>
-    </HvCard>
+    <HvBox sx={{ display: "flex", flexDirection: "row", gap: theme.space.md }}>
+      <HvCard
+        bgcolor="atmo1"
+        statusColor="sema4"
+        style={{ width: 360 }}
+        selectable
+      >
+        <HvCardHeader
+          title="Asset Avatar L90"
+          subheader="Compressor"
+          aria-label="Compressor"
+        />
+        <HvCardMedia
+          component="img"
+          alt="Compressor"
+          height={140}
+          image={compressor}
+        />
+        <HvCardContent>
+          <div style={{ paddingTop: "20px" }}>
+            <HvTypography variant="label">ID</HvTypography>
+            <HvTypography>2101cad3-7cd4-1000-bdp95-d8c497176e7c</HvTypography>
+          </div>
+          <div style={{ marginTop: "20px" }}>
+            <HvTypography variant="label">Last connected</HvTypography>
+            <HvTypography>Aug 30, 2017 12:27:53 PM</HvTypography>
+          </div>
+        </HvCardContent>
+      </HvCard>
+      <HvCard
+        bgcolor="atmo1"
+        style={{ width: 360, cursor: "pointer", height: 200 }}
+        tabIndex={0}
+        role="button"
+        aria-selected={undefined}
+        statusColor="sema1"
+      >
+        <HvCardHeader title="Asset Avatar L90" subheader="Compressor" />
+        <HvCardContent>
+          <div>
+            <HvTypography variant="label">ID</HvTypography>
+            <HvTypography>2101cad3-7cd4-1000-bdp95-d8c497176e7c</HvTypography>
+          </div>
+          <div style={{ marginTop: "20px" }}>
+            <HvTypography variant="label">Last connected</HvTypography>
+            <HvTypography>Aug 30, 2017 12:27:53 PM</HvTypography>
+          </div>
+        </HvCardContent>
+      </HvCard>
+    </HvBox>
   );
 };

--- a/app/src/components/components/Snackbars/Snackbars.tsx
+++ b/app/src/components/components/Snackbars/Snackbars.tsx
@@ -1,3 +1,4 @@
+import { css } from "@emotion/css";
 import { HvSnackbar } from "@hitachivantara/uikit-react-core";
 
 export const Snackbars = () => {
@@ -12,6 +13,7 @@ export const Snackbars = () => {
         offset={60}
         transitionDuration={300}
         autoHideDuration={5000}
+        classes={{ root: css({ marginRight: 400 }) }}
       />
       <HvSnackbar
         open={true}
@@ -22,6 +24,7 @@ export const Snackbars = () => {
         offset={120}
         transitionDuration={300}
         autoHideDuration={5000}
+        classes={{ root: css({ marginRight: 400 }) }}
       />
       <HvSnackbar
         open={true}
@@ -32,6 +35,7 @@ export const Snackbars = () => {
         offset={180}
         transitionDuration={300}
         autoHideDuration={5000}
+        classes={{ root: css({ marginRight: 400 }) }}
       />
     </>
   );

--- a/app/src/generator/Colors/Colors.styles.tsx
+++ b/app/src/generator/Colors/Colors.styles.tsx
@@ -1,0 +1,37 @@
+import { css } from "@emotion/css";
+import { theme } from "@hitachivantara/uikit-react-core";
+
+export const styles = {
+  root: css({
+    width: "100%",
+    display: "flex",
+    flexDirection: "column",
+    paddingLeft: theme.space.xs,
+  }),
+  group: css({
+    display: "flex",
+    flexDirection: "row",
+    flexWrap: "wrap",
+    justifyContent: "space-between",
+    marginBottom: theme.space.xs,
+  }),
+  groupName: css({
+    width: "30%",
+  }),
+  groupColors: css({
+    width: "70%",
+    textAlign: "end",
+  }),
+  color: css({
+    width: 20,
+    height: 25,
+    marginLeft: 5,
+    padding: 0,
+    backgroundColor: "transparent",
+  }),
+  tooltip: css({
+    display: "flex",
+    flexDirection: "column",
+    justifyContent: "center",
+  }),
+};

--- a/app/src/generator/Colors/Colors.tsx
+++ b/app/src/generator/Colors/Colors.tsx
@@ -1,0 +1,97 @@
+import {
+  createTheme,
+  HvTooltip,
+  HvTypography,
+  useTheme,
+} from "@hitachivantara/uikit-react-core";
+import { GeneratorContext } from "generator/GeneratorContext";
+import { useContext } from "react";
+import { styles } from "./Colors.styles";
+import { getColorGroupName, getColors } from "./utils";
+import debounce from "lodash/debounce";
+
+const groupsToShow = ["acce", "atmo", "base", "sema"]; // "sup", "cviz"
+
+const Colors = (): JSX.Element => {
+  const { activeTheme, selectedMode } = useTheme();
+  const { customTheme, updateCustomTheme, updateChangedValues } =
+    useContext(GeneratorContext);
+
+  const colors = activeTheme?.colors.modes[selectedMode];
+
+  const colorChangedHandler = (colorName, colorValue) => {
+    const newTheme = createTheme({
+      ...customTheme,
+      colors: {
+        ...customTheme.colors,
+        modes: {
+          ...customTheme.colors.modes,
+          [selectedMode]: {
+            ...customTheme.colors.modes[selectedMode],
+            [colorName]: colorValue,
+          },
+        },
+      },
+    });
+    updateCustomTheme(newTheme);
+    updateChangedValues?.(
+      ["colors", "modes", selectedMode, colorName],
+      colorValue
+    );
+  };
+
+  const debouncedHandler = debounce(colorChangedHandler, 250);
+
+  return (
+    <div className={styles.root}>
+      {groupsToShow.map((group) => {
+        const groupColors = getColors(colors, group);
+        return (
+          <div className={styles.group} key={group}>
+            <div className={styles.groupName}>
+              <HvTypography variant="label">
+                {getColorGroupName(group)}
+              </HvTypography>
+            </div>
+            <div className={styles.groupColors}>
+              {Object.keys(groupColors).map((c) => {
+                return (
+                  <HvTooltip
+                    key={c}
+                    title={
+                      <div className={styles.tooltip}>
+                        <HvTypography variant="label">{c}</HvTypography>
+                        <HvTypography>
+                          {customTheme?.colors?.modes?.[selectedMode]?.[c] ||
+                            groupColors[c]}
+                        </HvTypography>
+                      </div>
+                    }
+                  >
+                    <input
+                      key={c}
+                      type="color"
+                      className={styles.color}
+                      value={
+                        (customTheme &&
+                          customTheme.colors &&
+                          customTheme.colors.modes[selectedMode] &&
+                          customTheme.colors.modes?.[selectedMode][c]) ||
+                        groupColors[c]
+                      }
+                      onChange={(e) => {
+                        debouncedHandler(c, e.target.value);
+                      }}
+                    />
+                  </HvTooltip>
+                );
+              })}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+};
+
+export default Colors;

--- a/app/src/generator/Colors/index.ts
+++ b/app/src/generator/Colors/index.ts
@@ -1,0 +1,1 @@
+export { default as Colors } from "./Colors";

--- a/app/src/generator/Colors/utils.ts
+++ b/app/src/generator/Colors/utils.ts
@@ -1,0 +1,28 @@
+export const getColors = (colors, type) => {
+  const res = {};
+  for (const key in colors) {
+    if (key.includes(type)) {
+      res[key] = colors[key];
+    }
+  }
+  return res;
+};
+
+export const getColorGroupName = (color) => {
+  switch (color) {
+    case "acce":
+      return "Accent";
+    case "atmo":
+      return "Atmosphere";
+    case "base":
+      return "Base";
+    case "sema":
+      return "Semantic";
+    case "sup":
+      return "Support";
+    case "cviz":
+      return "Visualizations";
+    default:
+      return "";
+  }
+};

--- a/app/src/generator/Content.tsx
+++ b/app/src/generator/Content.tsx
@@ -1,0 +1,33 @@
+import { BrowserRouter as Router } from "react-router-dom";
+import { HvProvider, useTheme } from "@hitachivantara/uikit-react-core";
+import { Container } from "components/common";
+import { NavigationProvider } from "lib/context/NavigationContext";
+import navigation from "lib/navigation";
+import Routes from "lib/routes";
+import { GeneratorContext } from "./GeneratorContext";
+import { useContext } from "react";
+
+const Content = () => {
+  const { selectedMode } = useTheme();
+  const { customTheme } = useContext(GeneratorContext);
+
+  return (
+    <div id="gen-root">
+      <Router>
+        <HvProvider
+          rootElementId="gen-root"
+          themes={[customTheme]}
+          colorMode={selectedMode}
+        >
+          <NavigationProvider navigation={navigation}>
+            <Container maxWidth="xl">
+              <Routes />
+            </Container>
+          </NavigationProvider>
+        </HvProvider>
+      </Router>
+    </div>
+  );
+};
+
+export default Content;

--- a/app/src/generator/FontFamily/FontFamily.styles.tsx
+++ b/app/src/generator/FontFamily/FontFamily.styles.tsx
@@ -1,0 +1,12 @@
+import { css } from "@emotion/css";
+import { theme } from "@hitachivantara/uikit-react-core";
+
+export const styles = {
+  root: css({
+    width: "100%",
+    display: "flex",
+    flexDirection: "column",
+    paddingLeft: theme.space.xs,
+    marginBottom: theme.space.md,
+  }),
+};

--- a/app/src/generator/FontFamily/FontFamily.tsx
+++ b/app/src/generator/FontFamily/FontFamily.tsx
@@ -1,0 +1,103 @@
+import { useContext, useState } from "react";
+import {
+  createTheme,
+  HvBox,
+  HvButton,
+  HvDropdown,
+  HvInput,
+  HvListValue,
+  HvSnackbar,
+} from "@hitachivantara/uikit-react-core";
+import { GeneratorContext } from "generator/GeneratorContext";
+import { styles } from "./FontFamily.styles";
+import { Add } from "@hitachivantara/uikit-react-icons";
+import { css } from "@emotion/css";
+import { extractFontName } from "generator/utils";
+
+const FontFamily = () => {
+  const { customTheme, updateCustomTheme, updateChangedValues } =
+    useContext(GeneratorContext);
+
+  const [fontName, setFontName] = useState("");
+  const [fontValues, setFontValues] = useState<HvListValue[]>([
+    { label: "Open Sans" },
+  ]);
+
+  const [fontAdded, setFontAdded] = useState(false);
+  const [fontAddedMsg, setFontAddedMsg] = useState("");
+
+  const onDropdownClickHandler = (font) => {
+    const newTheme = createTheme({
+      ...customTheme,
+      fontFamily: {
+        body: font,
+      },
+    });
+    updateCustomTheme(newTheme);
+    updateChangedValues?.(["fontFamily", "body"], font);
+  };
+
+  const onAddHandler = () => {
+    const name = extractFontName(fontName);
+    setFontAdded(true);
+    setFontAddedMsg(`Font "${name}" added!`);
+
+    setFontName("");
+    setFontValues((prev) => [...prev, { label: name }]);
+
+    const link = document.createElement("link");
+    link.rel = "stylesheet";
+    link.href = fontName;
+    document.head.appendChild(link);
+  };
+
+  const handleClose = (event, reason) => {
+    if (reason === "clickaway") return;
+    setFontAdded(false);
+  };
+
+  return (
+    <div className={styles.root}>
+      <HvSnackbar
+        open={fontAdded}
+        variant={"success"}
+        label={fontAddedMsg}
+        onClose={handleClose}
+        autoHideDuration={2000}
+        offset={20}
+      />
+      <HvBox
+        css={{
+          display: "flex",
+          flexDirection: "row",
+          alignItems: "flex-end",
+          marginBottom: 10,
+        }}
+      >
+        <HvBox css={{ display: "flex", flexGrow: 1 }}>
+          <HvInput
+            value={fontName}
+            onChange={(event, value) => setFontName(value)}
+            label="Enter google font link"
+            classes={{ root: css({ width: "100%" }) }}
+          />
+        </HvBox>
+        <HvButton
+          icon
+          variant="secondaryGhost"
+          onClick={onAddHandler}
+          disabled={fontName === ""}
+        >
+          <Add />
+        </HvButton>
+      </HvBox>
+      <HvDropdown
+        label="Font Family"
+        values={fontValues}
+        onChange={(item) => onDropdownClickHandler(item.label)}
+      />
+    </div>
+  );
+};
+
+export default FontFamily;

--- a/app/src/generator/FontFamily/index.ts
+++ b/app/src/generator/FontFamily/index.ts
@@ -1,0 +1,1 @@
+export { default as FontFamily } from "./FontFamily";

--- a/app/src/generator/FontSizes/FontSizes.styles.tsx
+++ b/app/src/generator/FontSizes/FontSizes.styles.tsx
@@ -1,0 +1,11 @@
+import { css } from "@emotion/css";
+import { theme } from "@hitachivantara/uikit-react-core";
+
+export const styles = {
+  root: css({
+    width: "100%",
+    display: "flex",
+    flexDirection: "column",
+    paddingLeft: theme.space.xs,
+  }),
+};

--- a/app/src/generator/FontSizes/FontSizes.tsx
+++ b/app/src/generator/FontSizes/FontSizes.tsx
@@ -1,0 +1,132 @@
+import { useContext, useEffect, useState } from "react";
+import {
+  useTheme,
+  HvInput,
+  createTheme,
+  HvTypography,
+  HvDropdown,
+  HvBox,
+  HvListValue,
+} from "@hitachivantara/uikit-react-core";
+import { GeneratorContext } from "generator/GeneratorContext";
+import { styles } from "./FontSizes.styles";
+import { css } from "@emotion/css";
+
+const FontSizes = () => {
+  const { activeTheme } = useTheme();
+  const { customTheme, updateCustomTheme, updateChangedValues } =
+    useContext(GeneratorContext);
+  const [fontSizes, setFontSizes] = useState<HvListValue[]>([]);
+  const [fontSize, setFontSize] = useState(""); // base, sm, ...
+  const [fontValue, setFontValue] = useState<number>(0); // 14, 16, ...
+  const [unit, setUnit] = useState("px"); // px, rem, ...
+  const [currSizes, setCurrSizes] = useState<Map<string, string>>(
+    new Map<string, string>()
+  );
+
+  useEffect(() => {
+    let sizes: HvListValue[] = [];
+    if (activeTheme) {
+      Object.keys(activeTheme.fontSizes).map((size) => {
+        sizes.push({ label: size });
+      });
+    }
+    setFontSizes(sizes);
+  }, []);
+
+  const onSizeChangedHandler = (size: string) => {
+    const currSize = currSizes.get(size);
+    setFontSize(size);
+    if (currSize) {
+      const value = parseInt(currSize);
+      setUnit(currSize.replace(value.toString(), ""));
+      setFontValue(value);
+    } else {
+      setUnit("px");
+      setFontValue(parseInt(activeTheme?.fontSizes[size]));
+    }
+  };
+
+  const onValueChangedHandler = (event, value) => {
+    setFontValue(value);
+
+    // check updated font sizes
+    let currFontSizes = {};
+    for (const [key, val] of currSizes.entries()) {
+      currFontSizes[key] = val;
+    }
+
+    const newTheme = createTheme({
+      ...customTheme,
+      fontSizes: {
+        ...currFontSizes,
+        [fontSize]: `${value}${unit}`,
+      },
+    });
+    updateCustomTheme(newTheme);
+    updateChangedValues?.(["fontSizes", fontSize], `${value}${unit}`);
+
+    // update curr sizes
+    let map = new Map<string, string>(currSizes);
+    map.set(fontSize, `${value}${unit}`);
+    setCurrSizes(map);
+  };
+
+  const onUnitChangedHandler = (selectedUnit) => {
+    setUnit(selectedUnit);
+    const newTheme = createTheme({
+      ...customTheme,
+      fontSizes: {
+        [fontSize]: `${fontValue}${selectedUnit}`,
+      },
+    });
+    updateCustomTheme(newTheme);
+    updateChangedValues?.(
+      ["fontSizes", fontSize],
+      `${fontValue}${selectedUnit}`
+    );
+    // update curr sizes
+    let map = new Map<string, string>(currSizes);
+    map.set(fontSize, `${fontValue}${selectedUnit}`);
+    setCurrSizes(map);
+  };
+
+  return (
+    <div className={styles.root}>
+      <HvTypography variant="label">Font Sizes</HvTypography>
+      <HvBox
+        css={{
+          display: "flex",
+          flexDirection: "row",
+          justifyContent: "space-between",
+        }}
+      >
+        <HvDropdown
+          classes={{ root: css({ width: 120 }) }}
+          values={fontSizes}
+          onChange={(item) => onSizeChangedHandler(item.label)}
+        />
+        <HvDropdown
+          classes={{ root: css({ width: 120 }) }}
+          values={[
+            { label: "px", selected: unit === "px" },
+            {
+              label: "rem",
+              selected: unit === "rem",
+            },
+            { label: "em", selected: unit === "em" },
+            { label: "pt", selected: unit === "pt" },
+          ]}
+          onChange={(item) => onUnitChangedHandler(item.label)}
+        />
+        <HvInput
+          value={fontValue?.toString()}
+          classes={{ root: css({ width: 80 }) }}
+          onChange={onValueChangedHandler}
+        />
+      </HvBox>
+    </div>
+  );
+};
+
+export default FontSizes;

--- a/app/src/generator/FontSizes/index.ts
+++ b/app/src/generator/FontSizes/index.ts
@@ -1,0 +1,1 @@
+export { default as FontSizes } from "./FontSizes";

--- a/app/src/generator/GeneratorContext.tsx
+++ b/app/src/generator/GeneratorContext.tsx
@@ -1,0 +1,61 @@
+import { createTheme, HvTheme } from "@hitachivantara/uikit-react-core";
+import { HvThemeStructure } from "@hitachivantara/uikit-styles";
+import { createContext, useState } from "react";
+
+type GeneratorContextProp = {
+  customTheme: HvTheme | HvThemeStructure;
+  updateCustomTheme: (newTheme: any) => void;
+
+  changedValues?: Partial<HvTheme | HvThemeStructure>;
+  updateChangedValues?: (path: any, key: any) => void;
+};
+
+export const GeneratorContext = createContext<GeneratorContextProp>({
+  customTheme: createTheme({ name: "", base: "ds5" }),
+  updateCustomTheme: () => {},
+});
+
+const GeneratorProvider = ({ children }) => {
+  const [changedValues, setChangedValues] = useState({});
+
+  const [customTheme, setCustomTheme] = useState(
+    createTheme({ name: "", base: "ds5" })
+  );
+
+  const updateCustomTheme = (newTheme) => {
+    setCustomTheme(newTheme);
+  };
+
+  const updateChangedValues = (path, value) => {
+    setChangedValues((prevState) => {
+      const newState = { ...prevState };
+      let node = newState;
+      path.forEach((key, index) => {
+        if (!node[key]) {
+          node[key] = {};
+        }
+        if (index === path.length - 1) {
+          node[key] = value;
+        } else {
+          node = node[key];
+        }
+      });
+      return newState;
+    });
+  };
+
+  return (
+    <GeneratorContext.Provider
+      value={{
+        customTheme,
+        updateCustomTheme,
+        changedValues,
+        updateChangedValues,
+      }}
+    >
+      {children}
+    </GeneratorContext.Provider>
+  );
+};
+
+export default GeneratorProvider;

--- a/app/src/generator/GeneratorContext.tsx
+++ b/app/src/generator/GeneratorContext.tsx
@@ -7,11 +7,11 @@ type GeneratorContextProp = {
   updateCustomTheme: (newTheme: any) => void;
 
   changedValues?: Partial<HvTheme | HvThemeStructure>;
-  updateChangedValues?: (path: any, key: any) => void;
+  updateChangedValues?: (path: any, key: any, reset?: boolean) => void;
 };
 
 export const GeneratorContext = createContext<GeneratorContextProp>({
-  customTheme: createTheme({ name: "", base: "ds5" }),
+  customTheme: createTheme({ name: "customTheme", base: "ds5" }),
   updateCustomTheme: () => {},
 });
 
@@ -19,29 +19,34 @@ const GeneratorProvider = ({ children }) => {
   const [changedValues, setChangedValues] = useState({});
 
   const [customTheme, setCustomTheme] = useState(
-    createTheme({ name: "", base: "ds5" })
+    createTheme({ name: "customTheme", base: "ds5" })
   );
 
   const updateCustomTheme = (newTheme) => {
+    console.log(newTheme);
     setCustomTheme(newTheme);
   };
 
-  const updateChangedValues = (path, value) => {
-    setChangedValues((prevState) => {
-      const newState = { ...prevState };
-      let node = newState;
-      path.forEach((key, index) => {
-        if (!node[key]) {
-          node[key] = {};
-        }
-        if (index === path.length - 1) {
-          node[key] = value;
-        } else {
-          node = node[key];
-        }
+  const updateChangedValues = (path, value, reset = false) => {
+    if (reset) {
+      setChangedValues({ name: "customTheme", base: "ds5" });
+    } else {
+      setChangedValues((prevState) => {
+        const newState = { ...prevState };
+        let node = newState;
+        path.forEach((key, index) => {
+          if (!node[key]) {
+            node[key] = {};
+          }
+          if (index === path.length - 1) {
+            node[key] = value;
+          } else {
+            node = node[key];
+          }
+        });
+        return newState;
       });
-      return newState;
-    });
+    }
   };
 
   return (

--- a/app/src/generator/Radii/Radii.styles.tsx
+++ b/app/src/generator/Radii/Radii.styles.tsx
@@ -1,0 +1,21 @@
+import { css } from "@emotion/css";
+import { theme } from "@hitachivantara/uikit-react-core";
+
+export const styles = {
+  root: css({
+    width: "100%",
+    display: "flex",
+    flexDirection: "column",
+    gap: theme.space.xs,
+    paddingLeft: theme.space.xs,
+  }),
+  item: css({
+    display: "flex",
+    flexDirection: "row",
+    justifyContent: "space-between",
+    gap: 10,
+  }),
+  radii: css({ width: 60 }),
+  value: css({ width: 180 }),
+  set: css({ width: 70 }),
+};

--- a/app/src/generator/Radii/Radii.tsx
+++ b/app/src/generator/Radii/Radii.tsx
@@ -1,0 +1,86 @@
+import { styles } from "./Radii.styles";
+import { css } from "@emotion/css";
+import {
+  createTheme,
+  HvButton,
+  HvInput,
+  HvTypography,
+  useTheme,
+} from "@hitachivantara/uikit-react-core";
+import { useContext, useEffect, useState } from "react";
+import { GeneratorContext } from "generator/GeneratorContext";
+
+const Radii = () => {
+  const { activeTheme } = useTheme();
+  const { customTheme, updateCustomTheme, updateChangedValues } =
+    useContext(GeneratorContext);
+  const [currValues, setCurrValues] = useState<Map<string, string | number>>(
+    new Map<string, string | number>()
+  );
+
+  useEffect(() => {
+    let map = new Map<string, string | number>();
+    if (activeTheme) {
+      Object.keys(activeTheme.radii).map((s) => {
+        map.set(s, activeTheme.radii[s]);
+      });
+    }
+    setCurrValues(map);
+  }, []);
+
+  const valueChangedHandler = (spacing: string, value) => {
+    let map = new Map<string, string | number>(currValues);
+    map.set(spacing, value);
+    setCurrValues(map);
+  };
+
+  const setValueHandler = (radii: string) => {
+    let currRadii = {};
+    for (const [key, val] of currValues.entries()) {
+      currRadii[key] = val;
+    }
+    const spacingValue = currValues.get(radii) || 0;
+
+    const newTheme = createTheme({
+      ...customTheme,
+      radii: {
+        ...currRadii,
+        [radii]: radii === "base" ? spacingValue : spacingValue,
+      },
+    });
+    updateCustomTheme(newTheme);
+    updateChangedValues?.(["radii", radii], spacingValue);
+  };
+
+  return (
+    <div className={styles.root}>
+      {activeTheme &&
+        Object.keys(activeTheme.radii).map((r) => {
+          return (
+            <div key={r} className={styles.item}>
+              <div className={styles.radii}>
+                <HvTypography variant="label">{r}</HvTypography>
+              </div>
+              <div className={styles.value}>
+                <HvInput
+                  value={currValues?.get(r)?.toString() || ""}
+                  classes={{ root: css({ width: "100%" }) }}
+                  onChange={(event, value) => valueChangedHandler(r, value)}
+                />
+              </div>
+              <div>
+                <HvButton
+                  variant="secondarySubtle"
+                  onClick={() => setValueHandler(r)}
+                >
+                  Set
+                </HvButton>
+              </div>
+            </div>
+          );
+        })}
+    </div>
+  );
+};
+
+export default Radii;

--- a/app/src/generator/Radii/index.ts
+++ b/app/src/generator/Radii/index.ts
@@ -1,0 +1,1 @@
+export { default as Radii } from "./Radii";

--- a/app/src/generator/Sidebar/Sidebar.styles.tsx
+++ b/app/src/generator/Sidebar/Sidebar.styles.tsx
@@ -1,0 +1,44 @@
+import { css } from "@emotion/css";
+import { theme } from "@hitachivantara/uikit-react-core";
+
+export const styles = {
+  root: css({
+    backgroundColor: theme.colors.atmo3,
+    right: 0,
+    display: "flex",
+    width: 390,
+    height: "100vh",
+    flexDirection: "column",
+    gap: theme.space.sm,
+    position: "fixed",
+    borderRight: `1px solid ${theme.colors.atmo5}`,
+    padding: theme.space.sm,
+    overflowY: "scroll",
+    zIndex: theme.zIndices.overlay,
+  }),
+  label: css({
+    ...theme.typography.sectionTitle,
+    textTransform: "uppercase",
+  }),
+  code: css({
+    width: "100%",
+    height: 260,
+    fontFamily: "Courier New",
+    fontSize: "12px",
+    border: `1px solid ${theme.colors.acce4}`,
+  }),
+  themeName: css({
+    display: "flex",
+    gap: 10,
+    alignItems: "center",
+  }),
+  themeNameInput: css({
+    width: "100%",
+  }),
+  themeBase: css({
+    display: "flex",
+    justifyContent: "space-between",
+    gap: 20,
+    alignItems: "center",
+  }),
+};

--- a/app/src/generator/Sidebar/Sidebar.styles.tsx
+++ b/app/src/generator/Sidebar/Sidebar.styles.tsx
@@ -2,6 +2,16 @@ import { css } from "@emotion/css";
 import { theme } from "@hitachivantara/uikit-react-core";
 
 export const styles = {
+  closed: css({
+    width: 30,
+    height: "100vh",
+    boxShadow: `-10px 0px 10px 1px rgba(65,65,65,0.12)`,
+    backgroundColor: theme.colors.atmo3,
+    position: "fixed",
+    top: 0,
+    right: 0,
+    zIndex: theme.zIndices.popover,
+  }),
   root: css({
     backgroundColor: theme.colors.atmo3,
     right: 0,
@@ -15,6 +25,7 @@ export const styles = {
     padding: theme.space.sm,
     overflowY: "scroll",
     zIndex: theme.zIndices.overlay,
+    boxShadow: `-10px 0px 10px 1px rgba(65,65,65,0.12)`,
   }),
   label: css({
     ...theme.typography.sectionTitle,

--- a/app/src/generator/Sidebar/Sidebar.tsx
+++ b/app/src/generator/Sidebar/Sidebar.tsx
@@ -19,6 +19,8 @@ import debounce from "lodash/debounce";
 import { FontSizes } from "generator/FontSizes";
 import { FontFamily } from "generator/FontFamily";
 import { Duplicate } from "@hitachivantara/uikit-react-icons";
+import { Radii } from "generator/Radii";
+import { Spacing } from "generator/Spacing";
 
 const Sidebar = () => {
   const { selectedTheme, selectedMode, colorModes, themes, changeTheme } =
@@ -30,12 +32,17 @@ const Sidebar = () => {
   const [fullCode, setFullCode] = useState("");
   const [copied, setCopied] = useState(false);
 
+  // the `replace` bit below is just a regex to remove the quotes from
+  // the properties names, for displaying effect only.
   useEffect(() => {
     setFullCode(
       `import { createTheme } from "@hitachivantara/uikit-react-core";
 
 const ${themeName} = createTheme(` +
-        JSON.stringify(changedValues, null, 2) +
+        JSON.stringify(changedValues, null, 2).replace(
+          /\"([^(\")"]+)\":/g,
+          "$1:"
+        ) +
         `)
     
 export default ${themeName};`
@@ -141,6 +148,16 @@ export default ${themeName};`
       <HvAccordion id="fonts" label="fonts" classes={{ label: styles.label }}>
         <FontFamily />
         <FontSizes />
+      </HvAccordion>
+      <HvAccordion id="radii" label="radii" classes={{ label: styles.label }}>
+        <Radii />
+      </HvAccordion>
+      <HvAccordion
+        id="spacing"
+        label="spacing"
+        classes={{ label: styles.label }}
+      >
+        <Spacing />
       </HvAccordion>
       {/* <HvAccordion
         id="typography"

--- a/app/src/generator/Sidebar/Sidebar.tsx
+++ b/app/src/generator/Sidebar/Sidebar.tsx
@@ -22,7 +22,7 @@ import { Duplicate } from "@hitachivantara/uikit-react-icons";
 import { Radii } from "generator/Radii";
 import { Spacing } from "generator/Spacing";
 
-const Sidebar = () => {
+const Sidebar = ({ open }) => {
   const { selectedTheme, selectedMode, colorModes, themes, changeTheme } =
     useTheme();
 
@@ -84,89 +84,108 @@ export default ${themeName};`
     setCopied(false);
   };
 
+  console.log("open", open);
   return (
-    <div className={styles.root}>
-      <HvSnackbar
-        open={copied}
-        variant={"success"}
-        label={"Code copied to clipboard!"}
-        onClose={handleClose}
-        autoHideDuration={2000}
-        offset={20}
-      />
-      <HvBox className={styles.themeName}>
-        <HvTypography variant="label">Name: </HvTypography>
-        <HvBox className={styles.themeNameInput}>
-          <HvInput
-            onChange={(event, value) => debouncedNameChangeHandler(value)}
-            placeholder={themeName}
+    <>
+      {!open && <div className={styles.closed}></div>}
+      {open && (
+        <div className={styles.root}>
+          <HvSnackbar
+            open={copied}
+            variant={"success"}
+            label={"Code copied to clipboard!"}
+            onClose={handleClose}
+            autoHideDuration={2000}
+            offset={20}
           />
-        </HvBox>
-      </HvBox>
-      <HvBox className={styles.themeBase}>
-        <HvBox>
-          <HvTypography variant="label">Theme: </HvTypography>
-          <HvDropdown
-            css={{ width: 100 }}
-            values={themes.map((name) => ({
-              value: name,
-              label: name,
-              selected: name === selectedTheme,
-            }))}
-            onChange={(t) => changeTheme(t.value, selectedMode)}
-          />
-        </HvBox>
-        <HvBox>
-          <HvTypography variant="label">Mode: </HvTypography>
-          <HvDropdown
-            css={{ width: 120 }}
-            values={colorModes.map((name) => ({
-              value: name,
-              label: name,
-              selected: name === selectedMode,
-            }))}
-            onChange={(mode) => changeTheme(selectedTheme, mode.value)}
-          />
-        </HvBox>
-      </HvBox>
-      <HvBox css={{ position: "relative" }}>
-        <HvBox css={{ position: "absolute", top: 10, right: 10 }}>
-          <HvTooltip
-            placement="bottom-end"
-            title={<HvTypography>Copy to Clipboard</HvTypography>}
+          <HvBox className={styles.themeName}>
+            <HvTypography variant="label">Name: </HvTypography>
+            <HvBox className={styles.themeNameInput}>
+              <HvInput
+                onChange={(event, value) => debouncedNameChangeHandler(value)}
+                placeholder={themeName}
+              />
+            </HvBox>
+          </HvBox>
+          <HvBox className={styles.themeBase}>
+            <HvBox>
+              <HvTypography variant="label">Theme: </HvTypography>
+              <HvDropdown
+                css={{ width: 100 }}
+                values={themes.map((name) => ({
+                  value: name,
+                  label: name,
+                  selected: name === selectedTheme,
+                }))}
+                onChange={(t) => changeTheme(t.value, selectedMode)}
+              />
+            </HvBox>
+            <HvBox>
+              <HvTypography variant="label">Mode: </HvTypography>
+              <HvDropdown
+                css={{ width: 120 }}
+                values={colorModes.map((name) => ({
+                  value: name,
+                  label: name,
+                  selected: name === selectedMode,
+                }))}
+                onChange={(mode) => changeTheme(selectedTheme, mode.value)}
+              />
+            </HvBox>
+          </HvBox>
+          <HvBox css={{ position: "relative" }}>
+            <HvBox css={{ position: "absolute", top: 10, right: 10 }}>
+              <HvTooltip
+                placement="bottom-end"
+                title={<HvTypography>Copy to Clipboard</HvTypography>}
+              >
+                <HvButton
+                  variant="secondarySubtle"
+                  icon
+                  onClick={onCopyHandler}
+                >
+                  <Duplicate />
+                </HvButton>
+              </HvTooltip>
+            </HvBox>
+            <textarea
+              readOnly
+              className={styles.code}
+              value={fullCode}
+            ></textarea>
+          </HvBox>
+          <HvAccordion
+            id="colors"
+            label="colors"
+            classes={{ label: styles.label }}
           >
-            <HvButton variant="secondarySubtle" icon onClick={onCopyHandler}>
-              <Duplicate />
-            </HvButton>
-          </HvTooltip>
-        </HvBox>
-        <textarea readOnly className={styles.code} value={fullCode}></textarea>
-      </HvBox>
-      <HvAccordion id="colors" label="colors" classes={{ label: styles.label }}>
-        <Colors />
-      </HvAccordion>
-      <HvAccordion id="fonts" label="fonts" classes={{ label: styles.label }}>
-        <FontFamily />
-        <FontSizes />
-      </HvAccordion>
-      <HvAccordion id="radii" label="radii" classes={{ label: styles.label }}>
-        <Radii />
-      </HvAccordion>
-      <HvAccordion
-        id="spacing"
-        label="spacing"
-        classes={{ label: styles.label }}
-      >
-        <Spacing />
-      </HvAccordion>
-      {/* <HvAccordion
-        id="typography"
-        label="typography"
-        classes={{ label: styles.label }}
-      >
-        <Typography />
-      </HvAccordion> */}
-    </div>
+            <Colors />
+          </HvAccordion>
+          <HvAccordion
+            id="fonts"
+            label="fonts"
+            classes={{ label: styles.label }}
+          >
+            <FontFamily />
+            <FontSizes />
+          </HvAccordion>
+          <HvAccordion
+            id="radii"
+            label="radii"
+            classes={{ label: styles.label }}
+          >
+            <Radii />
+          </HvAccordion>
+          <HvAccordion
+            id="spacing"
+            label="spacing"
+            classes={{ label: styles.label }}
+          >
+            <Spacing />
+          </HvAccordion>
+        </div>
+      )}
+    </>
   );
 };
 

--- a/app/src/generator/Sidebar/Sidebar.tsx
+++ b/app/src/generator/Sidebar/Sidebar.tsx
@@ -18,7 +18,7 @@ import { styles } from "./Sidebar.styles";
 import debounce from "lodash/debounce";
 import { FontSizes } from "generator/FontSizes";
 import { FontFamily } from "generator/FontFamily";
-import { Duplicate } from "@hitachivantara/uikit-react-icons";
+import { Duplicate, Reset } from "@hitachivantara/uikit-react-icons";
 import { Radii } from "generator/Radii";
 import { Spacing } from "generator/Spacing";
 
@@ -79,12 +79,21 @@ export default ${themeName};`
     setCopied(true);
   };
 
+  const onResetHandler = () => {
+    const newTheme = createTheme({
+      name: "customTheme",
+      base: selectedTheme as HvBaseTheme,
+    });
+    console.log(newTheme);
+    updateCustomTheme(newTheme);
+    updateChangedValues?.([], "", true);
+  };
+
   const handleClose = (event, reason) => {
     if (reason === "clickaway") return;
     setCopied(false);
   };
 
-  console.log("open", open);
   return (
     <>
       {!open && <div className={styles.closed}></div>}
@@ -134,6 +143,20 @@ export default ${themeName};`
             </HvBox>
           </HvBox>
           <HvBox css={{ position: "relative" }}>
+            <HvBox css={{ position: "absolute", top: 10, right: 46 }}>
+              <HvTooltip
+                placement="bottom-end"
+                title={<HvTypography>Reset</HvTypography>}
+              >
+                <HvButton
+                  variant="secondarySubtle"
+                  icon
+                  onClick={onResetHandler}
+                >
+                  <Reset />
+                </HvButton>
+              </HvTooltip>
+            </HvBox>
             <HvBox css={{ position: "absolute", top: 10, right: 10 }}>
               <HvTooltip
                 placement="bottom-end"

--- a/app/src/generator/Sidebar/Sidebar.tsx
+++ b/app/src/generator/Sidebar/Sidebar.tsx
@@ -1,0 +1,156 @@
+import {
+  createTheme,
+  HvAccordion,
+  HvBaseTheme,
+  HvBox,
+  HvButton,
+  HvDropdown,
+  HvInput,
+  HvSnackbar,
+  HvTooltip,
+  HvTypography,
+  useTheme,
+} from "@hitachivantara/uikit-react-core";
+import { Colors } from "generator/Colors";
+import { GeneratorContext } from "generator/GeneratorContext";
+import { useContext, useEffect, useState } from "react";
+import { styles } from "./Sidebar.styles";
+import debounce from "lodash/debounce";
+import { FontSizes } from "generator/FontSizes";
+import { FontFamily } from "generator/FontFamily";
+import { Duplicate } from "@hitachivantara/uikit-react-icons";
+
+const Sidebar = () => {
+  const { selectedTheme, selectedMode, colorModes, themes, changeTheme } =
+    useTheme();
+
+  const { updateCustomTheme, changedValues, updateChangedValues } =
+    useContext(GeneratorContext);
+  const [themeName, setThemeName] = useState("customTheme");
+  const [fullCode, setFullCode] = useState("");
+  const [copied, setCopied] = useState(false);
+
+  useEffect(() => {
+    setFullCode(
+      `import { createTheme } from "@hitachivantara/uikit-react-core";
+
+const ${themeName} = createTheme(` +
+        JSON.stringify(changedValues, null, 2) +
+        `)
+    
+export default ${themeName};`
+    );
+  }, [changedValues]);
+
+  useEffect(() => {
+    updateChangedValues?.(["name"], themeName);
+  }, [themeName]);
+
+  useEffect(() => {
+    const newTheme = createTheme({
+      name: themeName,
+      base: selectedTheme as HvBaseTheme,
+    });
+    updateCustomTheme(newTheme);
+    updateChangedValues?.(["base"], selectedTheme);
+  }, [selectedTheme]);
+
+  const nameChangeHandler = (name) => {
+    const newTheme = createTheme({
+      name: name,
+      base: selectedTheme as HvBaseTheme,
+    });
+    updateCustomTheme(newTheme);
+    updateChangedValues?.(["name"], name);
+    setThemeName(name);
+  };
+
+  const debouncedNameChangeHandler = debounce(nameChangeHandler, 250);
+
+  const onCopyHandler = () => {
+    navigator.clipboard.writeText(fullCode);
+    setCopied(true);
+  };
+
+  const handleClose = (event, reason) => {
+    if (reason === "clickaway") return;
+    setCopied(false);
+  };
+
+  return (
+    <div className={styles.root}>
+      <HvSnackbar
+        open={copied}
+        variant={"success"}
+        label={"Code copied to clipboard!"}
+        onClose={handleClose}
+        autoHideDuration={2000}
+        offset={20}
+      />
+      <HvBox className={styles.themeName}>
+        <HvTypography variant="label">Name: </HvTypography>
+        <HvBox className={styles.themeNameInput}>
+          <HvInput
+            onChange={(event, value) => debouncedNameChangeHandler(value)}
+            placeholder={themeName}
+          />
+        </HvBox>
+      </HvBox>
+      <HvBox className={styles.themeBase}>
+        <HvBox>
+          <HvTypography variant="label">Theme: </HvTypography>
+          <HvDropdown
+            css={{ width: 100 }}
+            values={themes.map((name) => ({
+              value: name,
+              label: name,
+              selected: name === selectedTheme,
+            }))}
+            onChange={(t) => changeTheme(t.value, selectedMode)}
+          />
+        </HvBox>
+        <HvBox>
+          <HvTypography variant="label">Mode: </HvTypography>
+          <HvDropdown
+            css={{ width: 120 }}
+            values={colorModes.map((name) => ({
+              value: name,
+              label: name,
+              selected: name === selectedMode,
+            }))}
+            onChange={(mode) => changeTheme(selectedTheme, mode.value)}
+          />
+        </HvBox>
+      </HvBox>
+      <HvBox css={{ position: "relative" }}>
+        <HvBox css={{ position: "absolute", top: 10, right: 10 }}>
+          <HvTooltip
+            placement="bottom-end"
+            title={<HvTypography>Copy to Clipboard</HvTypography>}
+          >
+            <HvButton variant="secondarySubtle" icon onClick={onCopyHandler}>
+              <Duplicate />
+            </HvButton>
+          </HvTooltip>
+        </HvBox>
+        <textarea readOnly className={styles.code} value={fullCode}></textarea>
+      </HvBox>
+      <HvAccordion id="colors" label="colors" classes={{ label: styles.label }}>
+        <Colors />
+      </HvAccordion>
+      <HvAccordion id="fonts" label="fonts" classes={{ label: styles.label }}>
+        <FontFamily />
+        <FontSizes />
+      </HvAccordion>
+      {/* <HvAccordion
+        id="typography"
+        label="typography"
+        classes={{ label: styles.label }}
+      >
+        <Typography />
+      </HvAccordion> */}
+    </div>
+  );
+};
+
+export default Sidebar;

--- a/app/src/generator/Sidebar/index.ts
+++ b/app/src/generator/Sidebar/index.ts
@@ -1,0 +1,1 @@
+export { default as Sidebar } from "./Sidebar";

--- a/app/src/generator/Spacing/Spacing.styles.tsx
+++ b/app/src/generator/Spacing/Spacing.styles.tsx
@@ -1,0 +1,21 @@
+import { css } from "@emotion/css";
+import { theme } from "@hitachivantara/uikit-react-core";
+
+export const styles = {
+  root: css({
+    width: "100%",
+    display: "flex",
+    flexDirection: "column",
+    gap: theme.space.xs,
+    paddingLeft: theme.space.xs,
+  }),
+  item: css({
+    display: "flex",
+    flexDirection: "row",
+    justifyContent: "space-between",
+    gap: 10,
+  }),
+  spacing: css({ width: 60 }),
+  value: css({ width: 180 }),
+  set: css({ width: 70 }),
+};

--- a/app/src/generator/Spacing/Spacing.tsx
+++ b/app/src/generator/Spacing/Spacing.tsx
@@ -1,0 +1,92 @@
+import { styles } from "./Spacing.styles";
+import { css } from "@emotion/css";
+import {
+  createTheme,
+  HvButton,
+  HvInput,
+  HvTypography,
+  useTheme,
+} from "@hitachivantara/uikit-react-core";
+import { useContext, useEffect, useState } from "react";
+import { GeneratorContext } from "generator/GeneratorContext";
+
+const Spacing = () => {
+  const { activeTheme } = useTheme();
+  const { customTheme, updateCustomTheme, updateChangedValues } =
+    useContext(GeneratorContext);
+  const [currValues, setCurrValues] = useState<Map<string, string | number>>(
+    new Map<string, string | number>()
+  );
+
+  useEffect(() => {
+    let map = new Map<string, string | number>();
+    if (activeTheme) {
+      Object.keys(activeTheme.space).map((s) => {
+        map.set(s, activeTheme.space[s]);
+      });
+    }
+    setCurrValues(map);
+  }, []);
+
+  const valueChangedHandler = (spacing: string, value) => {
+    let map = new Map<string, string | number>(currValues);
+    map.set(spacing, value);
+    setCurrValues(map);
+  };
+
+  const setValueHandler = (spacing: string) => {
+    let currSpacing = {};
+    for (const [key, val] of currValues.entries()) {
+      currSpacing[key] = val;
+    }
+    const spacingValue =
+      spacing === "base"
+        ? parseInt(currValues.get(spacing)?.toString() || "")
+        : currValues.get(spacing) || 0;
+    console.log(typeof spacingValue);
+
+    const newTheme = createTheme({
+      ...customTheme,
+      space: {
+        ...currSpacing,
+        [spacing]:
+          spacing === "base" ? parseInt(spacingValue.toString()) : spacingValue,
+      },
+    });
+    updateCustomTheme(newTheme);
+    updateChangedValues?.(["space", spacing], spacingValue);
+  };
+
+  return (
+    <div className={styles.root}>
+      {activeTheme &&
+        Object.keys(activeTheme.space).map((s) => {
+          return (
+            <div key={s} className={styles.item}>
+              <div className={styles.spacing}>
+                <HvTypography variant="label">{s}</HvTypography>
+              </div>
+              <div className={styles.value}>
+                <HvInput
+                  value={currValues?.get(s)?.toString() || ""}
+                  classes={{ root: css({ width: "100%" }) }}
+                  onChange={(event, value) => valueChangedHandler(s, value)}
+                  // onInput={inputHandler}
+                />
+              </div>
+              <div>
+                <HvButton
+                  variant="secondarySubtle"
+                  onClick={() => setValueHandler(s)}
+                >
+                  Set
+                </HvButton>
+              </div>
+            </div>
+          );
+        })}
+    </div>
+  );
+};
+
+export default Spacing;

--- a/app/src/generator/Spacing/index.ts
+++ b/app/src/generator/Spacing/index.ts
@@ -1,0 +1,1 @@
+export { default as Spacing } from "./Spacing";

--- a/app/src/generator/Typography/Typography.styles.tsx
+++ b/app/src/generator/Typography/Typography.styles.tsx
@@ -1,0 +1,15 @@
+import { css } from "@emotion/css";
+import { theme } from "@hitachivantara/uikit-react-core";
+
+export const styles = {
+  root: css({
+    width: "100%",
+    display: "flex",
+    flexDirection: "column",
+    paddingLeft: theme.space.xs,
+  }),
+  label: css({
+    ...theme.typography.label,
+    textTransform: "capitalize",
+  }),
+};

--- a/app/src/generator/Typography/Typography.tsx
+++ b/app/src/generator/Typography/Typography.tsx
@@ -1,0 +1,50 @@
+// import { useContext } from "react";
+import { useTheme, HvAccordion, HvBox } from "@hitachivantara/uikit-react-core";
+// import { GeneratorContext } from "generator/GeneratorContext";
+import { styles } from "./Typography.styles";
+import { getVarValue } from "generator/utils";
+
+const typographyToShow = [
+  "display",
+  "title1",
+  "title2",
+  "title3",
+  "title4",
+  "body",
+  "label",
+  "caption1",
+  "caption2",
+];
+
+const Typography = () => {
+  const { activeTheme } = useTheme();
+  // const { customTheme, updateCustomTheme, updateChangedValues } =
+  //   useContext(GeneratorContext);
+
+  return (
+    <div className={styles.root}>
+      {typographyToShow.map((t) => {
+        const typography = activeTheme?.typography[t];
+        return (
+          <HvAccordion expanded label={t} className={styles.label}>
+            <HvBox css={{ display: "flex", flexDirection: "column", gap: 10 }}>
+              <div
+                style={{
+                  width: 20,
+                  height: 20,
+                  backgroundColor: typography.color,
+                }}
+              ></div>
+              <span>{getVarValue(typography.fontSize)}</span>
+              <span>{getVarValue(typography.letterSpacing)}</span>
+              <span>{getVarValue(typography.lineHeight)}</span>
+              <span>{getVarValue(typography.fontWeight)}</span>
+            </HvBox>
+          </HvAccordion>
+        );
+      })}
+    </div>
+  );
+};
+
+export default Typography;

--- a/app/src/generator/Typography/index.ts
+++ b/app/src/generator/Typography/index.ts
@@ -1,0 +1,1 @@
+export { default as Typography } from "./Typography";

--- a/app/src/generator/utils.ts
+++ b/app/src/generator/utils.ts
@@ -1,0 +1,15 @@
+export const getVarValue = (cssVar: string): string => {
+  // Creating a temporary element to get CSS variables
+  const tempEl = document.createElement("div");
+  tempEl.style.setProperty("--temp", cssVar);
+  document.body.appendChild(tempEl);
+  const computedValue = getComputedStyle(tempEl)
+    .getPropertyValue("--temp")
+    .trim();
+  document.body.removeChild(tempEl);
+
+  return computedValue;
+};
+
+export const extractFontName = (fontLink) =>
+  fontLink.substring(fontLink.indexOf("family=") + 7, fontLink.indexOf("&"));

--- a/app/src/pages/Components/Components.styles.tsx
+++ b/app/src/pages/Components/Components.styles.tsx
@@ -1,0 +1,30 @@
+import { css } from "@emotion/css";
+import { theme } from "@hitachivantara/uikit-styles";
+
+export const styles = {
+  component: css({
+    padding: theme.space.sm,
+    marginBottom: theme.space.lg,
+  }),
+  header: css({
+    display: "flex",
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    marginBottom: theme.space.sm,
+  }),
+  content: css({
+    paddingLeft: theme.space.md,
+    display: "flex",
+    flexDirection: "column",
+    gap: 10,
+  }),
+  docs: css({
+    border: `1px solid ${theme.colors.atmo4}`,
+    padding: `${theme.space.xs} ${theme.space.md}`,
+    "&:hover": {
+      borderColor: theme.colors.acce1,
+      backgroundColor: theme.colors.acce2s,
+    },
+  }),
+};

--- a/app/src/pages/Components/Components.tsx
+++ b/app/src/pages/Components/Components.tsx
@@ -1,43 +1,93 @@
-import { HvBox, theme } from "@hitachivantara/uikit-react-core";
-import { CSSProperties } from "react";
+import {
+  HvBox,
+  HvContainer,
+  HvTypography,
+} from "@hitachivantara/uikit-react-core";
 import {
   Buttons,
-  EmptyState,
-  Grid,
-  Icons,
   Cards,
-  Typography,
-  Tags,
-  CheckBox,
-  BaseDropdown,
-  BaseInput,
-  Radio,
-  TagsInput,
-  Input,
   FileUploader,
-  Pagination,
-  DotPagination,
-  BulkActions,
-  BreadCrumb,
-  Tooltip,
-  Dialogs,
-  DropDownMenu,
-  Switch,
-  Snackbars,
-  Calendar,
-  VerticalNavigation,
+  // EmptyState,
+  // Grid,
+  // Icons,
+  // Typography,
+  // Tags,
+  // CheckBox,
+  // BaseDropdown,
+  // BaseInput,
+  // Radio,
+  // TagsInput,
+  // Input,
+  // Pagination,
+  // DotPagination,
+  // BulkActions,
+  // BreadCrumb,
+  // Tooltip,
+  // Dialogs,
+  // DropDownMenu,
+  // Switch,
+  // Snackbars,
+  // Calendar,
+  // VerticalNavigation,
 } from "components/components";
-
-const styles = {
-  display: "flex",
-  flexDirection: "column",
-  gap: theme.spacing(5),
-} as CSSProperties;
+import { styles } from "./Components.styles";
 
 const App = () => {
   return (
-    <HvBox sx={styles}>
-      <Snackbars />
+    <HvContainer maxWidth="md">
+      <HvBox className={styles.component}>
+        <HvBox className={styles.header}>
+          <HvTypography variant="title2">Button</HvTypography>
+          <HvTypography
+            component="a"
+            href="https://lumada-design.github.io/uikit/master/?path=/docs/inputs-button--main"
+            target="_blank"
+            className={styles.docs}
+          >
+            Docs
+          </HvTypography>
+        </HvBox>
+        <HvBox className={styles.content}>
+          <Buttons />
+        </HvBox>
+      </HvBox>
+      <HvBox className={styles.component}>
+        <HvBox className={styles.header}>
+          <HvTypography variant="title2">Cards</HvTypography>
+          <HvTypography
+            component="a"
+            href="https://lumada-design.github.io/uikit/master/?path=/docs/display-card--main"
+            target="_blank"
+            className={styles.docs}
+          >
+            Docs
+          </HvTypography>
+        </HvBox>
+        <HvBox className={styles.content}>
+          <Cards />
+        </HvBox>
+      </HvBox>
+      <HvBox className={styles.component}>
+        <HvBox className={styles.header}>
+          <HvTypography variant="title2">FileUploader</HvTypography>
+          <HvTypography
+            component="a"
+            href="https://lumada-design.github.io/uikit/master/?path=/docs/inputs-file-uploader--main"
+            target="_blank"
+            className={styles.docs}
+          >
+            Docs
+          </HvTypography>
+        </HvBox>
+        <HvBox className={styles.content}>
+          <FileUploader />
+        </HvBox>
+      </HvBox>
+    </HvContainer>
+  );
+  {
+    /*<HvBox sx={styles}>
+       <Snackbars />
       <Typography />
       <BaseDropdown />
       <DotPagination />
@@ -47,7 +97,6 @@ const App = () => {
       <BaseInput />
       <Input />
       <TagsInput />
-      <FileUploader />
       <CheckBox />
       <Switch />
       <Radio />
@@ -57,14 +106,13 @@ const App = () => {
       <Tooltip />
       <Grid />
       <EmptyState />
-      <Buttons />
       <Icons />
       <BreadCrumb />
       <BulkActions />
       <Calendar />
       <VerticalNavigation />
-    </HvBox>
-  );
+    </HvBox> */
+  }
 };
 
 export default App;


### PR DESCRIPTION
- Add Theme generator which includes customizations for:
-- Custom theme name
-- Base theme
-- Color mode
-- Colors for each mode
-- Font family including adding Google fonts
-- Font sizes
-- Radii
-- Spacing
- Update `Components` page to provide a better overall experience (unfinished)
- Added collapsable side bar functionality
- Added reset customizations functionality