### PR TITLE
chore: update CodeEditor to use a different package and enable syntax highlighting and validation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5137,6 +5137,30 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/@monaco-editor/loader": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@monaco-editor/loader/-/loader-1.3.3.tgz",
+      "integrity": "sha512-6KKF4CTzcJiS8BJwtxtfyYt9shBiEv32ateQ9T4UVogwn4HM/uPo9iJd2Dmbkpz8CM6Y0PDUpjnZzCwC+eYo2Q==",
+      "dependencies": {
+        "state-local": "^1.0.6"
+      },
+      "peerDependencies": {
+        "monaco-editor": ">= 0.21.0 < 1"
+      }
+    },
+    "node_modules/@monaco-editor/react": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/@monaco-editor/react/-/react-4.5.1.tgz",
+      "integrity": "sha512-NNDFdP+2HojtNhCkRfE6/D6ro6pBNihaOzMbGK84lNWzRu+CfBjwzGt4jmnqimLuqp5yE5viHS2vi+QOAnD5FQ==",
+      "dependencies": {
+        "@monaco-editor/loader": "^1.3.3"
+      },
+      "peerDependencies": {
+        "monaco-editor": ">= 0.25.0 < 1",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/@mrmlnc/readdir-enhanced": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",
@@ -25823,11 +25847,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/monaco-editor": {
-      "version": "0.37.1",
-      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.37.1.tgz",
-      "integrity": "sha512-jLXEEYSbqMkT/FuJLBZAVWGuhIb4JNwHE9kPTorAVmsdZ4UzHAfgWxLsVtD7pLRFaOwYPhNG9nUCpmFL1t/dIg=="
-    },
     "node_modules/morgan": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.10.0.tgz",
@@ -27315,6 +27334,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -29953,6 +29973,7 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "dev": true,
       "dependencies": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -29962,7 +29983,8 @@
     "node_modules/prop-types/node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "dev": true
     },
     "node_modules/property-expr": {
       "version": "2.0.5",
@@ -30657,19 +30679,6 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
       "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
       "dev": true
-    },
-    "node_modules/react-monaco-editor": {
-      "version": "0.52.0",
-      "resolved": "https://registry.npmjs.org/react-monaco-editor/-/react-monaco-editor-0.52.0.tgz",
-      "integrity": "sha512-jhQSekf2JABbcpN45gKZlWfTS0QcBOZAbAWKGyfqy/KEcMXTwJpCOYGcn2Ur11SUUxWJUzhKjE2fx9BGBc5S8g==",
-      "dependencies": {
-        "prop-types": "^15.8.1"
-      },
-      "peerDependencies": {
-        "@types/react": ">=16 <= 18",
-        "monaco-editor": "^0.36.1",
-        "react": ">=16 <= 18"
-      }
     },
     "node_modules/react-popper": {
       "version": "2.3.0",
@@ -33387,6 +33396,11 @@
       "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.3.4.tgz",
       "integrity": "sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw==",
       "dev": true
+    },
+    "node_modules/state-local": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/state-local/-/state-local-1.0.7.tgz",
+      "integrity": "sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w=="
     },
     "node_modules/state-toggle": {
       "version": "1.0.3",
@@ -38393,9 +38407,8 @@
         "@emotion/cache": "^11.10.5",
         "@hitachivantara/uikit-react-core": "^5.5.0",
         "@hitachivantara/uikit-styles": "^5.4.0",
-        "clsx": "^1.2.1",
-        "monaco-editor": "^0.37.1",
-        "react-monaco-editor": "^0.52.0"
+        "@monaco-editor/react": "^4.5.1",
+        "clsx": "^1.2.1"
       },
       "devDependencies": {
         "@types/react": "^18.0.28",
@@ -41276,13 +41289,12 @@
         "@emotion/cache": "^11.10.5",
         "@hitachivantara/uikit-react-core": "^5.5.0",
         "@hitachivantara/uikit-styles": "^5.4.0",
+        "@monaco-editor/react": "^4.5.1",
         "@types/react": "^18.0.28",
         "@types/react-dom": "^18.0.11",
         "@vitest/coverage-c8": "^0.29.7",
         "clsx": "^1.2.1",
-        "monaco-editor": "^0.37.1",
         "npm-run-all": "^4.1.5",
-        "react-monaco-editor": "^0.52.0",
         "tsc-alias": "^1.8.2"
       }
     },
