### PR TITLE
fix(VerticalNavigation): use of `aria-current`

### DIFF
--- a/packages/core/src/components/VerticalNavigation/Navigation/Navigation.tsx
+++ b/packages/core/src/components/VerticalNavigation/Navigation/Navigation.tsx
@@ -1,4 +1,11 @@
-import { useCallback, useMemo, useContext, useEffect, useState } from "react";
+import {
+  useCallback,
+  useMemo,
+  useContext,
+  useEffect,
+  useState,
+  ComponentProps,
+} from "react";
 import { clsx } from "clsx";
 import uniqueId from "lodash/uniqueId";
 import { setId, wrapperTooltip } from "@core/utils";
@@ -16,44 +23,22 @@ import { HvVerticalNavigationSlider } from "..";
 import { VerticalNavigationContext } from "../VerticalNavigationContext";
 import { HvVerticalNavigationPopup } from "../NavigationPopup/NavigationPopup";
 
-export interface NavigationData {
-  /**
-   * the id to be applied to the root element.
-   */
-  id: string;
-  /**
-   * the label to be rendered on the menu item.
-   */
-  label: string;
-  /**
-   * The url for the link.
-   */
-  href?: string;
-  /**
-   * The behavior when opening a link.
-   */
-  target?: string;
-  /**
-   * Icon to be render.
-   */
-  icon?: React.ReactNode;
-  /**
-   * Data subset.
-   */
-  data?: NavigationData[];
-  /**
-   * if `true` the item is disabled and is not interactive.
-   */
-  disabled?: boolean;
-  /**
-   * if `true` the item doesn't have a selected state.
-   */
-  selectable?: boolean;
-  /**
-   * Any other properties.
-   */
-  [otherProperty: string]: any;
-}
+export type NavigationData<T extends React.ElementType = "a"> =
+  ComponentProps<T> &
+    Record<string, any> & {
+      /** The id to be applied to the root element. */
+      id: string;
+      /** The label to be rendered on the menu item. */
+      label: string;
+      /** The icon to be rendered. */
+      icon?: React.ReactNode;
+      /** The Data children subset. */
+      data?: NavigationData<T>[];
+      /** Whether the item is disabled and not interactive. */
+      disabled?: boolean;
+      /** Whether the item has a selected state. */
+      selectable?: boolean;
+    };
 
 const createListHierarchy = (
   items,

--- a/packages/core/src/components/VerticalNavigation/NavigationSlider/NavigationSlider.tsx
+++ b/packages/core/src/components/VerticalNavigation/NavigationSlider/NavigationSlider.tsx
@@ -73,8 +73,12 @@ export const HvVerticalNavigationSlider = ({
               ),
             }}
             onClick={(event) => {
-              if (onNavigateToTarget) onNavigateToTarget(event, item);
+              onNavigateToTarget?.(event, item);
             }}
