### PR TITLE
fix: d.ts typing file for the lab package

### DIFF
--- a/packages/lab/src/components/StepNavigation/SimpleNavigation/Dot/Dot.tsx
+++ b/packages/lab/src/components/StepNavigation/SimpleNavigation/Dot/Dot.tsx
@@ -1,7 +1,7 @@
 import { HvBaseProps } from "@hitachivantara/uikit-react-core";
 import { ClassNames } from "@emotion/react";
 import { theme } from "@hitachivantara/uikit-styles";
-import { HvStepProps } from "components/StepNavigation/DefaultNavigation";
+import { HvStepProps } from "../../DefaultNavigation";
 import { StyledButton } from "./Dot.styles";
 import dotClasses, { HvDotClasses } from "./dotClasses";
 import { getColor, dotSizes } from "../utils";

--- a/packages/lab/src/components/Wizard/WizardTitle/WizardTitle.tsx
+++ b/packages/lab/src/components/Wizard/WizardTitle/WizardTitle.tsx
@@ -8,8 +8,8 @@ import {
 } from "@hitachivantara/uikit-react-core";
 import { Report } from "@hitachivantara/uikit-react-icons";
 import { useContext, useEffect, useState } from "react";
-import { HvStepNavigation, HvStepNavigationProps } from "components";
-import { HvStepProps } from "components/StepNavigation/DefaultNavigation";
+import { HvStepNavigation, HvStepNavigationProps } from "../../StepNavigation";
+import { HvStepProps } from "../../StepNavigation/DefaultNavigation";
 import { HvWizardContext, wizardTitleClasses, HvWizardTitleClasses } from "..";
 import { styles } from "./WizardTitle.styles";
 


### PR DESCRIPTION
- Using absolute imports to fix the d.ts typing file for the lab package: aliases can't be used if not properly configured

Before:

<img width="614" alt="Screenshot 2023-05-26 at 12 34 41" src="https://github.com/lumada-design/hv-uikit-react/assets/43220251/8a3b99b3-006a-4bcd-9bf3-173f6f4c2d0a">

After:

<img width="614" alt="Screenshot 2023-05-26 at 12 42 08" src="https://github.com/lumada-design/hv-uikit-react/assets/43220251/06d766bd-f12e-4ca8-94b6-6531ed410186">
