### PR TITLE
fix(VerticalNavigation): disabled element styles

### DIFF
--- a/packages/core/src/components/Calendar/CalendarNavigation/ComposedNavigation/__snapshots__/ComposedNavigation.test.tsx.snap
+++ b/packages/core/src/components/Calendar/CalendarNavigation/ComposedNavigation/__snapshots__/ComposedNavigation.test.tsx.snap
@@ -36,7 +36,7 @@ exports[`<Navigation /> > should render correctly 1`] = `
           tabindex="0"
         >
           <p
-            class="HvTypography-root HvTypography-normalText css-1fbl1cl-getStyledComponent e1tnpalo0"
+            class="HvTypography-root HvTypography-body css-1fbl1cl-getStyledComponent e1tnpalo0"
           >
             April
           </p>
@@ -90,7 +90,7 @@ exports[`<Navigation /> > should render correctly 1`] = `
         tabindex="-1"
       >
         <p
-          class="HvTypography-root HvTypography-normalText css-1fbl1cl-getStyledComponent e1tnpalo0"
+          class="HvTypography-root HvTypography-body css-1fbl1cl-getStyledComponent e1tnpalo0"
         >
           2020
         </p>

--- a/packages/core/src/components/Calendar/__snapshots__/Calendar.test.tsx.snap
+++ b/packages/core/src/components/Calendar/__snapshots__/Calendar.test.tsx.snap
@@ -68,7 +68,7 @@ exports[`<Calendar /> with configurations > should render correctly 1`] = `
                   tabindex="0"
                 >
                   <p
-                    class="HvTypography-root HvTypography-normalText css-1fbl1cl-getStyledComponent e1tnpalo0"
+                    class="HvTypography-root HvTypography-body css-1fbl1cl-getStyledComponent e1tnpalo0"
                   >
                     January
                   </p>
@@ -125,7 +125,7 @@ exports[`<Calendar /> with configurations > should render correctly 1`] = `
                 tabindex="-1"
               >
                 <p
-                  class="HvTypography-root HvTypography-normalText css-1fbl1cl-getStyledComponent e1tnpalo0"
+                  class="HvTypography-root HvTypography-body css-1fbl1cl-getStyledComponent e1tnpalo0"
                 >
                   2023
                 </p>
@@ -157,37 +157,37 @@ exports[`<Calendar /> with configurations > should render correctly 1`] = `
           >
              
             <label
-              class="HvCalendarWeekLabels-calendarDay exstlpd0 HvTypography-root HvTypography-highlightText css-1smxvi3-getStyledComponent-StyledCalendarDay e1tnpalo0"
+              class="HvCalendarWeekLabels-calendarDay exstlpd0 HvTypography-root HvTypography-label css-1smxvi3-getStyledComponent-StyledCalendarDay e1tnpalo0"
             >
               S
             </label>
             <label
-              class="HvCalendarWeekLabels-calendarDay exstlpd0 HvTypography-root HvTypography-highlightText css-1smxvi3-getStyledComponent-StyledCalendarDay e1tnpalo0"
+              class="HvCalendarWeekLabels-calendarDay exstlpd0 HvTypography-root HvTypography-label css-1smxvi3-getStyledComponent-StyledCalendarDay e1tnpalo0"
             >
               M
             </label>
             <label
-              class="HvCalendarWeekLabels-calendarDay exstlpd0 HvTypography-root HvTypography-highlightText css-1smxvi3-getStyledComponent-StyledCalendarDay e1tnpalo0"
+              class="HvCalendarWeekLabels-calendarDay exstlpd0 HvTypography-root HvTypography-label css-1smxvi3-getStyledComponent-StyledCalendarDay e1tnpalo0"
             >
               T
             </label>
             <label
-              class="HvCalendarWeekLabels-calendarDay exstlpd0 HvTypography-root HvTypography-highlightText css-1smxvi3-getStyledComponent-StyledCalendarDay e1tnpalo0"
+              class="HvCalendarWeekLabels-calendarDay exstlpd0 HvTypography-root HvTypography-label css-1smxvi3-getStyledComponent-StyledCalendarDay e1tnpalo0"
             >
               W
             </label>
             <label
-              class="HvCalendarWeekLabels-calendarDay exstlpd0 HvTypography-root HvTypography-highlightText css-1smxvi3-getStyledComponent-StyledCalendarDay e1tnpalo0"
+              class="HvCalendarWeekLabels-calendarDay exstlpd0 HvTypography-root HvTypography-label css-1smxvi3-getStyledComponent-StyledCalendarDay e1tnpalo0"
             >
               T
             </label>
             <label
-              class="HvCalendarWeekLabels-calendarDay exstlpd0 HvTypography-root HvTypography-highlightText css-1smxvi3-getStyledComponent-StyledCalendarDay e1tnpalo0"
+              class="HvCalendarWeekLabels-calendarDay exstlpd0 HvTypography-root HvTypography-label css-1smxvi3-getStyledComponent-StyledCalendarDay e1tnpalo0"
             >
               F
             </label>
             <label
-              class="HvCalendarWeekLabels-calendarDay exstlpd0 HvTypography-root HvTypography-highlightText css-1smxvi3-getStyledComponent-StyledCalendarDay e1tnpalo0"
+              class="HvCalendarWeekLabels-calendarDay exstlpd0 HvTypography-root HvTypography-label css-1smxvi3-getStyledComponent-StyledCalendarDay e1tnpalo0"
             >
               S
             </label>
@@ -206,7 +206,7 @@ exports[`<Calendar /> with configurations > should render correctly 1`] = `
                 type="button"
               >
                 <p
