### PR TITLE
fix: dropdown menu popper positioning

### DIFF
--- a/packages/core/src/components/ActionsGeneric/ActionsGeneric.styles.tsx
+++ b/packages/core/src/components/ActionsGeneric/ActionsGeneric.styles.tsx
@@ -3,6 +3,7 @@ import { HvButton, HvButtonProps } from "~/components";
 import { transientOptions } from "~/utils/transientOptions";
 import { theme } from "@hitachivantara/uikit-styles";
 import fade from "~/utils/hexToRgbA";
+import { forwardRef, Ref } from "react";
 
 export const StyledRoot = styled(
   "div",
@@ -16,7 +17,9 @@ export const StyledRoot = styled(
 }));
 
 export const StyledButton = styled(
-  (props: HvButtonProps) => <HvButton {...props} />,
+  forwardRef((props: HvButtonProps, ref?: Ref<HTMLButtonElement>) => {
+    return <HvButton {...props} ref={ref} />;
+  }),
   transientOptions
 )(({ $baseColor }: { $baseColor: string }) => ({
   "&:not(:last-child)": {

--- a/packages/core/src/components/Banner/BannerContent/ActionContainer/ActionContainer.styles.tsx
+++ b/packages/core/src/components/Banner/BannerContent/ActionContainer/ActionContainer.styles.tsx
@@ -1,5 +1,6 @@
 import styled from "@emotion/styled";
 import { Close } from "@hitachivantara/uikit-react-icons";
+import { forwardRef, Ref } from "react";
 import { HvButton, HvButtonProps } from "~/components";
 import { outlineStyles } from "~/utils";
 import fade from "~/utils/hexToRgbA";
@@ -13,7 +14,9 @@ export const StyledActionContainer = styled("div")({
 });
 
 export const StyledButton = styled(
-  (props: HvButtonProps) => <HvButton {...props} />,
+  forwardRef((props: HvButtonProps, ref?: Ref<HTMLButtonElement>) => {
+    return <HvButton {...props} ref={ref} />;
+  }),
   transientOptions
 )(({ $baseColor }: { $baseColor: string }) => ({
   alignSelf: "flex-end",

--- a/packages/core/src/components/BreadCrumb/BreadCrumb.styles.tsx
+++ b/packages/core/src/components/BreadCrumb/BreadCrumb.styles.tsx
@@ -1,5 +1,6 @@
 import styled from "@emotion/styled";
 import { theme } from "@hitachivantara/uikit-styles";
+import { Ref, forwardRef } from "react";
 import { HvTypography, HvTypographyProps } from "~/components";
 
 export const StyledRoot = styled("nav")({
@@ -14,8 +15,10 @@ export const StyledOrderedList = styled("ol")({
   marginLeft: `-${theme.space.xs}`,
 });
 
-export const StyledTypography = styled((props: HvTypographyProps) => (
-  <HvTypography {...props} />
-))({
+export const StyledTypography = styled(
+  forwardRef((props: HvTypographyProps, ref?: Ref<HTMLElement>) => {
+    return <HvTypography {...props} ref={ref} />;
+  })
+)({
   padding: `8px ${theme.space.xs}`,
 });

--- a/packages/core/src/components/BreadCrumb/Page/Page.styles.tsx
+++ b/packages/core/src/components/BreadCrumb/Page/Page.styles.tsx
@@ -1,5 +1,6 @@
 import styled from "@emotion/styled";
 import { theme } from "@hitachivantara/uikit-styles";
+import { forwardRef, Ref } from "react";
 import {
   HvLink,
   HvLinkProps,
@@ -21,9 +22,11 @@ export const StyledLink = styled((props: HvLinkProps) => <HvLink {...props} />)(
   }
 );
 
-export const StyledTypography = styled((props: HvTypographyProps) => (
-  <HvTypography {...props} />
-))({
+export const StyledTypography = styled(
+  forwardRef((props: HvTypographyProps, ref?: Ref<HTMLElement>) => {
+    return <HvTypography {...props} ref={ref} />;
+  })
+)({
   maxWidth: "170px",
   textTransform: "capitalize",
   "&:hover": {

--- a/packages/core/src/components/Dialog/Dialog.styles.tsx
+++ b/packages/core/src/components/Dialog/Dialog.styles.tsx
@@ -8,6 +8,7 @@ import { theme } from "@hitachivantara/uikit-styles";
 import { transientOptions } from "~/utils/transientOptions";
 import fade from "~/utils/hexToRgbA";
 import { HvButton, HvButtonProps } from "~/components";
+import { forwardRef, Ref } from "react";
 
 export const StyledPaper = styled(
   MuiPaper,
@@ -42,9 +43,11 @@ export const StyledBackdrop = styled(
   background: fade($backColor, 0.8),
 }));
 
-export const StyledClose = styled((props: HvButtonProps) => (
-  <HvButton {...props} />
-))({
+export const StyledClose = styled(
+  forwardRef((props: HvButtonProps, ref?: Ref<HTMLButtonElement>) => {
+    return <HvButton {...props} ref={ref} />;
+  })
+)({
   padding: 0,
   minWidth: "auto",
   position: "absolute",

--- a/packages/core/src/components/DropDownMenu/DropDownMenu.styles.tsx
+++ b/packages/core/src/components/DropDownMenu/DropDownMenu.styles.tsx
@@ -9,6 +9,7 @@ import {
 } from "~/components";
 import { transientOptions } from "~/utils/transientOptions";
 import { theme } from "@hitachivantara/uikit-styles";
+import { Ref, forwardRef } from "react";
 
 export const StyledBaseDropDown = styled((props: HvBaseDropdownProps) => (
   <HvBaseDropdown {...props} />
@@ -17,7 +18,9 @@ export const StyledBaseDropDown = styled((props: HvBaseDropdownProps) => (
 });
 
 export const StyledButton = styled(
-  (props: HvButtonProps) => <HvButton {...props} />,
+  forwardRef((props: HvButtonProps, ref?: Ref<HTMLButtonElement>) => {
+    return <HvButton {...props} ref={ref} />;
+  }),
   transientOptions
 )(({ $open }: { $open: boolean }) => ({
   position: "relative",

--- a/packages/core/src/components/FileUploader/File/File.styles.tsx
+++ b/packages/core/src/components/FileUploader/File/File.styles.tsx
@@ -1,6 +1,7 @@
 import styled from "@emotion/styled";
 import { Fail, Success } from "@hitachivantara/uikit-react-icons";
 import { theme } from "@hitachivantara/uikit-styles";
+import { forwardRef, Ref } from "react";
 import { HvButton, HvButtonProps, HvTypography } from "~/components";
 
 const iconStyles = {
@@ -81,8 +82,10 @@ export const StyledPreviewContainer = styled("div")({
   },
 });
 
-export const StyledIconButton = styled((props: HvButtonProps) => (
-  <HvButton {...props} />
-))({
+export const StyledIconButton = styled(
+  forwardRef((props: HvButtonProps, ref?: Ref<HTMLButtonElement>) => {
+    return <HvButton {...props} ref={ref} />;
+  })
+)({
   margin: `0px ${theme.space.xs}`,
 });

--- a/packages/core/src/components/FileUploader/Preview/Preview.styles.tsx
+++ b/packages/core/src/components/FileUploader/Preview/Preview.styles.tsx
@@ -3,6 +3,7 @@ import { Preview } from "@hitachivantara/uikit-react-icons";
 import { theme } from "@hitachivantara/uikit-styles";
 import { HvButton, HvButtonProps } from "~/components";
 import fileUploaderPreviewClasses from "./previewClasses";
+import { forwardRef, Ref } from "react";
 
 export const StyledOverlay = styled("div")({
   position: "absolute",
@@ -34,9 +35,11 @@ export const StyledPreviewIcon = styled(Preview)({
   },
 });
 
-export const StyledButton = styled((props: HvButtonProps) => (
-  <HvButton {...props} />
-))({
+export const StyledButton = styled(
+  forwardRef((props: HvButtonProps, ref?: Ref<HTMLButtonElement>) => {
+    return <HvButton {...props} ref={ref} />;
+  })
+)({
   position: "relative",
   width: theme.fileUploader.preview.buttonSize,
   height: theme.fileUploader.preview.buttonSize,

--- a/packages/core/src/components/Header/Brand/Brand.styles.tsx
+++ b/packages/core/src/components/Header/Brand/Brand.styles.tsx
@@ -1,5 +1,6 @@
 import styled from "@emotion/styled";
 import { theme } from "@hitachivantara/uikit-styles";
+import { forwardRef, Ref } from "react";
 import { HvTypography, HvTypographyProps } from "~/components";
 
 export const BrandRoot = styled("div")({
@@ -14,8 +15,10 @@ export const BrandSeparator = styled("div")({
   backgroundColor: theme.colors.secondary,
 });
 
-export const BrandName = styled((props: HvTypographyProps) => (
-  <HvTypography {...props} />
-))({
+export const BrandName = styled(
+  forwardRef((props: HvTypographyProps, ref?: Ref<HTMLElement>) => {
+    return <HvTypography {...props} ref={ref} />;
+  })
+)({
   color: theme.header.brandColor,
 });

--- a/packages/core/src/components/Login/Login.stories.tsx
+++ b/packages/core/src/components/Login/Login.stories.tsx
@@ -14,6 +14,7 @@ import {
 import { HvLogin, HvLoginProps } from "./Login";
 import background from "./resources/background.png";
 import customBackground from "./resources/background-custom.jpg";
+import { forwardRef, Ref } from "react";
 
 // #region Styled components
 
@@ -30,7 +31,11 @@ const StyledInput = styled((props: HvInputProps) => <HvInput {...props} />)({
   marginTop: 40,
 });
 
-const StyledButton = styled((props: HvButtonProps) => <HvButton {...props} />)({
+const StyledButton = styled(
+  forwardRef((props: HvButtonProps, ref?: Ref<HTMLButtonElement>) => {
+    return <HvButton {...props} ref={ref} />;
+  })
+)({
   width: 120,
   float: "right",
   marginTop: theme.spacing(8),

--- a/packages/core/src/components/Table/TableHeader/TableHeader.styles.tsx
+++ b/packages/core/src/components/Table/TableHeader/TableHeader.styles.tsx
@@ -7,6 +7,7 @@ import {
 } from "~/components";
 import { transientOptions } from "~/utils/transientOptions";
 import tableHeaderClasses from "./tableHeaderClasses";
+import { Ref, forwardRef } from "react";
 
 export const StyledHeaderContent = styled(
   "div",
@@ -30,9 +31,11 @@ export const StyledHeaderContent = styled(
   }),
 }));
 
-export const StyledButton = styled((props: HvButtonProps) => (
-  <HvButton {...props} />
-))({
+export const StyledButton = styled(
+  forwardRef((props: HvButtonProps, ref?: Ref<HTMLButtonElement>) => {
+    return <HvButton {...props} ref={ref} />;
+  })
+)({
   [`.${tableHeaderClasses.root}.${tableHeaderClasses.sortable}`]: {
     boxShadow: "none",
     backgroundColor: "transparent",
@@ -43,7 +46,9 @@ export const StyledButton = styled((props: HvButtonProps) => (
 });
 
 export const StyledTypography = styled(
-  (props: HvTypographyProps) => <HvTypography {...props} />,
+  forwardRef((props: HvTypographyProps, ref?: Ref<HTMLElement>) => {
+    return <HvTypography {...props} ref={ref} />;
+  }),
   transientOptions
 )(
   ({

--- a/packages/core/src/components/Tag/Tag.styles.tsx
+++ b/packages/core/src/components/Tag/Tag.styles.tsx
@@ -3,7 +3,7 @@ import { CloseXS } from "@hitachivantara/uikit-react-icons";
 import { theme } from "@hitachivantara/uikit-styles";
 import Chip from "@mui/material/Chip";
 import { HvButton, HvButtonProps } from "~/components";
-import { CSSProperties } from "react";
+import { CSSProperties, Ref, forwardRef } from "react";
 import { outlineStyles } from "~/utils";
 import fade from "~/utils/hexToRgbA";
 import { transientOptions } from "~/utils/transientOptions";
@@ -122,9 +122,11 @@ export const StyledChip = styled(
   })
 );
 
-export const StyledButton = styled((props: HvButtonProps) => (
-  <HvButton {...props} />
-))({
+export const StyledButton = styled(
+  forwardRef((props: HvButtonProps, ref?: Ref<HTMLButtonElement>) => {
+    return <HvButton {...props} ref={ref} />;
+  })
+)({
   "& .MuiButton-startIcon": {
     width: 16,
     height: 16,

--- a/packages/core/src/components/VerticalNavigation/Header/Header.styles.tsx
+++ b/packages/core/src/components/VerticalNavigation/Header/Header.styles.tsx
@@ -1,6 +1,7 @@
 import styled from "@emotion/styled";
 import { HvButton, HvButtonProps } from "~/components";
 import verticalNavigationHeaderClasses from "./headerClasses";
+import { forwardRef, Ref } from "react";
 
 export const StyledHeader = styled("div")({
   width: "100%",
@@ -14,9 +15,11 @@ export const StyledHeader = styled("div")({
   },
 });
 
-export const StyledCollapseButton = styled((props: HvButtonProps) => (
-  <HvButton {...props} />
-))({
+export const StyledCollapseButton = styled(
+  forwardRef((props: HvButtonProps, ref?: Ref<HTMLButtonElement>) => {
+    return <HvButton {...props} ref={ref} />;
+  })
+)({
   marginLeft: "auto",
 
   [`&.${verticalNavigationHeaderClasses.minimized}`]: {


### PR DESCRIPTION
Since we were using functional components with the `styled` utility in some situations to avoid circular dependencies, the references were not being forwarded. This was fixed.