### PR TITLE
chore(VerticalNavigation): created a property to customize popup styling

### DIFF
--- a/packages/core/src/components/VerticalNavigation/Navigation/Navigation.tsx
+++ b/packages/core/src/components/VerticalNavigation/Navigation/Navigation.tsx
@@ -160,8 +160,6 @@ export const HvVerticalNavigationTree = ({
   defaultSelected,
   onChange,
 
-  popupStyles,
-
   ...others
 }: HvVerticalNavigationTreeProps) => {
   const [selected, setSelected] = useControlled(selectedProp, defaultSelected);
@@ -359,7 +357,10 @@ export const HvVerticalNavigationTree = ({
               data={navigationPopup.data}
               onClose={handleNavigationPopupClose}
               onChange={handleChange}
-              popupStyles={popupStyles}
+              className={clsx(
+                verticalNavigationTreeClasses.navigationPopup,
+                classes?.navigationPopup
+              )}
             />
           )}
           {children}
@@ -436,10 +437,6 @@ export interface HvVerticalNavigationTreeProps
    * target - the behavior when opening an url.
    */
   data?: NavigationData[];
-  /**
-   * Object with the custom css styles to be applied to the popup.
-   */
-  popupStyles?: any;
 }
 
 export type NavigationMode = "treeview" | "navigation" | "slider";

--- a/packages/core/src/components/VerticalNavigation/Navigation/Navigation.tsx
+++ b/packages/core/src/components/VerticalNavigation/Navigation/Navigation.tsx
@@ -160,6 +160,8 @@ export const HvVerticalNavigationTree = ({
   defaultSelected,
   onChange,
 
+  popupStyles,
+
   ...others
 }: HvVerticalNavigationTreeProps) => {
   const [selected, setSelected] = useControlled(selectedProp, defaultSelected);
@@ -357,6 +359,7 @@ export const HvVerticalNavigationTree = ({
               data={navigationPopup.data}
               onClose={handleNavigationPopupClose}
               onChange={handleChange}
+              popupStyles={popupStyles}
             />
           )}
           {children}
@@ -433,6 +436,10 @@ export interface HvVerticalNavigationTreeProps
    * target - the behavior when opening an url.
    */
   data?: NavigationData[];
+  /**
+   * Object with the custom css styles to be applied to the popup.
+   */
+  popupStyles?: any;
 }
 
 export type NavigationMode = "treeview" | "navigation" | "slider";