-                  class="HvSingleCalendar-calendarDate HvSingleCalendar-calendarDateNotInMonth eulxq3n1 HvTypography-root HvTypography-normalText css-1lpyu14-getStyledComponent-StyledCalendarDate e1tnpalo0"
+                  class="HvSingleCalendar-calendarDate HvSingleCalendar-calendarDateNotInMonth eulxq3n1 HvTypography-root HvTypography-body css-1lpyu14-getStyledComponent-StyledCalendarDate e1tnpalo0"
                 >
                   28
                 </p>
@@ -226,7 +226,7 @@ exports[`<Calendar /> with configurations > should render correctly 1`] = `
                 type="button"
               >
                 <p
-                  class="HvSingleCalendar-calendarDate HvSingleCalendar-calendarDateNotInMonth eulxq3n1 HvTypography-root HvTypography-normalText css-1lpyu14-getStyledComponent-StyledCalendarDate e1tnpalo0"
+                  class="HvSingleCalendar-calendarDate HvSingleCalendar-calendarDateNotInMonth eulxq3n1 HvTypography-root HvTypography-body css-1lpyu14-getStyledComponent-StyledCalendarDate e1tnpalo0"
                 >
                   29
                 </p>
@@ -246,7 +246,7 @@ exports[`<Calendar /> with configurations > should render correctly 1`] = `
                 type="button"
               >
                 <p
-                  class="HvSingleCalendar-calendarDate HvSingleCalendar-calendarDateNotInMonth eulxq3n1 HvTypography-root HvTypography-normalText css-1lpyu14-getStyledComponent-StyledCalendarDate e1tnpalo0"
+                  class="HvSingleCalendar-calendarDate HvSingleCalendar-calendarDateNotInMonth eulxq3n1 HvTypography-root HvTypography-body css-1lpyu14-getStyledComponent-StyledCalendarDate e1tnpalo0"
                 >
                   30
                 </p>
@@ -266,7 +266,7 @@ exports[`<Calendar /> with configurations > should render correctly 1`] = `
                 type="button"
               >
                 <p
-                  class="HvSingleCalendar-calendarDate HvSingleCalendar-calendarDateNotInMonth eulxq3n1 HvTypography-root HvTypography-normalText css-1lpyu14-getStyledComponent-StyledCalendarDate e1tnpalo0"
+                  class="HvSingleCalendar-calendarDate HvSingleCalendar-calendarDateNotInMonth eulxq3n1 HvTypography-root HvTypography-body css-1lpyu14-getStyledComponent-StyledCalendarDate e1tnpalo0"
                 >
                   31
                 </p>
@@ -285,7 +285,7 @@ exports[`<Calendar /> with configurations > should render correctly 1`] = `
                 type="button"
               >
                 <p
