### PR TITLE
fix(AppSwitcher): header and footer font styling

### DIFF
--- a/packages/core/src/components/AppSwitcher/AppSwitcher.styles.tsx
+++ b/packages/core/src/components/AppSwitcher/AppSwitcher.styles.tsx
@@ -1,7 +1,6 @@
 import styled from "@emotion/styled";
 import { theme } from "@hitachivantara/uikit-styles";
 import { HvTypography, HvListContainer } from "@core/components";
-import { CSSProperties } from "react";
 import { transientOptions } from "@core/utils/transientOptions";
 
 export const StyledRoot = styled(
@@ -42,7 +41,7 @@ export const StyledRoot = styled(
   })
 );
 
-export const StyledTitle = styled("div")({
+export const StyledTitle = styled(HvTypography)({
   minHeight: 36,
 
   // we need to play with the 4px because of the focus ring
@@ -90,19 +89,17 @@ export const StyledActionsContainer = styled(HvListContainer)({
 
   overflowY: "auto",
 
-  // we need to play with the 4px because of the focus ring
+  // We need to play with the 4px because of the focus ring
   padding: "4px 0 4px 4px",
 });
 
-export const StyledFooter = styled("div")({
+export const StyledFooter = styled(HvTypography)({
   display: "flex",
   alignItems: "center",
   marginTop: "auto",
   height: 52,
 
-  // we need to play with the 4px because of the focus ring
+  // We need to play with the 4px because of the focus ring
   // padding: `${theme.hv.spacing.sm - 4}px ${theme.hv.spacing.sm + 4}px 4px 4px`,
   padding: `${theme.space.sm} ${theme.space.sm} 4px 4px`,
-
-  ...(theme.typography.label as CSSProperties),
 });

--- a/packages/core/src/components/AppSwitcher/AppSwitcher.tsx
+++ b/packages/core/src/components/AppSwitcher/AppSwitcher.tsx
@@ -142,7 +142,11 @@ export const HvAppSwitcher = ({
       $layout={layout}
     >
       {(header && (
-        <StyledTitle className={clsx(appSwitcherClasses.title, classes?.title)}>
+        <StyledTitle
+          component="div"
+          variant="label"
+          className={clsx(appSwitcherClasses.title, classes?.title)}
+        >
           {header}
         </StyledTitle>
       )) ||
@@ -164,6 +168,8 @@ export const HvAppSwitcher = ({
       </StyledActionsContainer>
       {footer && (
         <StyledFooter
+          component="div"
+          variant="label"
           className={clsx(
             appSwitcherClasses.footerContainer,
             classes?.footerContainer


### PR DESCRIPTION
Before:

<img width="335" alt="Screenshot 2023-05-29 at 14 12 29" src="https://github.com/lumada-design/hv-uikit-react/assets/43220251/01c5a4ff-4a41-44ca-9ba8-bfa7b850944a">

After:

<img width="335" alt="Screenshot 2023-05-29 at 14 12 01" src="https://github.com/lumada-design/hv-uikit-react/assets/43220251/26d082aa-31f4-437b-9239-ff96b090795f">

