### PR TITLE
chore: convert components props types to interfaces

### DIFF
--- a/packages/core/src/components/Card/Card.tsx
+++ b/packages/core/src/components/Card/Card.tsx
@@ -10,7 +10,7 @@ import {
 import { styles } from "./Card.styles";
 import cardClasses, { HvCardClasses } from "./cardClasses";
 
-export type HvCardProps = HvBaseProps & {
+export interface HvCardProps extends HvBaseProps {
   /** The renderable content inside the icon slot of the header. */
   icon?: React.ReactNode;
   /** Whether the card is selectable. */
@@ -30,7 +30,7 @@ export type HvCardProps = HvBaseProps & {
   statusColor?: "sema0" | HvSemanticColorKeys | HvAtmosphereColorKeys;
   /** A Jss Object used to override or extend the styles applied to the component. */
   classes?: HvCardClasses;
-};
+}
 
 /**
  * A card is a container for a few short and related pieces of content.

--- a/packages/core/src/components/Card/Content/Content.tsx
+++ b/packages/core/src/components/Card/Content/Content.tsx
@@ -7,15 +7,16 @@ import MuiCardContent, {
 import cardContentClasses, { HvCardContentClasses } from "./contentClasses";
 import { ClassNames } from "@emotion/react";
 
-export type HvCardContentProps = Omit<MuiCardContentProps, "classes"> &
-  HvBaseProps & {
-    /** Id to be applied to the root node. */
-    id?: string;
-    /** The function that will be executed when this section is clicked. */
-    onClick?: (event: React.SyntheticEvent) => void;
-    /** A Jss Object used to override or extend the styles applied to the component. */
-    classes?: HvCardContentClasses;
-  };
+export interface HvCardContentProps
+  extends Omit<MuiCardContentProps, "classes">,
+    HvBaseProps {
+  /** Id to be applied to the root node. */
+  id?: string;
+  /** The function that will be executed when this section is clicked. */
+  onClick?: (event: React.SyntheticEvent) => void;
+  /** A Jss Object used to override or extend the styles applied to the component. */
+  classes?: HvCardContentClasses;
+}
 
 export const HvCardContent = ({
   id,

--- a/packages/core/src/components/Card/Content/contentClasses.ts
+++ b/packages/core/src/components/Card/Content/contentClasses.ts
@@ -1,8 +1,8 @@
 import { getClasses } from "@core/utils";
 
-export type HvCardContentClasses = {
+export interface HvCardContentClasses {
   content?: string;
-};
+}
 
 const classKeys: string[] = ["content"];
 

--- a/packages/core/src/components/Card/Header/Header.tsx
+++ b/packages/core/src/components/Card/Header/Header.tsx
@@ -8,19 +8,20 @@ import { styles } from "./Header.styles";
 import { useTheme } from "@core/hooks";
 import { ClassNames } from "@emotion/react";
 
-export type HvCardHeaderProps = Omit<MuiCardHeaderProps, "classes"> &
-  HvBaseProps<HTMLDivElement, { title }> & {
-    /** The renderable content inside the title slot of the header. */
-    title: React.ReactNode;
-    /** The renderable content inside the subheader slot of the header. */
-    subheader?: React.ReactNode;
-    /** The renderable content inside the icon slot of the header. */
-    icon?: React.ReactNode;
-    /** The function that will be executed when this section is clicked. */
-    onClick?: React.MouseEventHandler<HTMLDivElement> | undefined;
-    /** A Jss Object used to override or extend the styles applied to the component. */
-    classes?: HvCardHeaderClasses;
-  };
+export interface HvCardHeaderProps
+  extends Omit<MuiCardHeaderProps, "classes">,
+    HvBaseProps<HTMLDivElement, { title }> {
+  /** The renderable content inside the title slot of the header. */
+  title: React.ReactNode;
+  /** The renderable content inside the subheader slot of the header. */
+  subheader?: React.ReactNode;
+  /** The renderable content inside the icon slot of the header. */
+  icon?: React.ReactNode;
+  /** The function that will be executed when this section is clicked. */
+  onClick?: React.MouseEventHandler<HTMLDivElement> | undefined;
+  /** A Jss Object used to override or extend the styles applied to the component. */
+  classes?: HvCardHeaderClasses;
+}
 
 export const HvCardHeader = ({
   classes,

--- a/packages/core/src/components/Card/Header/headerClasses.ts
+++ b/packages/core/src/components/Card/Header/headerClasses.ts
@@ -1,13 +1,13 @@
 import { getClasses } from "@core/utils";
 
-export type HvCardHeaderClasses = {
+export interface HvCardHeaderClasses {
   root?: string;
   title?: string;
   titleShort?: string;
   subheader?: string;
   action?: string;
   content?: string;
-};
+}
 
 const classKeys: string[] = [
   "root",

--- a/packages/core/src/components/Card/Media/Media.tsx
+++ b/packages/core/src/components/Card/Media/Media.tsx
@@ -8,22 +8,23 @@ import { clsx } from "clsx";
 import { ImgHTMLAttributes } from "react";
 import { ClassNames } from "@emotion/react";
 
-export type HvCardMediaProps = Omit<MuiCardMediaProps, "classes"> &
-  ImgHTMLAttributes<HTMLImageElement> &
-  HvBaseProps<HTMLDivElement, { onClick; title }> & {
-    /** Id to be applied to the root node. */
-    id?: string;
-    /** The title of the media. */
-    title?: string;
-    /** The function that will be executed when this section is clicked. */
-    onClick?: React.MouseEventHandler<HTMLDivElement> | undefined;
-    /** The component used for the root node. Either a string to use a HTML element or a component. */
-    component?: React.ElementType;
-    /** The image to display. */
-    image?: string;
-    /** A Jss Object used to override or extend the styles applied to the component. */
-    classes?: HvCardMediaClasses;
-  };
+export interface HvCardMediaProps
+  extends Omit<MuiCardMediaProps, "classes">,
+    ImgHTMLAttributes<HTMLDivElement>,
+    HvBaseProps<HTMLDivElement, { onClick; title }> {
+  /** Id to be applied to the root node. */
+  id?: string;
+  /** The title of the media. */
+  title?: string;
+  /** The function that will be executed when this section is clicked. */
+  onClick?: React.MouseEventHandler<HTMLDivElement> | undefined;
+  /** The component used for the root node. Either a string to use a HTML element or a component. */
+  component?: React.ElementType;
+  /** The image to display. */
+  image?: string;
+  /** A Jss Object used to override or extend the styles applied to the component. */
+  classes?: HvCardMediaClasses;
+}
 
 export const HvCardMedia = ({
   id,

--- a/packages/core/src/components/Card/Media/mediaClasses.ts
+++ b/packages/core/src/components/Card/Media/mediaClasses.ts
@@ -1,9 +1,9 @@
 import { getClasses } from "@core/utils";
 
-export type HvCardMediaClasses = {
+export interface HvCardMediaClasses {
   root?: string;
   media?: string;
-};
+}
 
 const classKeys: string[] = ["root", "media"];
 

--- a/packages/core/src/components/Card/cardClasses.ts
+++ b/packages/core/src/components/Card/cardClasses.ts
@@ -1,13 +1,13 @@
 import { getClasses } from "@core/utils";
 
-export type HvCardClasses = {
+export interface HvCardClasses {
   root?: string;
   selectable?: string;
   selected?: string;
   semanticBar?: string;
   semanticContainer?: string;
   icon?: string;
-};
+}
 
 const classKeys: string[] = [
   "root",

--- a/packages/core/src/components/CheckBox/CheckBox.tsx
+++ b/packages/core/src/components/CheckBox/CheckBox.tsx
@@ -12,7 +12,7 @@ import {
 } from "./CheckBox.styles";
 import checkBoxClasses, { HvCheckBoxClasses } from "./checkBoxClasses";
 
-export type HvCheckBoxProps = Omit<HvBaseCheckBoxProps, "classes"> & {
+export interface HvCheckBoxProps extends Omit<HvBaseCheckBoxProps, "classes"> {
   /**
    * The label of the form element.
    *
@@ -43,7 +43,7 @@ export type HvCheckBoxProps = Omit<HvBaseCheckBoxProps, "classes"> & {
    * A Jss Object used to override or extend the styles applied to the checkbox.
    */
   classes?: HvCheckBoxClasses;
-};
+}
 
 /**
  * A Checkbox is a mechanism that allows the user to select one or more options.

--- a/packages/core/src/components/CheckBox/checkBoxClasses.ts
+++ b/packages/core/src/components/CheckBox/checkBoxClasses.ts
@@ -1,6 +1,6 @@
 import { getClasses } from "@core/utils";
 
-export type HvCheckBoxClasses = {
+export interface HvCheckBoxClasses {
   root?: string;
   container?: string;
   disabled?: string;
@@ -9,7 +9,7 @@ export type HvCheckBoxClasses = {
   checkbox?: string;
   invalidCheckbox?: string;
   label?: string;
-};
+}
 
 const classKeys: string[] = [
   "root",

--- a/packages/core/src/components/CheckBoxGroup/CheckBoxGroup.tsx
+++ b/packages/core/src/components/CheckBoxGroup/CheckBoxGroup.tsx
@@ -41,7 +41,8 @@ const getValueFromSelectedChildren = (children: React.ReactNode) => {
   return selectedValues;
 };
 
-export type HvCheckBoxGroupProps = HvBaseProps<HTMLDivElement, { onChange }> & {
+export interface HvCheckBoxGroupProps
+  extends HvBaseProps<HTMLDivElement, { onChange }> {
   /**
    * The form element name.
    *
@@ -124,7 +125,7 @@ export type HvCheckBoxGroupProps = HvBaseProps<HTMLDivElement, { onChange }> & {
    * A Jss Object used to override or extend the component styles applied.
    */
   classes?: HvCheckBoxGroupClasses;
-};
+}
 
 /**
  * A checkbox group is a type of selection list that allows the user to select multiple options through the use of checkboxes.

--- a/packages/core/src/components/CheckBoxGroup/checkBoxGroupClasses.ts
+++ b/packages/core/src/components/CheckBoxGroup/checkBoxGroupClasses.ts
@@ -1,6 +1,6 @@
 import { getClasses } from "@core/utils";
 
-export type HvCheckBoxGroupClasses = {
+export interface HvCheckBoxGroupClasses {
   root?: string;
   label?: string;
   group?: string;
@@ -9,7 +9,7 @@ export type HvCheckBoxGroupClasses = {
   invalid?: string;
   selectAll?: string;
   error?: string;
-};
+}
 
 const classKeys: string[] = [
   "root",

--- a/packages/core/src/components/Container/Container.tsx
+++ b/packages/core/src/components/Container/Container.tsx
@@ -6,31 +6,32 @@ import { StyledRoot } from "./Container.styles";
 import containerClasses, { HvContainerClasses } from "./containerClasses";
 import { clsx } from "clsx";
 
-export type HvContainerProps = Omit<MuiContainerProps, "classes"> &
-  HvBaseProps & {
-    /**
-     * The component used for the root node.
-     * Either a string to use a DOM element or a component.
-     */
-    component?: React.ElementType;
-    /**
-     * Determine the max-width of the container.
-     * The container width grows with the size of the screen.
-     * Set to `false` to disable `maxWidth`.
-     */
-    maxWidth?: "xs" | "sm" | "md" | "lg" | "xl" | false;
-    /** If `true`, the left and right padding is removed. */
-    disableGutters?: boolean;
-    /**
-     * Set the max-width to match the min-width of the current breakpoint.
-     * This is useful if you'd prefer to design for a fixed set of sizes
-     * instead of trying to accommodate a fully fluid viewport.
-     * It's fluid by default.
-     */
-    fixed?: boolean;
-    /** A Jss Object used to override or extend the styles applied to the component. */
-    classes?: HvContainerClasses;
-  };
+export interface HvContainerProps
+  extends Omit<MuiContainerProps, "classes">,
+    HvBaseProps {
+  /**
+   * The component used for the root node.
+   * Either a string to use a DOM element or a component.
+   */
+  component?: React.ElementType;
+  /**
+   * Determine the max-width of the container.
+   * The container width grows with the size of the screen.
+   * Set to `false` to disable `maxWidth`.
+   */
+  maxWidth?: "xs" | "sm" | "md" | "lg" | "xl" | false;
+  /** If `true`, the left and right padding is removed. */
+  disableGutters?: boolean;
+  /**
+   * Set the max-width to match the min-width of the current breakpoint.
+   * This is useful if you'd prefer to design for a fixed set of sizes
+   * instead of trying to accommodate a fully fluid viewport.
+   * It's fluid by default.
+   */
+  fixed?: boolean;
+  /** A Jss Object used to override or extend the styles applied to the component. */
+  classes?: HvContainerClasses;
+}
 
 export const HvContainer = forwardRef<HTMLDivElement, HvContainerProps>(
   ({ maxWidth = false, classes, className, fixed, ...others }, ref) => {

--- a/packages/core/src/components/Container/containerClasses.ts
+++ b/packages/core/src/components/Container/containerClasses.ts
@@ -1,6 +1,6 @@
 import { getClasses } from "@core/utils";
 
-export type HvContainerClasses = {
+export interface HvContainerClasses {
   root?: string;
   disableGutters?: string;
   fixed?: string;
@@ -9,7 +9,7 @@ export type HvContainerClasses = {
   maxWidthMd?: string;
   maxWidthLg?: string;
   maxWidthXl?: string;
-};
+}
 
 const classKeys: string[] = [
   "root",

--- a/packages/core/src/components/Controls/Controls.tsx
+++ b/packages/core/src/components/Controls/Controls.tsx
@@ -9,13 +9,13 @@ import { HvControlsContextProvider } from "./context/ControlsContext";
 import { Children } from "react";
 import { HvTableInstance } from "@core/components/Table/hooks/useTable";
 
-export type HvControlsViewConfiguration = {
+export interface HvControlsViewConfiguration extends HvExtraProps {
   id?: string;
   label?: string;
   icon?: React.ReactNode;
-} & HvExtraProps;
+}
 
-export type HvControlsProps = HvBaseProps & {
+export interface HvControlsProps extends HvBaseProps {
   /**
    * An instance of useHvTable or useTable used to manage the data
    * if this is not provided data sorting and search must be handled externally
@@ -48,7 +48,7 @@ export type HvControlsProps = HvBaseProps & {
   hideViewSwitcher?: boolean;
   /** A Jss Object used to override or extend the styles applied to the component. */
   classes?: HvControlsClasses;
-};
+}
 
 export const HvControls = ({
   id,

--- a/packages/core/src/components/Controls/LeftControl/LeftControl.tsx
+++ b/packages/core/src/components/Controls/LeftControl/LeftControl.tsx
@@ -7,7 +7,7 @@ import { HvInput, HvInputProps } from "@core/components";
 import leftControlClasses, { HvLeftControlClasses } from "./leftControlClasses";
 import { HvControlsContext } from "../context/ControlsContext";
 
-export type HvLeftControlProps = HvBaseProps & {
+export interface HvLeftControlProps extends HvBaseProps {
   /** if `true` the hide sort by dropdown is not rendered */
   hideSearch?: boolean;
   /** placeholder of the input */
@@ -21,7 +21,7 @@ export type HvLeftControlProps = HvBaseProps & {
   searchProps?: HvInputProps;
   /** A Jss Object used to override or extend the styles applied to the component. */
   classes?: HvLeftControlClasses;
-};
+}
 
 export const HvLeftControl = ({
   id,

--- a/packages/core/src/components/Controls/LeftControl/leftControlClasses.ts
+++ b/packages/core/src/components/Controls/LeftControl/leftControlClasses.ts
@@ -1,8 +1,8 @@
 import { getClasses } from "@core/utils";
 
-export type HvLeftControlClasses = {
+export interface HvLeftControlClasses {
   root: string;
-};
+}
 
 const classKeys: string[] = ["root"];
 

--- a/packages/core/src/components/Controls/RightControl/RightControl.tsx
+++ b/packages/core/src/components/Controls/RightControl/RightControl.tsx
@@ -9,12 +9,12 @@ import rightControlClasses, {
 } from "./rightControlClasses";
 import { HvControlsContext } from "../context/ControlsContext";
 
-export type HvRightListControls = HvListValue & {
+export interface HvRightListControls extends HvListValue {
   accessor: string;
   desc: boolean;
-};
+}
 
-export type HvRightControlProps = HvBaseProps & {
+export interface HvRightControlProps extends HvBaseProps {
   /** if `true` the hide sort by dropdown is not rendered */
   hideSortBy?: boolean;
   /** options for the dropdown to sort */
@@ -25,7 +25,7 @@ export type HvRightControlProps = HvBaseProps & {
   sortProps?: HvDropdownProps;
   /** A Jss Object used to override or extend the styles applied to the component. */
   classes?: HvRightControlClasses;
-};
+}
 
 export const HvRightControl = ({
   id,

--- a/packages/core/src/components/Controls/RightControl/rightControlClasses.ts
+++ b/packages/core/src/components/Controls/RightControl/rightControlClasses.ts
@@ -1,9 +1,9 @@
 import { getClasses } from "@core/utils";
 
-export type HvRightControlClasses = {
+export interface HvRightControlClasses {
   root?: string;
   sortDropdown?: string;
-};
+}
 
 const classKeys: string[] = ["root"];
 

--- a/packages/core/src/components/Controls/controlClasses.ts
+++ b/packages/core/src/components/Controls/controlClasses.ts
@@ -1,11 +1,11 @@
 import { getClasses } from "@core/utils";
 
-export type HvControlsClasses = {
+export interface HvControlsClasses {
   root: string;
   section: string;
   rightSection: string;
   leftSection: string;
-};
+}
 
 const classKeys: string[] = ["root", "section", "rightSection", "leftSection"];
 

--- a/packages/core/src/components/Dialog/Actions/Actions.tsx
+++ b/packages/core/src/components/Dialog/Actions/Actions.tsx
@@ -4,12 +4,13 @@ import { HvBaseProps } from "@core/types";
 import { StyledActions } from "./Actions.styles";
 import dialogActionClasses, { HvDialogActionClasses } from "./actionsClasses";
 
-export type HvDialogActionsProps = Omit<MuiDialogActionsProps, "classes"> &
-  HvBaseProps & {
-    /** Set the dialog to fullscreen mode. */
-    fullscreen?: boolean;
-    classes?: HvDialogActionClasses;
-  };
+export interface HvDialogActionsProps
+  extends Omit<MuiDialogActionsProps, "classes">,
+    HvBaseProps {
+  /** Set the dialog to fullscreen mode. */
+  fullscreen?: boolean;
+  classes?: HvDialogActionClasses;
+}
 
 export const HvDialogActions = ({
   classes,

--- a/packages/core/src/components/Dialog/Actions/actionsClasses.ts
+++ b/packages/core/src/components/Dialog/Actions/actionsClasses.ts
@@ -1,10 +1,10 @@
 import { getClasses } from "@core/utils";
 
-export type HvDialogActionClasses = {
+export interface HvDialogActionClasses {
   root?: string;
   fullscreen?: string;
   spacing?: string;
-};
+}
 
 const classKeys: string[] = ["root", "fullscreen", "spacing"];
 

--- a/packages/core/src/components/Dialog/Content/Content.tsx
+++ b/packages/core/src/components/Dialog/Content/Content.tsx
@@ -6,12 +6,13 @@ import { HvBaseProps } from "@core/types";
 import { StyledTypography } from "./Content.styles";
 import dialogContentClasses, { HvDialogContentClasses } from "./contentClasses";
 
-export type HvDialogContentProps = Omit<MuiDialogContentProps, "classes"> &
-  HvBaseProps & {
-    /** Content should be indented in relationship to the Dialog title. */
-    indentContent?: boolean;
-    classes?: HvDialogContentClasses;
-  };
+export interface HvDialogContentProps
+  extends Omit<MuiDialogContentProps, "classes">,
+    HvBaseProps {
+  /** Content should be indented in relationship to the Dialog title. */
+  indentContent?: boolean;
+  classes?: HvDialogContentClasses;
+}
 
 export const HvDialogContent = ({
   classes,

--- a/packages/core/src/components/Dialog/Content/contentClasses.ts
+++ b/packages/core/src/components/Dialog/Content/contentClasses.ts
@@ -1,9 +1,9 @@
 import { getClasses } from "@core/utils";
 
-export type HvDialogContentClasses = {
+export interface HvDialogContentClasses {
   root?: string;
   textContent?: string;
-};
+}
 
 const classKeys: string[] = ["root", "textContent"];
 

--- a/packages/core/src/components/Dialog/Dialog.tsx
+++ b/packages/core/src/components/Dialog/Dialog.tsx
@@ -17,28 +17,29 @@ import dialogClasses, { HvDialogClasses } from "./dialogClasses";
 import { useTheme } from "@core/hooks";
 import { ClassNames } from "@emotion/react";
 
-export type HvDialogProps = Omit<MuiDialogProps, "fullScreen" | "classes"> &
-  HvBaseProps & {
-    /** Id to be applied to the root node. */
-    id?: string;
-    /** Current state of the Dialog. */
-    open?: boolean;
-    /** Function executed on close. */
-    onClose?: (
-      event: React.SyntheticEvent,
-      reason?: "escapeKeyDown" | "backdropClick"
-    ) => void;
-    /** Element id that should be focus when the Dialog opens. */
-    firstFocusable?: string;
-    /** Title for the button close. */
-    buttonTitle?: string;
-    /** Set the dialog to fullscreen mode. */
-    fullscreen?: boolean;
-    /** Prevent closing the dialog when clicking on the backdrop. */
-    disableBackdropClick?: boolean;
-    /** A Jss Object used to override or extend the styles applied to the component. */
-    classes?: HvDialogClasses;
-  };
+export interface HvDialogProps
+  extends Omit<MuiDialogProps, "fullScreen" | "classes" | "open">,
+    HvBaseProps {
+  /** Id to be applied to the root node. */
+  id?: string;
+  /** Current state of the Dialog. */
+  open?: boolean;
+  /** Function executed on close. */
+  onClose?: (
+    event: React.SyntheticEvent,
+    reason?: "escapeKeyDown" | "backdropClick"
+  ) => void;
+  /** Element id that should be focus when the Dialog opens. */
+  firstFocusable?: string;
+  /** Title for the button close. */
+  buttonTitle?: string;
+  /** Set the dialog to fullscreen mode. */
+  fullscreen?: boolean;
+  /** Prevent closing the dialog when clicking on the backdrop. */
+  disableBackdropClick?: boolean;
+  /** A Jss Object used to override or extend the styles applied to the component. */
+  classes?: HvDialogClasses;
+}
 
 export const HvDialog = ({
   classes,

--- a/packages/core/src/components/Dialog/Title/Title.tsx
+++ b/packages/core/src/components/Dialog/Title/Title.tsx
@@ -18,19 +18,17 @@ export type HvDialogTitleVariant =
   | "info"
   | "default";
 
-export type HvDialogTitleProps = Omit<
-  MuiDialogTitleProps,
-  "variant" | "classes"
-> &
-  HvBaseProps & {
-    /** Variant of the Dialog. */
-    variant?: HvDialogTitleVariant;
-    /** Controls if the associated icon to the variant should be shown. */
-    showIcon?: boolean;
-    /** Custom icon to replace the variant default. */
-    customIcon?: React.ReactNode;
-    classes?: HvDialogTitleClasses;
-  };
+export interface HvDialogTitleProps
+  extends Omit<MuiDialogTitleProps, "variant" | "classes">,
+    HvBaseProps<HTMLSpanElement, { color }> {
+  /** Variant of the Dialog. */
+  variant?: HvDialogTitleVariant;
+  /** Controls if the associated icon to the variant should be shown. */
+  showIcon?: boolean;
+  /** Custom icon to replace the variant default. */
+  customIcon?: React.ReactNode;
+  classes?: HvDialogTitleClasses;
+}
 
 export const HvDialogTitle = ({
   classes,

--- a/packages/core/src/components/Dialog/Title/titleClasses.ts
+++ b/packages/core/src/components/Dialog/Title/titleClasses.ts
@@ -1,11 +1,11 @@
 import { getClasses } from "@core/utils";
 
-export type HvDialogTitleClasses = {
+export interface HvDialogTitleClasses {
   root?: string;
   fullscreen?: string;
   messageContainer?: string;
   textWithIcon?: string;
-};
+}
 
 const classKeys: string[] = [
   "root",

--- a/packages/core/src/components/Dialog/dialogClasses.ts
+++ b/packages/core/src/components/Dialog/dialogClasses.ts
@@ -1,12 +1,12 @@
 import { getClasses } from "@core/utils";
 
-export type HvDialogClasses = {
+export interface HvDialogClasses {
   root?: string;
   closeButton?: string;
   fullscreen?: string;
   background?: string;
   paper?: string;
-};
+}
 
 const classKeys: string[] = [
   "root",

--- a/packages/core/src/components/DotPagination/DotPagination.tsx
+++ b/packages/core/src/components/DotPagination/DotPagination.tsx
@@ -11,7 +11,8 @@ import {
 } from "./DotPagination.styles";
 import { cloneElement } from "react";
 
-export type HvDotPaginationProps = Omit<HvRadioGroupProps, "classes"> & {
+export interface HvDotPaginationProps
+  extends Omit<HvRadioGroupProps, "classes"> {
   /**
    * Icon to override the default one used for the unselected state.
    *
@@ -47,7 +48,7 @@ export type HvDotPaginationProps = Omit<HvRadioGroupProps, "classes"> & {
    * A Jss Object used to override or extend the styles applied.
    */
   classes?: HvDotPaginationClasses;
-};
+}
 
 const getSelectorIcons = (
   radioIcon?: React.ReactElement,

--- a/packages/core/src/components/DotPagination/dotPaginationClasses.ts
+++ b/packages/core/src/components/DotPagination/dotPaginationClasses.ts
@@ -1,12 +1,12 @@
 import { getClasses } from "@core/utils";
 
-export type HvDotPaginationClasses = {
+export interface HvDotPaginationClasses {
   root?: string;
   horizontal?: string;
   radioRoot?: string;
   radio?: string;
   icon?: string;
-};
+}
 
 const classKeys: string[] = [
   "root",

--- a/packages/core/src/components/DropDownMenu/DropDownMenu.tsx
+++ b/packages/core/src/components/DropDownMenu/DropDownMenu.tsx
@@ -30,7 +30,8 @@ import dropDownMenuClasses, {
   HvDropDownMenuClasses,
 } from "./dropDownMenuClasses";
 
-export type HvDropDownMenuProps = HvBaseProps<HTMLDivElement, { onClick }> & {
+export interface HvDropDownMenuProps
+  extends HvBaseProps<HTMLDivElement, { onClick }> {
   /** Icon. */
   icon?: React.ReactElement;
   /**
@@ -66,7 +67,7 @@ export type HvDropDownMenuProps = HvBaseProps<HTMLDivElement, { onClick }> & {
   category?: HvButtonVariant;
   /** A Jss Object used to override or extend the styles applied to the component. */
   classes?: HvDropDownMenuClasses;
-};
+}
 
 /**
  * A drop-down menu is a graphical control element, similar to a list box, that allows the user to choose a value from a list.

--- a/packages/core/src/components/DropDownMenu/dropDownMenuClasses.ts
+++ b/packages/core/src/components/DropDownMenu/dropDownMenuClasses.ts
@@ -1,6 +1,6 @@
 import { getClasses } from "@core/utils";
 
-export type HvDropDownMenuClasses = {
+export interface HvDropDownMenuClasses {
   /** Styles applied to the root. */
   root?: string;
   /** Styles applied to the container. */
@@ -13,7 +13,7 @@ export type HvDropDownMenuClasses = {
   iconSelected?: string;
   /** Styles applied to the list. */
   menuList?: string;
-};
+}
 
 const classKeys: string[] = [
   "root",

--- a/packages/core/src/components/Dropdown/Dropdown.tsx
+++ b/packages/core/src/components/Dropdown/Dropdown.tsx
@@ -22,7 +22,7 @@ import {
   HvWarningText,
 } from "@core/components";
 
-export type HvDropdownLabelsProps = {
+export interface HvDropdownLabelsProps {
   /**
    * Label for overwrite the default header behavior.
    */
@@ -47,11 +47,12 @@ export type HvDropdownLabelsProps = {
    * The label used in search.
    */
   searchPlaceholder?: string;
-};
+}
 
 export type HvDropdownStatus = "standBy" | "valid" | "invalid";
 
-export type HvDropdownProps = HvBaseProps<HTMLDivElement, { onChange }> & {
+export interface HvDropdownProps
+  extends HvBaseProps<HTMLDivElement, { onChange }> {
   /**
    * Class names to be applied.
    */
@@ -239,7 +240,7 @@ export type HvDropdownProps = HvBaseProps<HTMLDivElement, { onChange }> & {
    * Extra props passed to the list.
    */
   listProps?: HvDropdownListProps;
-};
+}
 
 const DEFAULT_LABELS: HvDropdownLabelsProps = {
   select: undefined,

--- a/packages/core/src/components/Dropdown/List/List.tsx
+++ b/packages/core/src/components/Dropdown/List/List.tsx
@@ -21,7 +21,7 @@ import { getSelected } from "../utils";
 import { HvDropdownLabelsProps } from "../Dropdown";
 import dropdownListClasses, { HvDropdownListClasses } from "./listClasses";
 
-export type HvDropdownListProps = {
+export interface HvDropdownListProps {
   /**
    * Id to be applied to the root node.
    */
@@ -79,7 +79,7 @@ export type HvDropdownListProps = {
    * Experimental. Uses dropdown in a virtualized form, where not all options are rendered initially. Good for use cases with a lot of options.
    */
   virtualized?: boolean;
-};
+}
 
 /**
  * The values property was being deeply cloned. That created a significant performance

--- a/packages/core/src/components/Dropdown/List/listClasses.tsx
+++ b/packages/core/src/components/Dropdown/List/listClasses.tsx
@@ -1,6 +1,6 @@
 import { getClasses } from "@core/utils";
 
-export type HvDropdownListClasses = {
+export interface HvDropdownListClasses {
   rootList?: string;
   dropdownListContainer?: string;
   searchContainer?: string;
@@ -9,7 +9,7 @@ export type HvDropdownListClasses = {
   selectAllContainer?: string;
   selection?: string;
   selectAll?: string;
-};
+}
 
 const classKeys: string[] = [
   "rootList",

--- a/packages/core/src/components/Dropdown/dropdownClasses.tsx
+++ b/packages/core/src/components/Dropdown/dropdownClasses.tsx
@@ -1,6 +1,6 @@
 import { getClasses } from "@core/utils";
 
-export type HvDropdownClasses = {
+export interface HvDropdownClasses {
   root?: string;
   labelContainer?: string;
   label?: string;
@@ -15,7 +15,7 @@ export type HvDropdownClasses = {
   dropdownHeaderOpen?: string;
   dropdownListContainer?: string;
   rootList?: string;
-};
+}
 
 const classKeys: string[] = [
   "root",

--- a/packages/core/src/components/EmptyState/EmptyState.tsx
+++ b/packages/core/src/components/EmptyState/EmptyState.tsx
@@ -12,7 +12,8 @@ import { HvTypographyProps } from "@core/components";
 import { useTheme as useHvTheme } from "@core/hooks";
 import { useTheme } from "@mui/material/styles";
 
-export type HvEmptyStateProps = HvBaseProps<HTMLDivElement, { title }> & {
+export interface HvEmptyStateProps
+  extends HvBaseProps<HTMLDivElement, { title }> {
   /** Icon to be presented. */
   icon: React.ReactNode;
   /** The title to be shown. */
@@ -23,7 +24,7 @@ export type HvEmptyStateProps = HvBaseProps<HTMLDivElement, { title }> & {
   action?: string | React.ReactNode;
   /** A Jss Object used to override or extend the styles applied to the empty state component. */
   classes?: HvEmptyStateClasses;
-};
+}
 
 /**
  * Empty states communicate that there’s no information, data or values to display in a given context.

--- a/packages/core/src/components/EmptyState/emptyStateClasses.ts
+++ b/packages/core/src/components/EmptyState/emptyStateClasses.ts
@@ -1,6 +1,6 @@
 import { getClasses } from "@core/utils";
 
-export type HvEmptyStateClasses = {
+export interface HvEmptyStateClasses {
   root?: string;
   container?: string;
   containerMessageOnly?: string;
@@ -9,7 +9,7 @@ export type HvEmptyStateClasses = {
   textContainer?: string;
   messageContainer?: string;
   actionContainer?: string;
-};
+}
 
 const classKeys: string[] = [
   "root",

--- a/packages/core/src/components/FileUploader/DropZone/DropZone.tsx
+++ b/packages/core/src/components/FileUploader/DropZone/DropZone.tsx
@@ -21,7 +21,7 @@ import { isKeypress, keyboardCodes, setId } from "@core/utils";
 import { convertUnits } from "../utils";
 import withId from "@core/hocs/withId";
 
-export type HvDropZoneLabels = {
+export interface HvDropZoneLabels {
   /**
    * Extensions of the accepted file types
    */
@@ -54,9 +54,9 @@ export type HvDropZoneLabels = {
    * Message to display when file type is greater than allowed
    * */
   fileTypeError?: string;
-};
+}
 
-export type HvDropZoneProps = {
+export interface HvDropZoneProps {
   /**
    * Id to be applied to the root node.
    */
@@ -97,7 +97,7 @@ export type HvDropZoneProps = {
    * A Jss Object used to override or extend the styles applied to the component.
    */
   classes?: HvDropZoneClasses;
-};
+}
 
 export const HvDropZone = withId(
   ({

--- a/packages/core/src/components/FileUploader/DropZone/dropZoneClasses.ts
+++ b/packages/core/src/components/FileUploader/DropZone/dropZoneClasses.ts
@@ -1,6 +1,6 @@
 import { getClasses } from "@core/utils";
 
-export type HvDropZoneClasses = {
+export interface HvDropZoneClasses {
   dropZoneContainer?: string;
   dropZoneLabelsGroup?: string;
   dragAction?: string;
@@ -12,7 +12,7 @@ export type HvDropZoneClasses = {
   dropZoneLabel?: string;
   dragText?: string;
   selectFilesText?: string;
-};
+}
 
 const classKeys: string[] = [
   "dropZoneContainer",

--- a/packages/core/src/components/FileUploader/File/File.tsx
+++ b/packages/core/src/components/FileUploader/File/File.tsx
@@ -17,7 +17,7 @@ import {
   StyledEmptyIcon,
 } from "./File.styles";
 
-export type HvFileData = File & {
+export interface HvFileData extends Omit<File, "name" | "size"> {
   /**
    * The file id.
    */
@@ -46,7 +46,7 @@ export type HvFileData = File & {
    * Error message when the upload failed.
    */
   errorMessage?: string;
-};
+}
 
 export type HvFilesAddedEvent = (files: HvFileData[]) => void;
 

--- a/packages/core/src/components/FileUploader/File/fileClasses.ts
+++ b/packages/core/src/components/FileUploader/File/fileClasses.ts
@@ -1,6 +1,6 @@
 import { getClasses } from "@core/utils";
 
-export type HvFileClasses = {
+export interface HvFileClasses {
   root?: string;
   progressbar?: string;
   progressbarBack?: string;
@@ -10,7 +10,7 @@ export type HvFileClasses = {
   previewContainer?: string;
   icon?: string;
   fail?: string;
-};
+}
 
 const classKeys: string[] = [
   "root",

--- a/packages/core/src/components/FileUploader/FileList/FileList.tsx
+++ b/packages/core/src/components/FileUploader/FileList/FileList.tsx
@@ -5,7 +5,7 @@ import { setId } from "@core/utils";
 import { StyledList } from "./FileList.styles";
 import { clsx } from "clsx";
 
-export type HvFileListProps = {
+export interface HvFileListProps {
   /**
    * Id to be applied to the root node.
    */
@@ -26,7 +26,7 @@ export type HvFileListProps = {
    * A Jss Object used to override or extend the styles applied to the component.
    */
   classes?: HvFileListClasses;
-};
+}
 
 export const HvFileList = ({
   id,

--- a/packages/core/src/components/FileUploader/FileList/fileListClasses.ts
+++ b/packages/core/src/components/FileUploader/FileList/fileListClasses.ts
@@ -1,9 +1,9 @@
 import { getClasses } from "@core/utils";
 
-export type HvFileListClasses = {
+export interface HvFileListClasses {
   list?: string;
   listItem?: string;
-};
+}
 
 const classKeys: string[] = ["list", "listItem"];
 

--- a/packages/core/src/components/FileUploader/FileUploader.stories.tsx
+++ b/packages/core/src/components/FileUploader/FileUploader.stories.tsx
@@ -224,7 +224,7 @@ export const WithPreviewThumbnails: StoryObj<HvFileUploaderProps> = {
 
       // See https://developer.mozilla.org/en-US/docs/Web/API/File/Using_files_from_web_applications#using_object_urls
       // specially to understand the need to explicitly call URL.revokeObjectURL() in Single Page Applications.
-      const url = URL.createObjectURL(file);
+      const url = URL.createObjectURL(file as File);
 
       newFile.preview = (
         <HvFileUploaderPreview

--- a/packages/core/src/components/FileUploader/FileUploader.tsx
+++ b/packages/core/src/components/FileUploader/FileUploader.tsx
@@ -5,14 +5,14 @@ import { HvDropZone, HvDropZoneLabels } from "./DropZone";
 import { HvFileData, HvFileRemovedEvent, HvFilesAddedEvent } from "./File";
 import { HvFileList } from "./FileList";
 
-export type HvFileUploaderLabels = HvDropZoneLabels & {
+export interface HvFileUploaderLabels extends HvDropZoneLabels {
   /**
    * Value of aria-label to apply to remove file button in FileList
    * */
   removeFileButtonLabel?: string;
-};
+}
 
-export type HvFileUploaderProps = HvBaseProps & {
+export interface HvFileUploaderProps extends HvBaseProps {
   /**
    * An object containing all the labels.
    */
@@ -53,7 +53,7 @@ export type HvFileUploaderProps = HvBaseProps & {
    * Attributes applied to the input element.
    */
   inputProps?: React.InputHTMLAttributes<HTMLInputElement>;
-};
+}
 
 // TODO: This component needs to adopt the Form element shape and deprecate its way of composing labels
 

--- a/packages/core/src/components/FileUploader/Preview/Preview.tsx
+++ b/packages/core/src/components/FileUploader/Preview/Preview.tsx
@@ -10,10 +10,8 @@ import {
   StyledPreviewIcon,
 } from "./Preview.styles";
 
-export type HvFileUploaderPreviewProps = Omit<
-  HvButtonProps,
-  "children" | "classes"
-> & {
+export interface HvFileUploaderPreviewProps
+  extends Omit<HvButtonProps, "children" | "classes"> {
   /**
    * Content that represents the preview of an uploaded file.
    */
@@ -34,7 +32,7 @@ export type HvFileUploaderPreviewProps = Omit<
    * A Jss Object used to override or extend the styles applied to the component.
    */
   classes?: HvFileUploaderPreviewClasses;
-};
+}
 
 /**
  * The `HvFileUploaderPreview` component is available to facilitate the styling

--- a/packages/core/src/components/FileUploader/Preview/previewClasses.ts
+++ b/packages/core/src/components/FileUploader/Preview/previewClasses.ts
@@ -1,9 +1,9 @@
 import { getClasses } from "@core/utils";
 
-export type HvFileUploaderPreviewClasses = {
+export interface HvFileUploaderPreviewClasses {
   previewButton?: string;
   overlay?: string;
-};
+}
 
 const classKeys: string[] = ["previewButton", "overlay"];
 

--- a/packages/core/src/components/Focus/Focus.tsx
+++ b/packages/core/src/components/Focus/Focus.tsx
@@ -42,7 +42,7 @@ const focusStyles = css`
 
 export type HvFocusStrategies = "listbox" | "menu" | "card" | "grid";
 
-export type HvFocusProps = HvBaseProps<HTMLElement, { children }> & {
+export interface HvFocusProps extends HvBaseProps<HTMLElement, { children }> {
   children: React.ReactElement;
   /** Extra configuration for the child element. */
   configuration?: {
@@ -72,7 +72,7 @@ export type HvFocusProps = HvBaseProps<HTMLElement, { children }> & {
   navigationJump?: number;
   /** A Jss Object used to override or extend the styles applied to the component. */
   classes?: HvFocusClasses;
-};
+}
 
 export const HvFocus = ({
   classes,

--- a/packages/core/src/components/Focus/focusClasses.ts
+++ b/packages/core/src/components/Focus/focusClasses.ts
@@ -1,6 +1,6 @@
 import { getClasses } from "@core/utils";
 
-export type HvFocusClasses = {
+export interface HvFocusClasses {
   root?: string;
   selected?: string;
   focused?: string;
@@ -9,7 +9,7 @@ export type HvFocusClasses = {
   externalReference?: string;
   falseFocus?: string;
   focusDisabled?: string;
-};
+}
 
 const classKeys: string[] = [
   "root",

--- a/packages/core/src/components/Footer/Footer.tsx
+++ b/packages/core/src/components/Footer/Footer.tsx
@@ -10,13 +10,13 @@ import {
   StyledSeparator,
 } from "./Footer.styles";
 
-export type HvFooterProps = HvBaseProps & {
+export interface HvFooterProps extends HvBaseProps {
   name?: React.ReactNode;
   copyright?: React.ReactNode;
   links?: React.ReactNode;
   /** A Jss Object used to override or extend the styles applied to the component. */
   classes?: HvFooterClasses;
-};
+}
 
 /**
  * A Footer is a way of providing extra information at the end of a page.

--- a/packages/core/src/components/Footer/footerClasses.ts
+++ b/packages/core/src/components/Footer/footerClasses.ts
@@ -1,12 +1,12 @@
 import { getClasses } from "@core/utils";
 
-export type HvFooterClasses = {
+export interface HvFooterClasses {
   root?: string;
   name?: string;
   copyright?: string;
   separator?: string;
   rightContainer?: string;
-};
+}
 
 const classKeys: string[] = [
   "root",

--- a/packages/core/src/components/Forms/Adornment/Adornment.tsx
+++ b/packages/core/src/components/Forms/Adornment/Adornment.tsx
@@ -12,10 +12,11 @@ import adornmentClasses, { HvAdornmentClasses } from "./adornmentClasses";
 const preventDefault = (event) => event.preventDefault();
 const noop = () => {};
 
-export type HvAdornmentProps = HvBaseProps<
-  HTMLDivElement | HTMLButtonElement,
-  { onMouseDown; onKeyDown }
-> & {
+export interface HvAdornmentProps
+  extends HvBaseProps<
+    HTMLDivElement | HTMLButtonElement,
+    { onMouseDown; onKeyDown }
+  > {
   /** The icon to be added into the input. */
   icon: React.ReactNode;
   /** When the adornment should be displayed. */
@@ -26,7 +27,7 @@ export type HvAdornmentProps = HvBaseProps<
   isVisible?: boolean;
   /** A Jss Object used to override or extend the styles applied to the component. */
   classes?: HvAdornmentClasses;
-};
+}
 
 /**
  * Allows to add a decorative icon or an action to a form element, usually on the right side of an input.

--- a/packages/core/src/components/Forms/Adornment/adornmentClasses.ts
+++ b/packages/core/src/components/Forms/Adornment/adornmentClasses.ts
@@ -1,13 +1,13 @@
 import { getClasses } from "@core/utils";
 
-export type HvAdornmentClasses = {
+export interface HvAdornmentClasses {
   root?: string;
   icon?: string;
   adornment?: string;
   adornmentIcon?: string;
   hideIcon?: string;
   adornmentButton?: string;
-};
+}
 
 const classKeys: string[] = [
   "root",

--- a/packages/core/src/components/Forms/CharCounter/CharCounter.tsx
+++ b/packages/core/src/components/Forms/CharCounter/CharCounter.tsx
@@ -6,7 +6,7 @@ import { StyledRoot, StyledTypography } from "./CharCounter.styles";
 import { HvFormElementContext } from "../FormElement";
 import charCounterClasses, { HvCharCounterClasses } from "./charCounterClasses";
 
-export type HvCharCounterProps = HvBaseProps & {
+export interface HvCharCounterProps extends HvBaseProps {
   /** The string that separates the current char quantity from the max quantity. */
   separator?: string;
   /** The maximum allowed length of the characters. */
@@ -19,7 +19,7 @@ export type HvCharCounterProps = HvBaseProps & {
   disableGutter?: boolean;
   /** A Jss Object used to override or extend the styles applied to the component. */
   classes?: HvCharCounterClasses;
-};
+}
 
 /**
  * Displays the capacity and current usage of a text input box (character count by default).

--- a/packages/core/src/components/Forms/CharCounter/charCounterClasses.ts
+++ b/packages/core/src/components/Forms/CharCounter/charCounterClasses.ts
@@ -1,11 +1,11 @@
 import { getClasses } from "@core/utils";
 
-export type HvCharCounterClasses = {
+export interface HvCharCounterClasses {
   root?: string;
   counterDisabled?: string;
   gutter?: string;
   overloaded?: string;
-};
+}
 
 const classKeys: string[] = ["root", "counterDisabled", "gutter", "overloaded"];
 

--- a/packages/core/src/components/Forms/FormElement/FormElement.tsx
+++ b/packages/core/src/components/Forms/FormElement/FormElement.tsx
@@ -10,7 +10,8 @@ import formElementClasses, { HvFormElementClasses } from "./formElementClasses";
 
 export type HvFormStatus = "standBy" | "valid" | "invalid" | "empty";
 
-export type HvFormElementProps = HvBaseProps<HTMLDivElement, { onChange }> & {
+export interface HvFormElementProps
+  extends HvBaseProps<HTMLDivElement, { onChange }> {
   /**
    * Name of the form element.
    *
@@ -53,7 +54,7 @@ export type HvFormElementProps = HvBaseProps<HTMLDivElement, { onChange }> & {
   onChange?: (event: React.FormEvent<HTMLDivElement>) => void;
   /** A Jss Object used to override or extend the styles applied to the component. */
   classes?: HvFormElementClasses;
-};
+}
 
 export const HvFormElement = ({
   classes,

--- a/packages/core/src/components/Forms/FormElement/formElementClasses.ts
+++ b/packages/core/src/components/Forms/FormElement/formElementClasses.ts
@@ -1,8 +1,8 @@
 import { getClasses } from "@core/utils";
 
-export type HvFormElementClasses = {
+export interface HvFormElementClasses {
   root?: string;
-};
+}
 
 const classKeys: string[] = ["root"];
 

--- a/packages/core/src/components/Forms/FormElement/utils/FormUtils.ts
+++ b/packages/core/src/components/Forms/FormElement/utils/FormUtils.ts
@@ -1,9 +1,9 @@
 import React from "react";
 
-type Descriptor = {
+interface Descriptor {
   id?: string;
   htmlFor?: string;
-};
+}
 /**
  * Scans the element's children looking for the children IDs that match the different form element types.
  * This function will produce an object that has a key for each provided name

--- a/packages/core/src/components/Forms/InfoMessage/InfoMessage.tsx
+++ b/packages/core/src/components/Forms/InfoMessage/InfoMessage.tsx
@@ -6,14 +6,14 @@ import { StyledTypography } from "./InfoMessage.styles";
 import { HvFormElementContext } from "../FormElement";
 import infoMessageClasses, { HvInfoMessageClasses } from "./infoMessageClasses";
 
-export type HvInfoMessageProps = HvBaseProps & {
+export interface HvInfoMessageProps extends HvBaseProps {
   /** If `true` the label is disabled. */
   disabled?: boolean;
   /** If `true` the info message won't have margins. */
   disableGutter?: boolean;
   /** A Jss Object used to override or extend the styles applied to the component. */
   classes?: HvInfoMessageClasses;
-};
+}
 
 /**
  * Provides the user with additional descriptive text for the form element.

--- a/packages/core/src/components/Forms/InfoMessage/infoMessageClasses.ts
+++ b/packages/core/src/components/Forms/InfoMessage/infoMessageClasses.ts
@@ -1,10 +1,10 @@
 import { getClasses } from "@core/utils";
 
-export type HvInfoMessageClasses = {
+export interface HvInfoMessageClasses {
   root?: string;
   infoDisabled?: string;
   gutter?: string;
-};
+}
 
 const classKeys: string[] = ["root", "infoDisabled", "gutter"];
 

--- a/packages/core/src/components/Forms/Label/Label.tsx
+++ b/packages/core/src/components/Forms/Label/Label.tsx
@@ -7,7 +7,7 @@ import { findDescriptors } from "../FormElement/utils/FormUtils";
 import { StyledTypography } from "./Label.styles";
 import labelClasses, { HvLabelClasses } from "./labelClasses";
 
-export type HvLabelProps = HvBaseProps & {
+export interface HvLabelProps extends HvBaseProps {
   /** The text to be shown by the label. */
   label?: React.ReactNode;
   /** The id of the form element the label is bound to. */
@@ -18,7 +18,7 @@ export type HvLabelProps = HvBaseProps & {
   required?: boolean;
   /** A Jss Object used to override or extend the styles applied to the component. */
   classes?: HvLabelClasses;
-};
+}
 
 /**
  * Provides the user with a recognizable name for a given form element.

--- a/packages/core/src/components/Forms/Label/labelClasses.ts
+++ b/packages/core/src/components/Forms/Label/labelClasses.ts
@@ -1,10 +1,10 @@
 import { getClasses } from "@core/utils";
 
-export type HvLabelClasses = {
+export interface HvLabelClasses {
   root?: string;
   labelDisabled?: string;
   childGutter?: string;
-};
+}
 
 const classKeys: string[] = ["root", "labelDisabled", "childGutter"];
 

--- a/packages/core/src/components/Forms/Suggestions/Suggestions.tsx
+++ b/packages/core/src/components/Forms/Suggestions/Suggestions.tsx
@@ -12,14 +12,14 @@ import { HvListItem } from "../../ListContainer/ListItem";
 import { HvClickOutsideEvent, useClickOutside } from "../../../hooks";
 import suggestionsClasses, { HvSuggestionsClasses } from "./suggestionsClasses";
 
-export type HvSuggestion = {
+export interface HvSuggestion {
   id?: string;
   label: React.ReactNode;
   value?: string;
   disabled?: boolean;
-};
+}
 
-export type HvSuggestionsProps = HvBaseProps & {
+export interface HvSuggestionsProps extends HvBaseProps {
   /** Whether suggestions is visible. */
   expanded?: boolean;
   /** The HTML element Suggestions attaches to. */
@@ -32,7 +32,7 @@ export type HvSuggestionsProps = HvBaseProps & {
   onClose?: (event: HvClickOutsideEvent) => void;
   /** A Jss Object used to override or extend the styles applied to the component. */
   classes?: HvSuggestionsClasses;
-};
+}
 
 export const HvSuggestions = ({
   id,

--- a/packages/core/src/components/Forms/Suggestions/suggestionsClasses.ts
+++ b/packages/core/src/components/Forms/Suggestions/suggestionsClasses.ts
@@ -1,10 +1,10 @@
 import { getClasses } from "@core/utils";
 
-export type HvSuggestionsClasses = {
+export interface HvSuggestionsClasses {
   root?: string;
   list?: string;
   popper?: string;
-};
+}
 
 const classKeys: string[] = ["root", "list", "popper"];
 

--- a/packages/core/src/components/Forms/WarningText/WarningText.tsx
+++ b/packages/core/src/components/Forms/WarningText/WarningText.tsx
@@ -7,7 +7,7 @@ import { StyledRoot, StyledTypography, StyledIcon } from "./WarningText.styles";
 import warningTextClasses, { HvWarningTextClasses } from "./warningTextClasses";
 import { HvFormElementContext } from "../FormElement";
 
-export type HvWarningTextProps = HvBaseProps & {
+export interface HvWarningTextProps extends HvBaseProps {
   /** Icon to be rendered alongside the warning text. */
   adornment?: React.ReactNode;
   /** If `true` the text is not rendered. */
@@ -24,7 +24,7 @@ export type HvWarningTextProps = HvBaseProps & {
   hideText?: boolean;
   /** A Jss Object used to override or extend the styles applied to the component. */
   classes?: HvWarningTextClasses;
-};
+}
 
 /**
  * Provides the user with a descriptive text, signaling an error, for when the form element is in an invalid state.

--- a/packages/core/src/components/Forms/WarningText/warningTextClasses.ts
+++ b/packages/core/src/components/Forms/WarningText/warningTextClasses.ts
@@ -1,6 +1,6 @@
 import { getClasses } from "@core/utils";
 
-export type HvWarningTextClasses = {
+export interface HvWarningTextClasses {
   root?: string;
   defaultIcon?: string;
   warningText?: string;
@@ -8,7 +8,7 @@ export type HvWarningTextClasses = {
   topGutter?: string;
   hideText?: string;
   topBorder?: string;
-};
+}
 
 const classKeys: string[] = [
   "root",

--- a/packages/core/src/components/GlobalActions/GlobalActions.tsx
+++ b/packages/core/src/components/GlobalActions/GlobalActions.tsx
@@ -20,7 +20,8 @@ export type HvGlobalActionsPosition = "sticky" | "fixed" | "relative";
 
 export type HvGlobalActionsHeadingLevel = 1 | 2 | 3 | 4 | 5 | 6;
 
-export type HvGlobalActionsProps = HvBaseProps<HTMLDivElement, { title }> & {
+export interface HvGlobalActionsProps
+  extends HvBaseProps<HTMLDivElement, { title }> {
   /** Text to display in the component. */
   title?: React.ReactNode;
   /** Denotes if this is a global or section component. */
@@ -36,7 +37,7 @@ export type HvGlobalActionsProps = HvBaseProps<HTMLDivElement, { title }> & {
   position?: HvGlobalActionsPosition;
   /** A Jss Object used to override or extend the styles applied to the component. */
   classes?: HvGlobalActionsClasses;
-};
+}
 
 /**
  * Global Actions are actions that affect the entire page they live in.

--- a/packages/core/src/components/GlobalActions/globalActionsClasses.ts
+++ b/packages/core/src/components/GlobalActions/globalActionsClasses.ts
@@ -1,6 +1,6 @@
 import { getClasses } from "@core/utils";
 
-export type HvGlobalActionsClasses = {
+export interface HvGlobalActionsClasses {
   root?: string;
   global?: string;
   backButton?: string;
@@ -11,7 +11,7 @@ export type HvGlobalActionsClasses = {
   positionFixed?: string;
   positionSticky?: string;
   globalWrapperComplement?: string;
-};
+}
 
 const classKeys: string[] = [
   "root",

--- a/packages/core/src/components/Grid/Grid.tsx
+++ b/packages/core/src/components/Grid/Grid.tsx
@@ -37,84 +37,85 @@ export type HvGridSpacing =
   | 9
   | 10;
 
-export type HvGridProps = Omit<MuiGridProps, "classes"> &
-  HvBaseProps & {
-    /**
-     * If `true`, the component will have the flex *container* behavior.
-     * You should be wrapping *items* with a *container*.
-     */
-    container?: boolean;
-    /**
-     * If `true`, the component will have the flex *item* behavior.
-     * You should be wrapping *items* with a *container*.
-     */
-    item?: boolean;
-    /**
-     * Defines the space between the type item component. It can only be used on a type container component.
-     * Based in the 8x factor defined in the theme, it allows the definition of this factor based on the factor
-     * (number between 0 and 10), breakpoint or auto.
-     */
-    spacing?: HvGridSpacing | number;
-    /**
-     * Defines the `flex-direction` style property.
-     * It is applied for all screen sizes.
-     */
-    direction?: HvGridDirection;
-    /**
-     * Defines the `justify-content` style property.
-     * It is applied for all screen sizes.
-     */
-    justify?:
-      | "flex-start"
-      | "center"
-      | "flex-end"
-      | "space-between"
-      | "space-around"
-      | "space-evenly";
-    /**
-     * Defines the number of grids the component is going to use.
-     * It's applied for all the screen sizes with the lowest priority.
-     */
-    xs?: number | boolean;
-    /**
-     * Defines the number of grids the component is going to use.
-     * It's applied for the `sm` breakpoint and wider screens if not overridden.
-     */
-    sm?: number | boolean;
-    /**
-     * Defines the number of grids the component is going to use.
-     * It's applied for the `md` breakpoint and wider screens if not overridden.
-     */
-    md?: number | boolean;
-    /**
-     * Defines the number of grids the component is going to use.
-     * It's applied for the `lg` breakpoint and wider screens if not overridden.
-     */
-    lg?: number | boolean;
-    /**
-     * Defines the number of grids the component is going to use.
-     * It's applied for the `xl` breakpoint and wider screens.
-     */
-    xl?: number | boolean;
-    /**
-     * Defines the `flex-wrap` style property.
-     * It's applied for all screen sizes.
-     */
-    wrap?: "nowrap" | "wrap" | "wrap-reverse";
-    /**
-     * If `true`, it sets `min-width: 0` on the item.
-     * Refer to the limitations section of the documentation to better understand the use case.
-     */
-    zeroMinWidth?: boolean;
-    /** A Jss Object used to override or extend the styles applied to the component. */
-    classes?: HvGridClasses;
-  };
+export interface HvGridProps
+  extends Omit<MuiGridProps, "classes">,
+    HvBaseProps<HTMLDivElement, { color }> {
+  /**
+   * If `true`, the component will have the flex *container* behavior.
+   * You should be wrapping *items* with a *container*.
+   */
+  container?: boolean;
+  /**
+   * If `true`, the component will have the flex *item* behavior.
+   * You should be wrapping *items* with a *container*.
+   */
+  item?: boolean;
+  /**
+   * Defines the space between the type item component. It can only be used on a type container component.
+   * Based in the 8x factor defined in the theme, it allows the definition of this factor based on the factor
+   * (number between 0 and 10), breakpoint or auto.
+   */
+  spacing?: HvGridSpacing | number;
+  /**
+   * Defines the `flex-direction` style property.
+   * It is applied for all screen sizes.
+   */
+  direction?: HvGridDirection;
+  /**
+   * Defines the `justify-content` style property.
+   * It is applied for all screen sizes.
+   */
+  justify?:
+    | "flex-start"
+    | "center"
+    | "flex-end"
+    | "space-between"
+    | "space-around"
+    | "space-evenly";
+  /**
+   * Defines the number of grids the component is going to use.
+   * It's applied for all the screen sizes with the lowest priority.
+   */
+  xs?: number | boolean;
+  /**
+   * Defines the number of grids the component is going to use.
+   * It's applied for the `sm` breakpoint and wider screens if not overridden.
+   */
+  sm?: number | boolean;
+  /**
+   * Defines the number of grids the component is going to use.
+   * It's applied for the `md` breakpoint and wider screens if not overridden.
+   */
+  md?: number | boolean;
+  /**
+   * Defines the number of grids the component is going to use.
+   * It's applied for the `lg` breakpoint and wider screens if not overridden.
+   */
+  lg?: number | boolean;
+  /**
+   * Defines the number of grids the component is going to use.
+   * It's applied for the `xl` breakpoint and wider screens.
+   */
+  xl?: number | boolean;
+  /**
+   * Defines the `flex-wrap` style property.
+   * It's applied for all screen sizes.
+   */
+  wrap?: "nowrap" | "wrap" | "wrap-reverse";
+  /**
+   * If `true`, it sets `min-width: 0` on the item.
+   * Refer to the limitations section of the documentation to better understand the use case.
+   */
+  zeroMinWidth?: boolean;
+  /** A Jss Object used to override or extend the styles applied to the component. */
+  classes?: HvGridClasses;
+}
 
 /**
  * The grid creates visual consistency between layouts while allowing flexibility
  * across a wide variety of designs. This component is based in a 12-column grid layout.
  *
- * It is is based in the [Material UI Grid]https://mui.com/material-ui/react-grid/).
+ * It is is based in the [Material UI Grid](https://mui.com/material-ui/react-grid/).
  *
  * The definitions were set following the Design System directives:
  *

--- a/packages/core/src/components/Grid/gridClasses.ts
+++ b/packages/core/src/components/Grid/gridClasses.ts
@@ -1,6 +1,6 @@
 import { getClasses } from "@core/utils";
 
-export type HvGridClasses = {
+export interface HvGridClasses {
   root?: string;
   container?: string;
   item?: string;
@@ -34,7 +34,7 @@ export type HvGridClasses = {
   "grid-xs-10"?: string;
   "grid-xs-11"?: string;
   "grid-xs-12"?: string;
-};
+}
 
 const classKeys: string[] = [
   "root",

--- a/packages/core/src/components/Header/Actions/Actions.tsx
+++ b/packages/core/src/components/Header/Actions/Actions.tsx
@@ -3,9 +3,9 @@ import { HvBaseProps } from "@core/types";
 import { StyledDiv } from "./Actions.styles";
 import headerActionsClasses, { HvHeaderActionsClasses } from "./actionsClasses";
 
-export type HvHeaderActionsProps = HvBaseProps & {
+export interface HvHeaderActionsProps extends HvBaseProps {
   classes?: HvHeaderActionsClasses;
-};
+}
 
 export const HvHeaderActions = ({
   classes,

--- a/packages/core/src/components/Header/Actions/actionsClasses.ts
+++ b/packages/core/src/components/Header/Actions/actionsClasses.ts
@@ -1,8 +1,8 @@
 import { getClasses } from "@core/utils";
 
-export type HvHeaderActionsClasses = {
+export interface HvHeaderActionsClasses {
   root?: string;
-};
+}
 
 const classKeys: string[] = ["root"];
 

--- a/packages/core/src/components/Header/Brand/Brand.tsx
+++ b/packages/core/src/components/Header/Brand/Brand.tsx
@@ -3,11 +3,11 @@ import { HvBaseProps } from "@core/types";
 import { BrandRoot, BrandSeparator, BrandName } from "./Brand.styles";
 import headerBrandClasses, { HvHeaderBrandClasses } from "./brandClasses";
 
-export type HvHeaderBrandProps = HvBaseProps & {
+export interface HvHeaderBrandProps extends HvBaseProps {
   logo?: React.ReactNode;
   name?: string;
   classes?: HvHeaderBrandClasses;
-};
+}
 
 /**
  * Header component is used to render a header bar with logo and brand name, navigation and actions.

--- a/packages/core/src/components/Header/Brand/brandClasses.ts
+++ b/packages/core/src/components/Header/Brand/brandClasses.ts
@@ -1,9 +1,9 @@
 import { getClasses } from "@core/utils";
 
-export type HvHeaderBrandClasses = {
+export interface HvHeaderBrandClasses {
   root?: string;
   separator?: string;
-};
+}
 
 const classKeys: string[] = ["root", "separator"];
 

--- a/packages/core/src/components/Header/Header.tsx
+++ b/packages/core/src/components/Header/Header.tsx
@@ -10,12 +10,12 @@ export type HvHeaderPosition =
   | "static"
   | "relative";
 
-export type HvHeaderProps = HvBaseProps & {
+export interface HvHeaderProps extends HvBaseProps {
   /** The position of the header bar */
   position?: HvHeaderPosition;
   /** A Jss Object used to override or extend the styles applied to the component. */
   classes?: HvHeaderClasses;
-};
+}
 
 /**
  * Header component is used to render a header bar with logo and brand name, navigation and actions.

--- a/packages/core/src/components/Header/Navigation/MenuBar/MenuBar.tsx
+++ b/packages/core/src/components/Header/Navigation/MenuBar/MenuBar.tsx
@@ -6,11 +6,11 @@ import { HvMenuItem } from "../MenuItem";
 import { SelectionContext } from "../utils/SelectionContext";
 import { MenuBarRoot, MenuBarUl } from "./MenuBar.styles";
 
-export type HvMenuBarProps = HvBaseProps<"div", { onClick }> & {
+export interface HvMenuBarProps extends HvBaseProps<"div", { onClick }> {
   data: HvHeaderNavigationItemProp[];
   type: string;
   onClick?: (event: MouseEvent, selection: HvHeaderNavigationItemProp) => void;
-};
+}
 
 export const HvMenuBar = ({
   id,

--- a/packages/core/src/components/Header/Navigation/MenuItem/MenuItem.tsx
+++ b/packages/core/src/components/Header/Navigation/MenuItem/MenuItem.tsx
@@ -7,11 +7,12 @@ import { FocusContext } from "../utils/FocusContext";
 import { SelectionContext } from "../utils/SelectionContext";
 import { MenuItemLabel, MenuItemLi, MenuItemLink } from "./MenuItem.styles";
 
-export type MenuItemProps = HvBaseProps<HTMLDivElement, { onClick }> & {
+export interface MenuItemProps
+  extends HvBaseProps<HTMLDivElement, { onClick }> {
   item: HvHeaderNavigationItemProp;
   type?: string;
   onClick?: (event: MouseEvent, selection: HvHeaderNavigationItemProp) => void;
-};
+}
 
 export const HvMenuItem = ({ id, item, type, onClick }: MenuItemProps) => {
   const selectionPath = useContext(SelectionContext);

--- a/packages/core/src/components/Header/Navigation/Navigation.tsx
+++ b/packages/core/src/components/Header/Navigation/Navigation.tsx
@@ -19,15 +19,13 @@ export interface HvHeaderNavigationItemProp {
   data?: HvHeaderNavigationItemProp[];
 }
 
-export type HvHeaderNavigationProps = HvBaseProps<
-  HTMLDivElement,
-  { onClick }
-> & {
+export interface HvHeaderNavigationProps
+  extends HvBaseProps<HTMLDivElement, { onClick }> {
   data: HvHeaderNavigationItemProp[];
   selected?: string;
   onClick?: (event: MouseEvent, selection: HvHeaderNavigationItemProp) => void;
   classes?: HvHeaderNavigationClasses;
-};
+}
 
 export const HvHeaderNavigation = ({
   data,

--- a/packages/core/src/components/Header/Navigation/navigationClasses.ts
+++ b/packages/core/src/components/Header/Navigation/navigationClasses.ts
@@ -1,6 +1,8 @@
 import { getClasses } from "@core/utils";
 
-export type HvHeaderNavigationClasses = { root?: string };
+export interface HvHeaderNavigationClasses {
+  root?: string;
+}
 
 const classKeys: string[] = ["root"];
 

--- a/packages/core/src/components/Header/Navigation/utils/FocusContext.tsx
+++ b/packages/core/src/components/Header/Navigation/utils/FocusContext.tsx
@@ -1,9 +1,9 @@
 import React, { createContext, useMemo, useReducer } from "react";
 
-type SetItemFocused = {
+interface SetItemFocused {
   type: "setItemFocused";
   itemFocused: EventTarget & Element;
-};
+}
 
 const reducer = (state, action) => {
   switch (action.type) {

--- a/packages/core/src/components/Header/headerClasses.ts
+++ b/packages/core/src/components/Header/headerClasses.ts
@@ -1,10 +1,10 @@
 import { getClasses } from "@core/utils";
 
-export type HvHeaderClasses = {
+export interface HvHeaderClasses {
   root?: string;
   header?: string;
   backgroundColor?: string;
-};
+}
 
 const classKeys: string[] = ["root", "header", "backgroundColor"];
 

--- a/packages/core/src/components/Input/Input.tsx
+++ b/packages/core/src/components/Input/Input.tsx
@@ -63,10 +63,11 @@ import {
 } from "../BaseInput/validations";
 import inputClasses, { HvInputClasses } from "./inputClasses";
 
-export type HvInputProps = HvBaseProps<
-  HTMLElement,
-  { onChange; onBlur; onFocus; onKeyDown; color }
-> & {
+export interface HvInputProps
+  extends HvBaseProps<
+    HTMLElement,
+    { onChange; onBlur; onFocus; onKeyDown; color }
+  > {
   /** The form element name. */
   name?: string;
   /** The value of the form element. */
@@ -184,7 +185,7 @@ export type HvInputProps = HvBaseProps<
   minCharQuantity?: number;
   /** A Jss Object used to override or extend the styles applied to the component. */
   classes?: HvInputClasses;
-};
+}
 
 const DEFAULT_LABELS = {
   clearButtonLabel: "Clear the text",

--- a/packages/core/src/components/Input/inputClasses.ts
+++ b/packages/core/src/components/Input/inputClasses.ts
@@ -1,6 +1,6 @@
 import { getClasses } from "@core/utils";
 
-export type HvInputClasses = {
+export interface HvInputClasses {
   /** Styles applied to the root container of the input. */
   root?: string;
   /** Styles applied to the root container when the suggestion list is open. */
@@ -39,7 +39,7 @@ export type HvInputClasses = {
   suggestionsContainer?: string;
   /** Styles applied to the suggestions list. */
   suggestionList?: string;
-};
+}
 
 const classKeys: string[] = [
   "root",

--- a/packages/core/src/components/Kpi/Kpi.tsx
+++ b/packages/core/src/components/Kpi/Kpi.tsx
@@ -16,7 +16,7 @@ import {
 } from "./Kpi.styles";
 import kpiClasses, { HvKpiClasses } from "./kpiClasses";
 
-export type HvKpiLabelProps = {
+export interface HvKpiLabelProps {
   /**
    * The text at the top of the kpi.
    */
@@ -33,9 +33,9 @@ export type HvKpiLabelProps = {
    * The text to the right of the visual comparison.
    */
   comparisonIndicatorInfo?: string;
-};
+}
 
-export type HvKpiProps = HvBaseProps<HTMLDivElement, { children }> & {
+export interface HvKpiProps extends HvBaseProps<HTMLDivElement, { children }> {
   /**
    * An Element that will be rendered to the left of the kpi indicator text.
    */
@@ -64,7 +64,7 @@ export type HvKpiProps = HvBaseProps<HTMLDivElement, { children }> & {
    * A Jss Object used to override or extend the component styles applied.
    */
   classes?: HvKpiClasses;
-};
+}
 
 const DEFAULT_LABELS = {
   title: "",

--- a/packages/core/src/components/Kpi/kpiClasses.ts
+++ b/packages/core/src/components/Kpi/kpiClasses.ts
@@ -1,6 +1,6 @@
 import { getClasses } from "@core/utils";
 
-export type HvKpiClasses = {
+export interface HvKpiClasses {
   root?: string;
   visualIndicatorContainer?: string;
   comparisons?: string;
@@ -11,7 +11,7 @@ export type HvKpiClasses = {
   indicatorUnit?: string;
   spacingToTheRight?: string;
   trendLine?: string;
-};
+}
 
 const classKeys: string[] = [
   "root",

--- a/packages/core/src/components/Link/Link.tsx
+++ b/packages/core/src/components/Link/Link.tsx
@@ -4,7 +4,8 @@ import { StyledA } from "./Link.styles";
 import linkClasses, { HvLinkClasses } from "./linkClasses";
 import { MouseEventHandler } from "react";
 
-export type HvLinkProps = HvBaseProps<HTMLAnchorElement, { onClick }> & {
+export interface HvLinkProps
+  extends HvBaseProps<HTMLAnchorElement, { onClick }> {
   onClick?: (
     event: MouseEventHandler<HTMLAnchorElement>,
     data: any
@@ -14,7 +15,7 @@ export type HvLinkProps = HvBaseProps<HTMLAnchorElement, { onClick }> & {
   children: any;
   /** A Jss Object used to override or extend the styles applied to the component. */
   classes?: HvLinkClasses;
-};
+}
 
 export const HvLink = ({
   onClick,

--- a/packages/core/src/components/Link/linkClasses.ts
+++ b/packages/core/src/components/Link/linkClasses.ts
@@ -1,8 +1,8 @@
 import { getClasses } from "@core/utils";
 
-export type HvLinkClasses = {
+export interface HvLinkClasses {
   a?: string;
-};
+}
 
 const classKeys: string[] = ["a"];
 

--- a/packages/core/src/components/List/List.tsx
+++ b/packages/core/src/components/List/List.tsx
@@ -16,7 +16,7 @@ import { parseList } from "./utils";
 import { HvListContainer, HvTypography } from "@core/components";
 import { setId, wrapperTooltip } from "@core/utils";
 
-export type HvListValue = {
+export interface HvListValue extends HvExtraProps {
   id?: string | number;
   label: React.ReactNode;
   searchValue?: string;
@@ -33,19 +33,17 @@ export type HvListValue = {
   path?: string;
   params?: object;
   tabIndex?: number;
-} & HvExtraProps;
+}
 
-export type HvListLabels = {
+export interface HvListLabels {
   /** The label used for the All checkbox action. */
   selectAll?: string;
   /** The label used in the middle of the multi-selection count. */
   selectionConjunction?: string;
-};
+}
 
-export type HvListProps = HvBaseProps<
-  HTMLUListElement,
-  { onChange; onClick }
-> & {
+export interface HvListProps
+  extends HvBaseProps<HTMLUListElement, { onChange; onClick }> {
   /**
    * A list containing the elements to be rendered.
    *
@@ -91,7 +89,7 @@ export type HvListProps = HvBaseProps<
   virtualized?: boolean;
   /** A Jss Object used to override or extend the styles applied to the component. */
   classes?: HvListClasses;
-};
+}
 
 const DEFAULT_LABELS = {
   selectAll: "Select All",

--- a/packages/core/src/components/List/listClasses.ts
+++ b/packages/core/src/components/List/listClasses.ts
@@ -1,6 +1,6 @@
 import { getClasses } from "@core/utils";
 
-export type HvListClasses = {
+export interface HvListClasses {
   /** Styles applied to the component root class. */
   root?: string;
   /** Styles applied to the component root class in virtualized form. */
@@ -21,7 +21,7 @@ export type HvListClasses = {
   link?: string;
   /** Styles applied to the select all selector. */
   selectAllSelector?: string;
-};
+}
 
 const classKeys: string[] = [
   "root",

--- a/packages/core/src/components/ListContainer/ListContainer.tsx
+++ b/packages/core/src/components/ListContainer/ListContainer.tsx
@@ -7,7 +7,7 @@ import listContainerClasses, {
   HvListContainerClasses,
 } from "./listContainerClasses";
 
-export type HvListContainerProps = HvBaseProps<HTMLUListElement> & {
+export interface HvListContainerProps extends HvBaseProps<HTMLUListElement> {
   /**
    * If the list items should be focusable and react to mouse over events.
    * Defaults to true if the list is selectable, false otherwise.
@@ -19,7 +19,7 @@ export type HvListContainerProps = HvBaseProps<HTMLUListElement> & {
   disableGutters?: boolean;
   /** A Jss Object used to override or extend the styles applied to the component. */
   classes?: HvListContainerClasses;
-};
+}
 
 /**
  * A <b>list</b> is any enumeration of a set of items.

--- a/packages/core/src/components/ListContainer/ListItem/ListItem.tsx
+++ b/packages/core/src/components/ListContainer/ListItem/ListItem.tsx
@@ -5,7 +5,7 @@ import HvListContext from "../ListContext";
 import { StyledListItem, StyledFocus } from "./ListItem.styles";
 import listItemClasses, { HvListItemClasses } from "./listItemClasses";
 
-export type HvListItemProps = HvBaseProps<HTMLLIElement, { role }> & {
+export interface HvListItemProps extends HvBaseProps<HTMLLIElement, { role }> {
   /**
    * Overrides the implicit list item role.
    * It defaults to "option" if unspecified and the container list role is "listbox".
@@ -51,7 +51,7 @@ export type HvListItemProps = HvBaseProps<HTMLLIElement, { role }> & {
   value?: any;
   /** A Jss Object used to override or extend the styles applied to the component. */
   classes?: HvListItemClasses;
-};
+}
 
 const applyClassNameAndStateToElement = (
   element,

--- a/packages/core/src/components/ListContainer/ListItem/listItemClasses.ts
+++ b/packages/core/src/components/ListContainer/ListItem/listItemClasses.ts
@@ -1,6 +1,6 @@
 import { getClasses } from "@core/utils";
 
-export type HvListItemClasses = {
+export interface HvListItemClasses {
   root?: string;
   focus?: string;
   startAdornment?: string;
@@ -12,7 +12,7 @@ export type HvListItemClasses = {
   disabled?: string;
   withStartAdornment?: string;
   withEndAdornment?: string;
-};
+}
 
 const classKeys: string[] = [
   "root",

--- a/packages/core/src/components/ListContainer/listContainerClasses.ts
+++ b/packages/core/src/components/ListContainer/listContainerClasses.ts
@@ -1,8 +1,8 @@
 import { getClasses } from "@core/utils";
 
-export type HvListContainerClasses = {
+export interface HvListContainerClasses {
   root?: string;
-};
+}
 
 const classKeys: string[] = ["root"];
 

--- a/packages/core/src/components/Loading/Loading.tsx
+++ b/packages/core/src/components/Loading/Loading.tsx
@@ -10,7 +10,7 @@ import {
 } from "./Loading.styles";
 import loadingClasses, { HvLoadingClasses } from "./loadingClasses";
 
-export type HvLoadingProps = HvBaseProps<HTMLDivElement> & {
+export interface HvLoadingProps extends HvBaseProps<HTMLDivElement> {
   /** Indicates if the component should be render in a small size. */
   small?: boolean;
   /** The label to be displayed.  */
@@ -20,7 +20,7 @@ export type HvLoadingProps = HvBaseProps<HTMLDivElement> & {
   /** Color applied to the bars. */
   color?: string;
   classes?: HvLoadingClasses;
-};
+}
 
 /**
  * Loading provides feedback about a process that is taking place in the application.

--- a/packages/core/src/components/Loading/loadingClasses.ts
+++ b/packages/core/src/components/Loading/loadingClasses.ts
@@ -1,6 +1,6 @@
 import { getClasses } from "@core/utils";
 
-export type HvLoadingClasses = {
+export interface HvLoadingClasses {
   root?: string;
   barContainer?: string;
   loadingBar?: string;
@@ -12,7 +12,7 @@ export type HvLoadingClasses = {
   regular?: string;
   smallColor?: string;
   regularColor?: string;
-};
+}
 
 const classKeys: string[] = [
   "root",

--- a/packages/core/src/components/Login/Login.tsx
+++ b/packages/core/src/components/Login/Login.tsx
@@ -3,7 +3,7 @@ import { HvBaseProps } from "@core/types";
 import { StyledFormContainer, StyledRoot } from "./Login.styles";
 import loginClasses, { HvLoginClasses } from "./loginClasses";
 
-export type HvLoginProps = HvBaseProps & {
+export interface HvLoginProps extends HvBaseProps {
   /**
    *  The path for the background image.
    */
@@ -12,7 +12,7 @@ export type HvLoginProps = HvBaseProps & {
    * Class names to be applied.
    */
   classes?: HvLoginClasses;
-};
+}
 
 /**
  * Container layout for the login form.

--- a/packages/core/src/components/Login/loginClasses.ts
+++ b/packages/core/src/components/Login/loginClasses.ts
@@ -1,9 +1,9 @@
 import { getClasses } from "@core/utils";
 
-export type HvLoginClasses = {
+export interface HvLoginClasses {
   root?: string;
   formContainer?: string;
-};
+}
 
 const classKeys: string[] = ["root", "formContainer"];
 

--- a/packages/core/src/components/MultiButton/MultiButton.tsx
+++ b/packages/core/src/components/MultiButton/MultiButton.tsx
@@ -5,7 +5,7 @@ import { HvBaseProps } from "@core/types";
 import { StyledButton, StyledRoot } from "./MultiButton.styles";
 import multiButtonClasses, { HvMultiButtonClasses } from "./multiButtonClasses";
 
-export type HvMultiButtonProps = HvBaseProps & {
+export interface HvMultiButtonProps extends HvBaseProps {
   /** If all the buttons are disabled. */
   disabled?: boolean;
   /** If the MultiButton is to be displayed vertically. */
@@ -14,7 +14,7 @@ export type HvMultiButtonProps = HvBaseProps & {
   variant?: HvButtonVariant;
   /** A Jss Object used to override or extend the styles applied to the component. */
   classes?: HvMultiButtonClasses;
-};
+}
 
 export const HvMultiButton = ({
   className,

--- a/packages/core/src/components/MultiButton/multiButtonClasses.ts
+++ b/packages/core/src/components/MultiButton/multiButtonClasses.ts
@@ -1,11 +1,11 @@
 import { getClasses } from "@core/utils";
 
-export type HvMultiButtonClasses = {
+export interface HvMultiButtonClasses {
   root?: string;
   button?: string;
   vertical?: string;
   selected?: string;
-};
+}
 
 const classKeys: string[] = ["root", "button", "vertical", "selected"];
 

--- a/packages/core/src/components/OverflowTooltip/OverflowTooltip.tsx
+++ b/packages/core/src/components/OverflowTooltip/OverflowTooltip.tsx
@@ -8,7 +8,7 @@ import overflowTooltipClasses, {
   HvOverflowTooltipClasses,
 } from "./overflowTooltipClasses";
 
-export type HvOverflowTooltipProps = HvBaseProps & {
+export interface HvOverflowTooltipProps extends HvBaseProps {
   /** The node that will be rendered inside the tooltip. */
   data: React.ReactNode;
   /** If true, the tooltip is shown. */
@@ -33,7 +33,7 @@ export type HvOverflowTooltipProps = HvBaseProps & {
   tooltipsProps?: HvTooltipProps;
   /** A Jss Object used to override or extend the styles applied to the component. */
   classes?: HvOverflowTooltipClasses;
-};
+}
 
 const isParagraph = (children) => /\s/.test(children);
 

--- a/packages/core/src/components/OverflowTooltip/overflowTooltipClasses.ts
+++ b/packages/core/src/components/OverflowTooltip/overflowTooltipClasses.ts
@@ -1,11 +1,11 @@
 import { getClasses } from "@core/utils";
 
-export type HvOverflowTooltipClasses = {
+export interface HvOverflowTooltipClasses {
   root?: string;
   tooltipAnchor?: string;
   tooltipAnchorParagraph?: string;
   tooltipData?: string;
-};
+}
 
 const classKeys: string[] = [
   "root",

--- a/packages/core/src/components/Pagination/Pagination.tsx
+++ b/packages/core/src/components/Pagination/Pagination.tsx
@@ -26,7 +26,7 @@ import { isKeypress, keyboardCodes, setId } from "@core/utils";
 import { usePageInput, getSafePage, setColor } from "./utils";
 import { useLabels } from "@core/hooks";
 
-export type HvPaginationLabels = {
+export interface HvPaginationLabels {
   /** The show label. */
   pageSizePrev?: string;
   /** Indicate the units of the page size selection. */
@@ -53,9 +53,9 @@ export type HvPaginationLabels = {
   nextPage?: string;
   /** Aria-label of the last page button */
   lastPage?: string;
-};
+}
 
-export type HvPaginationProps = HvBaseProps & {
+export interface HvPaginationProps extends HvBaseProps {
   /** The number of pages the component has. */
   pages?: number;
   /** The currently selected page (0-indexed). */
@@ -86,7 +86,7 @@ export type HvPaginationProps = HvBaseProps & {
   currentPageInputProps?: HvInputProps;
   /** A Jss Object used to override or extend the styles applied to the component. */
   classes?: HvPaginationClasses;
-};
+}
 
 const DEFAULT_LABELS = {
   pageSizePrev: "Show",

--- a/packages/core/src/components/Pagination/paginationClasses.ts
+++ b/packages/core/src/components/Pagination/paginationClasses.ts
@@ -1,6 +1,6 @@
 import { getClasses } from "@core/utils";
 
-export type HvPaginationClasses = {
+export interface HvPaginationClasses {
   /** Styles applied to the component root class. */
   root?: string;
   /** Styles applied to the page size selector container. */
@@ -25,7 +25,7 @@ export type HvPaginationClasses = {
   iconContainer?: string;
   /** Styles applied to each navigation icon. */
   icon?: string;
-};
+}
 
 const classKeys: string[] = [
   "root",

--- a/packages/core/src/components/Panel/Panel.tsx
+++ b/packages/core/src/components/Panel/Panel.tsx
@@ -3,10 +3,10 @@ import { HvBaseProps } from "@core/types";
 import { StyledDiv } from "./Panel.styles";
 import panelClasses, { HvPanelClasses } from "./panelClasses";
 
-export type HvPanelProps = HvBaseProps & {
+export interface HvPanelProps extends HvBaseProps {
   /** A Jss Object used to override or extend the styles applied. */
   classes?: HvPanelClasses;
-};
+}
 
 /**
  * A panel is a container used in a variety of patterns (e.g. dropdown, filter group, details section).

--- a/packages/core/src/components/Panel/panelClasses.ts
+++ b/packages/core/src/components/Panel/panelClasses.ts
@@ -1,9 +1,9 @@
 import { getClasses } from "@core/utils";
 
-export type HvPanelClasses = {
+export interface HvPanelClasses {
   /** Styles applied to the component root class. */
   root?: string;
-};
+}
 
 const classKeys: string[] = ["root"];
 

--- a/packages/core/src/components/ProgressBar/ProgressBar.tsx
+++ b/packages/core/src/components/ProgressBar/ProgressBar.tsx
@@ -16,7 +16,7 @@ export type HvProgressBarStatus = "inProgress" | "completed" | "error";
 /**
  * ProgressBar provides feedback about a process that is taking place in the application.
  */
-export type HvProgressBarProps = HvBaseProps & {
+export interface HvProgressBarProps extends HvBaseProps {
   /** The value of the progress bar. */
   value: number;
   /**
@@ -31,7 +31,7 @@ export type HvProgressBarProps = HvBaseProps & {
   labelProps?: HvTypographyProps;
   /** A Jss Object used to override or extend the styles applied to the component. */
   classes?: HvProgressBarClasses;
-};
+}
 
 export const HvProgressBar = (props: HvProgressBarProps) => {
   const {

--- a/packages/core/src/components/ProgressBar/progressBarClasses.ts
+++ b/packages/core/src/components/ProgressBar/progressBarClasses.ts
@@ -1,6 +1,6 @@
 import { getClasses } from "@core/utils";
 
-export type HvProgressBarClasses = {
+export interface HvProgressBarClasses {
   root?: string;
   progress?: string;
   progressBar?: string;
@@ -9,7 +9,7 @@ export type HvProgressBarClasses = {
   progressDone?: string;
   progressBarContainer?: string;
   progressError?: string;
-};
+}
 
 const classKeys: string[] = [
   "root",

--- a/packages/core/src/components/Radio/Radio.tsx
+++ b/packages/core/src/components/Radio/Radio.tsx
@@ -17,123 +17,124 @@ import radioClasses, { HvRadioClasses } from "./radioClasses";
 
 export type HvRadioStatus = "standBy" | "valid" | "invalid";
 
-export type HvRadioProps = Omit<MuiRadioProps, "onChange" | "classes"> &
-  HvBaseProps<HTMLInputElement, { onChange }> & {
-    /**
-     * Class names to be applied.
-     */
-    className?: string;
-    /**
-     * A Jss Object used to override or extend the styles applied to the radio button.
-     */
-    classes?: HvRadioClasses;
-    /**
-     * Id to be applied to the form element root node.
-     */
-    id?: string;
-    /**
-     * The form element name.
-     */
-    name?: string;
-    /**
-     * The value of the form element.
-     *
-     * The default value is "on".
-     */
-    value?: any;
-    /**
-     * The label of the form element.
-     *
-     * The form element must be labeled for accessibility reasons.
-     * If not provided, an aria-label or aria-labelledby must be provided.
-     */
-    label?: React.ReactNode;
-    /**
-     * @ignore
-     */
-    "aria-label"?: string;
-    /**
-     * @ignore
-     */
-    "aria-labelledby"?: string;
-    /**
-     * @ignore
-     */
-    "aria-describedby"?: string;
-    /**
-     * Properties passed on to the label element.
-     */
-    labelProps?: HvLabelProps;
-    /**
-     * Indicates that user input is required on the form element.
-     *
-     * If a single radio button in a group has the required attribute, a radio button in
-     * that group must be check, though it doesn't have to be the one with the attribute is applied.
-     *
-     * For that reason, the component doesn't make any uncontrolled changes to its validation status.
-     * That should ideally be managed in the context of a radio button group.
-     */
-    required?: boolean;
-    /**
-     * Indicates that the form element is not editable.
-     */
-    readOnly?: boolean;
-    /**
-     * Indicates that the form element is disabled.
-     */
-    disabled?: boolean;
-    /**
-     * If `true` the radio button is selected, if set to `false` the radio button is not selected.
-     *
-     * When defined the radio button state becomes controlled.
-     */
-    checked?: boolean;
-    /**
-     * When uncontrolled, defines the initial checked state.
-     */
-    defaultChecked?: boolean;
-    /**
-     * The status of the form element.
-     *
-     * Valid is correct, invalid is incorrect and standBy means no validations have run.
-     */
-    status?: HvRadioStatus;
-    /**
-     * The error message to show when `status` is "invalid".
-     */
-    statusMessage?: string;
-    /**
-     * Identifies the element that provides an error message for the radio button.
-     *
-     * Will only be used when the validation status is invalid.
-     */
-    "aria-errormessage"?: string;
-    /**
-     * The callback fired when the radio button is pressed.
-     */
-    onChange?: (
-      event: React.ChangeEvent<HTMLInputElement>,
-      checked: boolean,
-      value: any
-    ) => void;
-    /**
-     * Whether the selector should use semantic colors.
-     */
-    semantic?: boolean;
-    /**
-     * Properties passed on to the input element.
-     */
-    inputProps?: React.InputHTMLAttributes<HTMLInputElement>;
-    /**
-     * Callback fired when the component is focused with a keyboard.
-     * We trigger a `onFocus` callback too.
-     */
-    onFocusVisible?: (event: React.FocusEvent<any>) => void;
-    /**
-     * @ignore
-     */
-    onBlur?: (event: React.FocusEvent<any>) => void;
-  };
+export interface HvRadioProps
+  extends Omit<MuiRadioProps, "onChange" | "classes">,
+    HvBaseProps<HTMLButtonElement, { onChange; color }> {
+  /**
+   * Class names to be applied.
+   */
+  className?: string;
+  /**
+   * A Jss Object used to override or extend the styles applied to the radio button.
+   */
+  classes?: HvRadioClasses;
+  /**
+   * Id to be applied to the form element root node.
+   */
+  id?: string;
+  /**
+   * The form element name.
+   */
+  name?: string;
+  /**
+   * The value of the form element.
+   *
+   * The default value is "on".
+   */
+  value?: any;
+  /**
+   * The label of the form element.
+   *
+   * The form element must be labeled for accessibility reasons.
+   * If not provided, an aria-label or aria-labelledby must be provided.
+   */
+  label?: React.ReactNode;
+  /**
+   * @ignore
+   */
+  "aria-label"?: string;
+  /**
+   * @ignore
+   */
+  "aria-labelledby"?: string;
+  /**
+   * @ignore
+   */
+  "aria-describedby"?: string;
+  /**
+   * Properties passed on to the label element.
+   */
+  labelProps?: HvLabelProps;
+  /**
+   * Indicates that user input is required on the form element.
+   *
+   * If a single radio button in a group has the required attribute, a radio button in
+   * that group must be check, though it doesn't have to be the one with the attribute is applied.
+   *
+   * For that reason, the component doesn't make any uncontrolled changes to its validation status.
+   * That should ideally be managed in the context of a radio button group.
+   */
+  required?: boolean;
+  /**
+   * Indicates that the form element is not editable.
+   */
+  readOnly?: boolean;
+  /**
+   * Indicates that the form element is disabled.
+   */
+  disabled?: boolean;
+  /**
+   * If `true` the radio button is selected, if set to `false` the radio button is not selected.
+   *
+   * When defined the radio button state becomes controlled.
+   */
+  checked?: boolean;
+  /**
+   * When uncontrolled, defines the initial checked state.
+   */
+  defaultChecked?: boolean;
+  /**
+   * The status of the form element.
+   *
+   * Valid is correct, invalid is incorrect and standBy means no validations have run.
+   */
+  status?: HvRadioStatus;
+  /**
+   * The error message to show when `status` is "invalid".
+   */
+  statusMessage?: string;
+  /**
+   * Identifies the element that provides an error message for the radio button.
+   *
+   * Will only be used when the validation status is invalid.
+   */
+  "aria-errormessage"?: string;
+  /**
+   * The callback fired when the radio button is pressed.
+   */
+  onChange?: (
+    event: React.ChangeEvent<HTMLInputElement>,
+    checked: boolean,
+    value: any
+  ) => void;
+  /**
+   * Whether the selector should use semantic colors.
+   */
+  semantic?: boolean;
+  /**
+   * Properties passed on to the input element.
+   */
+  inputProps?: React.InputHTMLAttributes<HTMLInputElement>;
+  /**
+   * Callback fired when the component is focused with a keyboard.
+   * We trigger a `onFocus` callback too.
+   */
+  onFocusVisible?: (event: React.FocusEvent<any>) => void;
+  /**
+   * @ignore
+   */
+  onBlur?: (event: React.FocusEvent<any>) => void;
+}
 
 /**
  * A Radio Button is a mechanism that allows user to select just an option from a group of options.

--- a/packages/core/src/components/Radio/radioClasses.ts
+++ b/packages/core/src/components/Radio/radioClasses.ts
@@ -1,6 +1,6 @@
 import { getClasses } from "@core/utils";
 
-export type HvRadioClasses = {
+export interface HvRadioClasses {
   /** Styles applied to the component. */
   root?: string;
   /** Styles applied to the radio button+label container (only when a label is provided). */
@@ -17,7 +17,7 @@ export type HvRadioClasses = {
   label?: string;
   /** Class applied to the root element if keyboard focused. */
   focusVisible?: string;
-};
+}
 
 const classKeys: string[] = [
   "root",

--- a/packages/core/src/components/RadioGroup/RadioGroup.tsx
+++ b/packages/core/src/components/RadioGroup/RadioGroup.tsx
@@ -11,7 +11,8 @@ import { useControlled, useUniqueId } from "@core/hooks";
 import { setId } from "@core/utils";
 import radioGroupClasses, { HvRadioGroupClasses } from "./radioGroupClasses";
 
-export type HvRadioGroupProps = HvBaseProps<HTMLDivElement, { onChange }> & {
+export interface HvRadioGroupProps
+  extends HvBaseProps<HTMLDivElement, { onChange }> {
   /**
    * The form element name.
    *
@@ -81,7 +82,7 @@ export type HvRadioGroupProps = HvBaseProps<HTMLDivElement, { onChange }> & {
    * A Jss Object used to override or extend the component styles applied.
    */
   classes?: HvRadioGroupClasses;
-};
+}
 
 const getValueFromSelectedChildren = (children: React.ReactNode) => {
   const childrenArray = Children.toArray(children);

--- a/packages/core/src/components/RadioGroup/radioGroupClasses.ts
+++ b/packages/core/src/components/RadioGroup/radioGroupClasses.ts
@@ -1,6 +1,6 @@
 import { getClasses } from "@core/utils";
 
-export type HvRadioGroupClasses = {
+export interface HvRadioGroupClasses {
   root?: string;
   label?: string;
   group?: string;
@@ -8,7 +8,7 @@ export type HvRadioGroupClasses = {
   horizontal?: string;
   invalid?: string;
   error?: string;
-};
+}
 
 const classKeys: string[] = [
   "root",

--- a/packages/core/src/components/SelectionList/SelectionList.tsx
+++ b/packages/core/src/components/SelectionList/SelectionList.tsx
@@ -20,10 +20,8 @@ import selectionListClasses, {
   HvSelectionListClasses,
 } from "./selectionListClasses";
 
-export type HvSelectionListProps = HvBaseProps<
-  HTMLUListElement,
-  { onChange }
-> & {
+export interface HvSelectionListProps
+  extends HvBaseProps<HTMLUListElement, { onChange }> {
   /** The form element name. */
   name?: string;
   /**
@@ -77,7 +75,7 @@ export type HvSelectionListProps = HvBaseProps<
   onChange?: (event: React.MouseEvent, value: any) => void;
   /** A Jss Object used to override or extend the styles applied to the component. */
   classes?: HvSelectionListClasses;
-};
+}
 
 const getValueFromSelectedChildren = (children, multiple) => {
   const selectedValues = React.Children.toArray(children)

--- a/packages/core/src/components/SelectionList/selectionListClasses.ts
+++ b/packages/core/src/components/SelectionList/selectionListClasses.ts
@@ -1,6 +1,6 @@
 import { getClasses } from "@core/utils";
 
-export type HvSelectionListClasses = {
+export interface HvSelectionListClasses {
   root?: string;
   error?: string;
   listbox?: string;
@@ -9,7 +9,7 @@ export type HvSelectionListClasses = {
   horizontal?: string;
   vertical?: string;
   invalid?: string;
-};
+}
 
 const classKeys: string[] = [
   "root",

--- a/packages/core/src/components/SimpleGrid/SimpleGrid.tsx
+++ b/packages/core/src/components/SimpleGrid/SimpleGrid.tsx
@@ -3,14 +3,14 @@ import { StyledContainer } from "./SimpleGrid.styles";
 
 export type Spacing = "sm" | "md" | "lg" | "xl";
 
-export type Breakpoint = {
+export interface Breakpoint {
   cols?: number;
   maxWidth?: number;
   minWidth?: number;
   spacing?: Spacing;
-};
+}
 
-export type HvSimpleGridProps = HvBaseProps & {
+export interface HvSimpleGridProps extends HvBaseProps {
   /**
    * Spacing with pre-defined values according the values defined in the theme
    */
@@ -29,7 +29,7 @@ export type HvSimpleGridProps = HvBaseProps & {
    * Number of how many columns the content will be displayed
    */
   cols?: number;
-};
+}
 
 export const HvSimpleGrid = ({
   children,

--- a/packages/core/src/components/Snackbar/Snackbar.tsx
+++ b/packages/core/src/components/Snackbar/Snackbar.tsx
@@ -19,48 +19,49 @@ import { clsx } from "clsx";
 
 export type HvSnackbarVariant = "default" | "success" | "warning" | "error";
 
-export type HvSnackbarProps = Omit<MuiSnackbarProps, "action" | "classes"> &
-  HvBaseProps & {
-    /** If true, Snackbar is open. */
-    open?: boolean;
-    /** Callback fired when the component requests to be closed. Typically onClose is used to set state in the parent component, which is used to control the Snackbar open prop. The reason parameter can optionally be used to control the response to onClose, for example ignoring clickaway. */
-    onClose?:
-      | ((
-          event: Event | SyntheticEvent<any, Event>,
-          reason: SnackbarCloseReason
-        ) => void)
-      | undefined;
-    /** The message to display. */
-    label?: React.ReactNode;
-    /** The anchor of the Snackbar. vertical: "top", "bottom" | horizontal: "left","center","right. It defines where the snackbar will end his animation */
-    anchorOrigin?: SnackbarOrigin;
-    /** The number of milliseconds to wait before automatically calling the onClose function. onClose should then set the state of the open prop to hide the Snackbar */
-    autoHideDuration?: number;
-    /** Variant of the snackbar. */
-    variant?: HvSnackbarVariant;
-    /** Custom icon to replace the variant default. */
-    customIcon?: React.ReactNode;
-    /** Controls if the associated icon to the variant should be shown. */
-    showIcon?: boolean;
-    /** Action to display. */
-    action?: React.ReactNode | HvActionGeneric;
-    /** The callback function ran when an action is triggered, receiving `action` as param */
-    actionCallback?: (
-      event: React.SyntheticEvent,
-      id: string,
-      action: HvActionGeneric
-    ) => void;
-    /** Duration of transition in milliseconds. */
-    transitionDuration?: number;
-    /** Direction of slide transition. */
-    transitionDirection?: "up" | "down" | "left" | "right";
-    /** Custom offset from top/bottom of the page, in px. */
-    offset?: number;
-    /** Others applied to the content of the snackbar. */
-    snackbarContentProps?: HvSnackbarContentProps;
-    /** A Jss Object used to override or extend the styles applied to the component. */
-    classes?: HvSnackbarClasses;
-  };
+export interface HvSnackbarProps
+  extends Omit<MuiSnackbarProps, "action" | "classes">,
+    Omit<HvBaseProps, "children"> {
+  /** If true, Snackbar is open. */
+  open?: boolean;
+  /** Callback fired when the component requests to be closed. Typically onClose is used to set state in the parent component, which is used to control the Snackbar open prop. The reason parameter can optionally be used to control the response to onClose, for example ignoring clickaway. */
+  onClose?:
+    | ((
+        event: Event | SyntheticEvent<any, Event>,
+        reason: SnackbarCloseReason
+      ) => void)
+    | undefined;
+  /** The message to display. */
+  label?: React.ReactNode;
+  /** The anchor of the Snackbar. vertical: "top", "bottom" | horizontal: "left","center","right. It defines where the snackbar will end his animation */
+  anchorOrigin?: SnackbarOrigin;
+  /** The number of milliseconds to wait before automatically calling the onClose function. onClose should then set the state of the open prop to hide the Snackbar */
+  autoHideDuration?: number;
+  /** Variant of the snackbar. */
+  variant?: HvSnackbarVariant;
+  /** Custom icon to replace the variant default. */
+  customIcon?: React.ReactNode;
+  /** Controls if the associated icon to the variant should be shown. */
+  showIcon?: boolean;
+  /** Action to display. */
+  action?: React.ReactNode | HvActionGeneric;
+  /** The callback function ran when an action is triggered, receiving `action` as param */
+  actionCallback?: (
+    event: React.SyntheticEvent,
+    id: string,
+    action: HvActionGeneric
+  ) => void;
+  /** Duration of transition in milliseconds. */
+  transitionDuration?: number;
+  /** Direction of slide transition. */
+  transitionDirection?: "up" | "down" | "left" | "right";
+  /** Custom offset from top/bottom of the page, in px. */
+  offset?: number;
+  /** Others applied to the content of the snackbar. */
+  snackbarContentProps?: HvSnackbarContentProps;
+  /** A Jss Object used to override or extend the styles applied to the component. */
+  classes?: HvSnackbarClasses;
+}
 
 const transLeft = (props) => <Slide {...props} direction="left" />;
 const transRight = (props) => <Slide {...props} direction="right" />;

--- a/packages/core/src/components/Snackbar/SnackbarContentWrapper/SnackbarContentWrapper.tsx
+++ b/packages/core/src/components/Snackbar/SnackbarContentWrapper/SnackbarContentWrapper.tsx
@@ -15,30 +15,28 @@ import snackbarContentClasses, {
   HvSnackbarContentClasses,
 } from "./snackbarContentWrapperClasses";
 
-export type HvSnackbarContentProps = Omit<
-  MuiSnackbarContentProps,
-  "variant" | "action" | "classes"
-> &
-  HvBaseProps & {
-    /** The message to display. */
-    label?: React.ReactNode;
-    /** Variant of the snackbar. */
-    variant: HvSnackbarVariant;
-    /** Controls if the associated icon to the variant should be shown. */
-    showIcon?: boolean;
-    /** Custom icon to replace the variant default. */
-    customIcon?: React.ReactNode;
-    /** Action to display. */
-    action?: React.ReactNode | HvActionGeneric;
-    /** The callback function ran when an action is triggered, receiving `action` as param */
-    actionCallback?: (
-      event: React.SyntheticEvent,
-      id: string,
-      action: HvActionGeneric
-    ) => void;
-    /** A Jss Object used to override or extend the styles applied to the component. */
-    classes?: HvSnackbarContentClasses;
-  };
+export interface HvSnackbarContentProps
+  extends Omit<MuiSnackbarContentProps, "variant" | "action" | "classes">,
+    HvBaseProps {
+  /** The message to display. */
+  label?: React.ReactNode;
+  /** Variant of the snackbar. */
+  variant: HvSnackbarVariant;
+  /** Controls if the associated icon to the variant should be shown. */
+  showIcon?: boolean;
+  /** Custom icon to replace the variant default. */
+  customIcon?: React.ReactNode;
+  /** Action to display. */
+  action?: React.ReactNode | HvActionGeneric;
+  /** The callback function ran when an action is triggered, receiving `action` as param */
+  actionCallback?: (
+    event: React.SyntheticEvent,
+    id: string,
+    action: HvActionGeneric
+  ) => void;
+  /** A Jss Object used to override or extend the styles applied to the component. */
+  classes?: HvSnackbarContentClasses;
+}
 
 const HvSnackbarContent = forwardRef<HTMLDivElement, HvSnackbarContentProps>(
   (

--- a/packages/core/src/components/Snackbar/SnackbarContentWrapper/snackbarContentWrapperClasses.ts
+++ b/packages/core/src/components/Snackbar/SnackbarContentWrapper/snackbarContentWrapperClasses.ts
@@ -1,6 +1,6 @@
 import { getClasses } from "@core/utils";
 
-export type HvSnackbarContentClasses = {
+export interface HvSnackbarContentClasses {
   root?: string;
   message?: string;
   messageSpan?: string;
@@ -11,7 +11,7 @@ export type HvSnackbarContentClasses = {
   success?: string;
   warning?: string;
   error?: string;
-};
+}
 
 const classKeys: string[] = [
   "root",

--- a/packages/core/src/components/Snackbar/SnackbarProvider/SnackbarProvider.tsx
+++ b/packages/core/src/components/Snackbar/SnackbarProvider/SnackbarProvider.tsx
@@ -8,7 +8,7 @@ import { HvSnackbarVariant } from "../Snackbar";
 import { transientOptions } from "@core/utils/transientOptions";
 import { HvSnackbarContentProps } from "../SnackbarContentWrapper/SnackbarContentWrapper";
 
-export type HvSnackbarProviderProps = {
+export interface HvSnackbarProviderProps {
   /** Your component tree. */
   children: React.ReactNode;
   /** Max visible snackbars. */
@@ -19,9 +19,9 @@ export type HvSnackbarProviderProps = {
   anchorOrigin?: SnackbarOrigin;
   /** Class object used to override notistack classes. */
   notistackClassesOverride?: object;
-};
+}
 
-export type HvNotistackSnackMessageProps = {
+export interface HvNotistackSnackMessageProps {
   /** Id to be applied to the root node. */
   id?: string;
   /** Classname to apply on the root node */
@@ -32,7 +32,7 @@ export type HvNotistackSnackMessageProps = {
   variant?: HvSnackbarVariant;
   /** Extra values to pass to the snackbar. */
   snackbarContentProps?: HvSnackbarContentProps;
-};
+}
 
 const HvNotistackSnackMessage = forwardRef<
   HTMLDivElement,

--- a/packages/core/src/components/Snackbar/snackbarClasses.ts
+++ b/packages/core/src/components/Snackbar/snackbarClasses.ts
@@ -1,6 +1,6 @@
 import { getClasses } from "@core/utils";
 
-export type HvSnackbarClasses = {
+export interface HvSnackbarClasses {
   root?: string;
   /** Styles applied to the component when define as top right.  */
   anchorOriginTopRight?: string;
@@ -14,7 +14,7 @@ export type HvSnackbarClasses = {
   anchorOriginBottomLeft?: string;
   /** Styles applied to the component when define as bottom right.  */
   anchorOriginBottomRight?: string;
-};
+}
 
 const classKeys: string[] = [
   "root",

--- a/packages/core/src/components/Stack/Stack.tsx
+++ b/packages/core/src/components/Stack/Stack.tsx
@@ -14,9 +14,9 @@ import { HvBreakpoints } from "@core/types/tokens";
 import stackClasses, { HvStackClasses } from "./stackClasses";
 
 export type HvStackDirection = "column" | "row" | Partial<HvStackBreakpoints>;
-export type HvStackBreakpoints = Record<HvBreakpoints, string>;
+export interface HvStackBreakpoints extends Record<HvBreakpoints, string> {}
 
-export type HvStackProps = HvBaseProps & {
+export interface HvStackProps extends HvBaseProps {
   /** The direction of the stack. Can be either a string or an object that states the direction for each breakpoint. */
   direction?: HvStackDirection;
   /** The spacing between elements of the stack. */
@@ -32,7 +32,7 @@ export type HvStackProps = HvBaseProps & {
   withNavigation?: boolean;
   /** A Jss Object used to override or extend the styles applied to the component. */
   classes?: HvStackClasses;
-};
+}
 
 /**
  * @returns {string} - Returns a direction for the stack: column or row. If the

--- a/packages/core/src/components/Stack/stackClasses.ts
+++ b/packages/core/src/components/Stack/stackClasses.ts
@@ -1,8 +1,8 @@
 import { getClasses } from "@core/utils";
 
-export type HvStackClasses = {
+export interface HvStackClasses {
   root?: string;
-};
+}
 
 const classKeys: string[] = ["root"];
 

--- a/packages/core/src/components/Switch/Switch.tsx
+++ b/packages/core/src/components/Switch/Switch.tsx
@@ -18,108 +18,109 @@ import {
 import { HvBaseProps } from "@core/types";
 import switchClasses, { HvSwitchClasses } from "./switchClasses";
 
-export type HvSwitchProps = Omit<MuiSwitchProps, "onChange" | "classes"> &
-  HvBaseProps<HTMLInputElement, { onChange }> & {
-    /**
-     * Class names to be applied.
-     */
-    className?: string;
-    /**
-     * A Jss Object used to override or extend the styles applied to the switch.
-     */
-    classes?: HvSwitchClasses;
-    /**
-     * Id to be applied to the form element root node.
-     */
-    id?: string;
-    /**
-     * The form element name.
-     */
-    name?: string;
-    /**
-     * The value of the form element.
-     *
-     * Is up to the application's logic when to consider the submission of this value.
-     * Generally it should be used only when the switch is neither unchecked nor indeterminate.
-     *
-     * The default value is "on".
-     */
-    value?: any;
-    /**
-     * The label of the form element.
-     *
-     * The form element must be labeled for accessibility reasons.
-     * If not provided, an aria-label or aria-labelledby must be inputted via inputProps.
-     */
-    label?: React.ReactNode;
-    /**
-     * @ignore
-     */
-    "aria-label"?: string;
-    /**
-     * @ignore
-     */
-    "aria-labelledby"?: string;
-    /**
-     * @ignore
-     */
-    "aria-describedby"?: string;
-    /**
-     * Properties passed on to the label element.
-     */
-    labelProps?: HvLabelProps;
-    /**
-     * Indicates that the form element is disabled.
-     */
-    disabled?: boolean;
-    /**
-     * Indicates that the form element is not editable.
-     */
-    readOnly?: boolean;
-    /**
-     * Indicates that user input is required on the form element.
-     */
-    required?: boolean;
-    /**
-     * If `true` the switch is selected, if set to `false` the switch is not selected.
-     *
-     * When defined the switch state becomes controlled.
-     */
-    checked?: boolean;
-    /**
-     * When uncontrolled, defines the initial checked state.
-     */
-    defaultChecked?: boolean;
-    /**
-     * The status of the form element.
-     *
-     * Valid is correct, invalid is incorrect and standBy means no validations have run.
-     *
-     * When uncontrolled and unspecified it will default to "standBy" and change to either "valid"
-     * or "invalid" after any change to `checked`, depending of the values of both `required` and `checked`.
-     */
-    status?: HvFormStatus;
-    /**
-     * The error message to show when the validation status is "invalid".
-     *
-     * Defaults to "Required" when the status is uncontrolled and no `aria-errormessage` is provided.
-     */
-    statusMessage?: string;
-    /**
-     * Identifies the element that provides an error message for the switch.
-     *
-     * Will only be used when the validation status is invalid.
-     */
-    "aria-errormessage"?: string;
-    /**
-     * The callback fired when the switch is pressed.
-     */
-    onChange?: (event: React.ChangeEvent, checked: boolean, value: any) => void;
-    /**
-     * Properties passed on to the input element.
-     */
-    inputProps?: React.InputHTMLAttributes<HTMLInputElement>;
-  };
+export interface HvSwitchProps
+  extends Omit<MuiSwitchProps, "onChange" | "classes">,
+    HvBaseProps<HTMLButtonElement, { onChange; color }> {
+  /**
+   * Class names to be applied.
+   */
+  className?: string;
+  /**
+   * A Jss Object used to override or extend the styles applied to the switch.
+   */
+  classes?: HvSwitchClasses;
+  /**
+   * Id to be applied to the form element root node.
+   */
+  id?: string;
+  /**
+   * The form element name.
+   */
+  name?: string;
+  /**
+   * The value of the form element.
+   *
+   * Is up to the application's logic when to consider the submission of this value.
+   * Generally it should be used only when the switch is neither unchecked nor indeterminate.
+   *
+   * The default value is "on".
+   */
+  value?: any;
+  /**
+   * The label of the form element.
+   *
+   * The form element must be labeled for accessibility reasons.
+   * If not provided, an aria-label or aria-labelledby must be inputted via inputProps.
+   */
+  label?: React.ReactNode;
+  /**
+   * @ignore
+   */
+  "aria-label"?: string;
+  /**
+   * @ignore
+   */
+  "aria-labelledby"?: string;
+  /**
+   * @ignore
+   */
+  "aria-describedby"?: string;
+  /**
+   * Properties passed on to the label element.
+   */
+  labelProps?: HvLabelProps;
+  /**
+   * Indicates that the form element is disabled.
+   */
+  disabled?: boolean;
+  /**
+   * Indicates that the form element is not editable.
+   */
+  readOnly?: boolean;
+  /**
+   * Indicates that user input is required on the form element.
+   */
+  required?: boolean;
+  /**
+   * If `true` the switch is selected, if set to `false` the switch is not selected.
+   *
+   * When defined the switch state becomes controlled.
+   */
+  checked?: boolean;
+  /**
+   * When uncontrolled, defines the initial checked state.
+   */
+  defaultChecked?: boolean;
+  /**
+   * The status of the form element.
+   *
+   * Valid is correct, invalid is incorrect and standBy means no validations have run.
+   *
+   * When uncontrolled and unspecified it will default to "standBy" and change to either "valid"
+   * or "invalid" after any change to `checked`, depending of the values of both `required` and `checked`.
+   */
+  status?: HvFormStatus;
+  /**
+   * The error message to show when the validation status is "invalid".
+   *
+   * Defaults to "Required" when the status is uncontrolled and no `aria-errormessage` is provided.
+   */
+  statusMessage?: string;
+  /**
+   * Identifies the element that provides an error message for the switch.
+   *
+   * Will only be used when the validation status is invalid.
+   */
+  "aria-errormessage"?: string;
+  /**
+   * The callback fired when the switch is pressed.
+   */
+  onChange?: (event: React.ChangeEvent, checked: boolean, value: any) => void;
+  /**
+   * Properties passed on to the input element.
+   */
+  inputProps?: React.InputHTMLAttributes<HTMLInputElement>;
+}
 
 /**
  * A Switch is <b>binary</b> and work as a digital on/off button.

--- a/packages/core/src/components/Switch/switchClasses.ts
+++ b/packages/core/src/components/Switch/switchClasses.ts
@@ -1,6 +1,6 @@
 import { getClasses } from "@core/utils";
 
-export type HvSwitchClasses = {
+export interface HvSwitchClasses {
   /** Styles applied to the component. */
   root?: string;
   /** Styles applied to the label. */
@@ -11,7 +11,7 @@ export type HvSwitchClasses = {
   switchContainer?: string;
   /** Styles applied to the switch container when the validations status is invalid. */
   invalidSwitch?: string;
-};
+}
 
 const classKeys: string[] = [
   "root",

--- a/packages/core/src/components/Tab/Tab.tsx
+++ b/packages/core/src/components/Tab/Tab.tsx
@@ -5,19 +5,20 @@ import { StyledTab } from "./Tab.styles";
 import tabClasses, { HvTabClasses } from "./tabClasses";
 
 // Mui Tab props: https://mui.com/material-ui/api/tab/#props
-export type HvTabProps = Omit<MuiTabProps, "children"> &
-  HvBaseProps<HTMLDivElement, { children }> & {
-    /** If `true`, the tab will be disabled. */
-    disabled?: boolean;
-    /** The icon element. */
-    icon?: React.ReactElement | string;
-    /** The label element. */
-    label?: React.ReactNode;
-    /** The position of the icon relative to the label. */
-    iconPosition?: "bottom" | "end" | "start" | "top";
-    /** A Jss Object used to override or extend the component styles. */
-    classes?: HvTabClasses;
-  };
+export interface HvTabProps
+  extends Omit<MuiTabProps, "children">,
+    HvBaseProps<HTMLDivElement, { children }> {
+  /** If `true`, the tab will be disabled. */
+  disabled?: boolean;
+  /** The icon element. */
+  icon?: React.ReactElement | string;
+  /** The label element. */
+  label?: React.ReactNode;
+  /** The position of the icon relative to the label. */
+  iconPosition?: "bottom" | "end" | "start" | "top";
+  /** A Jss Object used to override or extend the component styles. */
+  classes?: HvTabClasses;
+}
 
 export const HvTab = ({
   classes,

--- a/packages/core/src/components/Tab/tabClasses.ts
+++ b/packages/core/src/components/Tab/tabClasses.ts
@@ -1,11 +1,11 @@
 import { getClasses } from "@core/utils";
 
-export type HvTabClasses = {
+export interface HvTabClasses {
   root?: string;
   selected?: string;
   disabled?: string;
   focusVisible?: string;
-};
+}
 
 const classKeys: string[] = ["root", "selected", "disabled", "focusVisible"];
 

--- a/packages/core/src/components/Tabs/Tabs.tsx
+++ b/packages/core/src/components/Tabs/Tabs.tsx
@@ -5,21 +5,22 @@ import tabsClasses, { HvTabsClasses } from "./tabsClasses";
 import { clsx } from "clsx";
 
 // Mui Tabs props: https://mui.com/material-ui/api/tabs/#props
-export type HvTabsProps = MuiTabsProps &
-  HvBaseProps<HTMLButtonElement, { onChange }> & {
-    /**
-     * The value of the currently selected Tab. If you don't want any selected Tab, you can set this property to `false`.
-     */
-    value?: any;
-    /**
-     * Callback fired when the value changes.
-     */
-    onChange?: (event: React.SyntheticEvent, value: any) => void;
-    /**
-     * A Jss Object used to override or extend the component styles.
-     */
-    classes?: HvTabsClasses;
-  };
+export interface HvTabsProps
+  extends MuiTabsProps,
+    HvBaseProps<HTMLButtonElement, { onChange }> {
+  /**
+   * The value of the currently selected Tab. If you don't want any selected Tab, you can set this property to `false`.
+   */
+  value?: any;
+  /**
+   * Callback fired when the value changes.
+   */
+  onChange?: (event: React.SyntheticEvent, value: any) => void;
+  /**
+   * A Jss Object used to override or extend the component styles.
+   */
+  classes?: HvTabsClasses;
+}
 
 /**
  * A Tab is a graphical control element that allows multiple documents or panels to be contained within a single window.

--- a/packages/core/src/components/Tabs/tabsClasses.ts
+++ b/packages/core/src/components/Tabs/tabsClasses.ts
@@ -1,11 +1,11 @@
 import { getClasses } from "@core/utils";
 
-export type HvTabsClasses = {
+export interface HvTabsClasses {
   root?: string;
   flexContainer?: string;
   indicator?: string;
   scroller?: string;
-};
+}
 
 const classKeys: string[] = ["root", "flexContainer", "indicator", "scroller"];
 

--- a/packages/core/src/components/Tag/Tag.tsx
+++ b/packages/core/src/components/Tag/Tag.tsx
@@ -13,36 +13,37 @@ import { HvButtonProps } from "../Button";
 import tagClasses, { HvTagClasses } from "./tagClasses";
 import { useTheme } from "@core/hooks";
 
-export type HvTagProps = Omit<MuiChipProps, "color" | "classes"> &
-  HvBaseProps<HTMLDivElement, { children }> & {
-    /** Inline styles to be applied to the root element. */
-    style?: CSSProperties;
-    /** The label of the tag element. */
-    label?: React.ReactNode;
-    /** Indicates that the form element is disabled. */
-    disabled?: boolean;
-    /** The type of the tag element. A tag can be of semantic or categoric type. */
-    type?: "semantic" | "categorical";
-    /** Background color to be applied to the tag */
-    color?: HvSemanticColorKeys | HvCategoricalColorKeys | string;
-    /** Icon used to customize the delete icon in the Chip element */
-    deleteIcon?: React.ReactElement;
-    /**
-     * The callback fired when the delete icon is pressed.
-     * This function has to be provided to the component, in order to render the delete icon
-     * */
-    onDelete?: (event: React.MouseEvent<HTMLElement>) => void;
-    /** Callback triggered when any item is clicked. */
-    onClick?: (event: React.MouseEvent<HTMLElement>) => void;
-    /** The role of the element with an attributed event. */
-    role?: string;
-    /** Aria properties to apply to delete button in tag */
-    deleteButtonArialLabel?: string;
-    /** Props to apply to delete button */
-    deleteButtonProps?: HvButtonProps;
-    /** A Jss Object used to override or extend the styles applied to the component. */
-    classes?: HvTagClasses;
-  };
+export interface HvTagProps
+  extends Omit<MuiChipProps, "color" | "classes">,
+    HvBaseProps<HTMLDivElement, { children }> {
+  /** Inline styles to be applied to the root element. */
+  style?: CSSProperties;
+  /** The label of the tag element. */
+  label?: React.ReactNode;
+  /** Indicates that the form element is disabled. */
+  disabled?: boolean;
+  /** The type of the tag element. A tag can be of semantic or categoric type. */
+  type?: "semantic" | "categorical";
+  /** Background color to be applied to the tag */
+  color?: HvSemanticColorKeys | HvCategoricalColorKeys | string;
+  /** Icon used to customize the delete icon in the Chip element */
+  deleteIcon?: React.ReactElement;
+  /**
+   * The callback fired when the delete icon is pressed.
+   * This function has to be provided to the component, in order to render the delete icon
+   * */
+  onDelete?: (event: React.MouseEvent<HTMLElement>) => void;
+  /** Callback triggered when any item is clicked. */
+  onClick?: (event: React.MouseEvent<HTMLElement>) => void;
+  /** The role of the element with an attributed event. */
+  role?: string;
+  /** Aria properties to apply to delete button in tag */
+  deleteButtonArialLabel?: string;
+  /** Props to apply to delete button */
+  deleteButtonProps?: HvButtonProps;
+  /** A Jss Object used to override or extend the styles applied to the component. */
+  classes?: HvTagClasses;
+}
 
 const getColor = (customColor, type, colors) => {
   const defaultSemanticColor = theme.colors.neutral_20;

--- a/packages/core/src/components/Tag/tagClasses.ts
+++ b/packages/core/src/components/Tag/tagClasses.ts
@@ -1,6 +1,6 @@
 import { getClasses } from "@core/utils";
 
-export type HvTagClasses = {
+export interface HvTagClasses {
   root?: string;
   tagButton?: string;
   focusVisible?: string;
@@ -14,7 +14,7 @@ export type HvTagClasses = {
   categoricalDisabled?: string;
   deleteIcon?: string;
   disabledDeleteIcon?: string;
-};
+}
 
 const classKeys: string[] = [
   "root",

--- a/packages/core/src/components/TagsInput/TagsInput.tsx
+++ b/packages/core/src/components/TagsInput/TagsInput.tsx
@@ -35,10 +35,11 @@ import { HvTagProps } from "../Tag";
 import tagsInputClasses, { HvTagsInputClasses } from "./tagsInputClasses";
 import { HvCharCounterProps, HvFormStatus } from "../Forms";
 
-export type HvTagsInputProps = HvBaseProps<
-  HTMLElement,
-  { onChange; onBlur; onFocus; onKeyDown; color }
-> & {
+export interface HvTagsInputProps
+  extends HvBaseProps<
+    HTMLElement,
+    { onChange; onBlur; onFocus; onKeyDown; color; defaultValue }
+  > {
   /** The form element name. */
   name?: string;
   /** The value of the form element. */
@@ -127,7 +128,7 @@ export type HvTagsInputProps = HvBaseProps<
   suggestionListCallback?: (value: string) => HvTagSuggestion[] | null;
   /** A Jss Object used to override or extend the styles applied to the component. */
   classes?: HvTagsInputClasses;
-};
+}
 
 /**
  * A tags input is a single or multiline control that allows the input of tags.

--- a/packages/core/src/components/TagsInput/tagsInputClasses.ts
+++ b/packages/core/src/components/TagsInput/tagsInputClasses.ts
@@ -1,6 +1,6 @@
 import { getClasses } from "@core/utils";
 
-export type HvTagsInputClasses = {
+export interface HvTagsInputClasses {
   /** Styles applied to the input element. */
   input?: string;
   /** Styles applied to the list item gutters. */
@@ -49,7 +49,7 @@ export type HvTagsInputClasses = {
   suggestionsContainer?: string;
   /** Styles applied to the suggestions list. */
   suggestionList?: string;
-};
+}
 
 const classKeys: string[] = [
   "input",

--- a/packages/core/src/components/TextArea/TextArea.tsx
+++ b/packages/core/src/components/TextArea/TextArea.tsx
@@ -29,10 +29,11 @@ import isNil from "lodash/isNil";
 import { HvValidationMessages } from "@core/types";
 import textAreaClasses, { HvTextAreaClasses } from "./textAreaClasses";
 
-export type HvTextAreaProps = Omit<
-  HvBaseInputProps,
-  "onChange" | "onBlur" | "rows" | "classes" | "onFocus"
-> & {
+export interface HvTextAreaProps
+  extends Omit<
+    HvBaseInputProps,
+    "onChange" | "onBlur" | "rows" | "classes" | "onFocus"
+  > {
   /**
    * The label of the form element.
    *
@@ -137,7 +138,7 @@ export type HvTextAreaProps = Omit<
    * A Jss Object used to override or extend the component styles applied.
    */
   classes?: HvTextAreaClasses;
-};
+}
 
 /**
  * A text area is a multiline text input box, with an optional character counter when there is a length limit.

--- a/packages/core/src/components/TextArea/textAreaClasses.ts
+++ b/packages/core/src/components/TextArea/textAreaClasses.ts
@@ -1,6 +1,6 @@
 import { getClasses } from "@core/utils";
 
-export type HvTextAreaClasses = {
+export interface HvTextAreaClasses {
   root?: string;
   disabled?: string;
   resizable?: string;
@@ -13,7 +13,7 @@ export type HvTextAreaClasses = {
   description?: string;
   characterCounter?: string;
   error?: string;
-};
+}
 
 const classKeys: string[] = [
   "root",

--- a/packages/core/src/components/ToggleButton/ToggleButton.tsx
+++ b/packages/core/src/components/ToggleButton/ToggleButton.tsx
@@ -1,12 +1,10 @@
 import { forwardRef } from "react";
 import { HvButton } from "../Button";
-import { useControlled } from "../../hooks";
+import { useControlled } from "@core/hooks";
 import { HvBaseProps } from "@core/types";
 
-export type HvToggleButtonProps = HvBaseProps<
-  HTMLButtonElement,
-  { onClick }
-> & {
+export interface HvToggleButtonProps
+  extends HvBaseProps<HTMLButtonElement, { onClick }> {
   /** When uncontrolled, defines the initial selected state. */
   defaultSelected?: boolean;
   /** Defines if the button is selected. When defined the button state becomes controlled. */
@@ -22,7 +20,7 @@ export type HvToggleButtonProps = HvBaseProps<
     event: React.MouseEvent<HTMLButtonElement>,
     selected: boolean
   ) => void;
-};
+}
 
 export const HvToggleButton = forwardRef<
   HTMLButtonElement,

--- a/packages/core/src/components/Tooltip/Tooltip.tsx
+++ b/packages/core/src/components/Tooltip/Tooltip.tsx
@@ -24,7 +24,8 @@ export type HvTooltipPlacementType =
   | "top-start"
   | "top";
 
-export type HvTooltipProps = Omit<MuiTooltipProps, "classes"> & {
+export interface HvTooltipProps
+  extends Omit<MuiTooltipProps, "classes" | "title"> {
   /**
    * Class names to be applied.
    */
@@ -68,7 +69,7 @@ export type HvTooltipProps = Omit<MuiTooltipProps, "classes"> & {
    * Node to apply the tooltip.
    */
   children: ReactElement;
-};
+}
 
 /**
  * Tooltips display informative text when users hover over, focus on, or tap an element.

--- a/packages/core/src/components/Tooltip/tooltipClasses.ts
+++ b/packages/core/src/components/Tooltip/tooltipClasses.ts
@@ -1,6 +1,6 @@
 import { getClasses } from "@core/utils";
 
-export type HvTooltipClasses = {
+export interface HvTooltipClasses {
   /** Styles applied to the tooltip root class. */
   root?: string;
   /** Styles applied to the tooltip class when it is single. */
@@ -23,7 +23,7 @@ export type HvTooltipClasses = {
   separator?: string;
   /** Styles applied to the values wrapper. */
   valueWrapper?: string;
-};
+}
 
 const classKeys: string[] = [
   "root",

--- a/packages/core/src/components/VerticalNavigation/Actions/Action.tsx
+++ b/packages/core/src/components/VerticalNavigation/Actions/Action.tsx
@@ -7,7 +7,7 @@ import actionClasses, {
   HvVerticalNavigationActionClasses,
 } from "./actionClasses";
 
-export type HvVerticalNavigationActionProps = {
+export interface HvVerticalNavigationActionProps {
   /**
    * Class names to be applied.
    */
@@ -32,7 +32,7 @@ export type HvVerticalNavigationActionProps = {
    * Callback called when clicked.
    */
   onClick?: MouseEventHandler<HTMLElement>;
-};
+}
 
 export const HvVerticalNavigationAction = ({
   className,

--- a/packages/core/src/components/VerticalNavigation/Actions/Actions.tsx
+++ b/packages/core/src/components/VerticalNavigation/Actions/Actions.tsx
@@ -6,7 +6,7 @@ import actionsClasses, {
   HvVerticalNavigationActionsClasses,
 } from "./actionsClasses";
 
-export type HvVerticalNavigationActionsProps = {
+export interface HvVerticalNavigationActionsProps {
   /**
    * Class names to be applied.
    */
@@ -23,7 +23,7 @@ export type HvVerticalNavigationActionsProps = {
    * Node to be rendered
    */
   children?: React.ReactNode;
-};
+}
 
 export const HvVerticalNavigationActions = ({
   className,

--- a/packages/core/src/components/VerticalNavigation/Actions/actionClasses.ts
+++ b/packages/core/src/components/VerticalNavigation/Actions/actionClasses.ts
@@ -1,10 +1,10 @@
 import { getClasses } from "@core/utils";
 
-export type HvVerticalNavigationActionClasses = {
+export interface HvVerticalNavigationActionClasses {
   action?: string;
   noIcon?: string;
   minimized?: string;
-};
+}
 
 const classKeys: string[] = ["action", "noIcon", "minimized"];
 

--- a/packages/core/src/components/VerticalNavigation/Actions/actionsClasses.ts
+++ b/packages/core/src/components/VerticalNavigation/Actions/actionsClasses.ts
@@ -1,9 +1,9 @@
 import { getClasses } from "@core/utils";
 
-export type HvVerticalNavigationActionsClasses = {
+export interface HvVerticalNavigationActionsClasses {
   root?: string;
   hide?: string;
-};
+}
 
 const classKeys: string[] = ["root", "hide"];
 

--- a/packages/core/src/components/VerticalNavigation/Header/Header.tsx
+++ b/packages/core/src/components/VerticalNavigation/Header/Header.tsx
@@ -8,7 +8,7 @@ import verticalNavigationHeaderClasses, {
   HvVerticalNavigationHeaderClasses,
 } from "./headerClasses";
 
-export type HvVerticalNavigationHeaderProps = {
+export interface HvVerticalNavigationHeaderProps {
   /**
    * Id to be applied to the root node.
    */
@@ -45,7 +45,7 @@ export type HvVerticalNavigationHeaderProps = {
    * Handler for the collapse button.
    */
   onCollapseButtonClick?: MouseEventHandler<HTMLElement>;
-};
+}
 
 export const HvVerticalNavigationHeader = ({
   title,

--- a/packages/core/src/components/VerticalNavigation/Header/headerClasses.ts
+++ b/packages/core/src/components/VerticalNavigation/Header/headerClasses.ts
@@ -1,9 +1,9 @@
 import { getClasses } from "@core/utils";
 
-export type HvVerticalNavigationHeaderClasses = {
+export interface HvVerticalNavigationHeaderClasses {
   root?: string;
   minimized?: string;
-};
+}
 
 const classKeys: string[] = ["root", "minimized"];
 

--- a/packages/core/src/components/VerticalNavigation/Navigation/Navigation.tsx
+++ b/packages/core/src/components/VerticalNavigation/Navigation/Navigation.tsx
@@ -360,10 +360,8 @@ export const HvVerticalNavigationTree = ({
   );
 };
 
-export type HvVerticalNavigationTreeProps = HvBaseProps<
-  HTMLDivElement,
-  { onChange }
-> & {
+export interface HvVerticalNavigationTreeProps
+  extends HvBaseProps<HTMLDivElement, { onChange }> {
   /**
    * Id to be applied to the root node.
    */
@@ -429,6 +427,6 @@ export type HvVerticalNavigationTreeProps = HvBaseProps<
    * target - the behavior when opening an url.
    */
   data?: NavigationData[];
-};
+}
 
 export type NavigationMode = "treeview" | "navigation" | "slider";

--- a/packages/core/src/components/VerticalNavigation/Navigation/navigationClasses.ts
+++ b/packages/core/src/components/VerticalNavigation/Navigation/navigationClasses.ts
@@ -1,12 +1,12 @@
 import { getClasses } from "@core/utils";
 
-export type HvVerticalNavigationTreeClasses = {
+export interface HvVerticalNavigationTreeClasses {
   root?: string;
   list?: string;
   listItem?: string;
   collapsed?: string;
   popup?: string;
-};
+}
 
 const classKeys: string[] = ["root", "list", "listItem", "collapsed", "popup"];
 

--- a/packages/core/src/components/VerticalNavigation/NavigationPopup/NavigationPopup.tsx
+++ b/packages/core/src/components/VerticalNavigation/NavigationPopup/NavigationPopup.tsx
@@ -11,7 +11,7 @@ import { setId } from "@core/utils";
 
 import { StyledPopupContainer } from "./NavigationPopup.styles";
 
-export type HvVerticalNavigationPopupProps = {
+export interface HvVerticalNavigationPopupProps {
   id?: string;
   anchorEl?: HTMLElement | null;
   fixedMode?: boolean;
@@ -19,7 +19,7 @@ export type HvVerticalNavigationPopupProps = {
   selected?: string;
   onClose?: () => void;
   onChange?: any;
-};
+}
 
 export const HvVerticalNavigationPopup = ({
   id,

--- a/packages/core/src/components/VerticalNavigation/NavigationPopup/navigationPopupClasses.tsx
+++ b/packages/core/src/components/VerticalNavigation/NavigationPopup/navigationPopupClasses.tsx
@@ -1,6 +1,6 @@
 import { getClasses } from "@core/utils";
 
-export type HvVerticalNavigationPopupClasses = {};
+export interface HvVerticalNavigationPopupClasses {}
 
 const classKeys: string[] = [];
 

--- a/packages/core/src/components/VerticalNavigation/NavigationSlider/NavigationSlider.tsx
+++ b/packages/core/src/components/VerticalNavigation/NavigationSlider/NavigationSlider.tsx
@@ -6,7 +6,7 @@ import verticalNavigationSliderClasses, {
   HvVerticalNavigationSliderClasses,
 } from "./navigationSliderClasses";
 
-export type HvVerticalNavigationSliderProps = {
+export interface HvVerticalNavigationSliderProps {
   /**
    * Id to be applied to the root node of the panel.
    */
@@ -44,7 +44,7 @@ export type HvVerticalNavigationSliderProps = {
     event: React.MouseEvent<HTMLButtonElement>,
     item: NavigationData
   ) => void;
-};
+}
 
 export const HvVerticalNavigationSlider = ({
   id,

--- a/packages/core/src/components/VerticalNavigation/NavigationSlider/navigationSliderClasses.ts
+++ b/packages/core/src/components/VerticalNavigation/NavigationSlider/navigationSliderClasses.ts
@@ -1,9 +1,9 @@
 import { getClasses } from "@core/utils";
 
-export type HvVerticalNavigationSliderClasses = {
+export interface HvVerticalNavigationSliderClasses {
   root?: string;
   listItemSelected?: string;
-};
+}
 
 const classKeys: string[] = ["root", "listItemSelected"];
 

--- a/packages/core/src/components/VerticalNavigation/TreeView/TreeView.tsx
+++ b/packages/core/src/components/VerticalNavigation/TreeView/TreeView.tsx
@@ -11,7 +11,7 @@ import { StyledRoot } from "./TreeView.styles";
 import { NavigationMode } from "../Navigation";
 import treeViewClasses from "./treeViewClasses";
 
-export type HvVerticalNavigationTreeViewProps = {
+export interface HvVerticalNavigationTreeViewProps {
   /**
    * Id to be applied to the root node.
    */
@@ -99,7 +99,7 @@ export type HvVerticalNavigationTreeViewProps = {
    * The content of the component.
    */
   children?: React.ReactNode;
-};
+}
 
 function isPrintableCharacter(string) {
   return string && string.length === 1 && string.match(/\S/);

--- a/packages/core/src/components/VerticalNavigation/TreeView/TreeViewItem.tsx
+++ b/packages/core/src/components/VerticalNavigation/TreeView/TreeViewItem.tsx
@@ -23,7 +23,7 @@ import {
 import { VerticalNavigationContext } from "../";
 import { IconWrapper } from "./IconWrapper";
 
-export type HvVerticalNavigationTreeViewItemProps = {
+export interface HvVerticalNavigationTreeViewItemProps {
   /**
    * Id to be applied to the root node.
    */
@@ -92,7 +92,7 @@ export type HvVerticalNavigationTreeViewItemProps = {
    * Disables the appearence of a tooltip on hovering an element ( Only applicable when the in collapsed mode)
    */
   disableTooltip?: boolean;
-};
+}
 
 const preventSelection = (event, disabled) => {
   if (event.shiftKey || event.ctrlKey || event.metaKey || disabled) {

--- a/packages/core/src/components/VerticalNavigation/TreeView/treeViewClasses.ts
+++ b/packages/core/src/components/VerticalNavigation/TreeView/treeViewClasses.ts
@@ -1,8 +1,8 @@
 import { getClasses } from "@core/utils";
 
-export type HvVerticalNavigationTreeViewClasses = {
+export interface HvVerticalNavigationTreeViewClasses {
   root?: string;
-};
+}
 
 const classKeys: string[] = ["root"];
 

--- a/packages/core/src/components/VerticalNavigation/TreeView/treeViewItemClasses.ts
+++ b/packages/core/src/components/VerticalNavigation/TreeView/treeViewItemClasses.ts
@@ -1,6 +1,6 @@
 import { getClasses } from "@core/utils";
 
-export type HvVerticalNavigationTreeViewItemClasses = {
+export interface HvVerticalNavigationTreeViewItemClasses {
   /** Style applied to the root of the component. */
   node?: string;
   /** Style applied to the content. */
@@ -30,7 +30,7 @@ export type HvVerticalNavigationTreeViewItemClasses = {
   /** Styled applied when navigation open is false */
   minimized?: string;
   hide?: string;
-};
+}
 
 const classKeys: string[] = [
   "node",

--- a/packages/core/src/components/VerticalNavigation/VerticalNavigation.tsx
+++ b/packages/core/src/components/VerticalNavigation/VerticalNavigation.tsx
@@ -12,7 +12,7 @@ import {
 } from "./NavigationSlider/utils";
 import { hasChildNavigationItems } from "./utils/VerticalNavigation.utils";
 
-export type HvVerticalNavigationProps = {
+export interface HvVerticalNavigationProps {
   /**
    * Id to be applied to the root node.
    */
@@ -41,7 +41,7 @@ export type HvVerticalNavigationProps = {
    * The content inside the actions container.
    */
   children?: React.ReactNode;
-};
+}
 
 /**
  * Navigation enables users to move through an app to complete tasks.

--- a/packages/core/src/components/VerticalNavigation/verticalNavigationClasses.tsx
+++ b/packages/core/src/components/VerticalNavigation/verticalNavigationClasses.tsx
@@ -1,13 +1,13 @@
 import { getClasses } from "@core/utils";
 
-export type HvVerticalNavigationClasses = {
+export interface HvVerticalNavigationClasses {
   /** Style applied to the root of the component. */
   root?: string;
   /** Style applied to the root of the component when its collapsed. */
   collapsed?: string;
   /** Style applied to the root of the component when its in slider mode. */
   slider?;
-};
+}
 
 const classKeys: string[] = ["root", "collapsed", "slider"];
 

--- a/packages/core/src/types/forms.ts
+++ b/packages/core/src/types/forms.ts
@@ -1,4 +1,4 @@
-export type HvValidationMessages = {
+export interface HvValidationMessages {
   /** The value when a validation fails. */
   error?: string;
   /** The message that appears when there are too many characters. */
@@ -9,9 +9,9 @@ export type HvValidationMessages = {
   requiredError?: string;
   /** The message that appears when the input is value is incompatible with the expected type. */
   typeMismatchError?: string;
-};
+}
 
-export type HvInputLabels = {
+export interface HvInputLabels {
   /** The label of the clear button. */
   clearButtonLabel?: string;
   /** The label of the reveal password button. */
@@ -22,12 +22,12 @@ export type HvInputLabels = {
   revealPasswordButtonClickToHideTooltip?: string;
   /** The label of the search button. */
   searchButtonLabel?: string;
-};
+}
 
-export type HvInputSuggestion = {
+export interface HvInputSuggestion {
   id: string;
   label: string;
   value?: string;
-};
+}
 
-export type HvTagSuggestion = HvInputSuggestion;
+export interface HvTagSuggestion extends HvInputSuggestion {}

--- a/packages/core/src/types/theme.ts
+++ b/packages/core/src/types/theme.ts
@@ -11,7 +11,7 @@ export type { HvTheme };
 /**
  * Create theme props
  */
-export type HvCreateThemeProps = {
+export interface HvCreateThemeProps extends HvThemeCustomizationProps {
   /**
    * The name used for the theme.
    *
@@ -31,7 +31,7 @@ export type HvCreateThemeProps = {
    * By default the color modes are inherited.
    */
   inheritColorModes?: boolean;
-} & HvThemeCustomizationProps;
+}
 
 // Theme customization
 export type HvThemeCustomizationProps = HvExtraDeepPartialProps<


### PR DESCRIPTION
All remaining components props types were converted to interfaces. Since we are now using relative imports on all components, the Storybook args tables were missing information. Converting types to interfaces fixes this issue. 