-                  class="HvSingleCalendar-calendarDate HvSingleCalendar-calendarDateSelected eulxq3n1 HvTypography-root HvTypography-normalText css-1lpyu14-getStyledComponent-StyledCalendarDate e1tnpalo0"
+                  class="HvSingleCalendar-calendarDate HvSingleCalendar-calendarDateSelected eulxq3n1 HvTypography-root HvTypography-body css-1lpyu14-getStyledComponent-StyledCalendarDate e1tnpalo0"
                 >
                   1
                 </p>
@@ -304,7 +304,7 @@ exports[`<Calendar /> with configurations > should render correctly 1`] = `
                 type="button"
               >
                 <p
-                  class="HvSingleCalendar-calendarDate eulxq3n1 HvTypography-root HvTypography-normalText css-1lpyu14-getStyledComponent-StyledCalendarDate e1tnpalo0"
+                  class="HvSingleCalendar-calendarDate eulxq3n1 HvTypography-root HvTypography-body css-1lpyu14-getStyledComponent-StyledCalendarDate e1tnpalo0"
                 >
                   2
                 </p>
@@ -323,7 +323,7 @@ exports[`<Calendar /> with configurations > should render correctly 1`] = `
                 type="button"
               >
                 <p
-                  class="HvSingleCalendar-calendarDate eulxq3n1 HvTypography-root HvTypography-normalText css-1lpyu14-getStyledComponent-StyledCalendarDate e1tnpalo0"
+                  class="HvSingleCalendar-calendarDate eulxq3n1 HvTypography-root HvTypography-body css-1lpyu14-getStyledComponent-StyledCalendarDate e1tnpalo0"
                 >
                   3
                 </p>
@@ -342,7 +342,7 @@ exports[`<Calendar /> with configurations > should render correctly 1`] = `
                 type="button"
               >
                 <p
-                  class="HvSingleCalendar-calendarDate eulxq3n1 HvTypography-root HvTypography-normalText css-1lpyu14-getStyledComponent-StyledCalendarDate e1tnpalo0"
+                  class="HvSingleCalendar-calendarDate eulxq3n1 HvTypography-root HvTypography-body css-1lpyu14-getStyledComponent-StyledCalendarDate e1tnpalo0"
                 >
                   4
                 </p>
@@ -361,7 +361,7 @@ exports[`<Calendar /> with configurations > should render correctly 1`] = `
                 type="button"
               >
                 <p
-                  class="HvSingleCalendar-calendarDate eulxq3n1 HvTypography-root HvTypography-normalText css-1lpyu14-getStyledComponent-StyledCalendarDate e1tnpalo0"
+                  class="HvSingleCalendar-calendarDate eulxq3n1 HvTypography-root HvTypography-body css-1lpyu14-getStyledComponent-StyledCalendarDate e1tnpalo0"
                 >
                   5
                 </p>
@@ -380,7 +380,7 @@ exports[`<Calendar /> with configurations > should render correctly 1`] = `
                 type="button"
               >
                 <p
-                  class="HvSingleCalendar-calendarDate eulxq3n1 HvTypography-root HvTypography-normalText css-1lpyu14-getStyledComponent-StyledCalendarDate e1tnpalo0"
+                  class="HvSingleCalendar-calendarDate eulxq3n1 HvTypography-root HvTypography-body css-1lpyu14-getStyledComponent-StyledCalendarDate e1tnpalo0"
                 >
                   6
                 </p>
@@ -399,7 +399,7 @@ exports[`<Calendar /> with configurations > should render correctly 1`] = `
                 type="button"
               >
                 <p
-                  class="HvSingleCalendar-calendarDate eulxq3n1 HvTypography-root HvTypography-normalText css-1lpyu14-getStyledComponent-StyledCalendarDate e1tnpalo0"
+                  class="HvSingleCalendar-calendarDate eulxq3n1 HvTypography-root HvTypography-body css-1lpyu14-getStyledComponent-StyledCalendarDate e1tnpalo0"
                 >
                   7
                 </p>
