### PR TITLE
chore: clsx replaced by cx and classes order updated

### DIFF
--- a/packages/core/src/components/Banner/BannerContent/BannerContent.tsx
+++ b/packages/core/src/components/Banner/BannerContent/BannerContent.tsx
@@ -106,10 +106,10 @@ export const HvBannerContent = forwardRef<HTMLDivElement, HvBannerContentProps>(
               }}
               className={cx(
                 bannerContentClasses.baseVariant,
-                css(styles.baseVariant),
-                classes?.baseVariant,
                 bannerContentClasses[variant],
+                css(styles.baseVariant),
                 css(styles[variant]),
+                classes?.baseVariant,
                 classes?.[variant]
               )}
               message={

--- a/packages/core/src/components/Card/Card.tsx
+++ b/packages/core/src/components/Card/Card.tsx
@@ -1,4 +1,3 @@
-import { clsx } from "clsx";
 import { ClassNames } from "@emotion/react";
 import { theme } from "@hitachivantara/uikit-styles";
 import { HvBox } from "@core/components";
@@ -51,44 +50,39 @@ export const HvCard = ({
 }: HvCardProps) => {
   return (
     <ClassNames>
-      {({ css }) => (
+      {({ css, cx }) => (
         <HvBox
           aria-selected={selectable ? selected : undefined}
-          className={clsx(
+          className={cx(
+            "HvIsCardGridElement",
+            cardClasses.root,
+            selectable && cardClasses.selectable,
+            selected && cardClasses.selected,
             css(styles.root),
             css({
               backgroundColor:
                 (bgcolor && theme.colors[bgcolor]) ||
                 theme.card.backgroundColor,
             }),
-            "HvIsCardGridElement",
-            cardClasses.root,
-            classes?.root,
+            selectable && css(styles.selectable),
+            selected && css(styles.selected),
             className,
-            selectable &&
-              clsx(
-                css(styles.selectable),
-                cardClasses.selectable,
-                classes?.selectable
-              ),
-            selected &&
-              clsx(
-                css(styles.selected),
-                cardClasses.selected,
-                classes?.selected
-              )
+            classes?.root,
+            selectable && css(styles.selectable),
+            selected && css(styles.selected)
           )}
           {...others}
         >
           <div
-            className={clsx(
-              css(styles.semanticContainer),
+            className={cx(
               cardClasses.semanticContainer,
+              css(styles.semanticContainer),
               classes?.semanticContainer
             )}
           >
             <div
-              className={clsx(
+              className={cx(
+                cardClasses.semanticBar,
                 css(styles.semanticBar),
                 css({
                   height: selected ? 4 : 2,
@@ -99,16 +93,11 @@ export const HvCard = ({
                         : theme.colors.atmo4
                       : theme.colors[statusColor],
                 }),
-                cardClasses.semanticBar,
                 classes?.semanticBar
               )}
             />
             <div
-              className={clsx(
-                css(styles.icon),
-                cardClasses.icon,
-                classes?.icon
-              )}
+              className={cx(cardClasses.icon, css(styles.icon), classes?.icon)}
             >
               {icon}
             </div>

--- a/packages/core/src/components/Card/Content/Content.tsx
+++ b/packages/core/src/components/Card/Content/Content.tsx
@@ -1,4 +1,3 @@
-import { clsx } from "clsx";
 import { HvBaseProps } from "@core/types";
 import { styles } from "./Content.styles";
 import MuiCardContent, {
@@ -28,14 +27,14 @@ export const HvCardContent = ({
 }: HvCardContentProps) => {
   return (
     <ClassNames>
-      {({ css }) => (
+      {({ css, cx }) => (
         <MuiCardContent
           id={id}
-          className={clsx(
-            css(styles.content),
-            classes?.content,
+          className={cx(
             cardContentClasses.content,
-            className
+            css(styles.content),
+            className,
+            classes?.content
           )}
           onClick={onClick}
           {...others}

--- a/packages/core/src/components/Card/Header/Header.tsx
+++ b/packages/core/src/components/Card/Header/Header.tsx
@@ -1,4 +1,3 @@
-import { clsx } from "clsx";
 import MuiCardHeader, {
   CardHeaderProps as MuiCardHeaderProps,
 } from "@mui/material/CardHeader";
@@ -36,51 +35,51 @@ export const HvCardHeader = ({
 
   return (
     <ClassNames>
-      {({ css }) => (
+      {({ css, cx }) => (
         <MuiCardHeader
           title={title}
           subheader={subheader}
           action={icon}
           onClick={onClick}
-          className={clsx(
-            css(styles.root),
-            classes?.root,
+          className={cx(
             cardHeaderClasses.root,
-            className
+            css(styles.root),
+            className,
+            classes?.root
           )}
           classes={{
             title: icon
-              ? clsx(
-                  css(styles.titleShort),
+              ? cx(
                   cardHeaderClasses.titleShort,
-                  classes?.titleShort,
+                  css(styles.titleShort),
                   css({
                     ...activeTheme?.typography[activeTheme?.card.titleVariant],
-                  })
+                  }),
+                  classes?.titleShort
                 )
-              : clsx(
-                  css(styles.title),
+              : cx(
                   cardHeaderClasses.title,
-                  classes?.title,
+                  css(styles.title),
                   css({
                     ...activeTheme?.typography[activeTheme?.card.titleVariant],
-                  })
+                  }),
+                  classes?.title
                 ),
-            subheader: clsx(
-              css(styles.subheader),
+            subheader: cx(
               cardHeaderClasses.subheader,
-              classes?.subheader,
+              css(styles.subheader),
               css({
                 ...activeTheme?.typography[activeTheme?.card.subheaderVariant],
                 color: activeTheme?.card.subheaderColor,
-              })
+              }),
+              classes?.subheader
             ),
-            action: clsx(
-              css(styles.action),
+            action: cx(
               cardHeaderClasses.action,
+              css(styles.action),
               classes?.action
             ),
-            content: clsx(cardHeaderClasses.content, classes?.content),
+            content: cx(cardHeaderClasses.content, classes?.content),
           }}
           {...others}
         />

--- a/packages/core/src/components/Card/Media/Media.tsx
+++ b/packages/core/src/components/Card/Media/Media.tsx
@@ -4,7 +4,6 @@ import MuiCardMedia, {
 import { styles } from "./Media.styles";
 import { HvBaseProps } from "@core/types";
 import cardMediaClasses, { HvCardMediaClasses } from "./mediaClasses";
-import { clsx } from "clsx";
 import { ImgHTMLAttributes } from "react";
 import { ClassNames } from "@emotion/react";
 
@@ -37,12 +36,12 @@ export const HvCardMedia = ({
 }: HvCardMediaProps) => {
   return (
     <ClassNames>
-      {({ css }) => (
+      {({ css, cx }) => (
         <MuiCardMedia
           id={id}
           classes={{
-            root: clsx(css(styles.root), cardMediaClasses.root, classes?.root),
-            media: clsx(cardMediaClasses.media, classes?.media),
+            root: cx(cardMediaClasses.root, css(styles.root), classes?.root),
+            media: cx(cardMediaClasses.media, classes?.media),
           }}
           className={className}
           role="img"

--- a/packages/core/src/components/Card/__snapshots__/Card.test.tsx.snap
+++ b/packages/core/src/components/Card/__snapshots__/Card.test.tsx.snap
@@ -3,31 +3,31 @@
 exports[`Card > should render all the compoents 1`] = `
 <div>
   <div
-    class="css-kdjrpy css-1ox5ug HvIsCardGridElement HvCard-root"
+    class="HvIsCardGridElement HvCard-root css-1wtktsk"
   >
     <div
-      class="css-emolmc HvCard-semanticContainer"
+      class="HvCard-semanticContainer css-emolmc"
     >
       <div
-        class="css-1v84tfs css-1hhae7u HvCard-semanticBar"
+        class="HvCard-semanticBar css-12y48s9"
       />
       <div
-        class="css-pzj2c4 HvCard-icon"
+        class="HvCard-icon css-pzj2c4"
       />
     </div>
     <div
-      class="MuiCardHeader-root css-pqwkee HvCard-Header-root css-185gdzj-MuiCardHeader-root"
+      class="MuiCardHeader-root HvCard-Header-root css-pqwkee css-185gdzj-MuiCardHeader-root"
     >
       <div
         class="MuiCardHeader-content HvCard-Header-content css-1qbkelo-MuiCardHeader-content"
       >
         <span
-          class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title css-1weuf4q HvCard-Header-title css-0 css-1qvr50w-MuiTypography-root"
+          class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title HvCard-Header-title css-yragcd css-1qvr50w-MuiTypography-root"
         >
           mockTitle
         </span>
         <span
-          class="MuiTypography-root MuiTypography-body1 MuiCardHeader-subheader css-1weuf4q HvCard-Header-subheader css-0 css-nrdprl-MuiTypography-root"
+          class="MuiTypography-root MuiTypography-body1 MuiCardHeader-subheader HvCard-Header-subheader css-yragcd css-nrdprl-MuiTypography-root"
         >
           mockSubtitle
         </span>
@@ -35,11 +35,11 @@ exports[`Card > should render all the compoents 1`] = `
     </div>
     <img
       alt="mockImg"
-      class="MuiCardMedia-root css-8atqhb HvCard-Media-root MuiCardMedia-media HvCard-Media-media MuiCardMedia-img css-o69gx8-MuiCardMedia-root"
+      class="MuiCardMedia-root HvCard-Media-root css-8atqhb MuiCardMedia-media HvCard-Media-media MuiCardMedia-img css-o69gx8-MuiCardMedia-root"
       role="img"
     />
     <div
-      class="MuiCardContent-root css-1ly90im HvCard-Content-content css-46bh2p-MuiCardContent-root"
+      class="MuiCardContent-root HvCard-Content-content css-1ly90im css-46bh2p-MuiCardContent-root"
     >
       <label
         class="HvTypography-root HvTypography-label css-9vbp9s-getStyledComponent e1tnpalo0"
@@ -54,20 +54,20 @@ exports[`Card > should render all the compoents 1`] = `
 exports[`Card > should render content 1`] = `
 <div>
   <div
-    class="css-kdjrpy css-1ox5ug HvIsCardGridElement HvCard-root"
+    class="HvIsCardGridElement HvCard-root css-1wtktsk"
   >
     <div
-      class="css-emolmc HvCard-semanticContainer"
+      class="HvCard-semanticContainer css-emolmc"
     >
       <div
-        class="css-1v84tfs css-1hhae7u HvCard-semanticBar"
+        class="HvCard-semanticBar css-12y48s9"
       />
       <div
-        class="css-pzj2c4 HvCard-icon"
+        class="HvCard-icon css-pzj2c4"
       />
     </div>
     <div
-      class="MuiCardContent-root css-1ly90im HvCard-Content-content css-46bh2p-MuiCardContent-root"
+      class="MuiCardContent-root HvCard-Content-content css-1ly90im css-46bh2p-MuiCardContent-root"
     >
       <label
         class="HvTypography-root HvTypography-label css-9vbp9s-getStyledComponent e1tnpalo0"
@@ -82,16 +82,16 @@ exports[`Card > should render content 1`] = `
 exports[`Card > should render correctly 1`] = `
 <div>
   <div
-    class="css-kdjrpy css-1ox5ug HvIsCardGridElement HvCard-root"
+    class="HvIsCardGridElement HvCard-root css-1wtktsk"
   >
     <div
-      class="css-emolmc HvCard-semanticContainer"
+      class="HvCard-semanticContainer css-emolmc"
     >
       <div
-        class="css-1v84tfs css-1hhae7u HvCard-semanticBar"
+        class="HvCard-semanticBar css-12y48s9"
       />
       <div
-        class="css-pzj2c4 HvCard-icon"
+        class="HvCard-icon css-pzj2c4"
       />
     </div>
   </div>
@@ -101,31 +101,31 @@ exports[`Card > should render correctly 1`] = `
 exports[`Card > should render header 1`] = `
 <div>
   <div
-    class="css-kdjrpy css-1ox5ug HvIsCardGridElement HvCard-root"
+    class="HvIsCardGridElement HvCard-root css-1wtktsk"
   >
     <div
-      class="css-emolmc HvCard-semanticContainer"
+      class="HvCard-semanticContainer css-emolmc"
     >
       <div
-        class="css-1v84tfs css-1hhae7u HvCard-semanticBar"
+        class="HvCard-semanticBar css-12y48s9"
       />
       <div
-        class="css-pzj2c4 HvCard-icon"
+        class="HvCard-icon css-pzj2c4"
       />
     </div>
     <div
-      class="MuiCardHeader-root css-pqwkee HvCard-Header-root css-185gdzj-MuiCardHeader-root"
+      class="MuiCardHeader-root HvCard-Header-root css-pqwkee css-185gdzj-MuiCardHeader-root"
     >
       <div
         class="MuiCardHeader-content HvCard-Header-content css-1qbkelo-MuiCardHeader-content"
       >
         <span
-          class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title css-1weuf4q HvCard-Header-title css-0 css-1qvr50w-MuiTypography-root"
+          class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title HvCard-Header-title css-yragcd css-1qvr50w-MuiTypography-root"
         >
           mockTitle
         </span>
         <span
-          class="MuiTypography-root MuiTypography-body1 MuiCardHeader-subheader css-1weuf4q HvCard-Header-subheader css-0 css-nrdprl-MuiTypography-root"
+          class="MuiTypography-root MuiTypography-body1 MuiCardHeader-subheader HvCard-Header-subheader css-yragcd css-nrdprl-MuiTypography-root"
         >
           mockSubtitle
         </span>
@@ -138,21 +138,21 @@ exports[`Card > should render header 1`] = `
 exports[`Card > should render image 1`] = `
 <div>
   <div
-    class="css-kdjrpy css-1ox5ug HvIsCardGridElement HvCard-root"
+    class="HvIsCardGridElement HvCard-root css-1wtktsk"
   >
     <div
-      class="css-emolmc HvCard-semanticContainer"
+      class="HvCard-semanticContainer css-emolmc"
     >
       <div
-        class="css-1v84tfs css-1hhae7u HvCard-semanticBar"
+        class="HvCard-semanticBar css-12y48s9"
       />
       <div
-        class="css-pzj2c4 HvCard-icon"
+        class="HvCard-icon css-pzj2c4"
       />
     </div>
     <img
       alt="mockImg"
-      class="MuiCardMedia-root css-8atqhb HvCard-Media-root MuiCardMedia-media HvCard-Media-media MuiCardMedia-img css-o69gx8-MuiCardMedia-root"
+      class="MuiCardMedia-root HvCard-Media-root css-8atqhb MuiCardMedia-media HvCard-Media-media MuiCardMedia-img css-o69gx8-MuiCardMedia-root"
       role="img"
     />
   </div>

--- a/packages/core/src/components/Controls/__snapshots__/Controls.test.tsx.snap
+++ b/packages/core/src/components/Controls/__snapshots__/Controls.test.tsx.snap
@@ -210,400 +210,400 @@ exports[`<HvControls> > sample snapshot testing > Controls 1`] = `
       spacing="sm"
     >
       <div
-        class="css-kdjrpy css-jvotyo HvIsCardGridElement HvCard-root"
+        class="HvIsCardGridElement HvCard-root css-9vqflq"
         style="width: 100%;"
       >
         <div
-          class="css-emolmc HvCard-semanticContainer"
+          class="HvCard-semanticContainer css-emolmc"
         >
           <div
-            class="css-1v84tfs css-1hhae7u HvCard-semanticBar"
+            class="HvCard-semanticBar css-12y48s9"
           />
           <div
-            class="css-pzj2c4 HvCard-icon"
+            class="HvCard-icon css-pzj2c4"
           />
         </div>
         <div
-          class="MuiCardHeader-root css-pqwkee HvCard-Header-root css-185gdzj-MuiCardHeader-root"
+          class="MuiCardHeader-root HvCard-Header-root css-pqwkee css-185gdzj-MuiCardHeader-root"
         >
           <div
             class="MuiCardHeader-content HvCard-Header-content css-1qbkelo-MuiCardHeader-content"
           >
             <span
-              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title css-1weuf4q HvCard-Header-title css-0 css-1qvr50w-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title HvCard-Header-title css-yragcd css-1qvr50w-MuiTypography-root"
             >
               Event 1
             </span>
           </div>
         </div>
         <div
-          class="MuiCardContent-root css-1ly90im HvCard-Content-content css-46bh2p-MuiCardContent-root"
+          class="MuiCardContent-root HvCard-Content-content css-1ly90im css-46bh2p-MuiCardContent-root"
         >
           Event: 
           Anomaly detection 0
         </div>
         <div
-          class="MuiCardContent-root css-1ly90im HvCard-Content-content css-46bh2p-MuiCardContent-root"
+          class="MuiCardContent-root HvCard-Content-content css-1ly90im css-46bh2p-MuiCardContent-root"
         >
           Severity: 
           Critical
         </div>
       </div>
       <div
-        class="css-kdjrpy css-jvotyo HvIsCardGridElement HvCard-root"
+        class="HvIsCardGridElement HvCard-root css-9vqflq"
         style="width: 100%;"
       >
         <div
-          class="css-emolmc HvCard-semanticContainer"
+          class="HvCard-semanticContainer css-emolmc"
         >
           <div
-            class="css-1v84tfs css-1hhae7u HvCard-semanticBar"
+            class="HvCard-semanticBar css-12y48s9"
           />
           <div
-            class="css-pzj2c4 HvCard-icon"
+            class="HvCard-icon css-pzj2c4"
           />
         </div>
         <div
-          class="MuiCardHeader-root css-pqwkee HvCard-Header-root css-185gdzj-MuiCardHeader-root"
+          class="MuiCardHeader-root HvCard-Header-root css-pqwkee css-185gdzj-MuiCardHeader-root"
         >
           <div
             class="MuiCardHeader-content HvCard-Header-content css-1qbkelo-MuiCardHeader-content"
           >
             <span
-              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title css-1weuf4q HvCard-Header-title css-0 css-1qvr50w-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title HvCard-Header-title css-yragcd css-1qvr50w-MuiTypography-root"
             >
               Event 2
             </span>
           </div>
         </div>
         <div
-          class="MuiCardContent-root css-1ly90im HvCard-Content-content css-46bh2p-MuiCardContent-root"
+          class="MuiCardContent-root HvCard-Content-content css-1ly90im css-46bh2p-MuiCardContent-root"
         >
           Event: 
           Anomaly detection 1
         </div>
         <div
-          class="MuiCardContent-root css-1ly90im HvCard-Content-content css-46bh2p-MuiCardContent-root"
+          class="MuiCardContent-root HvCard-Content-content css-1ly90im css-46bh2p-MuiCardContent-root"
         >
           Severity: 
           Major
         </div>
       </div>
       <div
-        class="css-kdjrpy css-jvotyo HvIsCardGridElement HvCard-root"
+        class="HvIsCardGridElement HvCard-root css-9vqflq"
         style="width: 100%;"
       >
         <div
-          class="css-emolmc HvCard-semanticContainer"
+          class="HvCard-semanticContainer css-emolmc"
         >
           <div
-            class="css-1v84tfs css-1hhae7u HvCard-semanticBar"
+            class="HvCard-semanticBar css-12y48s9"
           />
           <div
-            class="css-pzj2c4 HvCard-icon"
+            class="HvCard-icon css-pzj2c4"
           />
         </div>
         <div
-          class="MuiCardHeader-root css-pqwkee HvCard-Header-root css-185gdzj-MuiCardHeader-root"
+          class="MuiCardHeader-root HvCard-Header-root css-pqwkee css-185gdzj-MuiCardHeader-root"
         >
           <div
             class="MuiCardHeader-content HvCard-Header-content css-1qbkelo-MuiCardHeader-content"
           >
             <span
-              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title css-1weuf4q HvCard-Header-title css-0 css-1qvr50w-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title HvCard-Header-title css-yragcd css-1qvr50w-MuiTypography-root"
             >
               Event 3
             </span>
           </div>
         </div>
         <div
-          class="MuiCardContent-root css-1ly90im HvCard-Content-content css-46bh2p-MuiCardContent-root"
+          class="MuiCardContent-root HvCard-Content-content css-1ly90im css-46bh2p-MuiCardContent-root"
         >
           Event: 
           Anomaly detection 2
         </div>
         <div
-          class="MuiCardContent-root css-1ly90im HvCard-Content-content css-46bh2p-MuiCardContent-root"
+          class="MuiCardContent-root HvCard-Content-content css-1ly90im css-46bh2p-MuiCardContent-root"
         >
           Severity: 
           Average
         </div>
       </div>
       <div
-        class="css-kdjrpy css-jvotyo HvIsCardGridElement HvCard-root"
+        class="HvIsCardGridElement HvCard-root css-9vqflq"
         style="width: 100%;"
       >
         <div
-          class="css-emolmc HvCard-semanticContainer"
+          class="HvCard-semanticContainer css-emolmc"
         >
           <div
-            class="css-1v84tfs css-1hhae7u HvCard-semanticBar"
+            class="HvCard-semanticBar css-12y48s9"
           />
           <div
-            class="css-pzj2c4 HvCard-icon"
+            class="HvCard-icon css-pzj2c4"
           />
         </div>
         <div
-          class="MuiCardHeader-root css-pqwkee HvCard-Header-root css-185gdzj-MuiCardHeader-root"
+          class="MuiCardHeader-root HvCard-Header-root css-pqwkee css-185gdzj-MuiCardHeader-root"
         >
           <div
             class="MuiCardHeader-content HvCard-Header-content css-1qbkelo-MuiCardHeader-content"
           >
             <span
-              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title css-1weuf4q HvCard-Header-title css-0 css-1qvr50w-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title HvCard-Header-title css-yragcd css-1qvr50w-MuiTypography-root"
             >
               Event 4
             </span>
           </div>
         </div>
         <div
-          class="MuiCardContent-root css-1ly90im HvCard-Content-content css-46bh2p-MuiCardContent-root"
+          class="MuiCardContent-root HvCard-Content-content css-1ly90im css-46bh2p-MuiCardContent-root"
         >
           Event: 
           Anomaly detection 3
         </div>
         <div
-          class="MuiCardContent-root css-1ly90im HvCard-Content-content css-46bh2p-MuiCardContent-root"
+          class="MuiCardContent-root HvCard-Content-content css-1ly90im css-46bh2p-MuiCardContent-root"
         >
           Severity: 
           Minor
         </div>
       </div>
       <div
-        class="css-kdjrpy css-jvotyo HvIsCardGridElement HvCard-root"
+        class="HvIsCardGridElement HvCard-root css-9vqflq"
         style="width: 100%;"
       >
         <div
-          class="css-emolmc HvCard-semanticContainer"
+          class="HvCard-semanticContainer css-emolmc"
         >
           <div
-            class="css-1v84tfs css-1hhae7u HvCard-semanticBar"
+            class="HvCard-semanticBar css-12y48s9"
           />
           <div
-            class="css-pzj2c4 HvCard-icon"
+            class="HvCard-icon css-pzj2c4"
           />
         </div>
         <div
-          class="MuiCardHeader-root css-pqwkee HvCard-Header-root css-185gdzj-MuiCardHeader-root"
+          class="MuiCardHeader-root HvCard-Header-root css-pqwkee css-185gdzj-MuiCardHeader-root"
         >
           <div
             class="MuiCardHeader-content HvCard-Header-content css-1qbkelo-MuiCardHeader-content"
           >
             <span
-              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title css-1weuf4q HvCard-Header-title css-0 css-1qvr50w-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title HvCard-Header-title css-yragcd css-1qvr50w-MuiTypography-root"
             >
               Event 5
             </span>
           </div>
         </div>
         <div
-          class="MuiCardContent-root css-1ly90im HvCard-Content-content css-46bh2p-MuiCardContent-root"
+          class="MuiCardContent-root HvCard-Content-content css-1ly90im css-46bh2p-MuiCardContent-root"
         >
           Event: 
           Anomaly detection 0
         </div>
         <div
-          class="MuiCardContent-root css-1ly90im HvCard-Content-content css-46bh2p-MuiCardContent-root"
+          class="MuiCardContent-root HvCard-Content-content css-1ly90im css-46bh2p-MuiCardContent-root"
         >
           Severity: 
           Critical
         </div>
       </div>
       <div
-        class="css-kdjrpy css-jvotyo HvIsCardGridElement HvCard-root"
+        class="HvIsCardGridElement HvCard-root css-9vqflq"
         style="width: 100%;"
       >
         <div
-          class="css-emolmc HvCard-semanticContainer"
+          class="HvCard-semanticContainer css-emolmc"
         >
           <div
-            class="css-1v84tfs css-1hhae7u HvCard-semanticBar"
+            class="HvCard-semanticBar css-12y48s9"
           />
           <div
-            class="css-pzj2c4 HvCard-icon"
+            class="HvCard-icon css-pzj2c4"
           />
         </div>
         <div
-          class="MuiCardHeader-root css-pqwkee HvCard-Header-root css-185gdzj-MuiCardHeader-root"
+          class="MuiCardHeader-root HvCard-Header-root css-pqwkee css-185gdzj-MuiCardHeader-root"
         >
           <div
             class="MuiCardHeader-content HvCard-Header-content css-1qbkelo-MuiCardHeader-content"
           >
             <span
-              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title css-1weuf4q HvCard-Header-title css-0 css-1qvr50w-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title HvCard-Header-title css-yragcd css-1qvr50w-MuiTypography-root"
             >
               Event 6
             </span>
           </div>
         </div>
         <div
-          class="MuiCardContent-root css-1ly90im HvCard-Content-content css-46bh2p-MuiCardContent-root"
+          class="MuiCardContent-root HvCard-Content-content css-1ly90im css-46bh2p-MuiCardContent-root"
         >
           Event: 
           Anomaly detection 1
         </div>
         <div
-          class="MuiCardContent-root css-1ly90im HvCard-Content-content css-46bh2p-MuiCardContent-root"
+          class="MuiCardContent-root HvCard-Content-content css-1ly90im css-46bh2p-MuiCardContent-root"
         >
           Severity: 
           Major
         </div>
       </div>
       <div
-        class="css-kdjrpy css-jvotyo HvIsCardGridElement HvCard-root"
+        class="HvIsCardGridElement HvCard-root css-9vqflq"
         style="width: 100%;"
       >
         <div
-          class="css-emolmc HvCard-semanticContainer"
+          class="HvCard-semanticContainer css-emolmc"
         >
           <div
-            class="css-1v84tfs css-1hhae7u HvCard-semanticBar"
+            class="HvCard-semanticBar css-12y48s9"
           />
           <div
-            class="css-pzj2c4 HvCard-icon"
+            class="HvCard-icon css-pzj2c4"
           />
         </div>
         <div
-          class="MuiCardHeader-root css-pqwkee HvCard-Header-root css-185gdzj-MuiCardHeader-root"
+          class="MuiCardHeader-root HvCard-Header-root css-pqwkee css-185gdzj-MuiCardHeader-root"
         >
           <div
             class="MuiCardHeader-content HvCard-Header-content css-1qbkelo-MuiCardHeader-content"
           >
             <span
-              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title css-1weuf4q HvCard-Header-title css-0 css-1qvr50w-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title HvCard-Header-title css-yragcd css-1qvr50w-MuiTypography-root"
             >
               Event 7
             </span>
           </div>
         </div>
         <div
-          class="MuiCardContent-root css-1ly90im HvCard-Content-content css-46bh2p-MuiCardContent-root"
+          class="MuiCardContent-root HvCard-Content-content css-1ly90im css-46bh2p-MuiCardContent-root"
         >
           Event: 
           Anomaly detection 2
         </div>
         <div
-          class="MuiCardContent-root css-1ly90im HvCard-Content-content css-46bh2p-MuiCardContent-root"
+          class="MuiCardContent-root HvCard-Content-content css-1ly90im css-46bh2p-MuiCardContent-root"
         >
           Severity: 
           Average
         </div>
       </div>
       <div
-        class="css-kdjrpy css-jvotyo HvIsCardGridElement HvCard-root"
+        class="HvIsCardGridElement HvCard-root css-9vqflq"
         style="width: 100%;"
       >
         <div
-          class="css-emolmc HvCard-semanticContainer"
+          class="HvCard-semanticContainer css-emolmc"
         >
           <div
-            class="css-1v84tfs css-1hhae7u HvCard-semanticBar"
+            class="HvCard-semanticBar css-12y48s9"
           />
           <div
-            class="css-pzj2c4 HvCard-icon"
+            class="HvCard-icon css-pzj2c4"
           />
         </div>
         <div
-          class="MuiCardHeader-root css-pqwkee HvCard-Header-root css-185gdzj-MuiCardHeader-root"
+          class="MuiCardHeader-root HvCard-Header-root css-pqwkee css-185gdzj-MuiCardHeader-root"
         >
           <div
             class="MuiCardHeader-content HvCard-Header-content css-1qbkelo-MuiCardHeader-content"
           >
             <span
-              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title css-1weuf4q HvCard-Header-title css-0 css-1qvr50w-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title HvCard-Header-title css-yragcd css-1qvr50w-MuiTypography-root"
             >
               Event 8
             </span>
           </div>
         </div>
         <div
-          class="MuiCardContent-root css-1ly90im HvCard-Content-content css-46bh2p-MuiCardContent-root"
+          class="MuiCardContent-root HvCard-Content-content css-1ly90im css-46bh2p-MuiCardContent-root"
         >
           Event: 
           Anomaly detection 3
         </div>
         <div
-          class="MuiCardContent-root css-1ly90im HvCard-Content-content css-46bh2p-MuiCardContent-root"
+          class="MuiCardContent-root HvCard-Content-content css-1ly90im css-46bh2p-MuiCardContent-root"
         >
           Severity: 
           Minor
         </div>
       </div>
       <div
-        class="css-kdjrpy css-jvotyo HvIsCardGridElement HvCard-root"
+        class="HvIsCardGridElement HvCard-root css-9vqflq"
         style="width: 100%;"
       >
         <div
-          class="css-emolmc HvCard-semanticContainer"
+          class="HvCard-semanticContainer css-emolmc"
         >
           <div
-            class="css-1v84tfs css-1hhae7u HvCard-semanticBar"
+            class="HvCard-semanticBar css-12y48s9"
           />
           <div
-            class="css-pzj2c4 HvCard-icon"
+            class="HvCard-icon css-pzj2c4"
           />
         </div>
         <div
-          class="MuiCardHeader-root css-pqwkee HvCard-Header-root css-185gdzj-MuiCardHeader-root"
+          class="MuiCardHeader-root HvCard-Header-root css-pqwkee css-185gdzj-MuiCardHeader-root"
         >
           <div
             class="MuiCardHeader-content HvCard-Header-content css-1qbkelo-MuiCardHeader-content"
           >
             <span
-              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title css-1weuf4q HvCard-Header-title css-0 css-1qvr50w-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title HvCard-Header-title css-yragcd css-1qvr50w-MuiTypography-root"
             >
               Event 9
             </span>
           </div>
         </div>
         <div
-          class="MuiCardContent-root css-1ly90im HvCard-Content-content css-46bh2p-MuiCardContent-root"
+          class="MuiCardContent-root HvCard-Content-content css-1ly90im css-46bh2p-MuiCardContent-root"
         >
           Event: 
           Anomaly detection 0
         </div>
         <div
-          class="MuiCardContent-root css-1ly90im HvCard-Content-content css-46bh2p-MuiCardContent-root"
+          class="MuiCardContent-root HvCard-Content-content css-1ly90im css-46bh2p-MuiCardContent-root"
         >
           Severity: 
           Critical
         </div>
       </div>
       <div
-        class="css-kdjrpy css-jvotyo HvIsCardGridElement HvCard-root"
+        class="HvIsCardGridElement HvCard-root css-9vqflq"
         style="width: 100%;"
       >
         <div
-          class="css-emolmc HvCard-semanticContainer"
+          class="HvCard-semanticContainer css-emolmc"
         >
           <div
-            class="css-1v84tfs css-1hhae7u HvCard-semanticBar"
+            class="HvCard-semanticBar css-12y48s9"
           />
           <div
-            class="css-pzj2c4 HvCard-icon"
+            class="HvCard-icon css-pzj2c4"
           />
         </div>
         <div
-          class="MuiCardHeader-root css-pqwkee HvCard-Header-root css-185gdzj-MuiCardHeader-root"
+          class="MuiCardHeader-root HvCard-Header-root css-pqwkee css-185gdzj-MuiCardHeader-root"
         >
           <div
             class="MuiCardHeader-content HvCard-Header-content css-1qbkelo-MuiCardHeader-content"
           >
             <span
-              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title css-1weuf4q HvCard-Header-title css-0 css-1qvr50w-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title HvCard-Header-title css-yragcd css-1qvr50w-MuiTypography-root"
             >
               Event 10
             </span>
           </div>
         </div>
         <div
-          class="MuiCardContent-root css-1ly90im HvCard-Content-content css-46bh2p-MuiCardContent-root"
+          class="MuiCardContent-root HvCard-Content-content css-1ly90im css-46bh2p-MuiCardContent-root"
         >
           Event: 
           Anomaly detection 1
         </div>
         <div
-          class="MuiCardContent-root css-1ly90im HvCard-Content-content css-46bh2p-MuiCardContent-root"
+          class="MuiCardContent-root HvCard-Content-content css-1ly90im css-46bh2p-MuiCardContent-root"
         >
           Severity: 
           Major
@@ -823,340 +823,340 @@ exports[`<HvControls> > sample snapshot testing > Controls Controlled 1`] = `
       spacing="sm"
     >
       <div
-        class="css-kdjrpy css-jvotyo HvIsCardGridElement HvCard-root"
+        class="HvIsCardGridElement HvCard-root css-9vqflq"
         style="width: 100%;"
       >
         <div
-          class="css-emolmc HvCard-semanticContainer"
+          class="HvCard-semanticContainer css-emolmc"
         >
           <div
-            class="css-1v84tfs css-1hhae7u HvCard-semanticBar"
+            class="HvCard-semanticBar css-12y48s9"
           />
           <div
-            class="css-pzj2c4 HvCard-icon"
+            class="HvCard-icon css-pzj2c4"
           />
         </div>
         <div
-          class="MuiCardHeader-root css-pqwkee HvCard-Header-root css-185gdzj-MuiCardHeader-root"
+          class="MuiCardHeader-root HvCard-Header-root css-pqwkee css-185gdzj-MuiCardHeader-root"
         >
           <div
             class="MuiCardHeader-content HvCard-Header-content css-1qbkelo-MuiCardHeader-content"
           >
             <span
-              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title css-1weuf4q HvCard-Header-title css-0 css-1qvr50w-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title HvCard-Header-title css-yragcd css-1qvr50w-MuiTypography-root"
             >
               Event 1
             </span>
           </div>
         </div>
         <div
-          class="MuiCardContent-root css-1ly90im HvCard-Content-content css-46bh2p-MuiCardContent-root"
+          class="MuiCardContent-root HvCard-Content-content css-1ly90im css-46bh2p-MuiCardContent-root"
         >
           Severity: 
           Critical
         </div>
       </div>
       <div
-        class="css-kdjrpy css-jvotyo HvIsCardGridElement HvCard-root"
+        class="HvIsCardGridElement HvCard-root css-9vqflq"
         style="width: 100%;"
       >
         <div
-          class="css-emolmc HvCard-semanticContainer"
+          class="HvCard-semanticContainer css-emolmc"
         >
           <div
-            class="css-1v84tfs css-1hhae7u HvCard-semanticBar"
+            class="HvCard-semanticBar css-12y48s9"
           />
           <div
-            class="css-pzj2c4 HvCard-icon"
+            class="HvCard-icon css-pzj2c4"
           />
         </div>
         <div
-          class="MuiCardHeader-root css-pqwkee HvCard-Header-root css-185gdzj-MuiCardHeader-root"
+          class="MuiCardHeader-root HvCard-Header-root css-pqwkee css-185gdzj-MuiCardHeader-root"
         >
           <div
             class="MuiCardHeader-content HvCard-Header-content css-1qbkelo-MuiCardHeader-content"
           >
             <span
-              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title css-1weuf4q HvCard-Header-title css-0 css-1qvr50w-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title HvCard-Header-title css-yragcd css-1qvr50w-MuiTypography-root"
             >
               Event 2
             </span>
           </div>
         </div>
         <div
-          class="MuiCardContent-root css-1ly90im HvCard-Content-content css-46bh2p-MuiCardContent-root"
+          class="MuiCardContent-root HvCard-Content-content css-1ly90im css-46bh2p-MuiCardContent-root"
         >
           Severity: 
           Major
         </div>
       </div>
       <div
-        class="css-kdjrpy css-jvotyo HvIsCardGridElement HvCard-root"
+        class="HvIsCardGridElement HvCard-root css-9vqflq"
         style="width: 100%;"
       >
         <div
-          class="css-emolmc HvCard-semanticContainer"
+          class="HvCard-semanticContainer css-emolmc"
         >
           <div
-            class="css-1v84tfs css-1hhae7u HvCard-semanticBar"
+            class="HvCard-semanticBar css-12y48s9"
           />
           <div
-            class="css-pzj2c4 HvCard-icon"
+            class="HvCard-icon css-pzj2c4"
           />
         </div>
         <div
-          class="MuiCardHeader-root css-pqwkee HvCard-Header-root css-185gdzj-MuiCardHeader-root"
+          class="MuiCardHeader-root HvCard-Header-root css-pqwkee css-185gdzj-MuiCardHeader-root"
         >
           <div
             class="MuiCardHeader-content HvCard-Header-content css-1qbkelo-MuiCardHeader-content"
           >
             <span
-              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title css-1weuf4q HvCard-Header-title css-0 css-1qvr50w-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title HvCard-Header-title css-yragcd css-1qvr50w-MuiTypography-root"
             >
               Event 3
             </span>
           </div>
         </div>
         <div
-          class="MuiCardContent-root css-1ly90im HvCard-Content-content css-46bh2p-MuiCardContent-root"
+          class="MuiCardContent-root HvCard-Content-content css-1ly90im css-46bh2p-MuiCardContent-root"
         >
           Severity: 
           Average
         </div>
       </div>
       <div
-        class="css-kdjrpy css-jvotyo HvIsCardGridElement HvCard-root"
+        class="HvIsCardGridElement HvCard-root css-9vqflq"
         style="width: 100%;"
       >
         <div
-          class="css-emolmc HvCard-semanticContainer"
+          class="HvCard-semanticContainer css-emolmc"
         >
           <div
-            class="css-1v84tfs css-1hhae7u HvCard-semanticBar"
+            class="HvCard-semanticBar css-12y48s9"
           />
           <div
-            class="css-pzj2c4 HvCard-icon"
+            class="HvCard-icon css-pzj2c4"
           />
         </div>
         <div
-          class="MuiCardHeader-root css-pqwkee HvCard-Header-root css-185gdzj-MuiCardHeader-root"
+          class="MuiCardHeader-root HvCard-Header-root css-pqwkee css-185gdzj-MuiCardHeader-root"
         >
           <div
             class="MuiCardHeader-content HvCard-Header-content css-1qbkelo-MuiCardHeader-content"
           >
             <span
-              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title css-1weuf4q HvCard-Header-title css-0 css-1qvr50w-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title HvCard-Header-title css-yragcd css-1qvr50w-MuiTypography-root"
             >
               Event 4
             </span>
           </div>
         </div>
         <div
-          class="MuiCardContent-root css-1ly90im HvCard-Content-content css-46bh2p-MuiCardContent-root"
+          class="MuiCardContent-root HvCard-Content-content css-1ly90im css-46bh2p-MuiCardContent-root"
         >
           Severity: 
           Minor
         </div>
       </div>
       <div
-        class="css-kdjrpy css-jvotyo HvIsCardGridElement HvCard-root"
+        class="HvIsCardGridElement HvCard-root css-9vqflq"
         style="width: 100%;"
       >
         <div
-          class="css-emolmc HvCard-semanticContainer"
+          class="HvCard-semanticContainer css-emolmc"
         >
           <div
-            class="css-1v84tfs css-1hhae7u HvCard-semanticBar"
+            class="HvCard-semanticBar css-12y48s9"
           />
           <div
-            class="css-pzj2c4 HvCard-icon"
+            class="HvCard-icon css-pzj2c4"
           />
         </div>
         <div
-          class="MuiCardHeader-root css-pqwkee HvCard-Header-root css-185gdzj-MuiCardHeader-root"
+          class="MuiCardHeader-root HvCard-Header-root css-pqwkee css-185gdzj-MuiCardHeader-root"
         >
           <div
             class="MuiCardHeader-content HvCard-Header-content css-1qbkelo-MuiCardHeader-content"
           >
             <span
-              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title css-1weuf4q HvCard-Header-title css-0 css-1qvr50w-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title HvCard-Header-title css-yragcd css-1qvr50w-MuiTypography-root"
             >
               Event 5
             </span>
           </div>
         </div>
         <div
-          class="MuiCardContent-root css-1ly90im HvCard-Content-content css-46bh2p-MuiCardContent-root"
+          class="MuiCardContent-root HvCard-Content-content css-1ly90im css-46bh2p-MuiCardContent-root"
         >
           Severity: 
           Critical
         </div>
       </div>
       <div
-        class="css-kdjrpy css-jvotyo HvIsCardGridElement HvCard-root"
+        class="HvIsCardGridElement HvCard-root css-9vqflq"
         style="width: 100%;"
       >
         <div
-          class="css-emolmc HvCard-semanticContainer"
+          class="HvCard-semanticContainer css-emolmc"
         >
           <div
-            class="css-1v84tfs css-1hhae7u HvCard-semanticBar"
+            class="HvCard-semanticBar css-12y48s9"
           />
           <div
-            class="css-pzj2c4 HvCard-icon"
+            class="HvCard-icon css-pzj2c4"
           />
         </div>
         <div
-          class="MuiCardHeader-root css-pqwkee HvCard-Header-root css-185gdzj-MuiCardHeader-root"
+          class="MuiCardHeader-root HvCard-Header-root css-pqwkee css-185gdzj-MuiCardHeader-root"
         >
           <div
             class="MuiCardHeader-content HvCard-Header-content css-1qbkelo-MuiCardHeader-content"
           >
             <span
-              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title css-1weuf4q HvCard-Header-title css-0 css-1qvr50w-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title HvCard-Header-title css-yragcd css-1qvr50w-MuiTypography-root"
             >
               Event 6
             </span>
           </div>
         </div>
         <div
-          class="MuiCardContent-root css-1ly90im HvCard-Content-content css-46bh2p-MuiCardContent-root"
+          class="MuiCardContent-root HvCard-Content-content css-1ly90im css-46bh2p-MuiCardContent-root"
         >
           Severity: 
           Major
         </div>
       </div>
       <div
-        class="css-kdjrpy css-jvotyo HvIsCardGridElement HvCard-root"
+        class="HvIsCardGridElement HvCard-root css-9vqflq"
         style="width: 100%;"
       >
         <div
-          class="css-emolmc HvCard-semanticContainer"
+          class="HvCard-semanticContainer css-emolmc"
         >
           <div
-            class="css-1v84tfs css-1hhae7u HvCard-semanticBar"
+            class="HvCard-semanticBar css-12y48s9"
           />
           <div
-            class="css-pzj2c4 HvCard-icon"
+            class="HvCard-icon css-pzj2c4"
           />
         </div>
         <div
-          class="MuiCardHeader-root css-pqwkee HvCard-Header-root css-185gdzj-MuiCardHeader-root"
+          class="MuiCardHeader-root HvCard-Header-root css-pqwkee css-185gdzj-MuiCardHeader-root"
         >
           <div
             class="MuiCardHeader-content HvCard-Header-content css-1qbkelo-MuiCardHeader-content"
           >
             <span
-              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title css-1weuf4q HvCard-Header-title css-0 css-1qvr50w-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title HvCard-Header-title css-yragcd css-1qvr50w-MuiTypography-root"
             >
               Event 7
             </span>
           </div>
         </div>
         <div
-          class="MuiCardContent-root css-1ly90im HvCard-Content-content css-46bh2p-MuiCardContent-root"
+          class="MuiCardContent-root HvCard-Content-content css-1ly90im css-46bh2p-MuiCardContent-root"
         >
           Severity: 
           Average
         </div>
       </div>
       <div
-        class="css-kdjrpy css-jvotyo HvIsCardGridElement HvCard-root"
+        class="HvIsCardGridElement HvCard-root css-9vqflq"
         style="width: 100%;"
       >
         <div
-          class="css-emolmc HvCard-semanticContainer"
+          class="HvCard-semanticContainer css-emolmc"
         >
           <div
-            class="css-1v84tfs css-1hhae7u HvCard-semanticBar"
+            class="HvCard-semanticBar css-12y48s9"
           />
           <div
-            class="css-pzj2c4 HvCard-icon"
+            class="HvCard-icon css-pzj2c4"
           />
         </div>
         <div
-          class="MuiCardHeader-root css-pqwkee HvCard-Header-root css-185gdzj-MuiCardHeader-root"
+          class="MuiCardHeader-root HvCard-Header-root css-pqwkee css-185gdzj-MuiCardHeader-root"
         >
           <div
             class="MuiCardHeader-content HvCard-Header-content css-1qbkelo-MuiCardHeader-content"
           >
             <span
-              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title css-1weuf4q HvCard-Header-title css-0 css-1qvr50w-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title HvCard-Header-title css-yragcd css-1qvr50w-MuiTypography-root"
             >
               Event 8
             </span>
           </div>
         </div>
         <div
-          class="MuiCardContent-root css-1ly90im HvCard-Content-content css-46bh2p-MuiCardContent-root"
+          class="MuiCardContent-root HvCard-Content-content css-1ly90im css-46bh2p-MuiCardContent-root"
         >
           Severity: 
           Minor
         </div>
       </div>
       <div
-        class="css-kdjrpy css-jvotyo HvIsCardGridElement HvCard-root"
+        class="HvIsCardGridElement HvCard-root css-9vqflq"
         style="width: 100%;"
       >
         <div
-          class="css-emolmc HvCard-semanticContainer"
+          class="HvCard-semanticContainer css-emolmc"
         >
           <div
-            class="css-1v84tfs css-1hhae7u HvCard-semanticBar"
+            class="HvCard-semanticBar css-12y48s9"
           />
           <div
-            class="css-pzj2c4 HvCard-icon"
+            class="HvCard-icon css-pzj2c4"
           />
         </div>
         <div
-          class="MuiCardHeader-root css-pqwkee HvCard-Header-root css-185gdzj-MuiCardHeader-root"
+          class="MuiCardHeader-root HvCard-Header-root css-pqwkee css-185gdzj-MuiCardHeader-root"
         >
           <div
             class="MuiCardHeader-content HvCard-Header-content css-1qbkelo-MuiCardHeader-content"
           >
             <span
-              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title css-1weuf4q HvCard-Header-title css-0 css-1qvr50w-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title HvCard-Header-title css-yragcd css-1qvr50w-MuiTypography-root"
             >
               Event 9
             </span>
           </div>
         </div>
         <div
-          class="MuiCardContent-root css-1ly90im HvCard-Content-content css-46bh2p-MuiCardContent-root"
+          class="MuiCardContent-root HvCard-Content-content css-1ly90im css-46bh2p-MuiCardContent-root"
         >
           Severity: 
           Critical
         </div>
       </div>
       <div
-        class="css-kdjrpy css-jvotyo HvIsCardGridElement HvCard-root"
+        class="HvIsCardGridElement HvCard-root css-9vqflq"
         style="width: 100%;"
       >
         <div
-          class="css-emolmc HvCard-semanticContainer"
+          class="HvCard-semanticContainer css-emolmc"
         >
           <div
-            class="css-1v84tfs css-1hhae7u HvCard-semanticBar"
+            class="HvCard-semanticBar css-12y48s9"
           />
           <div
-            class="css-pzj2c4 HvCard-icon"
+            class="HvCard-icon css-pzj2c4"
           />
         </div>
         <div
-          class="MuiCardHeader-root css-pqwkee HvCard-Header-root css-185gdzj-MuiCardHeader-root"
+          class="MuiCardHeader-root HvCard-Header-root css-pqwkee css-185gdzj-MuiCardHeader-root"
         >
           <div
             class="MuiCardHeader-content HvCard-Header-content css-1qbkelo-MuiCardHeader-content"
           >
             <span
-              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title css-1weuf4q HvCard-Header-title css-0 css-1qvr50w-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title HvCard-Header-title css-yragcd css-1qvr50w-MuiTypography-root"
             >
               Event 10
             </span>
           </div>
         </div>
         <div
-          class="MuiCardContent-root css-1ly90im HvCard-Content-content css-46bh2p-MuiCardContent-root"
+          class="MuiCardContent-root HvCard-Content-content css-1ly90im css-46bh2p-MuiCardContent-root"
         >
           Severity: 
           Major
@@ -1399,690 +1399,690 @@ exports[`<HvControls> > sample snapshot testing > Custom Controls 1`] = `
       spacing="sm"
     >
       <div
-        class="css-kdjrpy css-jvotyo HvIsCardGridElement HvCard-root"
+        class="HvIsCardGridElement HvCard-root css-9vqflq"
         style="width: 100%;"
       >
         <div
-          class="css-emolmc HvCard-semanticContainer"
+          class="HvCard-semanticContainer css-emolmc"
         >
           <div
-            class="css-1v84tfs css-1hhae7u HvCard-semanticBar"
+            class="HvCard-semanticBar css-12y48s9"
           />
           <div
-            class="css-pzj2c4 HvCard-icon"
+            class="HvCard-icon css-pzj2c4"
           />
         </div>
         <div
-          class="MuiCardHeader-root css-pqwkee HvCard-Header-root css-185gdzj-MuiCardHeader-root"
+          class="MuiCardHeader-root HvCard-Header-root css-pqwkee css-185gdzj-MuiCardHeader-root"
         >
           <div
             class="MuiCardHeader-content HvCard-Header-content css-1qbkelo-MuiCardHeader-content"
           >
             <span
-              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title css-1weuf4q HvCard-Header-title css-0 css-1qvr50w-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title HvCard-Header-title css-yragcd css-1qvr50w-MuiTypography-root"
             >
               Event 1
             </span>
           </div>
         </div>
         <div
-          class="MuiCardContent-root css-1ly90im HvCard-Content-content css-46bh2p-MuiCardContent-root"
+          class="MuiCardContent-root HvCard-Content-content css-1ly90im css-46bh2p-MuiCardContent-root"
         >
           Event: 
           Anomaly detection 0
         </div>
         <div
-          class="MuiCardContent-root css-1ly90im HvCard-Content-content css-46bh2p-MuiCardContent-root"
+          class="MuiCardContent-root HvCard-Content-content css-1ly90im css-46bh2p-MuiCardContent-root"
         >
           Severity: 
           Critical
         </div>
         <div
-          class="MuiCardContent-root css-1ly90im HvCard-Content-content css-46bh2p-MuiCardContent-root"
+          class="MuiCardContent-root HvCard-Content-content css-1ly90im css-46bh2p-MuiCardContent-root"
         >
           Temperature: 
           35
         </div>
       </div>
       <div
-        class="css-kdjrpy css-jvotyo HvIsCardGridElement HvCard-root"
+        class="HvIsCardGridElement HvCard-root css-9vqflq"
         style="width: 100%;"
       >
         <div
-          class="css-emolmc HvCard-semanticContainer"
+          class="HvCard-semanticContainer css-emolmc"
         >
           <div
-            class="css-1v84tfs css-1hhae7u HvCard-semanticBar"
+            class="HvCard-semanticBar css-12y48s9"
           />
           <div
-            class="css-pzj2c4 HvCard-icon"
+            class="HvCard-icon css-pzj2c4"
           />
         </div>
         <div
-          class="MuiCardHeader-root css-pqwkee HvCard-Header-root css-185gdzj-MuiCardHeader-root"
+          class="MuiCardHeader-root HvCard-Header-root css-pqwkee css-185gdzj-MuiCardHeader-root"
         >
           <div
             class="MuiCardHeader-content HvCard-Header-content css-1qbkelo-MuiCardHeader-content"
           >
             <span
-              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title css-1weuf4q HvCard-Header-title css-0 css-1qvr50w-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title HvCard-Header-title css-yragcd css-1qvr50w-MuiTypography-root"
             >
               Event 2
             </span>
           </div>
         </div>
         <div
-          class="MuiCardContent-root css-1ly90im HvCard-Content-content css-46bh2p-MuiCardContent-root"
+          class="MuiCardContent-root HvCard-Content-content css-1ly90im css-46bh2p-MuiCardContent-root"
         >
           Event: 
           Anomaly detection 1
         </div>
         <div
-          class="MuiCardContent-root css-1ly90im HvCard-Content-content css-46bh2p-MuiCardContent-root"
+          class="MuiCardContent-root HvCard-Content-content css-1ly90im css-46bh2p-MuiCardContent-root"
         >
           Severity: 
           Major
         </div>
         <div
-          class="MuiCardContent-root css-1ly90im HvCard-Content-content css-46bh2p-MuiCardContent-root"
+          class="MuiCardContent-root HvCard-Content-content css-1ly90im css-46bh2p-MuiCardContent-root"
         >
           Temperature: 
           36
         </div>
       </div>
       <div
-        class="css-kdjrpy css-jvotyo HvIsCardGridElement HvCard-root"
+        class="HvIsCardGridElement HvCard-root css-9vqflq"
         style="width: 100%;"
       >
         <div
-          class="css-emolmc HvCard-semanticContainer"
+          class="HvCard-semanticContainer css-emolmc"
         >
           <div
-            class="css-1v84tfs css-1hhae7u HvCard-semanticBar"
+            class="HvCard-semanticBar css-12y48s9"
           />
           <div
-            class="css-pzj2c4 HvCard-icon"
+            class="HvCard-icon css-pzj2c4"
           />
         </div>
         <div
-          class="MuiCardHeader-root css-pqwkee HvCard-Header-root css-185gdzj-MuiCardHeader-root"
+          class="MuiCardHeader-root HvCard-Header-root css-pqwkee css-185gdzj-MuiCardHeader-root"
         >
           <div
             class="MuiCardHeader-content HvCard-Header-content css-1qbkelo-MuiCardHeader-content"
           >
             <span
-              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title css-1weuf4q HvCard-Header-title css-0 css-1qvr50w-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title HvCard-Header-title css-yragcd css-1qvr50w-MuiTypography-root"
             >
               Event 3
             </span>
           </div>
         </div>
         <div
-          class="MuiCardContent-root css-1ly90im HvCard-Content-content css-46bh2p-MuiCardContent-root"
+          class="MuiCardContent-root HvCard-Content-content css-1ly90im css-46bh2p-MuiCardContent-root"
         >
           Event: 
           Anomaly detection 2
         </div>
         <div
-          class="MuiCardContent-root css-1ly90im HvCard-Content-content css-46bh2p-MuiCardContent-root"
+          class="MuiCardContent-root HvCard-Content-content css-1ly90im css-46bh2p-MuiCardContent-root"
         >
           Severity: 
           Average
         </div>
         <div
-          class="MuiCardContent-root css-1ly90im HvCard-Content-content css-46bh2p-MuiCardContent-root"
+          class="MuiCardContent-root HvCard-Content-content css-1ly90im css-46bh2p-MuiCardContent-root"
         >
           Temperature: 
           37
         </div>
       </div>
       <div
-        class="css-kdjrpy css-jvotyo HvIsCardGridElement HvCard-root"
+        class="HvIsCardGridElement HvCard-root css-9vqflq"
         style="width: 100%;"
       >
         <div
-          class="css-emolmc HvCard-semanticContainer"
+          class="HvCard-semanticContainer css-emolmc"
         >
           <div
-            class="css-1v84tfs css-1hhae7u HvCard-semanticBar"
+            class="HvCard-semanticBar css-12y48s9"
           />
           <div
-            class="css-pzj2c4 HvCard-icon"
+            class="HvCard-icon css-pzj2c4"
           />
         </div>
         <div
-          class="MuiCardHeader-root css-pqwkee HvCard-Header-root css-185gdzj-MuiCardHeader-root"
+          class="MuiCardHeader-root HvCard-Header-root css-pqwkee css-185gdzj-MuiCardHeader-root"
         >
           <div
             class="MuiCardHeader-content HvCard-Header-content css-1qbkelo-MuiCardHeader-content"
           >
             <span
-              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title css-1weuf4q HvCard-Header-title css-0 css-1qvr50w-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title HvCard-Header-title css-yragcd css-1qvr50w-MuiTypography-root"
             >
               Event 4
             </span>
           </div>
         </div>
         <div
-          class="MuiCardContent-root css-1ly90im HvCard-Content-content css-46bh2p-MuiCardContent-root"
+          class="MuiCardContent-root HvCard-Content-content css-1ly90im css-46bh2p-MuiCardContent-root"
         >
           Event: 
           Anomaly detection 3
         </div>
         <div
-          class="MuiCardContent-root css-1ly90im HvCard-Content-content css-46bh2p-MuiCardContent-root"
+          class="MuiCardContent-root HvCard-Content-content css-1ly90im css-46bh2p-MuiCardContent-root"
         >
           Severity: 
           Minor
         </div>
         <div
-          class="MuiCardContent-root css-1ly90im HvCard-Content-content css-46bh2p-MuiCardContent-root"
+          class="MuiCardContent-root HvCard-Content-content css-1ly90im css-46bh2p-MuiCardContent-root"
         >
           Temperature: 
           38
         </div>
       </div>
       <div
-        class="css-kdjrpy css-jvotyo HvIsCardGridElement HvCard-root"
+        class="HvIsCardGridElement HvCard-root css-9vqflq"
         style="width: 100%;"
       >
         <div
-          class="css-emolmc HvCard-semanticContainer"
+          class="HvCard-semanticContainer css-emolmc"
         >
           <div
-            class="css-1v84tfs css-1hhae7u HvCard-semanticBar"
+            class="HvCard-semanticBar css-12y48s9"
           />
           <div
-            class="css-pzj2c4 HvCard-icon"
+            class="HvCard-icon css-pzj2c4"
           />
         </div>
         <div
-          class="MuiCardHeader-root css-pqwkee HvCard-Header-root css-185gdzj-MuiCardHeader-root"
+          class="MuiCardHeader-root HvCard-Header-root css-pqwkee css-185gdzj-MuiCardHeader-root"
         >
           <div
             class="MuiCardHeader-content HvCard-Header-content css-1qbkelo-MuiCardHeader-content"
           >
             <span
-              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title css-1weuf4q HvCard-Header-title css-0 css-1qvr50w-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title HvCard-Header-title css-yragcd css-1qvr50w-MuiTypography-root"
             >
               Event 5
             </span>
           </div>
         </div>
         <div
-          class="MuiCardContent-root css-1ly90im HvCard-Content-content css-46bh2p-MuiCardContent-root"
+          class="MuiCardContent-root HvCard-Content-content css-1ly90im css-46bh2p-MuiCardContent-root"
         >
           Event: 
           Anomaly detection 0
         </div>
         <div
-          class="MuiCardContent-root css-1ly90im HvCard-Content-content css-46bh2p-MuiCardContent-root"
+          class="MuiCardContent-root HvCard-Content-content css-1ly90im css-46bh2p-MuiCardContent-root"
         >
           Severity: 
           Critical
         </div>
         <div
-          class="MuiCardContent-root css-1ly90im HvCard-Content-content css-46bh2p-MuiCardContent-root"
+          class="MuiCardContent-root HvCard-Content-content css-1ly90im css-46bh2p-MuiCardContent-root"
         >
           Temperature: 
           39
         </div>
       </div>
       <div
-        class="css-kdjrpy css-jvotyo HvIsCardGridElement HvCard-root"
+        class="HvIsCardGridElement HvCard-root css-9vqflq"
         style="width: 100%;"
       >
         <div
-          class="css-emolmc HvCard-semanticContainer"
+          class="HvCard-semanticContainer css-emolmc"
         >
           <div
-            class="css-1v84tfs css-1hhae7u HvCard-semanticBar"
+            class="HvCard-semanticBar css-12y48s9"
           />
           <div
-            class="css-pzj2c4 HvCard-icon"
+            class="HvCard-icon css-pzj2c4"
           />
         </div>
         <div
-          class="MuiCardHeader-root css-pqwkee HvCard-Header-root css-185gdzj-MuiCardHeader-root"
+          class="MuiCardHeader-root HvCard-Header-root css-pqwkee css-185gdzj-MuiCardHeader-root"
         >
           <div
             class="MuiCardHeader-content HvCard-Header-content css-1qbkelo-MuiCardHeader-content"
           >
             <span
-              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title css-1weuf4q HvCard-Header-title css-0 css-1qvr50w-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title HvCard-Header-title css-yragcd css-1qvr50w-MuiTypography-root"
             >
               Event 6
             </span>
           </div>
         </div>
         <div
-          class="MuiCardContent-root css-1ly90im HvCard-Content-content css-46bh2p-MuiCardContent-root"
+          class="MuiCardContent-root HvCard-Content-content css-1ly90im css-46bh2p-MuiCardContent-root"
         >
           Event: 
           Anomaly detection 1
         </div>
         <div
-          class="MuiCardContent-root css-1ly90im HvCard-Content-content css-46bh2p-MuiCardContent-root"
+          class="MuiCardContent-root HvCard-Content-content css-1ly90im css-46bh2p-MuiCardContent-root"
         >
           Severity: 
           Major
         </div>
         <div
-          class="MuiCardContent-root css-1ly90im HvCard-Content-content css-46bh2p-MuiCardContent-root"
+          class="MuiCardContent-root HvCard-Content-content css-1ly90im css-46bh2p-MuiCardContent-root"
         >
           Temperature: 
           40
         </div>
       </div>
       <div
-        class="css-kdjrpy css-jvotyo HvIsCardGridElement HvCard-root"
+        class="HvIsCardGridElement HvCard-root css-9vqflq"
         style="width: 100%;"
       >
         <div
-          class="css-emolmc HvCard-semanticContainer"
+          class="HvCard-semanticContainer css-emolmc"
         >
           <div
-            class="css-1v84tfs css-1hhae7u HvCard-semanticBar"
+            class="HvCard-semanticBar css-12y48s9"
           />
           <div
-            class="css-pzj2c4 HvCard-icon"
+            class="HvCard-icon css-pzj2c4"
           />
         </div>
         <div
-          class="MuiCardHeader-root css-pqwkee HvCard-Header-root css-185gdzj-MuiCardHeader-root"
+          class="MuiCardHeader-root HvCard-Header-root css-pqwkee css-185gdzj-MuiCardHeader-root"
         >
           <div
             class="MuiCardHeader-content HvCard-Header-content css-1qbkelo-MuiCardHeader-content"
           >
             <span
-              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title css-1weuf4q HvCard-Header-title css-0 css-1qvr50w-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title HvCard-Header-title css-yragcd css-1qvr50w-MuiTypography-root"
             >
               Event 7
             </span>
           </div>
         </div>
         <div
-          class="MuiCardContent-root css-1ly90im HvCard-Content-content css-46bh2p-MuiCardContent-root"
+          class="MuiCardContent-root HvCard-Content-content css-1ly90im css-46bh2p-MuiCardContent-root"
         >
           Event: 
           Anomaly detection 2
         </div>
         <div
-          class="MuiCardContent-root css-1ly90im HvCard-Content-content css-46bh2p-MuiCardContent-root"
+          class="MuiCardContent-root HvCard-Content-content css-1ly90im css-46bh2p-MuiCardContent-root"
         >
           Severity: 
           Average
         </div>
         <div
-          class="MuiCardContent-root css-1ly90im HvCard-Content-content css-46bh2p-MuiCardContent-root"
+          class="MuiCardContent-root HvCard-Content-content css-1ly90im css-46bh2p-MuiCardContent-root"
         >
           Temperature: 
           41
         </div>
       </div>
       <div
-        class="css-kdjrpy css-jvotyo HvIsCardGridElement HvCard-root"
+        class="HvIsCardGridElement HvCard-root css-9vqflq"
         style="width: 100%;"
       >
         <div
-          class="css-emolmc HvCard-semanticContainer"
+          class="HvCard-semanticContainer css-emolmc"
         >
           <div
-            class="css-1v84tfs css-1hhae7u HvCard-semanticBar"
+            class="HvCard-semanticBar css-12y48s9"
           />
           <div
-            class="css-pzj2c4 HvCard-icon"
+            class="HvCard-icon css-pzj2c4"
           />
         </div>
         <div
-          class="MuiCardHeader-root css-pqwkee HvCard-Header-root css-185gdzj-MuiCardHeader-root"
+          class="MuiCardHeader-root HvCard-Header-root css-pqwkee css-185gdzj-MuiCardHeader-root"
         >
           <div
             class="MuiCardHeader-content HvCard-Header-content css-1qbkelo-MuiCardHeader-content"
           >
             <span
-              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title css-1weuf4q HvCard-Header-title css-0 css-1qvr50w-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title HvCard-Header-title css-yragcd css-1qvr50w-MuiTypography-root"
             >
               Event 8
             </span>
           </div>
         </div>
         <div
-          class="MuiCardContent-root css-1ly90im HvCard-Content-content css-46bh2p-MuiCardContent-root"
+          class="MuiCardContent-root HvCard-Content-content css-1ly90im css-46bh2p-MuiCardContent-root"
         >
           Event: 
           Anomaly detection 3
         </div>
         <div
-          class="MuiCardContent-root css-1ly90im HvCard-Content-content css-46bh2p-MuiCardContent-root"
+          class="MuiCardContent-root HvCard-Content-content css-1ly90im css-46bh2p-MuiCardContent-root"
         >
           Severity: 
           Minor
         </div>
         <div
-          class="MuiCardContent-root css-1ly90im HvCard-Content-content css-46bh2p-MuiCardContent-root"
+          class="MuiCardContent-root HvCard-Content-content css-1ly90im css-46bh2p-MuiCardContent-root"
         >
           Temperature: 
           42
         </div>
       </div>
       <div
-        class="css-kdjrpy css-jvotyo HvIsCardGridElement HvCard-root"
+        class="HvIsCardGridElement HvCard-root css-9vqflq"
         style="width: 100%;"
       >
         <div
-          class="css-emolmc HvCard-semanticContainer"
+          class="HvCard-semanticContainer css-emolmc"
         >
           <div
-            class="css-1v84tfs css-1hhae7u HvCard-semanticBar"
+            class="HvCard-semanticBar css-12y48s9"
           />
           <div
-            class="css-pzj2c4 HvCard-icon"
+            class="HvCard-icon css-pzj2c4"
           />
         </div>
         <div
-          class="MuiCardHeader-root css-pqwkee HvCard-Header-root css-185gdzj-MuiCardHeader-root"
+          class="MuiCardHeader-root HvCard-Header-root css-pqwkee css-185gdzj-MuiCardHeader-root"
         >
           <div
             class="MuiCardHeader-content HvCard-Header-content css-1qbkelo-MuiCardHeader-content"
           >
             <span
-              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title css-1weuf4q HvCard-Header-title css-0 css-1qvr50w-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title HvCard-Header-title css-yragcd css-1qvr50w-MuiTypography-root"
             >
               Event 9
             </span>
           </div>
         </div>
         <div
-          class="MuiCardContent-root css-1ly90im HvCard-Content-content css-46bh2p-MuiCardContent-root"
+          class="MuiCardContent-root HvCard-Content-content css-1ly90im css-46bh2p-MuiCardContent-root"
         >
           Event: 
           Anomaly detection 0
         </div>
         <div
-          class="MuiCardContent-root css-1ly90im HvCard-Content-content css-46bh2p-MuiCardContent-root"
+          class="MuiCardContent-root HvCard-Content-content css-1ly90im css-46bh2p-MuiCardContent-root"
         >
           Severity: 
           Critical
         </div>
         <div
-          class="MuiCardContent-root css-1ly90im HvCard-Content-content css-46bh2p-MuiCardContent-root"
+          class="MuiCardContent-root HvCard-Content-content css-1ly90im css-46bh2p-MuiCardContent-root"
         >
           Temperature: 
           43
         </div>
       </div>
       <div
-        class="css-kdjrpy css-jvotyo HvIsCardGridElement HvCard-root"
+        class="HvIsCardGridElement HvCard-root css-9vqflq"
         style="width: 100%;"
       >
         <div
-          class="css-emolmc HvCard-semanticContainer"
+          class="HvCard-semanticContainer css-emolmc"
         >
           <div
-            class="css-1v84tfs css-1hhae7u HvCard-semanticBar"
+            class="HvCard-semanticBar css-12y48s9"
           />
           <div
-            class="css-pzj2c4 HvCard-icon"
+            class="HvCard-icon css-pzj2c4"
           />
         </div>
         <div
-          class="MuiCardHeader-root css-pqwkee HvCard-Header-root css-185gdzj-MuiCardHeader-root"
+          class="MuiCardHeader-root HvCard-Header-root css-pqwkee css-185gdzj-MuiCardHeader-root"
         >
           <div
             class="MuiCardHeader-content HvCard-Header-content css-1qbkelo-MuiCardHeader-content"
           >
             <span
-              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title css-1weuf4q HvCard-Header-title css-0 css-1qvr50w-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title HvCard-Header-title css-yragcd css-1qvr50w-MuiTypography-root"
             >
               Event 10
             </span>
           </div>
         </div>
         <div
-          class="MuiCardContent-root css-1ly90im HvCard-Content-content css-46bh2p-MuiCardContent-root"
+          class="MuiCardContent-root HvCard-Content-content css-1ly90im css-46bh2p-MuiCardContent-root"
         >
           Event: 
           Anomaly detection 1
         </div>
         <div
-          class="MuiCardContent-root css-1ly90im HvCard-Content-content css-46bh2p-MuiCardContent-root"
+          class="MuiCardContent-root HvCard-Content-content css-1ly90im css-46bh2p-MuiCardContent-root"
         >
           Severity: 
           Major
         </div>
         <div
-          class="MuiCardContent-root css-1ly90im HvCard-Content-content css-46bh2p-MuiCardContent-root"
+          class="MuiCardContent-root HvCard-Content-content css-1ly90im css-46bh2p-MuiCardContent-root"
         >
           Temperature: 
           44
         </div>
       </div>
       <div
-        class="css-kdjrpy css-jvotyo HvIsCardGridElement HvCard-root"
+        class="HvIsCardGridElement HvCard-root css-9vqflq"
         style="width: 100%;"
       >
         <div
-          class="css-emolmc HvCard-semanticContainer"
+          class="HvCard-semanticContainer css-emolmc"
         >
           <div
-            class="css-1v84tfs css-1hhae7u HvCard-semanticBar"
+            class="HvCard-semanticBar css-12y48s9"
           />
           <div
-            class="css-pzj2c4 HvCard-icon"
+            class="HvCard-icon css-pzj2c4"
           />
         </div>
         <div
-          class="MuiCardHeader-root css-pqwkee HvCard-Header-root css-185gdzj-MuiCardHeader-root"
+          class="MuiCardHeader-root HvCard-Header-root css-pqwkee css-185gdzj-MuiCardHeader-root"
         >
           <div
             class="MuiCardHeader-content HvCard-Header-content css-1qbkelo-MuiCardHeader-content"
           >
             <span
-              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title css-1weuf4q HvCard-Header-title css-0 css-1qvr50w-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title HvCard-Header-title css-yragcd css-1qvr50w-MuiTypography-root"
             >
               Event 11
             </span>
           </div>
         </div>
         <div
-          class="MuiCardContent-root css-1ly90im HvCard-Content-content css-46bh2p-MuiCardContent-root"
+          class="MuiCardContent-root HvCard-Content-content css-1ly90im css-46bh2p-MuiCardContent-root"
         >
           Event: 
           Anomaly detection 2
         </div>
         <div
-          class="MuiCardContent-root css-1ly90im HvCard-Content-content css-46bh2p-MuiCardContent-root"
+          class="MuiCardContent-root HvCard-Content-content css-1ly90im css-46bh2p-MuiCardContent-root"
         >
           Severity: 
           Average
         </div>
         <div
-          class="MuiCardContent-root css-1ly90im HvCard-Content-content css-46bh2p-MuiCardContent-root"
+          class="MuiCardContent-root HvCard-Content-content css-1ly90im css-46bh2p-MuiCardContent-root"
         >
           Temperature: 
           45
         </div>
       </div>
       <div
-        class="css-kdjrpy css-jvotyo HvIsCardGridElement HvCard-root"
+        class="HvIsCardGridElement HvCard-root css-9vqflq"
         style="width: 100%;"
       >
         <div
-          class="css-emolmc HvCard-semanticContainer"
+          class="HvCard-semanticContainer css-emolmc"
         >
           <div
-            class="css-1v84tfs css-1hhae7u HvCard-semanticBar"
+            class="HvCard-semanticBar css-12y48s9"
           />
           <div
-            class="css-pzj2c4 HvCard-icon"
+            class="HvCard-icon css-pzj2c4"
           />
         </div>
         <div
-          class="MuiCardHeader-root css-pqwkee HvCard-Header-root css-185gdzj-MuiCardHeader-root"
+          class="MuiCardHeader-root HvCard-Header-root css-pqwkee css-185gdzj-MuiCardHeader-root"
         >
           <div
             class="MuiCardHeader-content HvCard-Header-content css-1qbkelo-MuiCardHeader-content"
           >
             <span
-              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title css-1weuf4q HvCard-Header-title css-0 css-1qvr50w-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title HvCard-Header-title css-yragcd css-1qvr50w-MuiTypography-root"
             >
               Event 12
             </span>
           </div>
         </div>
         <div
-          class="MuiCardContent-root css-1ly90im HvCard-Content-content css-46bh2p-MuiCardContent-root"
+          class="MuiCardContent-root HvCard-Content-content css-1ly90im css-46bh2p-MuiCardContent-root"
         >
           Event: 
           Anomaly detection 3
         </div>
         <div
-          class="MuiCardContent-root css-1ly90im HvCard-Content-content css-46bh2p-MuiCardContent-root"
+          class="MuiCardContent-root HvCard-Content-content css-1ly90im css-46bh2p-MuiCardContent-root"
         >
           Severity: 
           Minor
         </div>
         <div
-          class="MuiCardContent-root css-1ly90im HvCard-Content-content css-46bh2p-MuiCardContent-root"
+          class="MuiCardContent-root HvCard-Content-content css-1ly90im css-46bh2p-MuiCardContent-root"
         >
           Temperature: 
           46
         </div>
       </div>
       <div
-        class="css-kdjrpy css-jvotyo HvIsCardGridElement HvCard-root"
+        class="HvIsCardGridElement HvCard-root css-9vqflq"
         style="width: 100%;"
       >
         <div
-          class="css-emolmc HvCard-semanticContainer"
+          class="HvCard-semanticContainer css-emolmc"
         >
           <div
-            class="css-1v84tfs css-1hhae7u HvCard-semanticBar"
+            class="HvCard-semanticBar css-12y48s9"
           />
           <div
-            class="css-pzj2c4 HvCard-icon"
+            class="HvCard-icon css-pzj2c4"
           />
         </div>
         <div
-          class="MuiCardHeader-root css-pqwkee HvCard-Header-root css-185gdzj-MuiCardHeader-root"
+          class="MuiCardHeader-root HvCard-Header-root css-pqwkee css-185gdzj-MuiCardHeader-root"
         >
           <div
             class="MuiCardHeader-content HvCard-Header-content css-1qbkelo-MuiCardHeader-content"
           >
             <span
-              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title css-1weuf4q HvCard-Header-title css-0 css-1qvr50w-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title HvCard-Header-title css-yragcd css-1qvr50w-MuiTypography-root"
             >
               Event 13
             </span>
           </div>
         </div>
         <div
-          class="MuiCardContent-root css-1ly90im HvCard-Content-content css-46bh2p-MuiCardContent-root"
+          class="MuiCardContent-root HvCard-Content-content css-1ly90im css-46bh2p-MuiCardContent-root"
         >
           Event: 
           Anomaly detection 0
         </div>
         <div
-          class="MuiCardContent-root css-1ly90im HvCard-Content-content css-46bh2p-MuiCardContent-root"
+          class="MuiCardContent-root HvCard-Content-content css-1ly90im css-46bh2p-MuiCardContent-root"
         >
           Severity: 
           Critical
         </div>
         <div
-          class="MuiCardContent-root css-1ly90im HvCard-Content-content css-46bh2p-MuiCardContent-root"
+          class="MuiCardContent-root HvCard-Content-content css-1ly90im css-46bh2p-MuiCardContent-root"
         >
           Temperature: 
           47
         </div>
       </div>
       <div
-        class="css-kdjrpy css-jvotyo HvIsCardGridElement HvCard-root"
+        class="HvIsCardGridElement HvCard-root css-9vqflq"
         style="width: 100%;"
       >
         <div
-          class="css-emolmc HvCard-semanticContainer"
+          class="HvCard-semanticContainer css-emolmc"
         >
           <div
-            class="css-1v84tfs css-1hhae7u HvCard-semanticBar"
+            class="HvCard-semanticBar css-12y48s9"
           />
           <div
-            class="css-pzj2c4 HvCard-icon"
+            class="HvCard-icon css-pzj2c4"
           />
         </div>
         <div
-          class="MuiCardHeader-root css-pqwkee HvCard-Header-root css-185gdzj-MuiCardHeader-root"
+          class="MuiCardHeader-root HvCard-Header-root css-pqwkee css-185gdzj-MuiCardHeader-root"
         >
           <div
             class="MuiCardHeader-content HvCard-Header-content css-1qbkelo-MuiCardHeader-content"
           >
             <span
-              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title css-1weuf4q HvCard-Header-title css-0 css-1qvr50w-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title HvCard-Header-title css-yragcd css-1qvr50w-MuiTypography-root"
             >
               Event 14
             </span>
           </div>
         </div>
         <div
-          class="MuiCardContent-root css-1ly90im HvCard-Content-content css-46bh2p-MuiCardContent-root"
+          class="MuiCardContent-root HvCard-Content-content css-1ly90im css-46bh2p-MuiCardContent-root"
         >
           Event: 
           Anomaly detection 1
         </div>
         <div
-          class="MuiCardContent-root css-1ly90im HvCard-Content-content css-46bh2p-MuiCardContent-root"
+          class="MuiCardContent-root HvCard-Content-content css-1ly90im css-46bh2p-MuiCardContent-root"
         >
           Severity: 
           Major
         </div>
         <div
-          class="MuiCardContent-root css-1ly90im HvCard-Content-content css-46bh2p-MuiCardContent-root"
+          class="MuiCardContent-root HvCard-Content-content css-1ly90im css-46bh2p-MuiCardContent-root"
         >
           Temperature: 
           48
         </div>
       </div>
       <div
-        class="css-kdjrpy css-jvotyo HvIsCardGridElement HvCard-root"
+        class="HvIsCardGridElement HvCard-root css-9vqflq"
         style="width: 100%;"
       >
         <div
-          class="css-emolmc HvCard-semanticContainer"
+          class="HvCard-semanticContainer css-emolmc"
         >
           <div
-            class="css-1v84tfs css-1hhae7u HvCard-semanticBar"
+            class="HvCard-semanticBar css-12y48s9"
           />
           <div
-            class="css-pzj2c4 HvCard-icon"
+            class="HvCard-icon css-pzj2c4"
           />
         </div>
         <div
-          class="MuiCardHeader-root css-pqwkee HvCard-Header-root css-185gdzj-MuiCardHeader-root"
+          class="MuiCardHeader-root HvCard-Header-root css-pqwkee css-185gdzj-MuiCardHeader-root"
         >
           <div
             class="MuiCardHeader-content HvCard-Header-content css-1qbkelo-MuiCardHeader-content"
           >
             <span
-              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title css-1weuf4q HvCard-Header-title css-0 css-1qvr50w-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title HvCard-Header-title css-yragcd css-1qvr50w-MuiTypography-root"
             >
               Event 15
             </span>
           </div>
         </div>
         <div
-          class="MuiCardContent-root css-1ly90im HvCard-Content-content css-46bh2p-MuiCardContent-root"
+          class="MuiCardContent-root HvCard-Content-content css-1ly90im css-46bh2p-MuiCardContent-root"
         >
           Event: 
           Anomaly detection 2
         </div>
         <div
-          class="MuiCardContent-root css-1ly90im HvCard-Content-content css-46bh2p-MuiCardContent-root"
+          class="MuiCardContent-root HvCard-Content-content css-1ly90im css-46bh2p-MuiCardContent-root"
         >
           Severity: 
           Average
         </div>
         <div
-          class="MuiCardContent-root css-1ly90im HvCard-Content-content css-46bh2p-MuiCardContent-root"
+          class="MuiCardContent-root HvCard-Content-content css-1ly90im css-46bh2p-MuiCardContent-root"
         >
           Temperature: 
           49
@@ -2383,690 +2383,690 @@ exports[`<HvControls> > sample snapshot testing > Mixed Controls 1`] = `
       spacing="sm"
     >
       <div
-        class="css-kdjrpy css-jvotyo HvIsCardGridElement HvCard-root"
+        class="HvIsCardGridElement HvCard-root css-9vqflq"
         style="width: 100%;"
       >
         <div
-          class="css-emolmc HvCard-semanticContainer"
+          class="HvCard-semanticContainer css-emolmc"
         >
           <div
-            class="css-1v84tfs css-1hhae7u HvCard-semanticBar"
+            class="HvCard-semanticBar css-12y48s9"
           />
           <div
-            class="css-pzj2c4 HvCard-icon"
+            class="HvCard-icon css-pzj2c4"
           />
         </div>
         <div
-          class="MuiCardHeader-root css-pqwkee HvCard-Header-root css-185gdzj-MuiCardHeader-root"
+          class="MuiCardHeader-root HvCard-Header-root css-pqwkee css-185gdzj-MuiCardHeader-root"
         >
           <div
             class="MuiCardHeader-content HvCard-Header-content css-1qbkelo-MuiCardHeader-content"
           >
             <span
-              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title css-1weuf4q HvCard-Header-title css-0 css-1qvr50w-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title HvCard-Header-title css-yragcd css-1qvr50w-MuiTypography-root"
             >
               Event 1
             </span>
           </div>
         </div>
         <div
-          class="MuiCardContent-root css-1ly90im HvCard-Content-content css-46bh2p-MuiCardContent-root"
+          class="MuiCardContent-root HvCard-Content-content css-1ly90im css-46bh2p-MuiCardContent-root"
         >
           Event: 
           Anomaly detection 0
         </div>
         <div
-          class="MuiCardContent-root css-1ly90im HvCard-Content-content css-46bh2p-MuiCardContent-root"
+          class="MuiCardContent-root HvCard-Content-content css-1ly90im css-46bh2p-MuiCardContent-root"
         >
           Severity: 
           Critical
         </div>
         <div
-          class="MuiCardContent-root css-1ly90im HvCard-Content-content css-46bh2p-MuiCardContent-root"
+          class="MuiCardContent-root HvCard-Content-content css-1ly90im css-46bh2p-MuiCardContent-root"
         >
           Temperature: 
           35
         </div>
       </div>
       <div
-        class="css-kdjrpy css-jvotyo HvIsCardGridElement HvCard-root"
+        class="HvIsCardGridElement HvCard-root css-9vqflq"
         style="width: 100%;"
       >
         <div
-          class="css-emolmc HvCard-semanticContainer"
+          class="HvCard-semanticContainer css-emolmc"
         >
           <div
-            class="css-1v84tfs css-1hhae7u HvCard-semanticBar"
+            class="HvCard-semanticBar css-12y48s9"
           />
           <div
-            class="css-pzj2c4 HvCard-icon"
+            class="HvCard-icon css-pzj2c4"
           />
         </div>
         <div
-          class="MuiCardHeader-root css-pqwkee HvCard-Header-root css-185gdzj-MuiCardHeader-root"
+          class="MuiCardHeader-root HvCard-Header-root css-pqwkee css-185gdzj-MuiCardHeader-root"
         >
           <div
             class="MuiCardHeader-content HvCard-Header-content css-1qbkelo-MuiCardHeader-content"
           >
             <span
-              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title css-1weuf4q HvCard-Header-title css-0 css-1qvr50w-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title HvCard-Header-title css-yragcd css-1qvr50w-MuiTypography-root"
             >
               Event 2
             </span>
           </div>
         </div>
         <div
-          class="MuiCardContent-root css-1ly90im HvCard-Content-content css-46bh2p-MuiCardContent-root"
+          class="MuiCardContent-root HvCard-Content-content css-1ly90im css-46bh2p-MuiCardContent-root"
         >
           Event: 
           Anomaly detection 1
         </div>
         <div
-          class="MuiCardContent-root css-1ly90im HvCard-Content-content css-46bh2p-MuiCardContent-root"
+          class="MuiCardContent-root HvCard-Content-content css-1ly90im css-46bh2p-MuiCardContent-root"
         >
           Severity: 
           Major
         </div>
         <div
-          class="MuiCardContent-root css-1ly90im HvCard-Content-content css-46bh2p-MuiCardContent-root"
+          class="MuiCardContent-root HvCard-Content-content css-1ly90im css-46bh2p-MuiCardContent-root"
         >
           Temperature: 
           36
         </div>
       </div>
       <div
-        class="css-kdjrpy css-jvotyo HvIsCardGridElement HvCard-root"
+        class="HvIsCardGridElement HvCard-root css-9vqflq"
         style="width: 100%;"
       >
         <div
-          class="css-emolmc HvCard-semanticContainer"
+          class="HvCard-semanticContainer css-emolmc"
         >
           <div
-            class="css-1v84tfs css-1hhae7u HvCard-semanticBar"
+            class="HvCard-semanticBar css-12y48s9"
           />
           <div
-            class="css-pzj2c4 HvCard-icon"
+            class="HvCard-icon css-pzj2c4"
           />
         </div>
         <div
-          class="MuiCardHeader-root css-pqwkee HvCard-Header-root css-185gdzj-MuiCardHeader-root"
+          class="MuiCardHeader-root HvCard-Header-root css-pqwkee css-185gdzj-MuiCardHeader-root"
         >
           <div
             class="MuiCardHeader-content HvCard-Header-content css-1qbkelo-MuiCardHeader-content"
           >
             <span
-              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title css-1weuf4q HvCard-Header-title css-0 css-1qvr50w-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title HvCard-Header-title css-yragcd css-1qvr50w-MuiTypography-root"
             >
               Event 3
             </span>
           </div>
         </div>
         <div
-          class="MuiCardContent-root css-1ly90im HvCard-Content-content css-46bh2p-MuiCardContent-root"
+          class="MuiCardContent-root HvCard-Content-content css-1ly90im css-46bh2p-MuiCardContent-root"
         >
           Event: 
           Anomaly detection 2
         </div>
         <div
-          class="MuiCardContent-root css-1ly90im HvCard-Content-content css-46bh2p-MuiCardContent-root"
+          class="MuiCardContent-root HvCard-Content-content css-1ly90im css-46bh2p-MuiCardContent-root"
         >
           Severity: 
           Average
         </div>
         <div
-          class="MuiCardContent-root css-1ly90im HvCard-Content-content css-46bh2p-MuiCardContent-root"
+          class="MuiCardContent-root HvCard-Content-content css-1ly90im css-46bh2p-MuiCardContent-root"
         >
           Temperature: 
           37
         </div>
       </div>
       <div
-        class="css-kdjrpy css-jvotyo HvIsCardGridElement HvCard-root"
+        class="HvIsCardGridElement HvCard-root css-9vqflq"
         style="width: 100%;"
       >
         <div
-          class="css-emolmc HvCard-semanticContainer"
+          class="HvCard-semanticContainer css-emolmc"
         >
           <div
-            class="css-1v84tfs css-1hhae7u HvCard-semanticBar"
+            class="HvCard-semanticBar css-12y48s9"
           />
           <div
-            class="css-pzj2c4 HvCard-icon"
+            class="HvCard-icon css-pzj2c4"
           />
         </div>
         <div
-          class="MuiCardHeader-root css-pqwkee HvCard-Header-root css-185gdzj-MuiCardHeader-root"
+          class="MuiCardHeader-root HvCard-Header-root css-pqwkee css-185gdzj-MuiCardHeader-root"
         >
           <div
             class="MuiCardHeader-content HvCard-Header-content css-1qbkelo-MuiCardHeader-content"
           >
             <span
-              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title css-1weuf4q HvCard-Header-title css-0 css-1qvr50w-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title HvCard-Header-title css-yragcd css-1qvr50w-MuiTypography-root"
             >
               Event 4
             </span>
           </div>
         </div>
         <div
-          class="MuiCardContent-root css-1ly90im HvCard-Content-content css-46bh2p-MuiCardContent-root"
+          class="MuiCardContent-root HvCard-Content-content css-1ly90im css-46bh2p-MuiCardContent-root"
         >
           Event: 
           Anomaly detection 3
         </div>
         <div
-          class="MuiCardContent-root css-1ly90im HvCard-Content-content css-46bh2p-MuiCardContent-root"
+          class="MuiCardContent-root HvCard-Content-content css-1ly90im css-46bh2p-MuiCardContent-root"
         >
           Severity: 
           Minor
         </div>
         <div
-          class="MuiCardContent-root css-1ly90im HvCard-Content-content css-46bh2p-MuiCardContent-root"
+          class="MuiCardContent-root HvCard-Content-content css-1ly90im css-46bh2p-MuiCardContent-root"
         >
           Temperature: 
           38
         </div>
       </div>
       <div
-        class="css-kdjrpy css-jvotyo HvIsCardGridElement HvCard-root"
+        class="HvIsCardGridElement HvCard-root css-9vqflq"
         style="width: 100%;"
       >
         <div
-          class="css-emolmc HvCard-semanticContainer"
+          class="HvCard-semanticContainer css-emolmc"
         >
           <div
-            class="css-1v84tfs css-1hhae7u HvCard-semanticBar"
+            class="HvCard-semanticBar css-12y48s9"
           />
           <div
-            class="css-pzj2c4 HvCard-icon"
+            class="HvCard-icon css-pzj2c4"
           />
         </div>
         <div
-          class="MuiCardHeader-root css-pqwkee HvCard-Header-root css-185gdzj-MuiCardHeader-root"
+          class="MuiCardHeader-root HvCard-Header-root css-pqwkee css-185gdzj-MuiCardHeader-root"
         >
           <div
             class="MuiCardHeader-content HvCard-Header-content css-1qbkelo-MuiCardHeader-content"
           >
             <span
-              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title css-1weuf4q HvCard-Header-title css-0 css-1qvr50w-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title HvCard-Header-title css-yragcd css-1qvr50w-MuiTypography-root"
             >
               Event 5
             </span>
           </div>
         </div>
         <div
-          class="MuiCardContent-root css-1ly90im HvCard-Content-content css-46bh2p-MuiCardContent-root"
+          class="MuiCardContent-root HvCard-Content-content css-1ly90im css-46bh2p-MuiCardContent-root"
         >
           Event: 
           Anomaly detection 0
         </div>
         <div
-          class="MuiCardContent-root css-1ly90im HvCard-Content-content css-46bh2p-MuiCardContent-root"
+          class="MuiCardContent-root HvCard-Content-content css-1ly90im css-46bh2p-MuiCardContent-root"
         >
           Severity: 
           Critical
         </div>
         <div
-          class="MuiCardContent-root css-1ly90im HvCard-Content-content css-46bh2p-MuiCardContent-root"
+          class="MuiCardContent-root HvCard-Content-content css-1ly90im css-46bh2p-MuiCardContent-root"
         >
           Temperature: 
           39
         </div>
       </div>
       <div
-        class="css-kdjrpy css-jvotyo HvIsCardGridElement HvCard-root"
+        class="HvIsCardGridElement HvCard-root css-9vqflq"
         style="width: 100%;"
       >
         <div
-          class="css-emolmc HvCard-semanticContainer"
+          class="HvCard-semanticContainer css-emolmc"
         >
           <div
-            class="css-1v84tfs css-1hhae7u HvCard-semanticBar"
+            class="HvCard-semanticBar css-12y48s9"
           />
           <div
-            class="css-pzj2c4 HvCard-icon"
+            class="HvCard-icon css-pzj2c4"
           />
         </div>
         <div
-          class="MuiCardHeader-root css-pqwkee HvCard-Header-root css-185gdzj-MuiCardHeader-root"
+          class="MuiCardHeader-root HvCard-Header-root css-pqwkee css-185gdzj-MuiCardHeader-root"
         >
           <div
             class="MuiCardHeader-content HvCard-Header-content css-1qbkelo-MuiCardHeader-content"
           >
             <span
-              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title css-1weuf4q HvCard-Header-title css-0 css-1qvr50w-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title HvCard-Header-title css-yragcd css-1qvr50w-MuiTypography-root"
             >
               Event 6
             </span>
           </div>
         </div>
         <div
-          class="MuiCardContent-root css-1ly90im HvCard-Content-content css-46bh2p-MuiCardContent-root"
+          class="MuiCardContent-root HvCard-Content-content css-1ly90im css-46bh2p-MuiCardContent-root"
         >
           Event: 
           Anomaly detection 1
         </div>
         <div
-          class="MuiCardContent-root css-1ly90im HvCard-Content-content css-46bh2p-MuiCardContent-root"
+          class="MuiCardContent-root HvCard-Content-content css-1ly90im css-46bh2p-MuiCardContent-root"
         >
           Severity: 
           Major
         </div>
         <div
-          class="MuiCardContent-root css-1ly90im HvCard-Content-content css-46bh2p-MuiCardContent-root"
+          class="MuiCardContent-root HvCard-Content-content css-1ly90im css-46bh2p-MuiCardContent-root"
         >
           Temperature: 
           40
         </div>
       </div>
       <div
-        class="css-kdjrpy css-jvotyo HvIsCardGridElement HvCard-root"
+        class="HvIsCardGridElement HvCard-root css-9vqflq"
         style="width: 100%;"
       >
         <div
-          class="css-emolmc HvCard-semanticContainer"
+          class="HvCard-semanticContainer css-emolmc"
         >
           <div
-            class="css-1v84tfs css-1hhae7u HvCard-semanticBar"
+            class="HvCard-semanticBar css-12y48s9"
           />
           <div
-            class="css-pzj2c4 HvCard-icon"
+            class="HvCard-icon css-pzj2c4"
           />
         </div>
         <div
-          class="MuiCardHeader-root css-pqwkee HvCard-Header-root css-185gdzj-MuiCardHeader-root"
+          class="MuiCardHeader-root HvCard-Header-root css-pqwkee css-185gdzj-MuiCardHeader-root"
         >
           <div
             class="MuiCardHeader-content HvCard-Header-content css-1qbkelo-MuiCardHeader-content"
           >
             <span
-              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title css-1weuf4q HvCard-Header-title css-0 css-1qvr50w-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title HvCard-Header-title css-yragcd css-1qvr50w-MuiTypography-root"
             >
               Event 7
             </span>
           </div>
         </div>
         <div
-          class="MuiCardContent-root css-1ly90im HvCard-Content-content css-46bh2p-MuiCardContent-root"
+          class="MuiCardContent-root HvCard-Content-content css-1ly90im css-46bh2p-MuiCardContent-root"
         >
           Event: 
           Anomaly detection 2
         </div>
         <div
-          class="MuiCardContent-root css-1ly90im HvCard-Content-content css-46bh2p-MuiCardContent-root"
+          class="MuiCardContent-root HvCard-Content-content css-1ly90im css-46bh2p-MuiCardContent-root"
         >
           Severity: 
           Average
         </div>
         <div
-          class="MuiCardContent-root css-1ly90im HvCard-Content-content css-46bh2p-MuiCardContent-root"
+          class="MuiCardContent-root HvCard-Content-content css-1ly90im css-46bh2p-MuiCardContent-root"
         >
           Temperature: 
           41
         </div>
       </div>
       <div
-        class="css-kdjrpy css-jvotyo HvIsCardGridElement HvCard-root"
+        class="HvIsCardGridElement HvCard-root css-9vqflq"
         style="width: 100%;"
       >
         <div
-          class="css-emolmc HvCard-semanticContainer"
+          class="HvCard-semanticContainer css-emolmc"
         >
           <div
-            class="css-1v84tfs css-1hhae7u HvCard-semanticBar"
+            class="HvCard-semanticBar css-12y48s9"
           />
           <div
-            class="css-pzj2c4 HvCard-icon"
+            class="HvCard-icon css-pzj2c4"
           />
         </div>
         <div
-          class="MuiCardHeader-root css-pqwkee HvCard-Header-root css-185gdzj-MuiCardHeader-root"
+          class="MuiCardHeader-root HvCard-Header-root css-pqwkee css-185gdzj-MuiCardHeader-root"
         >
           <div
             class="MuiCardHeader-content HvCard-Header-content css-1qbkelo-MuiCardHeader-content"
           >
             <span
-              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title css-1weuf4q HvCard-Header-title css-0 css-1qvr50w-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title HvCard-Header-title css-yragcd css-1qvr50w-MuiTypography-root"
             >
               Event 8
             </span>
           </div>
         </div>
         <div
-          class="MuiCardContent-root css-1ly90im HvCard-Content-content css-46bh2p-MuiCardContent-root"
+          class="MuiCardContent-root HvCard-Content-content css-1ly90im css-46bh2p-MuiCardContent-root"
         >
           Event: 
           Anomaly detection 3
         </div>
         <div
-          class="MuiCardContent-root css-1ly90im HvCard-Content-content css-46bh2p-MuiCardContent-root"
+          class="MuiCardContent-root HvCard-Content-content css-1ly90im css-46bh2p-MuiCardContent-root"
         >
           Severity: 
           Minor
         </div>
         <div
-          class="MuiCardContent-root css-1ly90im HvCard-Content-content css-46bh2p-MuiCardContent-root"
+          class="MuiCardContent-root HvCard-Content-content css-1ly90im css-46bh2p-MuiCardContent-root"
         >
           Temperature: 
           42
         </div>
       </div>
       <div
-        class="css-kdjrpy css-jvotyo HvIsCardGridElement HvCard-root"
+        class="HvIsCardGridElement HvCard-root css-9vqflq"
         style="width: 100%;"
       >
         <div
-          class="css-emolmc HvCard-semanticContainer"
+          class="HvCard-semanticContainer css-emolmc"
         >
           <div
-            class="css-1v84tfs css-1hhae7u HvCard-semanticBar"
+            class="HvCard-semanticBar css-12y48s9"
           />
           <div
-            class="css-pzj2c4 HvCard-icon"
+            class="HvCard-icon css-pzj2c4"
           />
         </div>
         <div
-          class="MuiCardHeader-root css-pqwkee HvCard-Header-root css-185gdzj-MuiCardHeader-root"
+          class="MuiCardHeader-root HvCard-Header-root css-pqwkee css-185gdzj-MuiCardHeader-root"
         >
           <div
             class="MuiCardHeader-content HvCard-Header-content css-1qbkelo-MuiCardHeader-content"
           >
             <span
-              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title css-1weuf4q HvCard-Header-title css-0 css-1qvr50w-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title HvCard-Header-title css-yragcd css-1qvr50w-MuiTypography-root"
             >
               Event 9
             </span>
           </div>
         </div>
         <div
-          class="MuiCardContent-root css-1ly90im HvCard-Content-content css-46bh2p-MuiCardContent-root"
+          class="MuiCardContent-root HvCard-Content-content css-1ly90im css-46bh2p-MuiCardContent-root"
         >
           Event: 
           Anomaly detection 0
         </div>
         <div
-          class="MuiCardContent-root css-1ly90im HvCard-Content-content css-46bh2p-MuiCardContent-root"
+          class="MuiCardContent-root HvCard-Content-content css-1ly90im css-46bh2p-MuiCardContent-root"
         >
           Severity: 
           Critical
         </div>
         <div
-          class="MuiCardContent-root css-1ly90im HvCard-Content-content css-46bh2p-MuiCardContent-root"
+          class="MuiCardContent-root HvCard-Content-content css-1ly90im css-46bh2p-MuiCardContent-root"
         >
           Temperature: 
           43
         </div>
       </div>
       <div
-        class="css-kdjrpy css-jvotyo HvIsCardGridElement HvCard-root"
+        class="HvIsCardGridElement HvCard-root css-9vqflq"
         style="width: 100%;"
       >
         <div
-          class="css-emolmc HvCard-semanticContainer"
+          class="HvCard-semanticContainer css-emolmc"
         >
           <div
-            class="css-1v84tfs css-1hhae7u HvCard-semanticBar"
+            class="HvCard-semanticBar css-12y48s9"
           />
           <div
-            class="css-pzj2c4 HvCard-icon"
+            class="HvCard-icon css-pzj2c4"
           />
         </div>
         <div
-          class="MuiCardHeader-root css-pqwkee HvCard-Header-root css-185gdzj-MuiCardHeader-root"
+          class="MuiCardHeader-root HvCard-Header-root css-pqwkee css-185gdzj-MuiCardHeader-root"
         >
           <div
             class="MuiCardHeader-content HvCard-Header-content css-1qbkelo-MuiCardHeader-content"
           >
             <span
-              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title css-1weuf4q HvCard-Header-title css-0 css-1qvr50w-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title HvCard-Header-title css-yragcd css-1qvr50w-MuiTypography-root"
             >
               Event 10
             </span>
           </div>
         </div>
         <div
-          class="MuiCardContent-root css-1ly90im HvCard-Content-content css-46bh2p-MuiCardContent-root"
+          class="MuiCardContent-root HvCard-Content-content css-1ly90im css-46bh2p-MuiCardContent-root"
         >
           Event: 
           Anomaly detection 1
         </div>
         <div
-          class="MuiCardContent-root css-1ly90im HvCard-Content-content css-46bh2p-MuiCardContent-root"
+          class="MuiCardContent-root HvCard-Content-content css-1ly90im css-46bh2p-MuiCardContent-root"
         >
           Severity: 
           Major
         </div>
         <div
-          class="MuiCardContent-root css-1ly90im HvCard-Content-content css-46bh2p-MuiCardContent-root"
+          class="MuiCardContent-root HvCard-Content-content css-1ly90im css-46bh2p-MuiCardContent-root"
         >
           Temperature: 
           44
         </div>
       </div>
       <div
-        class="css-kdjrpy css-jvotyo HvIsCardGridElement HvCard-root"
+        class="HvIsCardGridElement HvCard-root css-9vqflq"
         style="width: 100%;"
       >
         <div
-          class="css-emolmc HvCard-semanticContainer"
+          class="HvCard-semanticContainer css-emolmc"
         >
           <div
-            class="css-1v84tfs css-1hhae7u HvCard-semanticBar"
+            class="HvCard-semanticBar css-12y48s9"
           />
           <div
-            class="css-pzj2c4 HvCard-icon"
+            class="HvCard-icon css-pzj2c4"
           />
         </div>
         <div
-          class="MuiCardHeader-root css-pqwkee HvCard-Header-root css-185gdzj-MuiCardHeader-root"
+          class="MuiCardHeader-root HvCard-Header-root css-pqwkee css-185gdzj-MuiCardHeader-root"
         >
           <div
             class="MuiCardHeader-content HvCard-Header-content css-1qbkelo-MuiCardHeader-content"
           >
             <span
-              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title css-1weuf4q HvCard-Header-title css-0 css-1qvr50w-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title HvCard-Header-title css-yragcd css-1qvr50w-MuiTypography-root"
             >
               Event 11
             </span>
           </div>
         </div>
         <div
-          class="MuiCardContent-root css-1ly90im HvCard-Content-content css-46bh2p-MuiCardContent-root"
+          class="MuiCardContent-root HvCard-Content-content css-1ly90im css-46bh2p-MuiCardContent-root"
         >
           Event: 
           Anomaly detection 2
         </div>
         <div
-          class="MuiCardContent-root css-1ly90im HvCard-Content-content css-46bh2p-MuiCardContent-root"
+          class="MuiCardContent-root HvCard-Content-content css-1ly90im css-46bh2p-MuiCardContent-root"
         >
           Severity: 
           Average
         </div>
         <div
-          class="MuiCardContent-root css-1ly90im HvCard-Content-content css-46bh2p-MuiCardContent-root"
+          class="MuiCardContent-root HvCard-Content-content css-1ly90im css-46bh2p-MuiCardContent-root"
         >
           Temperature: 
           45
         </div>
       </div>
       <div
-        class="css-kdjrpy css-jvotyo HvIsCardGridElement HvCard-root"
+        class="HvIsCardGridElement HvCard-root css-9vqflq"
         style="width: 100%;"
       >
         <div
-          class="css-emolmc HvCard-semanticContainer"
+          class="HvCard-semanticContainer css-emolmc"
         >
           <div
-            class="css-1v84tfs css-1hhae7u HvCard-semanticBar"
+            class="HvCard-semanticBar css-12y48s9"
           />
           <div
-            class="css-pzj2c4 HvCard-icon"
+            class="HvCard-icon css-pzj2c4"
           />
         </div>
         <div
-          class="MuiCardHeader-root css-pqwkee HvCard-Header-root css-185gdzj-MuiCardHeader-root"
+          class="MuiCardHeader-root HvCard-Header-root css-pqwkee css-185gdzj-MuiCardHeader-root"
         >
           <div
             class="MuiCardHeader-content HvCard-Header-content css-1qbkelo-MuiCardHeader-content"
           >
             <span
-              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title css-1weuf4q HvCard-Header-title css-0 css-1qvr50w-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title HvCard-Header-title css-yragcd css-1qvr50w-MuiTypography-root"
             >
               Event 12
             </span>
           </div>
         </div>
         <div
-          class="MuiCardContent-root css-1ly90im HvCard-Content-content css-46bh2p-MuiCardContent-root"
+          class="MuiCardContent-root HvCard-Content-content css-1ly90im css-46bh2p-MuiCardContent-root"
         >
           Event: 
           Anomaly detection 3
         </div>
         <div
-          class="MuiCardContent-root css-1ly90im HvCard-Content-content css-46bh2p-MuiCardContent-root"
+          class="MuiCardContent-root HvCard-Content-content css-1ly90im css-46bh2p-MuiCardContent-root"
         >
           Severity: 
           Minor
         </div>
         <div
-          class="MuiCardContent-root css-1ly90im HvCard-Content-content css-46bh2p-MuiCardContent-root"
+          class="MuiCardContent-root HvCard-Content-content css-1ly90im css-46bh2p-MuiCardContent-root"
         >
           Temperature: 
           46
         </div>
       </div>
       <div
-        class="css-kdjrpy css-jvotyo HvIsCardGridElement HvCard-root"
+        class="HvIsCardGridElement HvCard-root css-9vqflq"
         style="width: 100%;"
       >
         <div
-          class="css-emolmc HvCard-semanticContainer"
+          class="HvCard-semanticContainer css-emolmc"
         >
           <div
-            class="css-1v84tfs css-1hhae7u HvCard-semanticBar"
+            class="HvCard-semanticBar css-12y48s9"
           />
           <div
-            class="css-pzj2c4 HvCard-icon"
+            class="HvCard-icon css-pzj2c4"
           />
         </div>
         <div
-          class="MuiCardHeader-root css-pqwkee HvCard-Header-root css-185gdzj-MuiCardHeader-root"
+          class="MuiCardHeader-root HvCard-Header-root css-pqwkee css-185gdzj-MuiCardHeader-root"
         >
           <div
             class="MuiCardHeader-content HvCard-Header-content css-1qbkelo-MuiCardHeader-content"
           >
             <span
-              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title css-1weuf4q HvCard-Header-title css-0 css-1qvr50w-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title HvCard-Header-title css-yragcd css-1qvr50w-MuiTypography-root"
             >
               Event 13
             </span>
           </div>
         </div>
         <div
-          class="MuiCardContent-root css-1ly90im HvCard-Content-content css-46bh2p-MuiCardContent-root"
+          class="MuiCardContent-root HvCard-Content-content css-1ly90im css-46bh2p-MuiCardContent-root"
         >
           Event: 
           Anomaly detection 0
         </div>
         <div
-          class="MuiCardContent-root css-1ly90im HvCard-Content-content css-46bh2p-MuiCardContent-root"
+          class="MuiCardContent-root HvCard-Content-content css-1ly90im css-46bh2p-MuiCardContent-root"
         >
           Severity: 
           Critical
         </div>
         <div
-          class="MuiCardContent-root css-1ly90im HvCard-Content-content css-46bh2p-MuiCardContent-root"
+          class="MuiCardContent-root HvCard-Content-content css-1ly90im css-46bh2p-MuiCardContent-root"
         >
           Temperature: 
           47
         </div>
       </div>
       <div
-        class="css-kdjrpy css-jvotyo HvIsCardGridElement HvCard-root"
+        class="HvIsCardGridElement HvCard-root css-9vqflq"
         style="width: 100%;"
       >
         <div
-          class="css-emolmc HvCard-semanticContainer"
+          class="HvCard-semanticContainer css-emolmc"
         >
           <div
-            class="css-1v84tfs css-1hhae7u HvCard-semanticBar"
+            class="HvCard-semanticBar css-12y48s9"
           />
           <div
-            class="css-pzj2c4 HvCard-icon"
+            class="HvCard-icon css-pzj2c4"
           />
         </div>
         <div
-          class="MuiCardHeader-root css-pqwkee HvCard-Header-root css-185gdzj-MuiCardHeader-root"
+          class="MuiCardHeader-root HvCard-Header-root css-pqwkee css-185gdzj-MuiCardHeader-root"
         >
           <div
             class="MuiCardHeader-content HvCard-Header-content css-1qbkelo-MuiCardHeader-content"
           >
             <span
-              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title css-1weuf4q HvCard-Header-title css-0 css-1qvr50w-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title HvCard-Header-title css-yragcd css-1qvr50w-MuiTypography-root"
             >
               Event 14
             </span>
           </div>
         </div>
         <div
-          class="MuiCardContent-root css-1ly90im HvCard-Content-content css-46bh2p-MuiCardContent-root"
+          class="MuiCardContent-root HvCard-Content-content css-1ly90im css-46bh2p-MuiCardContent-root"
         >
           Event: 
           Anomaly detection 1
         </div>
         <div
-          class="MuiCardContent-root css-1ly90im HvCard-Content-content css-46bh2p-MuiCardContent-root"
+          class="MuiCardContent-root HvCard-Content-content css-1ly90im css-46bh2p-MuiCardContent-root"
         >
           Severity: 
           Major
         </div>
         <div
-          class="MuiCardContent-root css-1ly90im HvCard-Content-content css-46bh2p-MuiCardContent-root"
+          class="MuiCardContent-root HvCard-Content-content css-1ly90im css-46bh2p-MuiCardContent-root"
         >
           Temperature: 
           48
         </div>
       </div>
       <div
-        class="css-kdjrpy css-jvotyo HvIsCardGridElement HvCard-root"
+        class="HvIsCardGridElement HvCard-root css-9vqflq"
         style="width: 100%;"
       >
         <div
-          class="css-emolmc HvCard-semanticContainer"
+          class="HvCard-semanticContainer css-emolmc"
         >
           <div
-            class="css-1v84tfs css-1hhae7u HvCard-semanticBar"
+            class="HvCard-semanticBar css-12y48s9"
           />
           <div
-            class="css-pzj2c4 HvCard-icon"
+            class="HvCard-icon css-pzj2c4"
           />
         </div>
         <div
-          class="MuiCardHeader-root css-pqwkee HvCard-Header-root css-185gdzj-MuiCardHeader-root"
+          class="MuiCardHeader-root HvCard-Header-root css-pqwkee css-185gdzj-MuiCardHeader-root"
         >
           <div
             class="MuiCardHeader-content HvCard-Header-content css-1qbkelo-MuiCardHeader-content"
           >
             <span
-              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title css-1weuf4q HvCard-Header-title css-0 css-1qvr50w-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-h5 MuiCardHeader-title HvCard-Header-title css-yragcd css-1qvr50w-MuiTypography-root"
             >
               Event 15
             </span>
           </div>
         </div>
         <div
-          class="MuiCardContent-root css-1ly90im HvCard-Content-content css-46bh2p-MuiCardContent-root"
+          class="MuiCardContent-root HvCard-Content-content css-1ly90im css-46bh2p-MuiCardContent-root"
         >
           Event: 
           Anomaly detection 2
         </div>
         <div
-          class="MuiCardContent-root css-1ly90im HvCard-Content-content css-46bh2p-MuiCardContent-root"
+          class="MuiCardContent-root HvCard-Content-content css-1ly90im css-46bh2p-MuiCardContent-root"
         >
           Severity: 
           Average
         </div>
         <div
-          class="MuiCardContent-root css-1ly90im HvCard-Content-content css-46bh2p-MuiCardContent-root"
+          class="MuiCardContent-root HvCard-Content-content css-1ly90im css-46bh2p-MuiCardContent-root"
         >
           Temperature: 
           49

--- a/packages/core/src/components/DatePicker/DatePicker.tsx
+++ b/packages/core/src/components/DatePicker/DatePicker.tsx
@@ -1,7 +1,6 @@
 import { useState, useEffect, useRef } from "react";
 import { ClassNames } from "@emotion/react";
 import styled from "@emotion/styled";
-import { clsx } from "clsx";
 import { Calendar } from "@hitachivantara/uikit-react-icons";
 import { theme } from "@hitachivantara/uikit-styles";
 import {
@@ -430,31 +429,31 @@ export const HvDatePicker = ({
    */
   const renderActions = () => (
     <ClassNames>
-      {({ css }) => (
+      {({ css, cx }) => (
         <HvActionBar
           className={
             showClear
-              ? clsx(
+              ? cx(
                   datePickerClasses.actionContainer,
-                  classes?.actionContainer,
-                  css(styles.actionContainer)
+                  css(styles.actionContainer),
+                  classes?.actionContainer
                 )
               : ""
           }
         >
           {showClear && (
             <div
-              className={clsx(
+              className={cx(
                 datePickerClasses.leftContainer,
                 classes?.leftContainer
               )}
             >
               <HvButton
                 id={setId(id, "action", "clear")}
-                className={clsx(
+                className={cx(
                   datePickerClasses.action,
-                  classes?.action,
-                  css(styles.action)
+                  css(styles.action),
+                  classes?.action
                 )}
                 variant="primaryGhost"
                 onClick={handleClear}
@@ -464,17 +463,17 @@ export const HvDatePicker = ({
             </div>
           )}
           <div
-            className={clsx(
+            className={cx(
               datePickerClasses.rightContainer,
               classes?.rightContainer
             )}
           >
             <HvButton
               id={setId(id, "action", "apply")}
-              className={clsx(
+              className={cx(
                 datePickerClasses.action,
-                classes?.action,
-                css(styles.action)
+                css(styles.action),
+                classes?.action
               )}
               variant="primaryGhost"
               onClick={handleApply}
@@ -483,10 +482,10 @@ export const HvDatePicker = ({
             </HvButton>
             <HvButton
               id={setId(id, "action", "cancel")}
-              className={clsx(
+              className={cx(
                 datePickerClasses.action,
-                classes?.action,
-                css(styles.action)
+                css(styles.action),
+                classes?.action
               )}
               variant="primaryGhost"
               onClick={handleCancel}
@@ -541,7 +540,7 @@ export const HvDatePicker = ({
 
   return (
     <ClassNames>
-      {({ css }) => (
+      {({ css, cx }) => (
         <HvFormElement
           id={id}
           name={name}
@@ -549,31 +548,31 @@ export const HvDatePicker = ({
           status={validationState}
           disabled={disabled}
           required={required}
-          className={clsx(
-            className,
+          className={cx(
             datePickerClasses.root,
-            classes?.root,
-            css(styles.root)
+            css(styles.root),
+            className,
+            classes?.root
           )}
           readOnly={readOnly}
           {...others}
         >
           {(hasLabel || hasDescription) && (
             <div
-              className={clsx(
+              className={cx(
                 datePickerClasses.labelContainer,
-                classes?.labelContainer,
-                css(styles.labelContainer)
+                css(styles.labelContainer),
+                classes?.labelContainer
               )}
             >
               {hasLabel && (
                 <HvLabel
                   id={setId(elementId, "label")}
                   label={label}
-                  className={clsx(
+                  className={cx(
                     datePickerClasses.label,
-                    classes?.label,
-                    css(styles.label)
+                    css(styles.label),
+                    classes?.label
                   )}
                 />
               )}
@@ -581,10 +580,10 @@ export const HvDatePicker = ({
               {hasDescription && (
                 <HvInfoMessage
                   id={setId(elementId, "description")}
-                  className={clsx(
+                  className={cx(
                     datePickerClasses.description,
-                    classes?.description,
-                    css(styles.description)
+                    css(styles.description),
+                    classes?.description
                   )}
                 >
                   {description}
@@ -595,27 +594,27 @@ export const HvDatePicker = ({
           <HvBaseDropdown
             role="combobox"
             classes={{
-              root: clsx(
+              root: cx(
                 datePickerClasses.dropdown,
-                classes?.dropdown,
-                css(styles.dropdown)
+                css(styles.dropdown),
+                classes?.dropdown
               ),
-              panel: clsx(
+              panel: cx(
                 datePickerClasses.panel,
-                classes?.panel,
-                css(styles.panel)
+                css(styles.panel),
+                classes?.panel
               ),
               header: isStateInvalid
-                ? clsx(
+                ? cx(
                     datePickerClasses.dropdownHeaderInvalid,
-                    classes?.dropdownHeaderInvalid,
-                    css(styles.dropdownHeaderInvalid)
+                    css(styles.dropdownHeaderInvalid),
+                    classes?.dropdownHeaderInvalid
                   )
                 : undefined,
-              headerOpen: clsx(
+              headerOpen: cx(
                 datePickerClasses.dropdownHeaderOpen,
-                classes?.dropdownHeaderOpen,
-                css(styles.dropdownHeaderOpen)
+                css(styles.dropdownHeaderOpen),
+                classes?.dropdownHeaderOpen
               ),
             }}
             readOnly={readOnly}
@@ -632,10 +631,10 @@ export const HvDatePicker = ({
             )}
             adornment={
               <Calendar
-                className={clsx(
+                className={cx(
                   datePickerClasses.icon,
-                  classes?.icon,
-                  css(styles.icon)
+                  css(styles.icon),
+                  classes?.icon
                 )}
                 color={disabled ? "secondary_80" : undefined}
               />
@@ -680,7 +679,7 @@ export const HvDatePicker = ({
             <HvWarningText
               id={setId(elementId, "error")}
               disableBorder
-              className={clsx(datePickerClasses.error, classes?.error)}
+              className={cx(datePickerClasses.error, classes?.error)}
             >
               {validationMessage}
             </HvWarningText>

--- a/packages/core/src/components/Dialog/Dialog.tsx
+++ b/packages/core/src/components/Dialog/Dialog.tsx
@@ -1,5 +1,4 @@
 import React, { useCallback, useRef } from "react";
-import { clsx } from "clsx";
 import MuiDialog, { DialogProps as MuiDialogProps } from "@mui/material/Dialog";
 import { Close } from "@hitachivantara/uikit-react-icons";
 import { theme } from "@hitachivantara/uikit-styles";
@@ -143,10 +142,10 @@ export const HvDialog = ({
 
   return (
     <ClassNames>
-      {({ css }) => (
+      {({ css, cx }) => (
         <MuiDialog
           container={document.getElementById(rootId || "") || document.body}
-          className={clsx(dialogClasses.root, classes?.root, className)}
+          className={cx(dialogClasses.root, className, classes?.root)}
           id={id}
           ref={measuredRef}
           open={open}
@@ -171,22 +170,18 @@ export const HvDialog = ({
           classes={{ container: css({ position: "relative" }) }}
           BackdropProps={{
             classes: {
-              root: clsx(classes?.background, dialogClasses.background),
+              root: cx(dialogClasses.background, classes?.background),
             },
           }}
           PaperProps={{
             classes: {
-              root: clsx(
-                css(styles.paper),
-                classes?.paper,
+              root: cx(
                 dialogClasses.paper,
+                fullscreen && cx(dialogClasses.fullscreen, "fullscreen"),
+                css(styles.paper),
                 css({ position: "absolute" }),
-                fullscreen &&
-                  clsx(
-                    dialogClasses.fullscreen,
-                    classes?.fullscreen,
-                    "fullscreen"
-                  )
+                classes?.paper,
+                fullscreen && classes?.fullscreen
               ),
             },
           }}
@@ -195,7 +190,7 @@ export const HvDialog = ({
         >
           <StyledClose
             id={setId(id, "close")}
-            className={clsx(dialogClasses.closeButton, classes?.closeButton)}
+            className={cx(dialogClasses.closeButton, classes?.closeButton)}
             variant="secondaryGhost"
             onClick={(event) => wrappedClose(event, true, undefined)}
             aria-label={buttonTitle}

--- a/packages/core/src/components/DropDownMenu/DropDownMenu.tsx
+++ b/packages/core/src/components/DropDownMenu/DropDownMenu.tsx
@@ -3,7 +3,6 @@ import { useMemo } from "react";
 import { ClassNames } from "@emotion/react";
 import { theme } from "@hitachivantara/uikit-styles";
 import { MoreOptionsVertical } from "@hitachivantara/uikit-react-icons";
-
 import { useControlled } from "@core/hooks";
 import { HvBaseProps } from "@core/types";
 import withId from "@core/hocs/withId";
@@ -146,27 +145,27 @@ const HvDropDownMenu = ({
 
   return (
     <ClassNames>
-      {({ css }) => (
+      {({ css, cx }) => (
         <StyledBaseDropDown
           id={id}
-          className={clsx(
-            className,
+          className={cx(
             dropDownMenuClasses.container,
+            className,
             classes?.container
           )}
           classes={{
-            root: clsx(
+            root: cx(
               dropDownMenuClasses.root,
-              classes?.root,
               css({
                 display: "inline-block",
                 width: "auto",
                 "&.focus-visible $icon": {
                   ...outlineStyles,
                 },
-              })
+              }),
+              classes?.root
             ),
-            container: clsx(
+            container: cx(
               dropDownMenuClasses.baseContainer,
               classes?.baseContainer
             ),
@@ -199,7 +198,7 @@ const HvDropDownMenu = ({
               }}
               onKeyDown={handleKeyDown}
               classes={{
-                root: clsx(dropDownMenuClasses.menuList, classes?.menuList),
+                root: cx(dropDownMenuClasses.menuList, classes?.menuList),
               }}
             />
           </StyledPanel>

--- a/packages/core/src/components/FilterGroup/Counter/Counter.tsx
+++ b/packages/core/src/components/FilterGroup/Counter/Counter.tsx
@@ -3,7 +3,6 @@ import { HvFilterGroupContext } from "../FilterGroupContext";
 import { styles } from "./Counter.styles";
 import { HvFilterGroupFilters, HvFilterGroupValue } from "../FilterGroup";
 import { ClassNames } from "@emotion/react";
-import { clsx } from "clsx";
 import filterGroupCounterClasses, {
   HvFilterGroupCounterClasses,
 } from "./counterClasses";
@@ -66,9 +65,9 @@ export const HvFilterGroupCounter = ({
 
   return (
     <ClassNames>
-      {({ css }) => (
+      {({ css, cx }) => (
         <div
-          className={clsx(
+          className={cx(
             filterGroupCounterClasses.root,
             css(styles.root),
             className,
@@ -77,7 +76,7 @@ export const HvFilterGroupCounter = ({
         >
           {partialCounter > 0 ? (
             <p
-              className={clsx(
+              className={cx(
                 filterGroupCounterClasses.partialCounter,
                 css(styles.partialCounter),
                 classes?.partialCounter

--- a/packages/core/src/components/FilterGroup/FilterContent/FilterContent.tsx
+++ b/packages/core/src/components/FilterGroup/FilterContent/FilterContent.tsx
@@ -20,7 +20,6 @@ import filterGroupContentClasses, {
 import { HvFilterGroupContext } from "../FilterGroupContext";
 import { useContext, useMemo, useRef, useState } from "react";
 import { Filters } from "@hitachivantara/uikit-react-icons";
-import { clsx } from "clsx";
 import { HvFilterGroupCounter } from "../Counter";
 import { ClassNames } from "@emotion/react";
 import { HvFilterGroupLeftPanel } from "../LeftPanel";
@@ -130,26 +129,26 @@ export const HvFilterGroupContent = ({
 
   return (
     <ClassNames>
-      {({ css }) => (
+      {({ css, cx }) => (
         <HvBaseDropdown
           id={setId(id, "dropdown")}
           role="combobox"
           classes={{
-            root: clsx(classes?.dropdown, filterGroupContentClasses.dropdown),
-            panel: clsx(
-              classes?.panel,
+            root: cx(filterGroupContentClasses.dropdown, classes?.dropdown),
+            panel: cx(
               filterGroupContentClasses.panel,
-              css(styles.panel)
+              css(styles.panel),
+              classes?.panel
             ),
-            selection: clsx(
-              classes?.baseDropdownSelection,
+            selection: cx(
               filterGroupContentClasses.baseDropdownSelection,
-              css(styles.baseDropdownSelection)
+              css(styles.baseDropdownSelection),
+              classes?.baseDropdownSelection
             ),
-            header: clsx(
-              classes?.header,
+            header: cx(
               filterGroupContentClasses.header,
-              css(styles.header)
+              css(styles.header),
+              classes?.header
             ),
           }}
           disabled={disabled}
@@ -183,38 +182,38 @@ export const HvFilterGroupContent = ({
         >
           <div ref={focusTarget} tabIndex={-1} />
           <div
-            className={clsx(
-              classes?.root,
+            className={cx(
               filterGroupContentClasses.root,
-              css(styles.root)
+              css(styles.root),
+              classes?.root
             )}
             style={{ height }}
           >
             <HvFilterGroupLeftPanel
               id={id}
-              className={clsx(
-                classes?.leftSidePanel,
+              className={cx(
                 filterGroupContentClasses.leftSidePanel,
-                css(styles.leftSidePanel)
+                css(styles.leftSidePanel),
+                classes?.leftSidePanel
               )}
               emptyElement={leftEmptyElement}
             />
             <HvFilterGroupRightPanel
               id={id}
-              className={clsx(
-                classes?.rightSidePanel,
+              className={cx(
                 filterGroupContentClasses.rightSidePanel,
-                css(styles.rightSidePanel)
+                css(styles.rightSidePanel),
+                classes?.rightSidePanel
               )}
               emptyElement={rightEmptyElement}
               labels={labels}
             />
           </div>
           <HvActionBar
-            className={clsx(
-              classes?.actionBar,
+            className={cx(
               filterGroupContentClasses.actionBar,
-              css(styles.actionBar)
+              css(styles.actionBar),
+              classes?.actionBar
             )}
           >
             <HvButton
@@ -231,10 +230,10 @@ export const HvFilterGroupContent = ({
             </HvButton>
             <div
               aria-hidden="true"
-              className={clsx(
-                classes?.space,
+              className={cx(
                 filterGroupContentClasses.space,
-                css(styles.space)
+                css(styles.space),
+                classes?.space
               )}
             >
               &nbsp;
@@ -246,7 +245,7 @@ export const HvFilterGroupContent = ({
                 activeTheme?.filterGroup.applyButtonVariant as HvButtonVariant
               }
               onClick={onApplyHandler}
-              className={clsx(
+              className={cx(
                 filterGroupContentClasses.applyButton,
                 css(styles.applyButton),
                 classes?.applyButton

--- a/packages/core/src/components/FilterGroup/FilterGroup.tsx
+++ b/packages/core/src/components/FilterGroup/FilterGroup.tsx
@@ -11,7 +11,6 @@ import {
   HvFilterGroupContent,
   HvFilterGroupContentProps,
 } from "./FilterContent";
-import { clsx } from "clsx";
 import { useControlled, useLabels, useUniqueId } from "@core/hooks";
 import { styles } from "./FilterGroup.styles";
 import { setId } from "@core/utils";
@@ -171,7 +170,7 @@ export const HvFilterGroup = ({
 
   return (
     <ClassNames>
-      {({ css }) => (
+      {({ css, cx }) => (
         <HvFormElement
           id={id}
           name={name}
@@ -179,15 +178,15 @@ export const HvFilterGroup = ({
           status={status}
           disabled={disabled}
           required={required}
-          className={clsx(className, classes?.root, filterGroupClasses.root)}
+          className={cx(filterGroupClasses.root, className, classes?.root)}
           {...others}
         >
           {(hasLabel || hasDescription) && (
             <div
-              className={clsx(
-                classes?.labelContainer,
+              className={cx(
                 filterGroupClasses.labelContainer,
-                css(styles.labelContainer)
+                css(styles.labelContainer),
+                classes?.labelContainer
               )}
             >
               {hasLabel && (
@@ -195,10 +194,10 @@ export const HvFilterGroup = ({
                   id={setId(elementId, "label")}
                   htmlFor={setId(elementId, "input")}
                   label={label}
-                  className={clsx(
-                    classes?.label,
+                  className={cx(
                     filterGroupClasses.label,
-                    css(styles.label)
+                    css(styles.label),
+                    classes?.label
                   )}
                 />
               )}
@@ -206,9 +205,9 @@ export const HvFilterGroup = ({
               {hasDescription && (
                 <HvInfoMessage
                   id={setId(elementId, "description")}
-                  className={clsx(
-                    classes?.description,
-                    filterGroupClasses.description
+                  className={cx(
+                    filterGroupClasses.description,
+                    classes?.description
                   )}
                 >
                   {description}
@@ -242,7 +241,7 @@ export const HvFilterGroup = ({
               <HvWarningText
                 id={setId(elementId, "error")}
                 disableBorder
-                className={clsx(classes?.error, filterGroupClasses.error)}
+                className={cx(filterGroupClasses.error, classes?.error)}
               >
                 {validationMessage}
               </HvWarningText>

--- a/packages/core/src/components/FilterGroup/LeftPanel/LeftPanel.tsx
+++ b/packages/core/src/components/FilterGroup/LeftPanel/LeftPanel.tsx
@@ -5,7 +5,6 @@ import { setId, wrapperTooltip } from "@core/utils";
 import { HvFilterGroupCounter } from "../Counter";
 import { ClassNames } from "@emotion/react";
 import { styles } from "./LeftPanel.styles";
-import { clsx } from "clsx";
 import filterGroupLeftPanelClasses, {
   HvFilterGroupLeftPanelClasses,
 } from "./leftPanelClasses";
@@ -28,7 +27,7 @@ export const HvFilterGroupLeftPanel = ({
 
   return (
     <ClassNames>
-      {({ css }) => (
+      {({ css, cx }) => (
         <HvPanel id={setId(id, "leftPanel")} className={className}>
           {filterOptions.length > 0 ? (
             <HvListContainer
@@ -43,7 +42,7 @@ export const HvFilterGroupLeftPanel = ({
                   <HvListItem
                     id={group.id}
                     key={group.name}
-                    className={clsx(
+                    className={cx(
                       filterGroupLeftPanelClasses.listItem,
                       css(styles.listItem),
                       classes?.listItem

--- a/packages/core/src/components/FilterGroup/RightPanel/RightPanel.tsx
+++ b/packages/core/src/components/FilterGroup/RightPanel/RightPanel.tsx
@@ -11,7 +11,6 @@ import { HvFilterGroupContext } from "../FilterGroupContext";
 import cloneDeep from "lodash/cloneDeep";
 import { ClassNames } from "@emotion/react";
 import { styles } from "./RightPanel.styles";
-import { clsx } from "clsx";
 import filterGroupRightPanelClasses, {
   HvFilterGroupRightPanelClasses,
 } from "./rightPanelClasses";
@@ -134,9 +133,9 @@ export const HvFilterGroupRightPanel = ({
 
     return (
       <ClassNames>
-        {({ css }) => (
+        {({ css, cx }) => (
           <div
-            className={clsx(
+            className={cx(
               filterGroupRightPanelClasses.selectAllContainer,
               css(styles.selectAllContainer),
               classes?.selectAllContainer
@@ -146,7 +145,7 @@ export const HvFilterGroupRightPanel = ({
               id={setId(id, "select-all")}
               label={defaultLabel}
               onChange={() => handleSelectAll()}
-              className={clsx(
+              className={cx(
                 filterGroupRightPanelClasses.selectAll,
                 css(styles.selectAll),
                 classes?.selectAll
@@ -170,14 +169,14 @@ export const HvFilterGroupRightPanel = ({
 
   return (
     <ClassNames>
-      {({ css }) => (
+      {({ css, cx }) => (
         <HvPanel id={setId(id, "rightPanel")} className={className}>
           {listValues.length > 0 ? (
             <>
               <HvInput
                 id={setId(id, "search")}
                 classes={{
-                  root: clsx(
+                  root: cx(
                     filterGroupRightPanelClasses.search,
                     css(styles.search),
                     classes?.search
@@ -193,7 +192,7 @@ export const HvFilterGroupRightPanel = ({
                 key={activeGroup}
                 id={setId(id, "list")}
                 values={listValues}
-                className={clsx(
+                className={cx(
                   filterGroupRightPanelClasses.list,
                   css(styles.list),
                   classes?.list

--- a/packages/core/src/components/InlineEditor/InlineEditor.tsx
+++ b/packages/core/src/components/InlineEditor/InlineEditor.tsx
@@ -1,4 +1,3 @@
-import { clsx } from "clsx";
 import { ClassNames } from "@emotion/react";
 import React, { useLayoutEffect, useRef, useState } from "react";
 import { HvBaseProps } from "@core/types";
@@ -116,29 +115,29 @@ export const HvInlineEditor = ({
 
   return (
     <ClassNames>
-      {({ css }) => (
+      {({ css, cx }) => (
         <div
-          className={clsx(
-            className,
+          className={cx(
             inlineEditorClasses.root,
-            classes?.root,
-            css(styles.root)
+            css(styles.root),
+            className,
+            classes?.root
           )}
         >
           {editMode ? (
             <InputComponent
               inputRef={inputRef}
               classes={{
-                root: clsx(classes?.inputRoot, inlineEditorClasses.inputRoot),
-                input: clsx(
-                  classes?.input,
+                root: cx(inlineEditorClasses.inputRoot, classes?.inputRoot),
+                input: cx(
                   inlineEditorClasses.input,
-                  css(styles.input)
+                  css(styles.input),
+                  classes?.input
                 ),
-                inputBorderContainer: clsx(
-                  classes?.inputBorderContainer,
+                inputBorderContainer: cx(
                   inlineEditorClasses.inputBorderContainer,
-                  css(styles.inputBorderContainer)
+                  css(styles.inputBorderContainer),
+                  classes?.inputBorderContainer
                 ),
               }}
               inputProps={{
@@ -157,16 +156,15 @@ export const HvInlineEditor = ({
             <HvButton
               variant="secondaryGhost"
               overrideIconColors={false}
-              className={clsx(
-                classes?.button,
+              className={cx(
                 inlineEditorClasses.button,
+                parseInt(lineHeight as string, 10) >= 28 &&
+                  inlineEditorClasses.largeText,
                 css(styles.button),
                 parseInt(lineHeight as string, 10) >= 28 &&
-                  clsx(
-                    classes?.largeText,
-                    inlineEditorClasses.largeText,
-                    css(styles.largeText)
-                  )
+                  css(styles.largeText),
+                classes?.button,
+                parseInt(lineHeight as string, 10) >= 28 && classes?.largeText
               )}
               onClick={handleClick}
               {...buttonProps}
@@ -174,16 +172,13 @@ export const HvInlineEditor = ({
               <HvTypography
                 variant={variant}
                 noWrap
-                className={clsx(
-                  classes?.text,
+                className={cx(
                   inlineEditorClasses.text,
+                  !value && inlineEditorClasses.textEmpty,
                   css(styles.text),
-                  !value &&
-                    clsx(
-                      classes?.textEmpty,
-                      inlineEditorClasses.textEmpty,
-                      css(styles.textEmpty)
-                    )
+                  !value && css(styles.textEmpty),
+                  classes?.text,
+                  !value && classes?.textEmpty
                 )}
                 {...typographyProps}
               >
@@ -192,16 +187,13 @@ export const HvInlineEditor = ({
               <Edit
                 color="secondary_60"
                 role="presentation"
-                className={clsx(
-                  classes?.icon,
+                className={cx(
                   inlineEditorClasses.icon,
+                  showIcon && inlineEditorClasses.iconVisible,
                   css(styles.icon),
-                  showIcon &&
-                    clsx(
-                      classes?.iconVisible,
-                      inlineEditorClasses.iconVisible,
-                      css(styles.iconVisible)
-                    )
+                  showIcon && css(styles.iconVisible),
+                  classes?.icon,
+                  showIcon && classes?.iconVisible
                 )}
               />
             </HvButton>

--- a/packages/core/src/components/QueryBuilder/RuleGroup/RuleGroup.tsx
+++ b/packages/core/src/components/QueryBuilder/RuleGroup/RuleGroup.tsx
@@ -133,19 +133,13 @@ export const RuleGroup = ({
         <div
           className={cx(
             queryBuilderClasses.root,
-            css(styles.root),
-            classes?.root,
             level === 0
-              ? cx(
-                  queryBuilderClasses.topGroup,
-                  css(styles.topGroup),
-                  classes?.topGroup
-                )
-              : cx(
-                  queryBuilderClasses.subGroup,
-                  css(styles.subGroup),
-                  classes?.subGroup
-                )
+              ? queryBuilderClasses.topGroup
+              : queryBuilderClasses.subGroup,
+            css(styles.root),
+            level === 0 ? css(styles.topGroup) : css(styles.subGroup),
+            classes?.root,
+            level === 0 ? classes?.topGroup : classes?.subGroup
           )}
         >
           <HvGrid container>
@@ -153,10 +147,10 @@ export const RuleGroup = ({
               <HvMultiButton
                 className={cx(
                   queryBuilderClasses.combinator,
-                  css(styles.combinator),
-                  classes?.combinator,
                   queryBuilderClasses.topCombinator,
+                  css(styles.combinator),
                   css(styles.topCombinator),
+                  classes?.combinator,
                   classes?.topCombinator
                 )}
                 disabled={readOnly}
@@ -184,10 +178,10 @@ export const RuleGroup = ({
               <div
                 className={cx(
                   queryBuilderClasses.buttonBackground,
-                  css(styles.buttonBackground),
-                  classes?.buttonBackground,
                   queryBuilderClasses.topRemoveButton,
+                  css(styles.buttonBackground),
                   css(styles.topRemoveButton),
+                  classes?.buttonBackground,
                   classes?.topRemoveButton
                 )}
               >
@@ -224,22 +218,14 @@ export const RuleGroup = ({
             <div
               className={cx(
                 queryBuilderClasses.rulesContainer,
+                level > 0 && queryBuilderClasses.subRulesContainer,
+                level === 0 && queryBuilderClasses.topRulesContainer,
                 css(styles.rulesContainer),
+                level > 0 && css(styles.subRulesContainer),
+                level === 0 && css(styles.topRulesContainer),
                 classes?.rulesContainer,
-                level > 0
-                  ? cx(
-                      queryBuilderClasses.subRulesContainer,
-                      css(styles.subRulesContainer),
-                      classes?.subRulesContainer
-                    )
-                  : "",
-                level === 0
-                  ? cx(
-                      queryBuilderClasses.topRulesContainer,
-                      css(styles.topRulesContainer),
-                      classes?.topRulesContainer
-                    )
-                  : ""
+                level > 0 && classes?.subRulesContainer,
+                level === 0 && classes?.topRulesContainer
               )}
             >
               {rules.map((rule, index) => {
@@ -325,10 +311,10 @@ export const RuleGroup = ({
               item
               className={cx(
                 queryBuilderClasses.actionButtonContainer,
-                css(styles.actionButtonContainer),
-                classes?.actionButtonContainer,
                 queryBuilderClasses.topActionButtonContainer,
+                css(styles.actionButtonContainer),
                 css(styles.topActionButtonContainer),
+                classes?.actionButtonContainer,
                 classes?.topActionButtonContainer
               )}
             >

--- a/packages/core/src/components/ScrollTo/Horizontal/HorizontalScrollListItem/HorizontalScrollListItem.tsx
+++ b/packages/core/src/components/ScrollTo/Horizontal/HorizontalScrollListItem/HorizontalScrollListItem.tsx
@@ -3,7 +3,6 @@ import horizontalScrollListItemClasses, {
   HvHorizontalScrollListItemClasses,
 } from "./horizontalScrollListItemClasses";
 import { ClassNames } from "@emotion/react";
-import { clsx } from "clsx";
 import { setId } from "@core/utils";
 import { HvTypographyProps } from "@core/components";
 import { styles } from "./HorizontalScrollListItem.styles";
@@ -49,14 +48,14 @@ export const HvHorizontalScrollListItem = ({
 
   return (
     <ClassNames>
-      {({ css }) => (
+      {({ css, cx }) => (
         <li
           id={id}
-          className={clsx(
-            className,
-            classes?.root,
+          className={cx(
             horizontalScrollListItemClasses.root,
-            css(styles.root)
+            css(styles.root),
+            className,
+            classes?.root
           )}
           aria-current={selected}
         >
@@ -66,26 +65,23 @@ export const HvHorizontalScrollListItem = ({
             tabIndex={0}
             onClick={onClick}
             onKeyDown={onKeyDown}
-            className={clsx(
-              classes?.button,
+            className={cx(
               horizontalScrollListItemClasses.button,
-              css(styles.button)
+              css(styles.button),
+              classes?.button
             )}
             aria-labelledby={labelId}
             {...others}
           >
             <Tooltip
               id={labelId}
-              className={clsx(
-                classes?.text,
+              className={cx(
                 horizontalScrollListItemClasses.text,
+                selected && horizontalScrollListItemClasses.selected,
                 css(styles.text),
-                selected &&
-                  clsx(
-                    classes?.selected,
-                    horizontalScrollListItemClasses.selected,
-                    css(styles.selected)
-                  )
+                selected && css(styles.selected),
+                classes?.text,
+                selected && classes?.selected
               )}
               variant={variant}
             >

--- a/packages/core/src/components/ScrollTo/Horizontal/ScrollToHorizontal.tsx
+++ b/packages/core/src/components/ScrollTo/Horizontal/ScrollToHorizontal.tsx
@@ -3,7 +3,6 @@ import scrollToHorizontalClasses, {
   HvScrollToHorizontalClasses,
 } from "./scrollToHorizontalClasses";
 import { ClassNames } from "@emotion/react";
-import { clsx } from "clsx";
 import { useTheme, useUniqueId } from "@core/hooks";
 import { styles } from "./ScrollToHorizontal.styles";
 import { useScrollTo } from "../useScrollTo";
@@ -133,19 +132,19 @@ export const HvScrollToHorizontal = ({
   const NotSelected = useCallback(() => {
     return (
       <ClassNames>
-        {({ css }) => (
+        {({ css, cx }) => (
           <div
-            className={clsx(
-              classes?.notSelectedRoot,
+            className={cx(
               scrollToHorizontalClasses.notSelectedRoot,
-              css(styles.notSelectedRoot)
+              css(styles.notSelectedRoot),
+              classes?.notSelectedRoot
             )}
           >
             <div
-              className={clsx(
-                classes?.notSelected,
+              className={cx(
                 scrollToHorizontalClasses.notSelected,
-                css(styles.notSelected)
+                css(styles.notSelected),
+                classes?.notSelected
               )}
             />
           </div>
@@ -157,14 +156,14 @@ export const HvScrollToHorizontal = ({
   const Selected = useCallback(() => {
     return (
       <ClassNames>
-        {({ css }) => (
+        {({ css, cx }) => (
           <CurrentStep
             height={activeTheme?.scrollTo.dotSelectedSize}
             width={activeTheme?.scrollTo.dotSelectedSize}
-            className={clsx(
-              classes?.selected,
+            className={cx(
               scrollToHorizontalClasses.selected,
-              css(styles.selected)
+              css(styles.selected),
+              classes?.selected
             )}
           />
         )}
@@ -201,12 +200,12 @@ export const HvScrollToHorizontal = ({
 
   return (
     <ClassNames>
-      {({ css }) => (
+      {({ css, cx }) => (
         <ol
-          className={clsx(
-            className,
-            classes?.root,
+          className={cx(
             scrollToHorizontalClasses.root,
+            position === "sticky" && scrollToHorizontalClasses.positionSticky,
+            position === "fixed" && scrollToHorizontalClasses.positionFixed,
             css(styles.root),
             css({
               width:
@@ -228,18 +227,12 @@ export const HvScrollToHorizontal = ({
                 activeTheme?.scrollTo.backgroundColorOpacity
               ),
             }),
-            position === "sticky" &&
-              clsx(
-                classes?.positionSticky,
-                scrollToHorizontalClasses.positionSticky,
-                css(styles.positionSticky)
-              ),
-            position === "fixed" &&
-              clsx(
-                classes?.positionFixed,
-                scrollToHorizontalClasses.positionFixed,
-                css(styles.positionFixed)
-              )
+            position === "sticky" && css(styles.positionSticky),
+            position === "fixed" && css(styles.positionFixed),
+            className,
+            classes?.root,
+            position === "sticky" && classes?.positionSticky,
+            position === "fixed" && classes?.positionFixed
           )}
           id={elementId}
           {...others}

--- a/packages/core/src/components/ScrollTo/Horizontal/__snapshots__/ScrollToHorizontal.test.tsx.snap
+++ b/packages/core/src/components/ScrollTo/Horizontal/__snapshots__/ScrollToHorizontal.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`ScrollToHorizontal > should render correctly 1`] = `
 <div>
   <ol
-    class="HvScrollToHorizontal-root hv-uikit-css-4hrf9l hv-uikit-css-h74ip1"
+    class="HvScrollToHorizontal-root hv-uikit-css-jnv3q4"
     id="hvHorizontalScrollto2"
   >
     <li
@@ -24,7 +24,7 @@ exports[`ScrollToHorizontal > should render correctly 1`] = `
           style="overflow: hidden; text-overflow: ellipsis; white-space: nowrap;"
         >
           <div
-            class="HvHorizontalScrollListItem-text HvHorizontalScrollListItem-selected HvTypography-root HvTypography-label hv-uikit-css-119jq4f-getStyledComponent e1tnpalo0"
+            class="HvHorizontalScrollListItem-text HvHorizontalScrollListItem-selected HvTypography-root HvTypography-label hv-uikit-css-1ofmnzo-getStyledComponent e1tnpalo0"
             id="hvHorizontalScrollto2-item-0-label"
           >
             <p>

--- a/packages/core/src/components/ScrollTo/Vertical/ScrollToVertical.tsx
+++ b/packages/core/src/components/ScrollTo/Vertical/ScrollToVertical.tsx
@@ -3,7 +3,6 @@ import scrollToVerticalClasses, {
   HvScrollToVerticalClasses,
 } from "./scrollToVerticalClasses";
 import { generateDynamicStyles, styles } from "./ScrollToVertical.styles";
-import { clsx } from "clsx";
 import { useTheme, useUniqueId } from "@core/hooks";
 import { HvVerticalScrollListItem } from "./VerticalScrollListItem";
 import { isKeypress, keyboardCodes, setId } from "@core/utils";
@@ -150,12 +149,12 @@ export const HvScrollToVertical = ({
 
   return (
     <ClassNames>
-      {({ css }) => (
+      {({ css, cx }) => (
         <ol
-          className={clsx(
-            className,
-            classes?.root,
+          className={cx(
             scrollToVerticalClasses.root,
+            position === "fixed" && scrollToVerticalClasses.positionFixed,
+            position === "absolute" && scrollToVerticalClasses.positionAbsolute,
             css(styles.root),
             css({
               backgroundColor: fade(
@@ -163,18 +162,12 @@ export const HvScrollToVertical = ({
                 activeTheme?.scrollTo.backgroundColorOpacity
               ),
             }),
-            position === "fixed" &&
-              clsx(
-                classes?.positionFixed,
-                scrollToVerticalClasses.positionFixed,
-                css(dynamicClasses.positionFixed)
-              ),
-            position === "absolute" &&
-              clsx(
-                classes?.positionAbsolute,
-                scrollToVerticalClasses.positionAbsolute,
-                css(dynamicClasses.positionAbsolute)
-              )
+            position === "fixed" && css(dynamicClasses.positionFixed),
+            position === "absolute" && css(dynamicClasses.positionAbsolute),
+            className,
+            classes?.root,
+            position === "fixed" && classes?.positionFixed,
+            position === "absolute" && classes?.positionAbsolute
           )}
           id={elementId}
           {...others}

--- a/packages/core/src/components/ScrollTo/Vertical/VerticalScrollListItem/VerticalScrollListItem.tsx
+++ b/packages/core/src/components/ScrollTo/Vertical/VerticalScrollListItem/VerticalScrollListItem.tsx
@@ -3,7 +3,6 @@ import verticalScrollListItemClasses, {
   HvVerticalScrollListItemClasses,
 } from "./verticalScrollListItemClasses";
 import { ClassNames } from "@emotion/react";
-import { clsx } from "clsx";
 import { styles } from "./VerticalScrollListItem.styles";
 import { HvTypographyProps } from "@core/components";
 import { setId } from "@core/utils";
@@ -56,12 +55,12 @@ export const HvVerticalScrollListItem = ({
   const NotSelected = useCallback(() => {
     return (
       <ClassNames>
-        {({ css }) => (
+        {({ css, cx }) => (
           <div
-            className={clsx(
-              classes?.notSelected,
+            className={cx(
               verticalScrollListItemClasses.notSelected,
-              css(styles.notSelected)
+              css(styles.notSelected),
+              classes?.notSelected
             )}
           />
         )}
@@ -80,14 +79,14 @@ export const HvVerticalScrollListItem = ({
 
   return (
     <ClassNames>
-      {({ css }) => (
+      {({ css, cx }) => (
         <li
           id={id}
-          className={clsx(
-            className,
-            classes?.root,
+          className={cx(
             verticalScrollListItemClasses.root,
-            css(styles.root)
+            css(styles.root),
+            className,
+            classes?.root
           )}
           aria-current={selected}
         >
@@ -97,10 +96,10 @@ export const HvVerticalScrollListItem = ({
             tabIndex={0}
             onClick={onClick}
             onKeyDown={onKeyDown}
-            className={clsx(
-              classes?.button,
+            className={cx(
               verticalScrollListItemClasses.button,
-              css(styles.button)
+              css(styles.button),
+              classes?.button
             )}
             aria-label={ariaLabel}
             aria-labelledby={labelId}
@@ -108,10 +107,10 @@ export const HvVerticalScrollListItem = ({
           >
             <Tooltip
               id={labelId}
-              className={clsx(
-                classes?.text,
+              className={cx(
                 verticalScrollListItemClasses.text,
-                css(styles.text)
+                css(styles.text),
+                classes?.text
               )}
               variant={variant}
             >

--- a/packages/core/src/components/ScrollTo/Vertical/__snapshots__/ScrollToVertical.test.tsx.snap
+++ b/packages/core/src/components/ScrollTo/Vertical/__snapshots__/ScrollToVertical.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`ScrollToVertical > should render correctly 1`] = `
 <div>
   <ol
-    class="HvScrollToVertical-root hv-uikit-css-1qyiqv5 hv-uikit-css-mnhjhi"
+    class="HvScrollToVertical-root hv-uikit-css-1iz8oef"
     id="hvVerticalScrollto2"
   >
     <li

--- a/packages/lab/src/components/StepNavigation/SimpleNavigation/Dot/Dot.tsx
+++ b/packages/lab/src/components/StepNavigation/SimpleNavigation/Dot/Dot.tsx
@@ -1,4 +1,3 @@
-import { clsx } from "clsx";
 import { HvBaseProps } from "@hitachivantara/uikit-react-core";
 import { StyledButton } from "./Dot.styles";
 import dotClasses, { HvDotClasses } from "./dotClasses";
@@ -30,12 +29,13 @@ export const HvDot = ({
 
   return (
     <ClassNames>
-      {({ css }) => (
+      {({ css, cx }) => (
         <StyledButton
-          className={clsx(
-            className,
-            classes?.root,
+          className={cx(
             dotClasses.root,
+            state === "Current" && dotClasses.active,
+            (disabled ?? ["Current", "Disabled"].includes(state)) &&
+              dotClasses.ghostDisabled,
             css({
               backgroundColor: getColor(state, theme),
               width: dotSize,
@@ -44,9 +44,11 @@ export const HvDot = ({
                 backgroundColor: getColor(state, theme),
               },
             }),
-            state === "Current" && clsx(dotClasses.active, classes?.active),
+            className,
+            classes?.root,
+            state === "Current" && classes?.active,
             (disabled ?? ["Current", "Disabled"].includes(state)) &&
-              clsx(dotClasses.ghostDisabled, classes?.ghostDisabled)
+              classes?.ghostDisabled
           )}
           aria-label={`step-${title}`}
           icon

--- a/packages/lab/src/components/StepNavigation/StepNavigation.tsx
+++ b/packages/lab/src/components/StepNavigation/StepNavigation.tsx
@@ -1,4 +1,3 @@
-import { clsx } from "clsx";
 import { ClassNames } from "@emotion/react";
 import styled from "@emotion/styled";
 import { theme } from "@hitachivantara/uikit-styles";
@@ -120,18 +119,18 @@ export const HvStepNavigation = ({
 
     return (
       <ClassNames key={`separator-${title}`}>
-        {({ css }) => (
+        {({ css, cx }) => (
           <StyledLi
             aria-hidden
-            className={clsx(
-              css(styles.separator),
+            className={cx(
               stepNavigationClasses.separator,
+              css(styles.separator),
               classes?.separator
             )}
           >
             <div
               aria-label={`separator-${title}`}
-              className={clsx(separatorClassName)}
+              className={separatorClassName}
             />
           </StyledLi>
         )}
@@ -159,11 +158,11 @@ export const HvStepNavigation = ({
         };
         const stepElement = (
           <ClassNames key={`step-${title}`}>
-            {({ css }) => (
+            {({ css, cx }) => (
               <StepContainer
-                className={clsx(
-                  css(styles.li),
+                className={cx(
                   stepNavigationClasses.li,
+                  css(styles.li),
                   classes?.li
                 )}
               >
@@ -182,9 +181,9 @@ export const HvStepNavigation = ({
                   >
                     <div aria-label={`step-container-${title}`}>
                       <Step
-                        className={clsx(
-                          css(styles.li),
+                        className={cx(
                           stepNavigationClasses.li,
+                          css(styles.li),
                           classes?.li
                         )}
                       >
@@ -222,11 +221,11 @@ export const HvStepNavigation = ({
 
     return (
       <ClassNames>
-        {({ css }) => (
+        {({ css, cx }) => (
           <ol
-            className={clsx(
-              css(styles.ol),
+            className={cx(
               stepNavigationClasses.ol,
+              css(styles.ol),
               classes?.ol
             )}
           >
@@ -290,11 +289,11 @@ export const HvStepNavigation = ({
   const getTitles = (getTitleProps) =>
     hasTitles ? (
       <ClassNames>
-        {({ css }) => (
+        {({ css, cx }) => (
           <div
-            className={clsx(
-              css(styles.titles),
+            className={cx(
               stepNavigationClasses.titles,
+              css(styles.titles),
               classes?.titles
             )}
           >
@@ -330,18 +329,18 @@ export const HvStepNavigation = ({
 
   return (
     <ClassNames>
-      {({ css }) => (
+      {({ css, cx }) => (
         <StepNavigation
           {...{
             numSteps: steps.length,
             stepSize: stepSizeKey,
             getTitles,
             getDynamicValues,
-            className: clsx(
-              className,
+            className: cx(
               stepNavigationClasses.root,
-              classes?.root,
-              css(styles.root)
+              css(styles.root),
+              className,
+              classes?.root
             ),
             ...others,
           }}

--- a/packages/lab/src/components/StepNavigation/__snapshots__/StepNavigation.test.tsx.snap
+++ b/packages/lab/src/components/StepNavigation/__snapshots__/StepNavigation.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`StepNavigation > should render correctly 1`] = `
       style="margin: 0px;"
     >
       <ol
-        class="css-fg3xwr HvStepNavigation-ol"
+        class="HvStepNavigation-ol css-fg3xwr"
       >
         <li
           class="HvStepNavigation-li css-6715mb-styledLi e1wrrltm3"
@@ -83,7 +83,6 @@ exports[`StepNavigation > should render correctly 1`] = `
         >
           <div
             aria-label="separator-Completed"
-            class=""
           />
         </li>
         <li
@@ -158,7 +157,6 @@ exports[`StepNavigation > should render correctly 1`] = `
         >
           <div
             aria-label="separator-Failed"
-            class=""
           />
         </li>
         <li
@@ -228,7 +226,6 @@ exports[`StepNavigation > should render correctly 1`] = `
         >
           <div
             aria-label="separator-Pending"
-            class=""
           />
         </li>
         <li
@@ -283,7 +280,6 @@ exports[`StepNavigation > should render correctly 1`] = `
         >
           <div
             aria-label="separator-Current"
-            class=""
           />
         </li>
         <li
@@ -336,7 +332,6 @@ exports[`StepNavigation > should render correctly 1`] = `
         >
           <div
             aria-label="separator-Enabled"
-            class=""
           />
         </li>
         <li

--- a/packages/lab/src/components/Wizard/WizardActions/WizardActions.tsx
+++ b/packages/lab/src/components/Wizard/WizardActions/WizardActions.tsx
@@ -1,6 +1,5 @@
 import { useCallback, useContext, useEffect, useState } from "react";
 import { ClassNames } from "@emotion/react";
-import { clsx } from "clsx";
 import {
   HvBaseProps,
   HvButton,
@@ -101,22 +100,22 @@ export const HvWizardActions = ({
 
   return (
     <ClassNames>
-      {({ css }) => (
+      {({ css, cx }) => (
         <HvDialogActions
-          className={clsx(
-            classes?.actionsContainer,
+          className={cx(
             wizardActionsClasses.actionsContainer,
-            css(styles.actionsContainer)
+            css(styles.actionsContainer),
+            classes?.actionsContainer
           )}
         >
           <HvGrid>
             <HvButton
               variant="secondaryGhost"
               onClick={handleClose}
-              className={clsx(
-                classes?.buttonWidth,
+              className={cx(
                 wizardActionsClasses.buttonWidth,
-                css(styles.buttonWidth)
+                css(styles.buttonWidth),
+                classes?.buttonWidth
               )}
             >
               {`${labels.cancel ?? "Cancel"}`}
@@ -125,10 +124,10 @@ export const HvWizardActions = ({
               <HvButton
                 variant="secondaryGhost"
                 disabled={isLastPage}
-                className={clsx(
-                  classes?.buttonWidth,
+                className={cx(
                   wizardActionsClasses.buttonWidth,
-                  css(styles.buttonWidth)
+                  css(styles.buttonWidth),
+                  classes?.buttonWidth
                 )}
                 onClick={handleSkip}
               >
@@ -137,18 +136,18 @@ export const HvWizardActions = ({
             )}
           </HvGrid>
           <HvGrid
-            className={clsx(
-              classes?.buttonsContainer,
+            className={cx(
               wizardActionsClasses.buttonsContainer,
-              css(styles.buttonsContainer)
+              css(styles.buttonsContainer),
+              classes?.buttonsContainer
             )}
           >
             <HvButton
               variant="secondaryGhost"
-              className={clsx(
-                classes?.buttonWidth,
+              className={cx(
                 wizardActionsClasses.buttonWidth,
-                css(styles.buttonWidth)
+                css(styles.buttonWidth),
+                classes?.buttonWidth
               )}
               disabled={tab <= 0}
               onClick={() => setTab((t) => t - 1)}
@@ -159,10 +158,10 @@ export const HvWizardActions = ({
             {isLastPage ? (
               <HvButton
                 variant="primary"
-                className={clsx(
-                  classes?.buttonWidth,
+                className={cx(
                   wizardActionsClasses.buttonWidth,
-                  css(styles.buttonWidth)
+                  css(styles.buttonWidth),
+                  classes?.buttonWidth
                 )}
                 disabled={loading || !canSubmit}
                 onClick={handleSubmitInternal}
@@ -172,13 +171,13 @@ export const HvWizardActions = ({
             ) : (
               <HvButton
                 variant="secondaryGhost"
-                className={clsx(
-                  classes?.buttonWidth,
+                className={cx(
                   wizardActionsClasses.buttonWidth,
-                  css(styles.buttonWidth),
-                  classes?.buttonSpacing,
                   wizardActionsClasses.buttonSpacing,
-                  css(styles.buttonSpacing)
+                  css(styles.buttonWidth),
+                  css(styles.buttonSpacing),
+                  classes?.buttonWidth,
+                  classes?.buttonSpacing
                 )}
                 onClick={() => setTab((t) => t + 1)}
                 disabled={!skippable && !context?.[tab]?.valid}

--- a/packages/lab/src/components/Wizard/WizardContainer/WizardContainer.tsx
+++ b/packages/lab/src/components/Wizard/WizardContainer/WizardContainer.tsx
@@ -1,6 +1,5 @@
 import { ClassNames } from "@emotion/react";
 import { HvBaseProps, HvDialog } from "@hitachivantara/uikit-react-core";
-import { clsx } from "clsx";
 import wizardContainerClasses, {
   HvWizardContainerClasses,
 } from "./wizardContainerClasses";
@@ -29,25 +28,21 @@ export const HvWizardContainer = ({
 }: HvWizardContainerProps) => {
   return (
     <ClassNames>
-      {({ css }) => (
+      {({ css, cx }) => (
         <HvDialog
           classes={{
-            closeButton: clsx(
-              classes?.closeButton,
+            closeButton: cx(
               wizardContainerClasses.closeButton,
-              css(styles.closeButton)
+              css(styles.closeButton),
+              classes?.closeButton
             ),
-            paper: clsx(
-              classes?.paper,
+            paper: cx(
               wizardContainerClasses.paper,
-              css(styles.paper)
+              css(styles.paper),
+              classes?.paper
             ),
           }}
-          className={clsx(
-            className,
-            classes?.root,
-            wizardContainerClasses.root
-          )}
+          className={cx(wizardContainerClasses.root, className, classes?.root)}
           open={open}
           onClose={handleClose}
           {...others}

--- a/packages/lab/src/components/Wizard/WizardContent/WizardContent.tsx
+++ b/packages/lab/src/components/Wizard/WizardContent/WizardContent.tsx
@@ -1,6 +1,5 @@
 import { ClassNames } from "@emotion/react";
 import { HvBaseProps, HvDialogContent } from "@hitachivantara/uikit-react-core";
-import { clsx } from "clsx";
 import wizardContentClasses, {
   HvWizardContentClasses,
 } from "./wizardContentClasses";
@@ -126,12 +125,12 @@ export const HvWizardContent = ({
 
   return (
     <ClassNames>
-      {({ css }) => (
+      {({ css, cx }) => (
         <div
-          className={clsx(
-            classes?.summaryRef,
+          className={cx(
             wizardContentClasses.summaryRef,
-            css(styles.summaryRef)
+            css(styles.summaryRef),
+            classes?.summaryRef
           )}
           ref={(el) => {
             containerRef(el);
@@ -142,17 +141,17 @@ export const HvWizardContent = ({
         >
           {summary !== null && (
             <div
-              className={clsx(
-                classes?.summarySticky,
+              className={cx(
                 wizardContentClasses.summarySticky,
-                css(styles.summarySticky)
+                css(styles.summarySticky),
+                classes?.summarySticky
               )}
             >
               <div
-                className={clsx(
-                  classes?.summaryContainer,
+                className={cx(
                   wizardContentClasses.summaryContainer,
-                  css(styles.summaryContainer)
+                  css(styles.summaryContainer),
+                  classes?.summaryContainer
                 )}
                 style={{
                   left: summaryLeft,
@@ -166,16 +165,13 @@ export const HvWizardContent = ({
             </div>
           )}
           <HvDialogContent
-            className={clsx(
-              classes?.contentContainer,
+            className={cx(
               wizardContentClasses.contentContainer,
+              fixedHeight && wizardContentClasses.fixedHeight,
               css(styles.contentContainer),
-              fixedHeight &&
-                clsx(
-                  classes?.fixedHeight,
-                  wizardContentClasses.fixedHeight,
-                  css(styles.fixedHeight)
-                )
+              fixedHeight && css(styles.fixedHeight),
+              classes?.contentContainer,
+              fixedHeight && classes?.fixedHeight
             )}
             indentContent
           >

--- a/packages/lab/src/components/Wizard/WizardTitle/WizardTitle.tsx
+++ b/packages/lab/src/components/Wizard/WizardTitle/WizardTitle.tsx
@@ -7,7 +7,6 @@ import {
   HvTypography,
 } from "@hitachivantara/uikit-react-core";
 import { Report } from "@hitachivantara/uikit-react-icons";
-import { clsx } from "clsx";
 import wizardTitleClasses, { HvWizardTitleClasses } from "./wizardTitleClasses";
 import { styles } from "./WizardTitle.styles";
 import { useContext, useEffect, useState } from "react";
@@ -87,18 +86,18 @@ export const HvWizardTitle = ({
 
   return (
     <ClassNames>
-      {({ css }) => (
+      {({ css, cx }) => (
         <HvDialogTitle
-          className={clsx(
-            classes?.headerContainer,
+          className={cx(
             wizardTitleClasses.headerContainer,
-            css(styles.headerContainer)
+            css(styles.headerContainer),
+            classes?.headerContainer
           )}
           classes={{
-            messageContainer: clsx(
-              classes?.messageContainer,
+            messageContainer: cx(
               wizardTitleClasses.messageContainer,
-              css(styles.messageContainer)
+              css(styles.messageContainer),
+              classes?.messageContainer
             ),
           }}
         >
@@ -106,10 +105,10 @@ export const HvWizardTitle = ({
             container
             justifyContent="space-between"
             alignItems="center"
-            className={clsx(
-              classes?.titleContainer,
+            className={cx(
               wizardTitleClasses.titleContainer,
-              css(styles.titleContainer)
+              css(styles.titleContainer),
+              classes?.titleContainer
             )}
           >
             {title && (
@@ -119,10 +118,10 @@ export const HvWizardTitle = ({
             )}
             {!!steps.length && (
               <HvStepNavigation
-                className={clsx(
-                  classes?.stepContainer,
+                className={cx(
                   wizardTitleClasses.stepContainer,
-                  css(styles.stepContainer)
+                  css(styles.stepContainer),
+                  classes?.stepContainer
                 )}
                 steps={steps}
                 type={customStep?.type ?? "Default"}
@@ -135,16 +134,16 @@ export const HvWizardTitle = ({
             {hasSummary && (
               <HvButton
                 variant="secondarySubtle"
-                className={clsx(
-                  classes?.buttonWidth,
+                className={cx(
                   wizardTitleClasses.buttonWidth,
-                  css(styles.buttonWidth)
+                  css(styles.buttonWidth),
+                  classes?.buttonWidth
                 )}
                 classes={{
-                  root: clsx(
-                    classes?.rootSummaryButton,
+                  root: cx(
                     wizardTitleClasses.rootSummaryButton,
-                    css(styles.rootSummaryButton)
+                    css(styles.rootSummaryButton),
+                    classes?.rootSummaryButton
                   ),
                 }}
                 onClick={toggleSummary}


### PR DESCRIPTION
- We started using `cx` in some components to fix override problems we were having when external classes were provided to the component. To maintain consistency I did the same for all the components that are using `ClassNames`. The classes order was also changed in some cases since external classes should be the last ones listed.