### PR TITLE
chore(app): improve `ThemeCreator` download & action buttons

### DIFF
--- a/app/src/components/common/IconButton.tsx
+++ b/app/src/components/common/IconButton.tsx
@@ -1,0 +1,26 @@
+import { ReactNode } from "react";
+import {
+  HvTooltip,
+  HvTypography,
+  HvButton,
+  HvButtonProps,
+} from "@hitachivantara/uikit-react-core";
+
+export interface IconButtonProps extends Omit<HvButtonProps, "icon"> {
+  label: string;
+  icon: ReactNode;
+  onClick?: HvButtonProps["onClick"];
+}
+
+/** An `HvButton` of type icon wrapped in a tooltip  */
+export const IconButton = ({ label, icon, ...others }: IconButtonProps) => {
+  return (
+    <HvTooltip title={<HvTypography>{label}</HvTypography>}>
+      <span>
+        <HvButton icon variant="secondaryGhost" aria-label={label} {...others}>
+          {icon}
+        </HvButton>
+      </span>
+    </HvTooltip>
+  );
+};

--- a/app/src/generator/CodeEditor/CodeEditor.tsx
+++ b/app/src/generator/CodeEditor/CodeEditor.tsx
@@ -8,7 +8,7 @@ import {
   useTheme,
 } from "@hitachivantara/uikit-react-core";
 import { GeneratorContext } from "generator/GeneratorContext";