@@ -418,7 +418,7 @@ exports[`<Calendar /> with configurations > should render correctly 1`] = `
                 type="button"
               >
                 <p
-                  class="HvSingleCalendar-calendarDate eulxq3n1 HvTypography-root HvTypography-normalText css-1lpyu14-getStyledComponent-StyledCalendarDate e1tnpalo0"
+                  class="HvSingleCalendar-calendarDate eulxq3n1 HvTypography-root HvTypography-body css-1lpyu14-getStyledComponent-StyledCalendarDate e1tnpalo0"
                 >
                   8
                 </p>
@@ -437,7 +437,7 @@ exports[`<Calendar /> with configurations > should render correctly 1`] = `
                 type="button"
               >
                 <p
-                  class="HvSingleCalendar-calendarDate eulxq3n1 HvTypography-root HvTypography-normalText css-1lpyu14-getStyledComponent-StyledCalendarDate e1tnpalo0"
+                  class="HvSingleCalendar-calendarDate eulxq3n1 HvTypography-root HvTypography-body css-1lpyu14-getStyledComponent-StyledCalendarDate e1tnpalo0"
                 >
                   9
                 </p>
@@ -456,7 +456,7 @@ exports[`<Calendar /> with configurations > should render correctly 1`] = `
                 type="button"
               >
                 <p
-                  class="HvSingleCalendar-calendarDate eulxq3n1 HvTypography-root HvTypography-normalText css-1lpyu14-getStyledComponent-StyledCalendarDate e1tnpalo0"
+                  class="HvSingleCalendar-calendarDate eulxq3n1 HvTypography-root HvTypography-body css-1lpyu14-getStyledComponent-StyledCalendarDate e1tnpalo0"
                 >
                   10
                 </p>
@@ -475,7 +475,7 @@ exports[`<Calendar /> with configurations > should render correctly 1`] = `
                 type="button"
               >
                 <p
-                  class="HvSingleCalendar-calendarDate eulxq3n1 HvTypography-root HvTypography-normalText css-1lpyu14-getStyledComponent-StyledCalendarDate e1tnpalo0"
+                  class="HvSingleCalendar-calendarDate eulxq3n1 HvTypography-root HvTypography-body css-1lpyu14-getStyledComponent-StyledCalendarDate e1tnpalo0"
                 >
                   11
                 </p>
@@ -494,7 +494,7 @@ exports[`<Calendar /> with configurations > should render correctly 1`] = `
                 type="button"
               >
                 <p
-                  class="HvSingleCalendar-calendarDate eulxq3n1 HvTypography-root HvTypography-normalText css-1lpyu14-getStyledComponent-StyledCalendarDate e1tnpalo0"
+                  class="HvSingleCalendar-calendarDate eulxq3n1 HvTypography-root HvTypography-body css-1lpyu14-getStyledComponent-StyledCalendarDate e1tnpalo0"
                 >
                   12
                 </p>
@@ -513,7 +513,7 @@ exports[`<Calendar /> with configurations > should render correctly 1`] = `
                 type="button"
               >
                 <p
-                  class="HvSingleCalendar-calendarDate eulxq3n1 HvTypography-root HvTypography-normalText css-1lpyu14-getStyledComponent-StyledCalendarDate e1tnpalo0"
+                  class="HvSingleCalendar-calendarDate eulxq3n1 HvTypography-root HvTypography-body css-1lpyu14-getStyledComponent-StyledCalendarDate e1tnpalo0"
                 >
                   13
                 </p>
@@ -532,7 +532,7 @@ exports[`<Calendar /> with configurations > should render correctly 1`] = `
                 type="button"
               >
                 <p
-                  class="HvSingleCalendar-calendarDate eulxq3n1 HvTypography-root HvTypography-normalText css-1lpyu14-getStyledComponent-StyledCalendarDate e1tnpalo0"
+                  class="HvSingleCalendar-calendarDate eulxq3n1 HvTypography-root HvTypography-body css-1lpyu14-getStyledComponent-StyledCalendarDate e1tnpalo0"
                 >
                   14
                 </p>
@@ -551,7 +551,7 @@ exports[`<Calendar /> with configurations > should render correctly 1`] = `
                 type="button"
               >
                 <p
-                  class="HvSingleCalendar-calendarDate eulxq3n1 HvTypography-root HvTypography-normalText css-1lpyu14-getStyledComponent-StyledCalendarDate e1tnpalo0"
+                  class="HvSingleCalendar-calendarDate eulxq3n1 HvTypography-root HvTypography-body css-1lpyu14-getStyledComponent-StyledCalendarDate e1tnpalo0"
                 >
                   15
                 </p>
