### PR TITLE
chore: refactor Theme Generator

### DIFF
--- a/app/src/components/common/Header/Header.tsx
+++ b/app/src/components/common/Header/Header.tsx
@@ -1,14 +1,13 @@
 import { useContext, MouseEvent } from "react";
 import { useNavigate } from "react-router-dom";
 import { useMediaQuery, useTheme } from "@mui/material";
-import { Alert, Menu } from "@hitachivantara/uikit-react-icons";
+import { Menu } from "@hitachivantara/uikit-react-icons";
 import {
   HvHeader,
   HvHeaderBrand,
   HvHeaderActions,
   HvHeaderNavigation,
   HvButton,
-  HvBadge,
   HvTooltip,
   HvTypography,
 } from "@hitachivantara/uikit-react-core";
@@ -73,13 +72,6 @@ export const Header = () => {
           >
             TUTORIAL
           </HvButton>
-          <HvBadge
-            id="badge7"
-            showCount
-            count={8}
-            icon={<Alert />}
-            style={{ marginRight: 10 }}
-          />
           <HvTooltip
             title={
               <HvTypography>

--- a/app/src/generator/Colors/Colors.tsx
+++ b/app/src/generator/Colors/Colors.tsx
@@ -14,8 +14,7 @@ export const groupsToShow = ["acce", "atmo", "base", "sema"] as const; // "sup",
 
 const Colors = (): JSX.Element => {
   const { activeTheme, selectedMode } = useTheme();
-  const { customTheme, updateCustomTheme, updateChangedValues } =
-    useContext(GeneratorContext);
+  const { customTheme, updateCustomTheme } = useContext(GeneratorContext);
 
   const colors = activeTheme?.colors.modes[selectedMode];
 
@@ -33,11 +32,8 @@ const Colors = (): JSX.Element => {
         },
       },
     });
+
     updateCustomTheme(newTheme);
-    updateChangedValues?.(
-      ["colors", "modes", selectedMode, colorName],
-      colorValue
-    );
   };
 
   const debouncedHandler = debounce(colorChangedHandler, 250);

--- a/app/src/generator/FontFamily/FontFamily.tsx
+++ b/app/src/generator/FontFamily/FontFamily.tsx
@@ -15,8 +15,7 @@ import { css } from "@emotion/css";
 import { extractFontsNames } from "generator/utils";
 
 const FontFamily = () => {
-  const { customTheme, updateCustomTheme, updateChangedValues } =
-    useContext(GeneratorContext);
+  const { customTheme, updateCustomTheme } = useContext(GeneratorContext);
 
   const [fontName, setFontName] = useState("");
   const [fontValues, setFontValues] = useState<HvListValue[]>([
@@ -34,7 +33,6 @@ const FontFamily = () => {
       },
     });
     updateCustomTheme(newTheme);
-    updateChangedValues?.(["fontFamily", "body"], font);
   };
 
   const onAddHandler = () => {
@@ -101,7 +99,7 @@ const FontFamily = () => {
       <HvDropdown
         label="Font Family"
         values={fontValues}
-        onChange={(item) => onDropdownClickHandler(item.label)}
+        onChange={(item) => onDropdownClickHandler((item as HvListValue).label)}
       />
     </div>
   );

--- a/app/src/generator/FontSizes/FontSizes.tsx
+++ b/app/src/generator/FontSizes/FontSizes.tsx
@@ -14,8 +14,7 @@ import { css } from "@emotion/css";
 
 const FontSizes = () => {
   const { activeTheme } = useTheme();
-  const { customTheme, updateCustomTheme, updateChangedValues } =
-    useContext(GeneratorContext);
+  const { customTheme, updateCustomTheme } = useContext(GeneratorContext);
   const [fontSizes, setFontSizes] = useState<HvListValue[]>([]);
   const [fontSize, setFontSize] = useState(""); // base, sm, ...
   const [fontValue, setFontValue] = useState<number>(0); // 14, 16, ...
@@ -64,7 +63,6 @@ const FontSizes = () => {
       },
     });
     updateCustomTheme(newTheme);
-    updateChangedValues?.(["fontSizes", fontSize], `${value}${unit}`);
 
     // update curr sizes
     let map = new Map<string, string>(currSizes);
@@ -81,10 +79,6 @@ const FontSizes = () => {
       },
     });
     updateCustomTheme(newTheme);
-    updateChangedValues?.(
-      ["fontSizes", fontSize],
-      `${fontValue}${selectedUnit}`
-    );
     // update curr sizes
     let map = new Map<string, string>(currSizes);
     map.set(fontSize, `${fontValue}${selectedUnit}`);