--- a/packages/core/src/components/VerticalNavigation/Navigation/navigationClasses.ts
+++ b/packages/core/src/components/VerticalNavigation/Navigation/navigationClasses.ts
@@ -6,6 +6,7 @@ export interface HvVerticalNavigationTreeClasses {
   listItem?: string;
   collapsed?: string;
   popup?: string;
+  navigationPopup?: string;
 }
 
 const classKeys: (keyof HvVerticalNavigationTreeClasses)[] = [
@@ -14,6 +15,7 @@ const classKeys: (keyof HvVerticalNavigationTreeClasses)[] = [
   "listItem",
   "collapsed",
   "popup",
+  "navigationPopup",
 ];
 
 const verticalNavigationTreeClasses = getClasses(

--- a/packages/core/src/components/VerticalNavigation/NavigationPopup/NavigationPopup.tsx
+++ b/packages/core/src/components/VerticalNavigation/NavigationPopup/NavigationPopup.tsx
@@ -7,11 +7,13 @@ import {
   HvVerticalNavigation,
   verticalNavigationTreeClasses,
 } from "@core/components";
+import { HvBaseProps } from "@core/types";
 import { setId } from "@core/utils";
 
 import { StyledPopper, StyledPopupContainer } from "./NavigationPopup.styles";
 
-export interface HvVerticalNavigationPopupProps {
+export interface HvVerticalNavigationPopupProps
+  extends HvBaseProps<HTMLDivElement> {
   id?: string;
   anchorEl?: HTMLElement | null;
   fixedMode?: boolean;
@@ -19,7 +21,6 @@ export interface HvVerticalNavigationPopupProps {
   selected?: string;
   onClose?: () => void;
   onChange?: any;
-  popupStyles?: any;
 }
 
 export const HvVerticalNavigationPopup = ({
@@ -30,7 +31,8 @@ export const HvVerticalNavigationPopup = ({
   data,
   selected,
   onChange,
-  popupStyles,
+
+  ...others
 }: HvVerticalNavigationPopupProps) => {
   const handleClickAway = () => {
     onClose?.();
@@ -47,12 +49,7 @@ export const HvVerticalNavigationPopup = ({
   };
 
   return (
-    <StyledPopper
-      open
-      anchorEl={anchorEl}
-      placement="right-start"
-      style={popupStyles}
-    >
+    <StyledPopper open anchorEl={anchorEl} placement="right-start" {...others}>
       <ClickAwayListener onClickAway={handleClickAway}>
         <StyledPopupContainer>
           <HvVerticalNavigation open>

--- a/packages/core/src/components/VerticalNavigation/NavigationPopup/NavigationPopup.tsx
+++ b/packages/core/src/components/VerticalNavigation/NavigationPopup/NavigationPopup.tsx
@@ -19,6 +19,7 @@ export interface HvVerticalNavigationPopupProps {
   selected?: string;
   onClose?: () => void;
   onChange?: any;
+  popupStyles?: any;
 }
 
 export const HvVerticalNavigationPopup = ({
@@ -29,6 +30,7 @@ export const HvVerticalNavigationPopup = ({
   data,
   selected,
   onChange,
+  popupStyles,
 }: HvVerticalNavigationPopupProps) => {
   const handleClickAway = () => {
     onClose?.();
@@ -45,7 +47,12 @@ export const HvVerticalNavigationPopup = ({
   };
 
   return (
-    <StyledPopper open anchorEl={anchorEl} placement="right-start">
+    <StyledPopper
+      open
+      anchorEl={anchorEl}
+      placement="right-start"
+      style={popupStyles}
+    >
       <ClickAwayListener onClickAway={handleClickAway}>
         <StyledPopupContainer>
           <HvVerticalNavigation open>

--- a/packages/core/src/components/VerticalNavigation/VerticalNavigation.stories.tsx
+++ b/packages/core/src/components/VerticalNavigation/VerticalNavigation.stories.tsx
@@ -1,3 +1,4 @@
+import { css } from "@emotion/css";
 import {
   BarChart,
   Cloud,
@@ -716,6 +717,15 @@ export const CollapsibleIconsWithCustomPopupStyles: StoryObj<HvVerticalNavigatio
         setShow(!show);
       };
 
+      const popupStyles = css({
+        padding: "20px",
+        backgroundColor: "coral",
+
+        "& > div": {
+          border: "3px solid orange",
+        },
+      });
+
       return (
         <div style={{ display: "flex", width: 220, height: 530 }}>
           <HvVerticalNavigation open={show} collapsedMode={"icon"}>
@@ -737,9 +747,7 @@ export const CollapsibleIconsWithCustomPopupStyles: StoryObj<HvVerticalNavigatio
                 setValue(data.id);
               }}
               data={navigationDataState}
-              popupStyles={{
-                backgroundColor: "red",
-              }}
+              classes={{ navigationPopup: popupStyles }}
             />
             <HvVerticalNavigationActions>
               <HvVerticalNavigationAction label="Profile" icon={<User />} />

--- a/packages/core/src/components/VerticalNavigation/VerticalNavigation.stories.tsx
+++ b/packages/core/src/components/VerticalNavigation/VerticalNavigation.stories.tsx
@@ -612,6 +612,145 @@ export const CollapsibleIconsWithoutSubItems: StoryObj<HvVerticalNavigationProps
     },
   };
 
+export const CollapsibleIconsWithCustomPopupStyles: StoryObj<HvVerticalNavigationProps> =
+  {
+    parameters: {
+      docs: {
+        description: {
+          story:
+            "Custom popup styles can be applied to the popup container by passing a style object to the popupStyles prop.",
+        },
+      },
+    },
+
+    render: () => {
+      const [navigationDataState, setNavigationDataState] = useState<
+        NavigationData[]
+      >([]);
+
+      useEffect(() => {
+        setNavigationDataState([
+          { id: "00", label: "Instalation Overview", icon: <Open /> },
+          {
+            id: "01",
+            label: "Hardware",
+            icon: <BarChart />,
+            data: [
+              {
+                id: "01-01",
+                label: "Ambient Monitoring",
+              },
+              {
+                id: "01-02",
+                label: "Server Status Summary",
+              },
+            ],
+          },
+          {
+            id: "02",
+            label: "System",
+            icon: <Deploy />,
+            data: [
+              {
+                id: "02-01",
+                label: "Buckets",
+                icon: <Deploy />,
+              },
+              {
+                id: "02-02",
+                label: "Admin Users",
+              },
+              {
+                id: "02-03",
+                label: "Log Bundle",
+                data: [
+                  {
+                    id: "02-03-01",
+                    label: "Rest API",
+                  },
+                  {
+                    id: "02-03-02",
+                    label: "License",
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            id: "03",
+            label: "System 2",
+            // icon: <Deploy />,
+            data: [
+              {
+                id: "03-01",
+                label: "Buckets",
+              },
+              {
+                id: "03-02",
+                label: "Admin Users",
+              },
+              {
+                id: "03-03",
+                label: "Log Bundle",
+                data: [
+                  {
+                    id: "03-03-01",
+                    label: "Rest API",
+                  },
+                  {
+                    id: "03-03-02",
+                    label: "License",
+                  },
+                ],
+              },
+            ],
+          },
+        ]);
+      }, []);
+
+      const [value, setValue] = useState("01-01");
+
+      const [show, setShow] = useState(false);
+
+      const handleIsExpanded = () => {
+        setShow(!show);
+      };
+
+      return (
+        <div style={{ display: "flex", width: 220, height: 530 }}>
+          <HvVerticalNavigation open={show} collapsedMode={"icon"}>
+            <HvVerticalNavigationHeader
+              title="Menu"
+              onCollapseButtonClick={handleIsExpanded}
+              collapseButtonProps={{
+                "aria-label": "collapseButton",
+                "aria-expanded": show,
+              }}
+            />
+            <HvVerticalNavigationTree
+              collapsible
+              defaultExpanded
+              aria-label="Example 3 navigation"
+              selected={value}
+              onChange={(event, data) => {
+                console.log(data);
+                setValue(data.id);
+              }}
+              data={navigationDataState}
+              popupStyles={{
+                backgroundColor: "red",
+              }}
+            />
+            <HvVerticalNavigationActions>
+              <HvVerticalNavigationAction label="Profile" icon={<User />} />
+              <HvVerticalNavigationAction label="Logout" icon={<LogOut />} />
+            </HvVerticalNavigationActions>
+          </HvVerticalNavigation>
+        </div>
+      );
+    },
+  };
+
 export const SliderMode: StoryObj<HvVerticalNavigationProps> = {
   render: () => {
     const [navigationDataState, setNavigationDataState] = useState<


### PR DESCRIPTION
Hi guys,

On App Shell we need to be able to customize the VerticalNavigation popup, at this point we need to customize the maximum height of the popup. The approach we were using was to wrap App Shell in a GlobalStyles and the then force the customization of the popup with this css code:

```
      div[role="tooltip"] {
        max-height: calc(100vh - 64px);
        overflow-y: auto;
      }
```

However, by doing so, we detected that this could cause some issue on the embedded application when using tooltips, we need to get rid of that global style but still be able to customize the Vertical Navigation popup.

The content of this PR opens the possibility for us to customize the styling of the popup, however, we are aware that this is not at all a very elegant solution. If you have a better approach to achieve this, please let us know and we will change the code to the appropriate one. In the meantime it would be really useful for us to have this merged to solve our issue.