@@ -570,7 +570,7 @@ exports[`<Calendar /> with configurations > should render correctly 1`] = `
                 type="button"
               >
                 <p
-                  class="HvSingleCalendar-calendarDate eulxq3n1 HvTypography-root HvTypography-normalText css-1lpyu14-getStyledComponent-StyledCalendarDate e1tnpalo0"
+                  class="HvSingleCalendar-calendarDate eulxq3n1 HvTypography-root HvTypography-body css-1lpyu14-getStyledComponent-StyledCalendarDate e1tnpalo0"
                 >
                   16
                 </p>
@@ -589,7 +589,7 @@ exports[`<Calendar /> with configurations > should render correctly 1`] = `
                 type="button"
               >
                 <p
-                  class="HvSingleCalendar-calendarDate eulxq3n1 HvTypography-root HvTypography-normalText css-1lpyu14-getStyledComponent-StyledCalendarDate e1tnpalo0"
+                  class="HvSingleCalendar-calendarDate eulxq3n1 HvTypography-root HvTypography-body css-1lpyu14-getStyledComponent-StyledCalendarDate e1tnpalo0"
                 >
                   17
                 </p>
@@ -608,7 +608,7 @@ exports[`<Calendar /> with configurations > should render correctly 1`] = `
                 type="button"
               >
                 <p
-                  class="HvSingleCalendar-calendarDate eulxq3n1 HvTypography-root HvTypography-normalText css-1lpyu14-getStyledComponent-StyledCalendarDate e1tnpalo0"
+                  class="HvSingleCalendar-calendarDate eulxq3n1 HvTypography-root HvTypography-body css-1lpyu14-getStyledComponent-StyledCalendarDate e1tnpalo0"
                 >
                   18
                 </p>
@@ -627,7 +627,7 @@ exports[`<Calendar /> with configurations > should render correctly 1`] = `
                 type="button"
               >
                 <p
-                  class="HvSingleCalendar-calendarDate eulxq3n1 HvTypography-root HvTypography-normalText css-1lpyu14-getStyledComponent-StyledCalendarDate e1tnpalo0"
+                  class="HvSingleCalendar-calendarDate eulxq3n1 HvTypography-root HvTypography-body css-1lpyu14-getStyledComponent-StyledCalendarDate e1tnpalo0"
                 >
                   19
                 </p>
@@ -646,7 +646,7 @@ exports[`<Calendar /> with configurations > should render correctly 1`] = `
                 type="button"
               >
                 <p
-                  class="HvSingleCalendar-calendarDate eulxq3n1 HvTypography-root HvTypography-normalText css-1lpyu14-getStyledComponent-StyledCalendarDate e1tnpalo0"
+                  class="HvSingleCalendar-calendarDate eulxq3n1 HvTypography-root HvTypography-body css-1lpyu14-getStyledComponent-StyledCalendarDate e1tnpalo0"
                 >
                   20
                 </p>
@@ -665,7 +665,7 @@ exports[`<Calendar /> with configurations > should render correctly 1`] = `
                 type="button"
               >
                 <p
-                  class="HvSingleCalendar-calendarDate eulxq3n1 HvTypography-root HvTypography-normalText css-1lpyu14-getStyledComponent-StyledCalendarDate e1tnpalo0"
+                  class="HvSingleCalendar-calendarDate eulxq3n1 HvTypography-root HvTypography-body css-1lpyu14-getStyledComponent-StyledCalendarDate e1tnpalo0"
                 >
                   21
                 </p>
@@ -684,7 +684,7 @@ exports[`<Calendar /> with configurations > should render correctly 1`] = `
                 type="button"
               >
                 <p
-                  class="HvSingleCalendar-calendarDate eulxq3n1 HvTypography-root HvTypography-normalText css-1lpyu14-getStyledComponent-StyledCalendarDate e1tnpalo0"
+                  class="HvSingleCalendar-calendarDate eulxq3n1 HvTypography-root HvTypography-body css-1lpyu14-getStyledComponent-StyledCalendarDate e1tnpalo0"
                 >
                   22
                 </p>
@@ -703,7 +703,7 @@ exports[`<Calendar /> with configurations > should render correctly 1`] = `
                 type="button"
               >
                 <p