-import { useContext, useEffect, useState } from "react";
+import { useContext } from "react";
 import {
   Download,
   Undo,
@@ -16,49 +16,32 @@ import {
   Reset,
   Duplicate,
 } from "@hitachivantara/uikit-react-icons";
-import { downloadTheme, themeDiff } from "generator/utils";
+import { getThemeCode } from "generator/utils";
 import { HvCodeEditor } from "@hitachivantara/uikit-react-code-editor";
+import { IconButton } from "components/common/IconButton";
 import { styles } from "./CodeEditor.styles";
 
 export const groupsToShow = ["acce", "atmo", "base", "sema"] as const; // "sup", "cat"
 
 const CodeEditor = ({ themeName, setCopied }): JSX.Element => {
-  const [fullCode, setFullCode] = useState("");
   const { activeTheme, selectedTheme } = useTheme();
 
   const { customTheme, updateCustomTheme, undo, redo, canUndo, canRedo } =
     useContext(GeneratorContext);
 
-  useEffect(() => {
-    const temp: any = {};
-    temp.name = themeName;
-    temp.base = selectedTheme;
-    const final = {
-      ...temp,
-      ...themeDiff(activeTheme as object, customTheme),
-    };
+  const fileName = `${themeName}.ts`;
 
-    // the `replace` bit below is just a regex to remove the quotes from
-    // the properties names, for displaying effect only.
-    setFullCode(
-      `import { createTheme } from "@hitachivantara/uikit-react-core";
-  
-const ${themeName} = createTheme(${JSON.stringify(final, null, 2).replace(
-        /"([^(")"]+)":/g,
-        "$1:"
-      )})
-      
-export default ${themeName};`
-    );
-  }, [customTheme]);
+  const fullCode = getThemeCode(
+    themeName,
+    selectedTheme,
+    activeTheme,
+    customTheme
+  );
+  const encodedCode = encodeURIComponent(fullCode);
 
   const onCopyHandler = () => {
     navigator.clipboard.writeText(fullCode);
     setCopied(true);
-  };
-
-  const onDownloadHandler = () => {
-    downloadTheme(`${themeName}.ts`, fullCode);
   };
 
   const onResetHandler = () => {
@@ -69,71 +52,44 @@ export default ${themeName};`
     updateCustomTheme(newTheme);
   };
 
-  const onUndoHandler = () => {
-    undo?.();
-  };
-
-  const onRedoHandler = () => {
-    redo?.();
-  };
-
   return (
     <HvBox css={{ position: "relative" }}>
       <HvBox className={styles.codeEditorTools}>
-        <HvBox>
-          <HvTypography variant="label">{themeName}.ts</HvTypography>
-          <HvTooltip title={<HvTypography>Download</HvTypography>}>
-            <HvButton variant="secondaryGhost" icon onClick={onDownloadHandler}>
-              <Download />
-            </HvButton>
-          </HvTooltip>
-        </HvBox>
+        <HvTooltip title={<HvTypography>Download</HvTypography>}>
+          <HvButton
+            variant="secondaryGhost"
+            component="a"
+            download={fileName}
+            href={`data:text/plain;charset=utf-8,${encodedCode}`}
+            endIcon={<Download />}
+          >
+            {fileName}
+          </HvButton>
+        </HvTooltip>
         <HvBox css={{ display: "flex" }}>
-          <HvBox>
-            {canUndo ? (
-              <HvTooltip title={<HvTypography>Undo</HvTypography>}>
-                <HvButton variant="secondaryGhost" icon onClick={onUndoHandler}>
-                  <Undo />
-                </HvButton>
-              </HvTooltip>
-            ) : (
-              <HvButton variant="secondaryGhost" icon disabled={!canUndo}>
-                <Undo />
-              </HvButton>
-            )}
-          </HvBox>
-          <HvBox>
-            {canRedo ? (
-              <HvTooltip title={<HvTypography>Redo</HvTypography>}>
-                <HvButton variant="secondaryGhost" icon onClick={onRedoHandler}>
-                  <Redo />
-                </HvButton>
-              </HvTooltip>
-            ) : (
-              <HvButton variant="secondaryGhost" icon disabled={!canRedo}>
-                <Redo />
-              </HvButton>
-            )}
-          </HvBox>
-          <HvBox>
-            <HvTooltip title={<HvTypography>Reset</HvTypography>}>
-              <HvButton
-                variant="secondaryGhost"
-                icon
-                onClick={onResetHandler}
-                disabled={!canUndo && !canRedo}
-              >
-                <Reset />
-              </HvButton>
-            </HvTooltip>
-          </HvBox>
-          <HvBox>
-            <HvTooltip title={<HvTypography>Copy to Clipboard</HvTypography>}>
-              <HvButton variant="secondaryGhost" icon onClick={onCopyHandler}>
-                <Duplicate />
-              </HvButton>
-            </HvTooltip>
-          </HvBox>
+          <IconButton
+            label="Undo"
+            icon={<Undo />}
+            disabled={!canUndo}
+            onClick={undo}
+          />
+          <IconButton
+            label="Redo"
+            icon={<Redo />}
+            disabled={!canRedo}
+            onClick={redo}
+          />
+          <IconButton
+            label="Reset"
+            icon={<Reset />}
+            disabled={!canUndo && !canRedo}
+            onClick={onResetHandler}
+          />
+          <IconButton
+            label="Copy to Clipboard"
+            icon={<Duplicate />}
+            onClick={onCopyHandler}
+          />
         </HvBox>
       </HvBox>
       <HvCodeEditor

--- a/app/src/generator/utils.ts
+++ b/app/src/generator/utils.ts
@@ -56,6 +56,29 @@ export const themeDiff = (a: object, b: object, rootLevel = true): object => {
   return diff;
 };
 
+export const getThemeCode = (
+  themeName: string,
+  selectedTheme: string,
+  activeTheme,
+  customTheme
+) => {
+  const final = {
+    name: themeName,
+    base: selectedTheme,
+    ...themeDiff(activeTheme, customTheme),
+  };
+
+  // the `replace` bit below is just a regex to remove the quotes from
+  // the properties names, for displaying effect only.
+  return `import { createTheme } from "@hitachivantara/uikit-react-core";
+  
+export default createTheme(${JSON.stringify(final, null, 2).replace(
+    /"([^(")"]+)":/g,
+    "$1:"
+  )});
+`;
+};
+
 export const downloadTheme = (filename, text) => {
   const element = document.createElement("a");
   element.setAttribute(


### PR DESCRIPTION
- accessible Download button
  - leverages new `HvButton`'s `component` prop
  - allows to "save as" theme, open in new tab (sharable URL), etc.
- add `IconButton` component to dedupe code
  - includes `aria-label` and `span` to always show tooltip