### PR TITLE
feat(app-switcher | accessibility): remove description from <a>/<li> name - issue 3234

### DIFF
--- a/packages/core/src/components/AppSwitcher/Action/Action.tsx
+++ b/packages/core/src/components/AppSwitcher/Action/Action.tsx
@@ -15,6 +15,7 @@ import {
 import appSwitcherActionClasses, {
   HvAppSwitcherActionClasses,
 } from "./actionClasses";
+import { useUniqueId } from "../../../hooks";
 
 export type HvAppSwitcherActionProps = HvBaseProps & {
   /** The application data to be used to render the Action object. */
@@ -95,6 +96,7 @@ export const HvAppSwitcherAction = ({
   };
 
   const isLink = url != null;
+  const descriptionElementId = useUniqueId(id, "hvAction-description");
 
   return (
     <StyledListItem
@@ -111,6 +113,8 @@ export const HvAppSwitcherAction = ({
         isSelected && clsx(appSwitcherActionClasses.selected, classes?.selected)
       )}
     >
+      {/*As HvTooltip don't have the id prop, is not possible to use the aria-labelledby to reference it.
+       In substitution is used the aria-label with the "title" value*/}
       <StyledTypography
         component={isLink ? "a" : "button"}
         href={isLink ? url : undefined}
@@ -121,6 +125,8 @@ export const HvAppSwitcherAction = ({
         )}
         onClick={handleOnClick}
         style={{ borderColor: color }}
+        aria-describedby={descriptionElementId}
+        aria-label={name}
       >
         <StyledIcon
           className={clsx(appSwitcherActionClasses.icon, classes?.icon)}
@@ -148,6 +154,7 @@ export const HvAppSwitcherAction = ({
                 )}
                 role="img"
                 aria-label={description}
+                id={descriptionElementId}
               />
             </div>
           </HvTooltip>

--- a/packages/core/src/components/AppSwitcher/__snapshots__/AppSwitcher.test.tsx.snap
+++ b/packages/core/src/components/AppSwitcher/__snapshots__/AppSwitcher.test.tsx.snap
@@ -19,6 +19,8 @@ exports[`<AppSwitcher /> with minimum configuration > should render correctly 1`
         tabindex="-1"
       >
         <a
+          aria-describedby="hvAction-description1"
+          aria-label="Mock App 1"
           class="HvAppSwitcher-Action-typography HvAppSwitcher-itemTrigger e187pp8e3 HvTypography-root HvTypography-body css-t4szxu-getStyledComponent-StyledTypography e1tnpalo0"
           href="http://mockapp1/"
           tabindex="0"
@@ -45,6 +47,8 @@ exports[`<AppSwitcher /> with minimum configuration > should render correctly 1`
         tabindex="-1"
       >
         <a
+          aria-describedby="hvAction-description2"
+          aria-label="Mock App 2"
           class="HvAppSwitcher-Action-typography HvAppSwitcher-itemTrigger e187pp8e3 HvTypography-root HvTypography-body css-t4szxu-getStyledComponent-StyledTypography e1tnpalo0"
           href="http://mockapp2/"
           tabindex="0"
@@ -72,6 +76,7 @@ exports[`<AppSwitcher /> with minimum configuration > should render correctly 1`
             <div
               aria-label="Mock App 2 Description"
               class="HvAppSwitcher-Action-iconInfo HvAppSwitcher-itemInfoIcon e187pp8e1 css-1xjgxlv-StyledIconInfo"
+              id="hvAction-description2"
               name="Info"
               role="img"
             >
@@ -97,6 +102,8 @@ exports[`<AppSwitcher /> with minimum configuration > should render correctly 1`
         tabindex="-1"
       >
         <a
+          aria-describedby="hvAction-description3"
+          aria-label="Mock App 3"
           class="HvAppSwitcher-Action-typography HvAppSwitcher-itemTrigger e187pp8e3 HvTypography-root HvTypography-body css-t4szxu-getStyledComponent-StyledTypography e1tnpalo0"
           href="http://mockapp2/"
           tabindex="0"
@@ -124,6 +131,7 @@ exports[`<AppSwitcher /> with minimum configuration > should render correctly 1`
             <div
               aria-label="Mock App 2 Description"
               class="HvAppSwitcher-Action-iconInfo HvAppSwitcher-itemInfoIcon e187pp8e1 css-1xjgxlv-StyledIconInfo"
+              id="hvAction-description3"
               name="Info"
               role="img"
             >


### PR DESCRIPTION
Fix for https://github.com/lumada-design/hv-uikit-react/issues/3234

<A> or <BUTTON> elements have now aria-describedby & aria-label

After a further analysis was decided to not add aria-label also to the <LI> as it's not required (Action is at <A> or <BUTTON>