-                  class="HvSingleCalendar-calendarDate eulxq3n1 HvTypography-root HvTypography-normalText css-1lpyu14-getStyledComponent-StyledCalendarDate e1tnpalo0"
+                  class="HvSingleCalendar-calendarDate eulxq3n1 HvTypography-root HvTypography-body css-1lpyu14-getStyledComponent-StyledCalendarDate e1tnpalo0"
                 >
                   23
                 </p>
@@ -722,7 +722,7 @@ exports[`<Calendar /> with configurations > should render correctly 1`] = `
                 type="button"
               >
                 <p
-                  class="HvSingleCalendar-calendarDate eulxq3n1 HvTypography-root HvTypography-normalText css-1lpyu14-getStyledComponent-StyledCalendarDate e1tnpalo0"
+                  class="HvSingleCalendar-calendarDate eulxq3n1 HvTypography-root HvTypography-body css-1lpyu14-getStyledComponent-StyledCalendarDate e1tnpalo0"
                 >
                   24
                 </p>
@@ -741,7 +741,7 @@ exports[`<Calendar /> with configurations > should render correctly 1`] = `
                 type="button"
               >
                 <p
-                  class="HvSingleCalendar-calendarDate eulxq3n1 HvTypography-root HvTypography-normalText css-1lpyu14-getStyledComponent-StyledCalendarDate e1tnpalo0"
+                  class="HvSingleCalendar-calendarDate eulxq3n1 HvTypography-root HvTypography-body css-1lpyu14-getStyledComponent-StyledCalendarDate e1tnpalo0"
                 >
                   25
                 </p>
@@ -760,7 +760,7 @@ exports[`<Calendar /> with configurations > should render correctly 1`] = `
                 type="button"
               >
                 <p
-                  class="HvSingleCalendar-calendarDate eulxq3n1 HvTypography-root HvTypography-normalText css-1lpyu14-getStyledComponent-StyledCalendarDate e1tnpalo0"
+                  class="HvSingleCalendar-calendarDate eulxq3n1 HvTypography-root HvTypography-body css-1lpyu14-getStyledComponent-StyledCalendarDate e1tnpalo0"
                 >
                   26
                 </p>
@@ -779,7 +779,7 @@ exports[`<Calendar /> with configurations > should render correctly 1`] = `
                 type="button"
               >
                 <p
-                  class="HvSingleCalendar-calendarDate eulxq3n1 HvTypography-root HvTypography-normalText css-1lpyu14-getStyledComponent-StyledCalendarDate e1tnpalo0"
+                  class="HvSingleCalendar-calendarDate eulxq3n1 HvTypography-root HvTypography-body css-1lpyu14-getStyledComponent-StyledCalendarDate e1tnpalo0"
                 >
                   27
                 </p>
@@ -798,7 +798,7 @@ exports[`<Calendar /> with configurations > should render correctly 1`] = `
                 type="button"
               >
                 <p
-                  class="HvSingleCalendar-calendarDate eulxq3n1 HvTypography-root HvTypography-normalText css-1lpyu14-getStyledComponent-StyledCalendarDate e1tnpalo0"
+                  class="HvSingleCalendar-calendarDate eulxq3n1 HvTypography-root HvTypography-body css-1lpyu14-getStyledComponent-StyledCalendarDate e1tnpalo0"
                 >
                   28
                 </p>
@@ -817,7 +817,7 @@ exports[`<Calendar /> with configurations > should render correctly 1`] = `
                 type="button"
               >
                 <p
-                  class="HvSingleCalendar-calendarDate eulxq3n1 HvTypography-root HvTypography-normalText css-1lpyu14-getStyledComponent-StyledCalendarDate e1tnpalo0"
+                  class="HvSingleCalendar-calendarDate eulxq3n1 HvTypography-root HvTypography-body css-1lpyu14-getStyledComponent-StyledCalendarDate e1tnpalo0"
                 >
                   29
                 </p>