--- a/app/src/generator/GeneratorContext.tsx
+++ b/app/src/generator/GeneratorContext.tsx
@@ -6,9 +6,6 @@ type GeneratorContextProp = {
   customTheme: HvTheme | HvThemeStructure;
   updateCustomTheme: (newTheme: any) => void;
 
-  changedValues?: Partial<HvTheme | HvThemeStructure>;
-  updateChangedValues?: (path: any, key: any, reset?: boolean) => void;
-
   open?: boolean;
   setOpen?: Dispatch<SetStateAction<boolean>>;
 
@@ -28,8 +25,6 @@ const GeneratorProvider = ({ children }) => {
   const [open, setOpen] = useState(false);
   const [tutorialOpen, setTutorialOpen] = useState(false);
   const [currentStep, setCurrentStep] = useState(1);
-  const [changedValues, setChangedValues] = useState({});
-
   const [customTheme, setCustomTheme] = useState(
     createTheme({ name: "customTheme", base: "ds5" })
   );
@@ -38,35 +33,11 @@ const GeneratorProvider = ({ children }) => {
     setCustomTheme(newTheme);
   };
 
-  const updateChangedValues = (path, value, reset = false) => {
-    if (reset) {
-      setChangedValues({ name: "customTheme", base: "ds5" });
-    } else {
-      setChangedValues((prevState) => {
-        const newState = { ...prevState };
-        let node = newState;
-        path.forEach((key, index) => {
-          if (!node[key]) {
-            node[key] = {};
-          }
-          if (index === path.length - 1) {
-            node[key] = value;
-          } else {
-            node = node[key];
-          }
-        });
-        return newState;
-      });
-    }
-  };
-
   return (
     <GeneratorContext.Provider
       value={{
         customTheme,
         updateCustomTheme,
-        changedValues,
-        updateChangedValues,
         open,
         setOpen,
         tutorialOpen,

--- a/app/src/generator/Radii/Radii.tsx
+++ b/app/src/generator/Radii/Radii.tsx
@@ -12,8 +12,7 @@ import { GeneratorContext } from "generator/GeneratorContext";
 
 const Radii = () => {
   const { activeTheme } = useTheme();
-  const { customTheme, updateCustomTheme, updateChangedValues } =
-    useContext(GeneratorContext);
+  const { customTheme, updateCustomTheme } = useContext(GeneratorContext);
   const [currValues, setCurrValues] = useState<Map<string, string | number>>(
     new Map<string, string | number>()
   );
@@ -49,7 +48,6 @@ const Radii = () => {
       },
     });
     updateCustomTheme(newTheme);
-    updateChangedValues?.(["radii", radii], radiiValue);
   };
 
   return (

--- a/app/src/generator/Sidebar/Sidebar.styles.tsx
+++ b/app/src/generator/Sidebar/Sidebar.styles.tsx
@@ -51,7 +51,6 @@ export const styles = {
   }),
   codeEditorTools: css({
     display: "flex",
-    gap: theme.space.xs,
     padding: 8,
     border: `1px solid ${theme.colors.atmo4}`,
     borderBottom: "none",

--- a/app/src/generator/Sidebar/Sidebar.tsx
+++ b/app/src/generator/Sidebar/Sidebar.tsx
@@ -22,6 +22,7 @@ import {
   Duplicate,
   Reset,
   Undo,
+  Redo,
 } from "@hitachivantara/uikit-react-icons";
 import { HvCodeEditor } from "@hitachivantara/uikit-react-code-editor";
 import { downloadTheme, themeDiff } from "generator/utils";
@@ -45,7 +46,8 @@ const Sidebar = () => {
     changeTheme,
   } = useTheme();
 
-  const { customTheme, updateCustomTheme, open } = useContext(GeneratorContext);
+  const { customTheme, updateCustomTheme, open, undo, redo, canUndo, canRedo } =
+    useContext(GeneratorContext);
   const [themeName, setThemeName] = useState("customTheme");
   const [fullCode, setFullCode] = useState("");
   const [copied, setCopied] = useState(false);
@@ -54,6 +56,14 @@ const Sidebar = () => {
   const [fontsOpen, setFontsOpen] = useState(false);
   const [typographyOpen, setTypographyOpen] = useState(false);
   const [layoutOpen, setLayoutOpen] = useState(false);
+
+  useEffect(() => {
+    const newTheme = createTheme({
+      name: "customTheme",
+      base: selectedTheme as HvBaseTheme,
+    });
+    updateCustomTheme(newTheme);
+  }, []);
 
   useEffect(() => {
     const temp: any = {};
@@ -86,7 +96,7 @@ export default ${themeName};`
       name: themeName,
       base: selectedTheme as HvBaseTheme,
     });
-    updateCustomTheme(newTheme);
+    updateCustomTheme(newTheme, false);
   }, [themeName, selectedTheme]);
 
   const debouncedNameChangeHandler = debounce(nameChangeHandler, 250);
@@ -106,11 +116,14 @@ export default ${themeName};`
       base: selectedTheme as HvBaseTheme,
     });
     updateCustomTheme(newTheme);
-    updateChangedValues?.([], "", true);
   };
 
   const onUndoHandler = () => {
     undo?.();
+  };
+
+  const onRedoHandler = () => {
+    redo?.();
   };
 
   const handleClose = (event, reason) => {
@@ -175,7 +188,7 @@ export default ${themeName};`
           </HvBox>
           <HvBox css={{ position: "relative" }}>
             <HvBox className={styles.codeEditorTools}>
-              <HvBox css={{ display: "flex", gap: 8, alignItems: "center" }}>
+              <HvBox css={{ display: "flex", alignItems: "center" }}>
                 <HvTypography variant="label">{themeName}.ts</HvTypography>
                 <HvTooltip title={<HvTypography>Download</HvTypography>}>
                   <HvButton
@@ -187,17 +200,40 @@ export default ${themeName};`
                   </HvButton>
                 </HvTooltip>
               </HvBox>
-              <HvBox css={{ display: "flex", gap: 8 }}>
+              <HvBox css={{ display: "flex" }}>
                 <HvBox>
-                  <HvTooltip title={<HvTypography>Undo</HvTypography>}>
-                    <HvButton
-                      variant="secondaryGhost"
-                      icon
-                      onClick={onUndoHandler}
-                    >
+                  {canUndo ? (
+                    <HvTooltip title={<HvTypography>Undo</HvTypography>}>
+                      <HvButton
+                        variant="secondaryGhost"
+                        icon
+                        onClick={onUndoHandler}
+                      >
+                        <Undo />
+                      </HvButton>
+                    </HvTooltip>
+                  ) : (
+                    <HvButton variant="secondaryGhost" icon disabled={!canUndo}>
                       <Undo />
                     </HvButton>
-                  </HvTooltip>
+                  )}
+                </HvBox>
+                <HvBox>
+                  {canRedo ? (
+                    <HvTooltip title={<HvTypography>Redo</HvTypography>}>
+                      <HvButton
+                        variant="secondaryGhost"
+                        icon
+                        onClick={onRedoHandler}
+                      >
+                        <Redo />
+                      </HvButton>
+                    </HvTooltip>
+                  ) : (
+                    <HvButton variant="secondaryGhost" icon disabled={!canRedo}>
+                      <Redo />
+                    </HvButton>
+                  )}
                 </HvBox>
                 <HvBox>
                   <HvTooltip title={<HvTypography>Reset</HvTypography>}>

--- a/app/src/generator/Sizes/Sizes.tsx
+++ b/app/src/generator/Sizes/Sizes.tsx
@@ -12,8 +12,7 @@ import { GeneratorContext } from "generator/GeneratorContext";
 
 const Sizes = () => {
   const { activeTheme } = useTheme();
-  const { customTheme, updateCustomTheme, updateChangedValues } =
-    useContext(GeneratorContext);
+  const { customTheme, updateCustomTheme } = useContext(GeneratorContext);
   const [currValues, setCurrValues] = useState<Map<string, string>>(
     new Map<string, string>()
   );
@@ -49,7 +48,6 @@ const Sizes = () => {
       },
     });
     updateCustomTheme(newTheme);
-    updateChangedValues?.(["sizes", size], sizeValue);
   };
 
   return (

--- a/app/src/generator/Spacing/Spacing.tsx
+++ b/app/src/generator/Spacing/Spacing.tsx
@@ -12,8 +12,7 @@ import { GeneratorContext } from "generator/GeneratorContext";
 
 const Spacing = () => {
   const { activeTheme } = useTheme();
-  const { customTheme, updateCustomTheme, updateChangedValues } =
-    useContext(GeneratorContext);
+  const { customTheme, updateCustomTheme } = useContext(GeneratorContext);
   const [currValues, setCurrValues] = useState<Map<string, string | number>>(
     new Map<string, string | number>()
   );
@@ -53,7 +52,6 @@ const Spacing = () => {
       },
     });
     updateCustomTheme(newTheme);
-    updateChangedValues?.(["space", spacing], spacingValue);
   };
 
   return (

--- a/app/src/generator/Typography/Typography.tsx
+++ b/app/src/generator/Typography/Typography.tsx
@@ -28,8 +28,7 @@ const typographyToShow = [
 ];
 
 const Typography = () => {
-  const { customTheme, updateCustomTheme, updateChangedValues } =
-    useContext(GeneratorContext);
+  const { customTheme, updateCustomTheme } = useContext(GeneratorContext);
   const [updatedHeights, setUpdatedHeights] = useState<Map<string, string>>(
     new Map<string, string>()
   );
@@ -75,10 +74,6 @@ const Typography = () => {
       },
     });
     updateCustomTheme(newTheme);
-    updateChangedValues?.(
-      ["typography", typographyName, "fontSize"],
-      sizeValue
-    );
   };
 
   const getLineHeights = (typographyName: string) => {
@@ -156,10 +151,6 @@ const Typography = () => {
       },
     });
     updateCustomTheme(newTheme);
-    updateChangedValues?.(
-      ["typography", typographyName, "lineHeight"],
-      getVarValue(customTheme?.lineHeights[lineHeight])
-    );
 
     let map = new Map<string, string>(updatedHeights);
     map.set(typographyName, lineHeight);
@@ -178,10 +169,6 @@ const Typography = () => {
       },
     });
     updateCustomTheme(newTheme);