@@ -42361,6 +42373,22 @@
             "path-parse": "^1.0.6"
           }
         }
+      }
+    },
+    "@monaco-editor/loader": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@monaco-editor/loader/-/loader-1.3.3.tgz",
+      "integrity": "sha512-6KKF4CTzcJiS8BJwtxtfyYt9shBiEv32ateQ9T4UVogwn4HM/uPo9iJd2Dmbkpz8CM6Y0PDUpjnZzCwC+eYo2Q==",
+      "requires": {
+        "state-local": "^1.0.6"
+      }
+    },
+    "@monaco-editor/react": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/@monaco-editor/react/-/react-4.5.1.tgz",
+      "integrity": "sha512-NNDFdP+2HojtNhCkRfE6/D6ro6pBNihaOzMbGK84lNWzRu+CfBjwzGt4jmnqimLuqp5yE5viHS2vi+QOAnD5FQ==",
+      "requires": {
+        "@monaco-editor/loader": "^1.3.3"
       }
     },
     "@mrmlnc/readdir-enhanced": {
@@ -58145,11 +58173,6 @@
       "integrity": "sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==",
       "dev": true
     },
-    "monaco-editor": {
-      "version": "0.37.1",
-      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.37.1.tgz",
-      "integrity": "sha512-jLXEEYSbqMkT/FuJLBZAVWGuhIb4JNwHE9kPTorAVmsdZ4UzHAfgWxLsVtD7pLRFaOwYPhNG9nUCpmFL1t/dIg=="
-    },
     "morgan": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.10.0.tgz",
@@ -59333,7 +59356,8 @@
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true
     },
     "object-copy": {
       "version": "0.1.0",
@@ -61339,6 +61363,7 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "dev": true,
       "requires": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -61348,7 +61373,8 @@
         "react-is": {
           "version": "16.13.1",
           "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+          "dev": true
         }
       }
     },
@@ -61879,14 +61905,6 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
       "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
       "dev": true