+            aria-label={item.label}
+            aria-current={
+              selected === item.id ? (item.href ? "page" : true) : undefined
+            }
             selected={selected === item.id}
             startAdornment={<div>{item.icon}</div>}
             endAdornment={
@@ -83,7 +87,7 @@ export const HvVerticalNavigationSlider = ({
                   variant="secondaryGhost"
                   icon
                   onClick={(event) => {
-                    if (onNavigateToChild) onNavigateToChild(event, item);
+                    onNavigateToChild?.(event, item);
                   }}
                 >
                   <DropRightXS />

--- a/packages/core/src/components/VerticalNavigation/TreeView/TreeViewItem.tsx
+++ b/packages/core/src/components/VerticalNavigation/TreeView/TreeViewItem.tsx
@@ -434,20 +434,21 @@ export const HvVerticalNavigationTreeViewItem = forwardRef(
               (expandable || icon != null || !isOpen ? 0 : 10) +
               level * (collapsible ? 32 : 10),
           }}
+          role={href ? undefined : "button"}
           {...(treeviewMode
             ? {
-                role: "button",
                 tabIndex: -1,
                 onFocus: handleFocus,
               }
             : {
-                role: "button",
                 tabIndex: selectable || expandable ? 0 : -1,
                 onKeyDown: handleKeyDown,
                 "aria-current":
                   (selectable && selected) ||
                   (!isOpen && isChildSelected?.(nodeId))
-                    ? "page"
+                    ? href
+                      ? "page"
+                      : true
                     : undefined,
                 "aria-expanded": expandable ? expanded : undefined,
                 "aria-controls": expandable ? setId(id, "group") : undefined,

--- a/packages/core/src/components/VerticalNavigation/VerticalNavigation.stories.tsx
+++ b/packages/core/src/components/VerticalNavigation/VerticalNavigation.stories.tsx
@@ -17,13 +17,11 @@ import {
   HvVerticalNavigationHeader,
   HvVerticalNavigationProps,
   HvVerticalNavigationSlider,
+  HvVerticalNavigationTree,
   HvVerticalNavigationTreeView,
   HvVerticalNavigationTreeViewItem,
-} from ".";
-import {
-  HvVerticalNavigationTree,
   NavigationData,
-} from "./Navigation/Navigation";
+} from ".";
 
 export default {
   title: "Widgets/Vertical Navigation",
@@ -47,10 +45,10 @@ export const Main: StoryObj<HvVerticalNavigationProps> = {
   },
   argTypes: {},
   render: (args) => {
-    const navigationData = useMemo(
+    const navigationData = useMemo<NavigationData[]>(
       () => [
         { id: "00", label: "Overview" },
-        { id: "01", label: "Analytics", selectable: false },
+        { id: "01", label: "Analytics" },
         {
           id: "02",
           label: "Storage",
@@ -67,7 +65,6 @@ export const Main: StoryObj<HvVerticalNavigationProps> = {
                 {
                   id: "02-01-02",
                   label: "HCP Anywhere",
-                  href: "/?path=/story/structure-vertical-navigation--main",
                 },
                 {
                   id: "02-01-03",
@@ -81,14 +78,17 @@ export const Main: StoryObj<HvVerticalNavigationProps> = {
         {
           id: "03",
           label: "Administration",
+          href: "#admin",
           data: [
             {
               id: "03-01",
               label: "Rest API",
+              href: "#admin-rest",
               data: [
                 {
                   id: "03-01-01",
                   label: "Log Bundle",
+                  href: "#admin-rest-logs",
                 },
               ],
             },
@@ -101,12 +101,7 @@ export const Main: StoryObj<HvVerticalNavigationProps> = {
     const [value, setValue] = useState("00");
     return (
       <div style={{ display: "flex", width: 220, height: 530 }}>
-        <HvVerticalNavigation
-          id="sample1"
-          open={args.open}
-          slider={args.slider}
-          collapsedMode={args.collapsedMode}
-        >
+        <HvVerticalNavigation {...args}>
           <HvVerticalNavigationTree
             aria-label="Example 1 navigation"
             selected={value}

--- a/packages/core/src/components/VerticalNavigation/VerticalNavigation.tsx
+++ b/packages/core/src/components/VerticalNavigation/VerticalNavigation.tsx
@@ -49,7 +49,7 @@ export interface HvVerticalNavigationProps {
  * It is recommended to use vertical navigation when your application requires global navigation that is displayed on the left.
  * While vertical navigation menus generally consume more space than their horizontal counterparts, they have become more popular as desktop monitors move to wide-screen formats.
  *
- * Even thou both the hierarchically organized data and the visual style ressemble a treeview-like structure, the [Treeview Design Pattern](https://w3c.github.io/aria-practices/#TreeView)
+ * Although both the hierarchically organized data and the visual style resemble a treeview-like structure, the [Treeview Design Pattern](https://w3c.github.io/aria-practices/#TreeView)
  * isn't necessarily the most appropriate.
  *
  * The tree role provides complex functionality that is not needed for typical site navigation, and changes the most common keyboard navigation using TAB.

--- a/packages/core/src/components/VerticalNavigation/__snapshots__/VerticalNavigation.test.tsx.snap
+++ b/packages/core/src/components/VerticalNavigation/__snapshots__/VerticalNavigation.test.tsx.snap
@@ -7,7 +7,6 @@ exports[`VerticalNavigation > should render correctly 1`] = `
   >
     <div
       class="HvVerticalNavigation-root css-18tuupo-StyledRoot eyka99t0"
-      id="sample1"
     >
       <div
         class="HvVerticalNavigationHeader-root css-7xt91a-StyledHeader e1arrhkt1"
@@ -62,7 +61,7 @@ exports[`VerticalNavigation > should render correctly 1`] = `
             id="hvtreeview3-00"
           >
             <div
-              aria-current="page"
+              aria-current="true"
               aria-label="Overview"
               class="HvVerticalNavigationTreeViewItem-content er1eqbm0 HvTypography-root HvTypography-body css-9vz4rk-getStyledComponent-StyledContent e1tnpalo0"
               id="hvtreeview3-00-button"
@@ -83,7 +82,7 @@ exports[`VerticalNavigation > should render correctly 1`] = `
             </div>
           </li>
           <li
-            class="HvVerticalNavigationTreeViewItem-node HvVerticalNavigationTreeViewItem-unselectable css-1y9s9wc-StyledNode er1eqbm1"
+            class="HvVerticalNavigationTreeViewItem-node HvVerticalNavigationTreeViewItem-selectable HvVerticalNavigationTreeViewItem-unselected css-1y9s9wc-StyledNode er1eqbm1"
             id="hvtreeview3-01"
           >
             <div
@@ -92,7 +91,7 @@ exports[`VerticalNavigation > should render correctly 1`] = `
               id="hvtreeview3-01-button"
               role="button"
               style="padding-left: 10px;"
-              tabindex="-1"
+              tabindex="0"
             >
               <div
                 class="css-vykerq-StyledIconsContainer emephz1"
@@ -209,7 +208,6 @@ exports[`VerticalNavigation > should render correctly 1`] = `
                       class="HvVerticalNavigationTreeViewItem-content HvVerticalNavigationTreeViewItem-link er1eqbm0 HvTypography-root HvTypography-body css-9vz4rk-getStyledComponent-StyledContent e1tnpalo0"
                       href="https://www.hitachivantara.com/en-us/news.html"
                       id="hvtreeview3-02-01-01-button"
-                      role="button"
                       style="padding-left: 74px;"
                       tabindex="0"
                     >
@@ -229,10 +227,9 @@ exports[`VerticalNavigation > should render correctly 1`] = `
                     class="HvVerticalNavigationTreeViewItem-node HvVerticalNavigationTreeViewItem-selectable HvVerticalNavigationTreeViewItem-unselected css-1y9s9wc-StyledNode er1eqbm1"
                     id="hvtreeview3-02-01-02"
                   >
-                    <a
+                    <div
                       aria-label="HCP Anywhere"
-                      class="HvVerticalNavigationTreeViewItem-content HvVerticalNavigationTreeViewItem-link er1eqbm0 HvTypography-root HvTypography-body css-9vz4rk-getStyledComponent-StyledContent e1tnpalo0"
-                      href="/?path=/story/structure-vertical-navigation--main"
+                      class="HvVerticalNavigationTreeViewItem-content er1eqbm0 HvTypography-root HvTypography-body css-9vz4rk-getStyledComponent-StyledContent e1tnpalo0"
                       id="hvtreeview3-02-01-02-button"
                       role="button"
                       style="padding-left: 74px;"
@@ -248,7 +245,7 @@ exports[`VerticalNavigation > should render correctly 1`] = `
                       >
                         HCP Anywhere
                       </div>
-                    </a>
+                    </div>
                   </li>
                   <li
                     class="HvVerticalNavigationTreeViewItem-node HvVerticalNavigationTreeViewItem-disabled css-1y9s9wc-StyledNode er1eqbm1"
@@ -282,13 +279,13 @@ exports[`VerticalNavigation > should render correctly 1`] = `
             class="HvVerticalNavigationTreeViewItem-node HvVerticalNavigationTreeViewItem-expandable HvVerticalNavigationTreeViewItem-collapsed HvVerticalNavigationTreeViewItem-unselectable css-1y9s9wc-StyledNode er1eqbm1"
             id="hvtreeview3-03"
           >
-            <div
+            <a
               aria-controls="hvtreeview3-03-group"
               aria-expanded="false"
               aria-label="Administration"
-              class="HvVerticalNavigationTreeViewItem-content er1eqbm0 HvTypography-root HvTypography-body css-9vz4rk-getStyledComponent-StyledContent e1tnpalo0"
+              class="HvVerticalNavigationTreeViewItem-content HvVerticalNavigationTreeViewItem-link er1eqbm0 HvTypography-root HvTypography-body css-9vz4rk-getStyledComponent-StyledContent e1tnpalo0"
+              href="#admin"
               id="hvtreeview3-03-button"
-              role="button"
               style="padding-left: 0px;"
               tabindex="0"
             >
@@ -320,7 +317,7 @@ exports[`VerticalNavigation > should render correctly 1`] = `
               >
                 Administration
               </div>
-            </div>
+            </a>
             <ul
               class="HvVerticalNavigationTreeViewItem-group css-zinev9-StyledGroup er1eqbm2"
               id="hvtreeview3-03-group"
@@ -329,13 +326,13 @@ exports[`VerticalNavigation > should render correctly 1`] = `
                 class="HvVerticalNavigationTreeViewItem-node HvVerticalNavigationTreeViewItem-expandable HvVerticalNavigationTreeViewItem-collapsed HvVerticalNavigationTreeViewItem-unselectable css-1y9s9wc-StyledNode er1eqbm1"
                 id="hvtreeview3-03-01"
               >
-                <div
+                <a
                   aria-controls="hvtreeview3-03-01-group"
                   aria-expanded="false"
                   aria-label="Rest API"
-                  class="HvVerticalNavigationTreeViewItem-content er1eqbm0 HvTypography-root HvTypography-body css-9vz4rk-getStyledComponent-StyledContent e1tnpalo0"
+                  class="HvVerticalNavigationTreeViewItem-content HvVerticalNavigationTreeViewItem-link er1eqbm0 HvTypography-root HvTypography-body css-9vz4rk-getStyledComponent-StyledContent e1tnpalo0"
+                  href="#admin-rest"
                   id="hvtreeview3-03-01-button"
-                  role="button"
                   style="padding-left: 32px;"
                   tabindex="0"
                 >
@@ -367,7 +364,7 @@ exports[`VerticalNavigation > should render correctly 1`] = `
                   >
                     Rest API
                   </div>
-                </div>
+                </a>
                 <ul
                   class="HvVerticalNavigationTreeViewItem-group css-zinev9-StyledGroup er1eqbm2"
                   id="hvtreeview3-03-01-group"
@@ -376,11 +373,11 @@ exports[`VerticalNavigation > should render correctly 1`] = `
                     class="HvVerticalNavigationTreeViewItem-node HvVerticalNavigationTreeViewItem-selectable HvVerticalNavigationTreeViewItem-unselected css-1y9s9wc-StyledNode er1eqbm1"
                     id="hvtreeview3-03-01-01"
                   >
-                    <div
+                    <a
                       aria-label="Log Bundle"
-                      class="HvVerticalNavigationTreeViewItem-content er1eqbm0 HvTypography-root HvTypography-body css-9vz4rk-getStyledComponent-StyledContent e1tnpalo0"
+                      class="HvVerticalNavigationTreeViewItem-content HvVerticalNavigationTreeViewItem-link er1eqbm0 HvTypography-root HvTypography-body css-9vz4rk-getStyledComponent-StyledContent e1tnpalo0"
+                      href="#admin-rest-logs"
                       id="hvtreeview3-03-01-01-button"
-                      role="button"
                       style="padding-left: 74px;"
                       tabindex="0"
                     >
@@ -394,7 +391,7 @@ exports[`VerticalNavigation > should render correctly 1`] = `
                       >
                         Log Bundle
                       </div>
-                    </div>
+                    </a>
                   </li>
                 </ul>
               </li>


### PR DESCRIPTION
Fixes the usage of `aria-current` in `VerticalNavigation`

- use `aria-current="page"` when selected **and** element is a `link`, otherwise `aria-current="true"`
- add `aria-current` to Slider variant
- improve `NavigationData` typings. defaults to `"a"`'s properties, but can be overriden with other types
  - eg. `NavigationData<"button">[]` or `NavigationData<typeof Link>[]`
- add & improve tests