-    updateChangedValues?.(
-      ["typography", typographyName, "fontWeight"],
-      getVarValue(customTheme?.fontWeights[fontWeight])
-    );
 
     let map = new Map<string, string>(updatedWeights);
     map.set(typographyName, fontWeight);
@@ -200,7 +187,6 @@ const Typography = () => {
       },
     });
     updateCustomTheme(newTheme);
-    updateChangedValues?.(["typography", typographyName, "color"], colorValue);
   };
 
   const debouncedHandler = debounce(colorChangedHandler, 250);

--- a/app/src/generator/Zindices/Zindices.tsx
+++ b/app/src/generator/Zindices/Zindices.tsx
@@ -12,8 +12,7 @@ import { GeneratorContext } from "generator/GeneratorContext";
 
 const Zindices = () => {
   const { activeTheme } = useTheme();
-  const { customTheme, updateCustomTheme, updateChangedValues } =
-    useContext(GeneratorContext);
+  const { customTheme, updateCustomTheme } = useContext(GeneratorContext);
   const [currValues, setCurrValues] = useState<Map<string, number>>(
     new Map<string, number>()
   );
@@ -49,7 +48,6 @@ const Zindices = () => {
       },
     });
     updateCustomTheme(newTheme);
-    updateChangedValues?.(["zIndices", zIndex], zIndexValue);
   };
 
   return (

--- a/app/src/generator/utils.ts
+++ b/app/src/generator/utils.ts
@@ -33,3 +33,42 @@ export const extractFontsNames = (webfontLink: string): string[] => {
 
   return fontNames;
 };
+
+export const themeDiff = (a: object, b: object, rootLevel = true): object => {
+  const diff = {};
+  for (const key in b) {
+    if (rootLevel && (key === "name" || key === "base")) {
+      continue; // ignore 'name' and 'base' at the root level
+    }
+    if (
+      typeof b[key] === "object" &&
+      b[key] !== null &&
+      typeof a[key] === "object" &&
+      a[key] !== null
+    ) {
+      const nestedDiff = themeDiff(a[key], b[key], false);
+      if (Object.keys(nestedDiff).length > 0) {
+        diff[key] = nestedDiff;
+      }
+    } else if (!a.hasOwnProperty(key) || a[key] !== b[key]) {
+      diff[key] = b[key];
+    }
+  }
+  return diff;
+};
+
+export const downloadTheme = (filename, text) => {
+  const element = document.createElement("a");
+  element.setAttribute(
+    "href",
+    "data:text/plain;charset=utf-8," + encodeURIComponent(text)
+  );
+  element.setAttribute("download", filename);
+
+  element.style.display = "none";
+  document.body.appendChild(element);
+
+  element.click();
+
+  document.body.removeChild(element);
+};


### PR DESCRIPTION
- removed the unnecessary `changedValues` logic. It was only used to keep track of the changes made to the theme and show those on the Code Editor but was very prone to mistakes. Now the actual changed theme is used to display those changes;
- removed the badge icon on Header as it's totally irrelevant there and `Badge` component is already on the components list;
- added Undo / Redo logic to the Code Editor as it might be useful whenever someone is updating the theme and making several changes;