-    },
-    "react-monaco-editor": {
-      "version": "0.52.0",
-      "resolved": "https://registry.npmjs.org/react-monaco-editor/-/react-monaco-editor-0.52.0.tgz",
-      "integrity": "sha512-jhQSekf2JABbcpN45gKZlWfTS0QcBOZAbAWKGyfqy/KEcMXTwJpCOYGcn2Ur11SUUxWJUzhKjE2fx9BGBc5S8g==",
-      "requires": {
-        "prop-types": "^15.8.1"
-      }
     },
     "react-popper": {
       "version": "2.3.0",
@@ -64059,6 +64077,11 @@
       "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.3.4.tgz",
       "integrity": "sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw==",
       "dev": true
+    },
+    "state-local": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/state-local/-/state-local-1.0.7.tgz",
+      "integrity": "sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w=="
     },
     "state-toggle": {
       "version": "1.0.3",

--- a/packages/code-editor/README.md
+++ b/packages/code-editor/README.md
@@ -1,6 +1,6 @@
 # @hitachivantara/uikit-react-code-editor
 
-A wrapper to the React Monaco editor (https://github.com/react-monaco-editor/react-monaco-editor) using the Hitachi Vantara's Design System styles.
+A wrapper to the React Monaco editor (https://github.com/suren-atoyan/monaco-react) using the Hitachi Vantara's Design System styles.
 
 ## Installation
 
@@ -12,4 +12,4 @@ npm install @hitachivantara/uikit-react-code-editor
 
 ## Getting Started
 
-Webpack configurations and MonacoWebpackPlugin are required to see the editor syntax highlight. Additional configuration information can be found here: [Monaco Editor for React](https://github.com/react-monaco-editor/react-monaco-editor).
+Additional configuration information can be found here: [Monaco Editor for React](https://github.com/suren-atoyan/monaco-react).

--- a/packages/code-editor/package.json
+++ b/packages/code-editor/package.json
@@ -39,9 +39,8 @@
     "@emotion/cache": "^11.10.5",
     "@hitachivantara/uikit-react-core": "^5.5.0",
     "@hitachivantara/uikit-styles": "^5.4.0",
-    "clsx": "^1.2.1",
-    "monaco-editor": "^0.37.1",
-    "react-monaco-editor": "^0.52.0"
+    "@monaco-editor/react": "^4.5.1",
+    "clsx": "^1.2.1"
   },
   "devDependencies": {
     "@types/react": "^18.0.28",

--- a/packages/code-editor/src/components/CodeEditor/CodeEditor.stories.tsx
+++ b/packages/code-editor/src/components/CodeEditor/CodeEditor.stories.tsx
@@ -143,6 +143,11 @@ const defaultValueJson = `{
   }`;
 
 export const Main: StoryObj<HvCodeEditorProps> = {
+  parameters: {
+    eyes: {
+      waitBeforeCapture: 5000,
+    },
+  },
   render: () => {
     const getModalStyle = () => {
       return {
@@ -173,17 +178,12 @@ export const Main: StoryObj<HvCodeEditorProps> = {
     const codeEditor = (height: number) => {
       return (
         <HvCodeEditor
-          options={{
-            dimension: {
-              height,
-              width: 800,
-            },
-          }}
+          height={height}
           editorProps={{
             language: "json",
           }}
           onChange={(input) => {
-            setEditorContent(input);
+            setEditorContent(input || "");
           }}
           value={editorContent}
         />
@@ -220,16 +220,14 @@ export const YamlEditor: StoryObj<HvCodeEditorProps> = {
         story: "Yaml editor.",
       },
     },
+    eyes: {
+      waitBeforeCapture: 5000,
+    },
   },
   render: () => {
     return (
       <HvCodeEditor
-        options={{
-          dimension: {
-            height: 270,
-            width: 800,
-          },
-        }}
+        height={270}
         language="yaml"
         onChange={(input) => console.log(input)}
         value={defaultValueYaml}


### PR DESCRIPTION
- Updated the React package that the `CodeEditor` was using from `react-monaco-editor` to `@monaco-editor/react`:

> react-monaco-editor is a third-party package that provides a React wrapper around Monaco Editor. While it's still actively maintained and used by many developers, it's no longer the recommended package for using Monaco Editor with React.
> 
> The reason for this is that react-monaco-editor hasn't been updated to use the latest version of Monaco Editor (currently version 0.28.2 as of this writing). This means that it's missing some of the latest features and bug fixes available in the latest version.
> 
> @monaco-editor/react, on the other hand, is maintained by the same team that develops Monaco Editor and is updated to use the latest version. It also provides a more intuitive and flexible interface for use with React components.

This gives us syntax highlighting OOB. From our `Code Editor` Storybook stories:

JSON:
![image](https://github.com/lumada-design/hv-uikit-react/assets/7498785/9abb6ed7-e0af-47ca-a6dc-66ea2a5f35c9)

YAML:
![image](https://github.com/lumada-design/hv-uikit-react/assets/7498785/8602e267-e1a8-41b4-9005-f32c0dc22a32)

It also provides validation according to the specified language:
![image](https://github.com/lumada-design/hv-uikit-react/assets/7498785/e2849b61-2b8b-48e2-9da6-26db0cea612a)

And it responds to the theme accordigly:
![code_editor_theme](https://github.com/lumada-design/hv-uikit-react/assets/7498785/81899bc5-26fd-4419-895e-0ab68374b2ee)