@@ -836,7 +836,7 @@ exports[`<Calendar /> with configurations > should render correctly 1`] = `
                 type="button"
               >
                 <p
-                  class="HvSingleCalendar-calendarDate eulxq3n1 HvTypography-root HvTypography-normalText css-1lpyu14-getStyledComponent-StyledCalendarDate e1tnpalo0"
+                  class="HvSingleCalendar-calendarDate eulxq3n1 HvTypography-root HvTypography-body css-1lpyu14-getStyledComponent-StyledCalendarDate e1tnpalo0"
                 >
                   30
                 </p>
@@ -855,7 +855,7 @@ exports[`<Calendar /> with configurations > should render correctly 1`] = `
                 type="button"
               >
                 <p
-                  class="HvSingleCalendar-calendarDate eulxq3n1 HvTypography-root HvTypography-normalText css-1lpyu14-getStyledComponent-StyledCalendarDate e1tnpalo0"
+                  class="HvSingleCalendar-calendarDate eulxq3n1 HvTypography-root HvTypography-body css-1lpyu14-getStyledComponent-StyledCalendarDate e1tnpalo0"
                 >
                   31
                 </p>
@@ -875,7 +875,7 @@ exports[`<Calendar /> with configurations > should render correctly 1`] = `
                 type="button"
               >
                 <p
-                  class="HvSingleCalendar-calendarDate HvSingleCalendar-calendarDateNotInMonth eulxq3n1 HvTypography-root HvTypography-normalText css-1lpyu14-getStyledComponent-StyledCalendarDate e1tnpalo0"
+                  class="HvSingleCalendar-calendarDate HvSingleCalendar-calendarDateNotInMonth eulxq3n1 HvTypography-root HvTypography-body css-1lpyu14-getStyledComponent-StyledCalendarDate e1tnpalo0"
                 >
                   1
                 </p>
@@ -895,7 +895,7 @@ exports[`<Calendar /> with configurations > should render correctly 1`] = `
                 type="button"
               >
                 <p
-                  class="HvSingleCalendar-calendarDate HvSingleCalendar-calendarDateNotInMonth eulxq3n1 HvTypography-root HvTypography-normalText css-1lpyu14-getStyledComponent-StyledCalendarDate e1tnpalo0"
+                  class="HvSingleCalendar-calendarDate HvSingleCalendar-calendarDateNotInMonth eulxq3n1 HvTypography-root HvTypography-body css-1lpyu14-getStyledComponent-StyledCalendarDate e1tnpalo0"
                 >
                   2
                 </p>
@@ -915,7 +915,7 @@ exports[`<Calendar /> with configurations > should render correctly 1`] = `
                 type="button"
               >
                 <p
-                  class="HvSingleCalendar-calendarDate HvSingleCalendar-calendarDateNotInMonth eulxq3n1 HvTypography-root HvTypography-normalText css-1lpyu14-getStyledComponent-StyledCalendarDate e1tnpalo0"
+                  class="HvSingleCalendar-calendarDate HvSingleCalendar-calendarDateNotInMonth eulxq3n1 HvTypography-root HvTypography-body css-1lpyu14-getStyledComponent-StyledCalendarDate e1tnpalo0"
                 >
                   3
                 </p>
@@ -935,7 +935,7 @@ exports[`<Calendar /> with configurations > should render correctly 1`] = `
                 type="button"
               >
                 <p
-                  class="HvSingleCalendar-calendarDate HvSingleCalendar-calendarDateNotInMonth eulxq3n1 HvTypography-root HvTypography-normalText css-1lpyu14-getStyledComponent-StyledCalendarDate e1tnpalo0"
+                  class="HvSingleCalendar-calendarDate HvSingleCalendar-calendarDateNotInMonth eulxq3n1 HvTypography-root HvTypography-body css-1lpyu14-getStyledComponent-StyledCalendarDate e1tnpalo0"
                 >
                   4
                 </p>
@@ -955,7 +955,7 @@ exports[`<Calendar /> with configurations > should render correctly 1`] = `
                 type="button"
               >
                 <p
-                  class="HvSingleCalendar-calendarDate HvSingleCalendar-calendarDateNotInMonth eulxq3n1 HvTypography-root HvTypography-normalText css-1lpyu14-getStyledComponent-StyledCalendarDate e1tnpalo0"
+                  class="HvSingleCalendar-calendarDate HvSingleCalendar-calendarDateNotInMonth eulxq3n1 HvTypography-root HvTypography-body css-1lpyu14-getStyledComponent-StyledCalendarDate e1tnpalo0"
                 >
                   5
                 </p>
@@ -975,7 +975,7 @@ exports[`<Calendar /> with configurations > should render correctly 1`] = `
                 type="button"
               >
                 <p
