### PR TITLE
fix(VerticalNavigation): no padding on menu items

### DIFF
--- a/packages/core/src/components/VerticalNavigation/NavigationSlider/NavigationSlider.tsx
+++ b/packages/core/src/components/VerticalNavigation/NavigationSlider/NavigationSlider.tsx
@@ -80,7 +80,7 @@ export const HvVerticalNavigationSlider = ({
               selected === item.id ? (item.href ? "page" : true) : undefined
             }
             selected={selected === item.id}
-            startAdornment={<div>{item.icon}</div>}
+            startAdornment={item.icon ? <div>{item.icon}</div> : undefined}
             endAdornment={
               item.data && item.data.length > 0 ? (
                 <HvButton


### PR DESCRIPTION
`HvListItem` expects `undefined` if no adornment is present and having `<div>{item.icon}</div>` incorrectly messes that up.