### PR TITLE
feat(app-switcher | accessibility): remove avatar from accessibility tree - issue 3233

### DIFF
--- a/packages/core/src/components/AppSwitcher/Action/Action.tsx
+++ b/packages/core/src/components/AppSwitcher/Action/Action.tsx
@@ -74,7 +74,7 @@ export const HvAction = ({
       (brokenTitle[1] ? brokenTitle[1].substring(0, 1) : "");
 
     return (
-      <HvAvatar size="sm" backgroundColor={color} variant="square">
+      <HvAvatar size="sm" backgroundColor={color} variant="square" aria-hidden>
         {initials}
       </HvAvatar>
     );

--- a/packages/core/src/components/AppSwitcher/AppSwitcher.test.tsx
+++ b/packages/core/src/components/AppSwitcher/AppSwitcher.test.tsx
@@ -13,7 +13,6 @@ describe("<AppSwitcher /> with minimum configuration", () => {
       {
         id: "app-1",
         name: "Mock App 1",
-        iconUrl: "http://mockapp1/icon",
         url: "http://mockapp1/",
         target: "_top",
       },
@@ -63,5 +62,24 @@ describe("<AppSwitcher /> with minimum configuration", () => {
     );
     const images = getAllByLabelText("Description", { exact: false });
     expect(images.length).toBe(2);
+  });
+
+  it("should use an avatar for actions without icon", () => {
+    const { getAllByText } = render(
+      <HvAppSwitcher {...mockAppSwitcherProps} />
+    );
+    const avatars = getAllByText("MA", { exact: true });
+    expect(avatars.length).toBe(1);
+  });
+
+  it('should have "aria-hidden" for avatars', () => {
+    const { getAllByRole } = render(
+      <HvAppSwitcher {...mockAppSwitcherProps} />
+    );
+
+    const hiddenAvatar = getAllByRole("listitem")[0].querySelector(
+      '[aria-hidden="true"]'
+    );
+    expect(hiddenAvatar).not.toBeNull();
   });
 });

--- a/packages/core/src/components/AppSwitcher/__snapshots__/AppSwitcher.test.tsx.snap
+++ b/packages/core/src/components/AppSwitcher/__snapshots__/AppSwitcher.test.tsx.snap
@@ -27,10 +27,20 @@ exports[`<AppSwitcher /> with minimum configuration > should render correctly 1`
           <div
             class="HvAppSwitcher-Action-icon HvAppSwitcher-itemIcon css-14gx8az-StyledIcon e187pp8e0"
           >
-            <img
-              class="HvAppSwitcher-Action-iconUrl css-lotzyn-StyledImg e187pp8e2"
-              src="http://mockapp1/icon"
-            />
+            <div
+              aria-hidden="true"
+              class="HvAvatar-container css-1a4hhck-StyledContainer e1sw81qd4"
+            >
+              <div
+                class="HvAvatar-status HvAvatar-square css-vfafbb-StyledStatus e1sw81qd2"
+              >
+                <div
+                  class="MuiAvatar-root MuiAvatar-square MuiAvatar-colorDefault HvAvatar-root HvAvatar-avatar css-1lnuk2l-StyledAvatar e1sw81qd1 css-18gxrea-MuiAvatar-root"
+                >
+                  MA
+                </div>
+              </div>
+            </div>
           </div>
           <span
             class="HvAppSwitcher-Action-title HvAppSwitcher-itemTitle e1lxr4i82 HvTypography-root HvTypography-label css-9n4p48-getStyledComponent-StyledTitleWithTooltip e1tnpalo0"


### PR DESCRIPTION
Fix for https://github.com/lumada-design/hv-uikit-react/issues/3233


I decided to implement the change limited to the appswitcher component (and not at Avatar component) as I'm not aware of the consequences that could occur at any other components/scenarios where Avatar is used.