### PR TITLE
fix: header hover

### DIFF
--- a/packages/core/src/components/Header/Navigation/MenuItem/MenuItem.styles.tsx
+++ b/packages/core/src/components/Header/Navigation/MenuItem/MenuItem.styles.tsx
@@ -14,11 +14,17 @@ export const MenuItemLi = styled(
     color: theme.header.color,
   },
   "&:hover": {
-    "& > a:first-child, div:first-child": {
+    "& > a:first-child": {
+      backgroundColor: hoverColor,
+    },
+    "& > div:first-child": {
       backgroundColor: hoverColor,
     },
     "&:focus-within": {
-      "& > a:first-child, div:first-child": {
+      "& > div:first-child": {
+        backgroundColor: hoverColor,
+      },
+      "& > a:first-child": {
         backgroundColor: hoverColor,
       },
     },


### PR DESCRIPTION
- The hover was not behaving correctly: when hovering a parent item, the child items were also highlighted. This was detected on our local app. On storybook everything seemed to be fine.