-                  class="HvSingleCalendar-calendarDate HvSingleCalendar-calendarDateNotInMonth eulxq3n1 HvTypography-root HvTypography-normalText css-1lpyu14-getStyledComponent-StyledCalendarDate e1tnpalo0"
+                  class="HvSingleCalendar-calendarDate HvSingleCalendar-calendarDateNotInMonth eulxq3n1 HvTypography-root HvTypography-body css-1lpyu14-getStyledComponent-StyledCalendarDate e1tnpalo0"
                 >
                   6
                 </p>
@@ -995,7 +995,7 @@ exports[`<Calendar /> with configurations > should render correctly 1`] = `
                 type="button"
               >
                 <p
-                  class="HvSingleCalendar-calendarDate HvSingleCalendar-calendarDateNotInMonth eulxq3n1 HvTypography-root HvTypography-normalText css-1lpyu14-getStyledComponent-StyledCalendarDate e1tnpalo0"
+                  class="HvSingleCalendar-calendarDate HvSingleCalendar-calendarDateNotInMonth eulxq3n1 HvTypography-root HvTypography-body css-1lpyu14-getStyledComponent-StyledCalendarDate e1tnpalo0"
                 >
                   7
                 </p>

--- a/packages/core/src/components/VerticalNavigation/TreeView/TreeViewItem.tsx
+++ b/packages/core/src/components/VerticalNavigation/TreeView/TreeViewItem.tsx
@@ -429,7 +429,8 @@ export const HvVerticalNavigationTreeViewItem = forwardRef(
             href != null && clsx(treeViewItemClasses.link, classes?.link),
             !isOpen && clsx(treeViewItemClasses.minimized, classes?.minimized)
           )}
-          variant={disabled ? "placeholderText" : "body"}
+          variant="body"
+          disabled={disabled}
           onClick={handleClick}
           onMouseDown={handleMouseDown}
           style={{

--- a/packages/core/src/components/VerticalNavigation/TreeView/__snapshots__/TreeView.test.tsx.snap
+++ b/packages/core/src/components/VerticalNavigation/TreeView/__snapshots__/TreeView.test.tsx.snap
@@ -70,7 +70,7 @@ exports[`VerticalNavigation - Actions > should render correctly 1`] = `
               id="hvtreeview2-3"
             >
               <div
-                class="HvVerticalNavigationTreeViewItem-content er1eqbm0 HvTypography-root HvTypography-placeholderText css-1i34dze-getStyledComponent-StyledContent e1tnpalo0"
+                class="HvVerticalNavigationTreeViewItem-content er1eqbm0 HvTypography-root HvTypography-body css-1bej1oo-getStyledComponent-StyledContent e1tnpalo0"
                 id="hvtreeview2-3-button"
                 role="button"
                 style="padding-left: 30px;"

--- a/packages/core/src/components/VerticalNavigation/__snapshots__/VerticalNavigation.test.tsx.snap
+++ b/packages/core/src/components/VerticalNavigation/__snapshots__/VerticalNavigation.test.tsx.snap
@@ -256,7 +256,7 @@ exports[`VerticalNavigation > should render correctly 1`] = `
                   >
                     <div
                       aria-label="This Computer"
-                      class="HvVerticalNavigationTreeViewItem-content er1eqbm0 HvTypography-root HvTypography-placeholderText css-1i34dze-getStyledComponent-StyledContent e1tnpalo0"
+                      class="HvVerticalNavigationTreeViewItem-content er1eqbm0 HvTypography-root HvTypography-body css-1bej1oo-getStyledComponent-StyledContent e1tnpalo0"
                       id="hvtreeview3-02-01-03-button"
                       role="button"
                       style="padding-left: 74px;"


### PR DESCRIPTION
- Change `VerticalNavigation`'s deprecated `placeholderText` Typography variant to `body` + `disabled`