### PR TITLE
fix(DropdownMenu): fix missing border

### DIFF
--- a/packages/core/src/components/BulkActions/__snapshots__/BulkActions.test.tsx.snap
+++ b/packages/core/src/components/BulkActions/__snapshots__/BulkActions.test.tsx.snap
@@ -156,7 +156,7 @@ exports[`BulkActions > With actions > should render correctly 1`] = `
           <button
             aria-expanded="false"
             aria-label="Dropdown menu"
-            class="HvDropDownMenu-icon HvActionsGeneric-dropDownMenuButton e13q7myz1 HvButton-root css-8lowi7-StyledButton-StyledButton e138pvrm0"
+            class="HvDropDownMenu-icon HvActionsGeneric-dropDownMenuButton e13q7myz1 HvButton-root css-12vulei-StyledButton-StyledButton e138pvrm0"
             disabled=""
             id="hv-drop-down-menu-20-icon-button"
           >

--- a/packages/core/src/components/DropDownMenu/DropDownMenu.styles.tsx
+++ b/packages/core/src/components/DropDownMenu/DropDownMenu.styles.tsx
@@ -29,7 +29,6 @@ export const StyledButton = styled(
 
   borderRadius: theme.dropDownMenu.borderRadius,
   border: theme.dropDownMenu.borderClosed,
-  borderBottom: "none",
 
   ...($open && {
     backgroundColor: theme.colors.atmo1,
@@ -45,7 +44,6 @@ export const StyledButton = styled(
 
     borderRadius: `${theme.radii.base} ${theme.radii.base} 0px 0px`,
     border: theme.dropDownMenu.borderOpened,
-    borderBottom: "none",
   }),
 }));
 

--- a/packages/core/src/components/DropDownMenu/__snapshots__/DropDownMenu.test.tsx.snap
+++ b/packages/core/src/components/DropDownMenu/__snapshots__/DropDownMenu.test.tsx.snap
@@ -15,7 +15,7 @@ exports[`DropDownMenu > should render correctly 1`] = `
       <button
         aria-expanded="false"
         aria-label="Dropdown menu"
-        class="HvDropDownMenu-icon e13q7myz1 HvButton-root hv-uikit-css-jt0ozn-StyledButton-StyledButton e138pvrm0"
+        class="HvDropDownMenu-icon e13q7myz1 HvButton-root hv-uikit-css-15tynx0-StyledButton-StyledButton e138pvrm0"
         id="hv-drop-down-menu-4-icon-button"
       >
         <div


### PR DESCRIPTION
## Before

DS3:
![image](https://github.com/lumada-design/hv-uikit-react/assets/7498785/b53b44d8-9ee4-4056-971e-49589056108a)

DS5:
![image](https://github.com/lumada-design/hv-uikit-react/assets/7498785/9400b9ce-603f-44c4-a0d9-0f9f06a3e29b)


## After

DS3:
![image](https://github.com/lumada-design/hv-uikit-react/assets/7498785/043786ab-9b2b-45f3-9d72-4fe84b9ccbe7)

DS5:
![image](https://github.com/lumada-design/hv-uikit-react/assets/7498785/d0b62cdc-7624-493b-9708-6f6bc99d5e1e)
