### PR TITLE
chore: import lodash functions one-by-one to reduce bundle size

### DIFF
--- a/packages/core/src/components/BreadCrumb/Page/Page.tsx
+++ b/packages/core/src/components/BreadCrumb/Page/Page.tsx
@@ -1,6 +1,6 @@
 import clsx from "clsx";
 import { HvOverflowTooltip } from "components";
-import { startCase } from "lodash";
+import startCase from "lodash/startCase";
 import { MouseEventHandler } from "react";
 import pageClasses, { HvPageClasses } from "./pageClasses";
 import { StyledLink, StyledTypography } from "./Page.styles";

--- a/packages/core/src/components/BulkActions/BulkActions.stories.tsx
+++ b/packages/core/src/components/BulkActions/BulkActions.stories.tsx
@@ -8,7 +8,7 @@ import {
   HvPagination,
   HvActionGeneric,
 } from "components";
-import { uniqueId } from "lodash";
+import uniqueId from "lodash/uniqueId";
 import { useState } from "react";
 import { HvBulkActions, HvBulkActionsProps } from "./BulkActions";
 

--- a/packages/core/src/components/Dialog/Dialog.tsx
+++ b/packages/core/src/components/Dialog/Dialog.tsx
@@ -3,7 +3,7 @@ import clsx from "clsx";
 import MuiDialog, { DialogProps as MuiDialogProps } from "@mui/material/Dialog";
 import { Close } from "@hitachivantara/uikit-react-icons";
 import { theme } from "@hitachivantara/uikit-styles";
-import { isNil } from "lodash";
+import isNil from "lodash/isNil";
 import { HvBaseProps } from "../../types/generic";
 import { StyledBackdrop, StyledClose, StyledPaper } from "./Dialog.styles";
 import { getFocusableList } from "utils/focusableElementFinder";

--- a/packages/core/src/components/FileUploader/DropZone/DropZone.tsx
+++ b/packages/core/src/components/FileUploader/DropZone/DropZone.tsx
@@ -1,7 +1,7 @@
 import { HvFileData, HvFilesAddedEvent } from "../File";
 import dropZoneClasses, { HvDropZoneClasses } from "./dropZoneClasses";
 import React, { useRef, useState } from "react";
-import { uniqueId } from "lodash";
+import uniqueId from "lodash/uniqueId";
 import accept from "attr-accept";
 import {
   StyledDragText,

--- a/packages/core/src/components/Focus/Focus.tsx
+++ b/packages/core/src/components/Focus/Focus.tsx
@@ -1,5 +1,5 @@
 import clsx from "clsx";
-import { isNil } from "lodash";
+import isNil from "lodash/isNil";
 import React, { RefObject, useState } from "react";
 import { HvBaseProps } from "../../types";
 import { keyboardCodes, isBrowser } from "utils";

--- a/packages/core/src/components/GlobalActions/GlobalActions.tsx
+++ b/packages/core/src/components/GlobalActions/GlobalActions.tsx
@@ -1,6 +1,6 @@
 import clsx from "clsx";
 import { HvBaseProps } from "../../types";
-import { isString } from "lodash";
+import isString from "lodash/isString";
 import { HvTypography } from "components";
 import {
   StyledActions,

--- a/packages/core/src/components/Grid/Grid.tsx
+++ b/packages/core/src/components/Grid/Grid.tsx
@@ -1,5 +1,5 @@
 import { Grid as MuiGrid, GridProps as MuiGridProps } from "@mui/material";
-import { isString } from "lodash";
+import isString from "lodash/isString";
 import { forwardRef } from "react";
 import { useWidth } from "hooks";
 import { HvBaseProps } from "../../types";

--- a/packages/core/src/components/MultiButton/MultiButton.stories.tsx
+++ b/packages/core/src/components/MultiButton/MultiButton.stories.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { range } from "lodash";
+import range from "lodash/range";
 import { Meta, StoryObj } from "@storybook/react";
 import { LocationPin, Map } from "@hitachivantara/uikit-react-icons";
 

--- a/packages/core/src/components/Snackbar/Snackbar.tsx
+++ b/packages/core/src/components/Snackbar/Snackbar.tsx
@@ -7,7 +7,7 @@ import {
 import { HvBaseProps } from "../../types";
 import { StyledSnackbar } from "./Snackbar.styles";
 import snackbarClasses, { HvSnackbarClasses } from "./snackbarClasses";
-import { capitalize } from "lodash";
+import capitalize from "lodash/capitalize";
 import { SyntheticEvent } from "react";
 import { setId } from "utils";
 import { HvActionGeneric } from "components";

--- a/packages/core/src/components/Table/TableCell/TableCell.tsx
+++ b/packages/core/src/components/Table/TableCell/TableCell.tsx
@@ -18,7 +18,7 @@ import {
 import TableContext from "../TableContext";
 import { transientOptions } from "utils/transientOptions";
 import TableSectionContext from "../TableSectionContext";
-import { capitalize } from "lodash";
+import capitalize from "lodash/capitalize";
 import { theme } from "@hitachivantara/uikit-styles";
 import { getBorderStyles } from "../utils/utils";
 import { useTheme } from "hooks";

--- a/packages/core/src/components/Table/TableHeader/TableHeader.tsx
+++ b/packages/core/src/components/Table/TableHeader/TableHeader.tsx
@@ -7,7 +7,7 @@ import {
   useMemo,
 } from "react";
 import clsx from "clsx";
-import { capitalize } from "lodash";
+import capitalize from "lodash/capitalize";
 import styled from "@emotion/styled";
 import { hexToRgb, alpha } from "@mui/material";
 import { theme } from "@hitachivantara/uikit-styles";

--- a/packages/core/src/components/TagsInput/TagsInput.stories.tsx
+++ b/packages/core/src/components/TagsInput/TagsInput.stories.tsx
@@ -9,7 +9,7 @@ import {
   HvTagProps,
   HvFormStatus,
 } from "components";
-import { isEmpty } from "lodash";
+import isEmpty from "lodash/isEmpty";
 import { useState } from "react";
 import countryNamesArray from "./countries";
 import tagsInputClasses from "./tagsInputClasses";

--- a/packages/core/src/components/TextArea/TextArea.tsx
+++ b/packages/core/src/components/TextArea/TextArea.tsx
@@ -25,7 +25,7 @@ import {
   validationTypes,
 } from "../BaseInput/validations";
 import { setId } from "utils";
-import { isNil } from "lodash";
+import isNil from "lodash/isNil";
 import { HvValidationMessages } from "types/forms";
 import textAreaClasses, { HvTextAreaClasses } from "./textAreaClasses";
 


### PR DESCRIPTION
- Lodash functions are imported one-by-one to reduce the bundle size.