### PR TITLE
chore(app): use `HvCheckBoxGroup`, improve links, state in searchParams

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -45,6 +45,7 @@
     "react/no-unescaped-entities": "off",
     "react/no-unstable-nested-components": "off",
     "react/destructuring-assignment": "off",
+    "react/no-unknown-property": "off",
     "no-restricted-globals": "off",
     "react/no-unused-prop-types": "off",
     "react/no-array-index-key": "off",

--- a/app/src/components/components/BulkActions/BulkActions.tsx
+++ b/app/src/components/components/BulkActions/BulkActions.tsx
@@ -142,7 +142,6 @@ export const BulkActions = () => {
       />
       <br />
       <HvBulkActions
-        id="bulkActions"
         semantic={semantic}
         numTotal={data.length}
         numSelected={data.filter((el) => el.checked).length}
@@ -159,7 +158,6 @@ export const BulkActions = () => {
       />
       <p />
       <HvPagination
-        id="pagination"
         pages={numPages}
         page={page}
         canPrevious={page > 0}

--- a/app/src/pages/Components/Components.styles.tsx
+++ b/app/src/pages/Components/Components.styles.tsx
@@ -20,12 +20,7 @@ export const styles = {
     gap: 10,
   }),
   docs: css({
-    border: `1px solid ${theme.colors.atmo4}`,
-    padding: `${theme.space.xs} ${theme.space.md}`,
-    "&:hover": {
-      borderColor: theme.colors.secondary,
-      backgroundColor: theme.colors.primary_20,
-    },
+    padding: theme.spacing(["xs", "md"]),
   }),
   label: css({
     width: "100%",

--- a/app/src/pages/Components/Components.tsx
+++ b/app/src/pages/Components/Components.tsx
@@ -1,7 +1,11 @@
-import { useState } from "react";
+import { useEffect, useMemo, useState } from "react";
+import { useSearchParams } from "react-router-dom";
+import { Global } from "@emotion/react";
 import {
   HvBox,
+  HvButton,
   HvCheckBox,
+  HvCheckBoxGroup,
   HvContainer,
   HvTypography,
   theme,
@@ -42,147 +46,126 @@ const components = [
     content: <Avatar />,
     title: "Avatar",
     link: "https://lumada-design.github.io/uikit/master/?path=/docs/components-avatar--main",
-    selected: true,
   },
   {
     id: "badge",
     content: <Badge />,
     title: "Badge",
     link: "https://lumada-design.github.io/uikit/master/?path=/docs/components-badge--main",
-    selected: false,
   },
   {
     id: "breadcrumb",
     content: <BreadCrumb />,
     title: "Breadcrumb",
     link: "https://lumada-design.github.io/uikit/master/?path=/docs/widgets-breadcrumb--main",
-    selected: false,
   },
   {
     id: "bulkactions",
     content: <BulkActions />,
     title: "Bulk Actions",
     link: "https://lumada-design.github.io/uikit/master/?path=/docs/widgets-bulk-actions--main",
-    selected: false,
   },
   {
     id: "button",
     content: <Buttons />,
     title: "Button",
     link: "https://lumada-design.github.io/uikit/master/?path=/docs/components-button-button--main",
-    selected: true,
   },
   {
     id: "calendar",
     content: <Calendar />,
     title: "Calendar",
     link: "https://lumada-design.github.io/uikit/master/?path=/docs/components-button-button--main",
-    selected: false,
   },
   {
     id: "card",
     content: <Cards />,
     title: "Card",
     link: "https://lumada-design.github.io/uikit/master/?path=/docs/components-card--main",
-    selected: true,
   },
   {
     id: "checkbox",
     content: <CheckBox />,
     title: "Checkbox",
     link: "https://lumada-design.github.io/uikit/master/?path=/docs/components-checkbox-checkbox--main",
-    selected: false,
   },
   {
     id: "dialog",
     content: <Dialogs />,
     title: "Dialog",
     link: "https://lumada-design.github.io/uikit/master/?path=/docs/components-dialog--main",
-    selected: false,
   },
   {
     id: "dotpagination",
     content: <DotPagination />,
     title: "Dot Pagination",
     link: "https://lumada-design.github.io/uikit/master/?path=/docs/components-pagination-dot-pagination--main",
-    selected: false,
   },
   {
     id: "dropdownmenu",
     content: <DropDownMenu />,
     title: "Dropdown Menu",
     link: "https://lumada-design.github.io/uikit/master/?path=/docs/components-dropdown-dropdown-menu--main",
-    selected: false,
   },
   {
     id: "emptystate",
     content: <EmptyState />,
     title: "Empty State",
     link: "https://lumada-design.github.io/uikit/master/?path=/docs/components-empty-state--main",
-    selected: true,
   },
   {
     id: "fileuploader",
     content: <FileUploader />,
     title: "File Uploaded",
     link: "https://lumada-design.github.io/uikit/master/?path=/docs/widgets-file-uploader--main",
-    selected: false,
   },
   {
     id: "icons",
     content: <Icons />,
     title: "Icons",
     link: "https://lumada-design.github.io/uikit/master/?path=/docs/foundation-icons--icons",
-    selected: false,
   },
   {
     id: "input",
     content: <Input />,
     title: "Input",
     link: "https://lumada-design.github.io/uikit/master/?path=/docs/components-input--main",
-    selected: true,
   },
   {
     id: "loading",
     content: <Loading />,
     title: "Loading",
     link: "https://lumada-design.github.io/uikit/master/?path=/docs/components-loading-loading--main",
-    selected: true,
   },
   {
     id: "pagination",
     content: <Pagination />,
     title: "Pagination",
     link: "https://lumada-design.github.io/uikit/master/?path=/docs/components-pagination--main",
-    selected: false,
   },
   {
     id: "progressbar",
     content: <ProgressBar />,
     title: "Progress Bar",
     link: "https://lumada-design.github.io/uikit/master/?path=/docs/components-loading-progress-bar--main",
-    selected: false,
   },
   {
     id: "snackbar",
     content: <Snackbars />,
     title: "Snackbar",
     link: "https://lumada-design.github.io/uikit/master/?path=/docs/components-snackbar--main",
-    selected: true,
   },
   {
     id: "radio",
     content: <Radio />,
     title: "Radio",
     link: "https://lumada-design.github.io/uikit/master/?path=/docs/components-radio-radio--main",
-    selected: false,
   },
   {
     id: "switch",
     content: <Switch />,
     title: "Switch",
     link: "https://lumada-design.github.io/uikit/master/?path=/docs/components-switch--main",
-    selected: false,
   },
   {
     id: "tags",
@@ -195,28 +178,24 @@ const components = [
     content: <TagsInput />,
     title: "Tags Input",
     link: "https://lumada-design.github.io/uikit/master/?path=/docs/components-tag-tags-input--main",
-    selected: false,
   },
   {
     id: "tooltip",
     content: <Tooltip />,
     title: "Tooltip",
     link: "https://lumada-design.github.io/uikit/master/?path=/docs/components-tooltip-tooltip--main",
-    selected: false,
   },
   {
     id: "typography",
     content: <Typography />,
     title: "Typography",
     link: "https://lumada-design.github.io/uikit/master/?path=/docs/foundation-typography--main",
-    selected: true,
   },
   {
     id: "verticalnavigation",
     content: <VerticalNavigation />,
     title: "Vertical Navigation",
     link: "https://lumada-design.github.io/uikit/master/?path=/docs/foundation-typography--main",
-    selected: false,
   },
 ];
 
@@ -233,48 +212,58 @@ const Component = ({
 }) => {
   return (
     <HvBox className={styles.component}>
-      <div style={{ position: "absolute", marginTop: "-100px" }}>
-        {/* eslint-disable-next-line jsx-a11y/anchor-has-content,jsx-a11y/anchor-is-valid  */}
-        <a id={id} />
-      </div>
       <HvBox className={styles.header}>
-        <HvTypography variant="title2">{title}</HvTypography>
-        <HvTypography
+        <HvTypography variant="title2" component="a" href={`#${id}`}>
+          {title}
+        </HvTypography>
+        <HvButton
           component="a"
           href={link}
           target="_blank"
           className={styles.docs}
+          variant="secondarySubtle"
         >
           Docs
-        </HvTypography>
+        </HvButton>
       </HvBox>
       <HvBox className={styles.content}>{content}</HvBox>
     </HvBox>
   );
 };
 
+const initialSelection = [
+  "avatar",
+  "button",
+  "card",
+  "emptystate",
+  "input",
+  "loading",
+  "snackbar",
+  "typography",
+];
+
 const App = () => {
-  const [componentsToShow, setComponentsToShow] = useState(components);
+  const [params, setParams] = useSearchParams();
+  const [selection, setSelection] = useState(
+    params.get("selection")?.split(",") ?? initialSelection
+  );
 
-  const handleOnChange = (id) => {
-    const comp = componentsToShow.find((c) => c.id === id);
-    if (comp) {
-      const newComponents = componentsToShow.map((c) =>
-        c === comp ? { ...c, selected: !comp.selected } : c
-      );
-      setComponentsToShow(newComponents);
-      setTimeout(() => {
-        document.getElementById(id)?.scrollIntoView({ behavior: "smooth" });
-      }, 250);
-    }
-  };
+  useEffect(() => {
+    setParams({ selection: selection.join(",") }, { replace: true });
+  }, [selection]);
 
-  const labelClickHandler = (id) => {
+  const componentsToShow = useMemo(
+    () => components.map((c) => ({ ...c, selected: selection.includes(c.id) })),
+    [selection]
+  );
+
+  const handleClick = (id: string) => {
     document.getElementById(id)?.scrollIntoView({ behavior: "smooth" });
   };
 
   return (
     <>
+      <Global styles={{ html: { scrollBehavior: "smooth" } }} />
       <HvBox
         css={{
           position: "fixed",
@@ -289,30 +278,36 @@ const App = () => {
         }}
       >
         <HvBox css={{ display: "flex", flexDirection: "column" }}>
-          {componentsToShow.map((c) => {
-            return (
-              <HvBox key={c.id} css={{ display: "flex", alignItems: "center" }}>
-                <HvCheckBox
-                  key={c.id}
-                  value={c.id}
-                  checked={!!c.selected}
-                  onChange={() => handleOnChange(c.id)}
-                />
-                <HvTypography
-                  onClick={() => labelClickHandler(c.id)}
-                  className={styles.label}
-                  disabled={!c.selected}
-                >
-                  {c.title}
-                </HvTypography>
-              </HvBox>
-            );
-          })}
+          <HvCheckBoxGroup
+            showSelectAll
+            value={selection}
+            onChange={(event, newSelection) => setSelection(newSelection)}
+          >
+            {componentsToShow.map((c) => (
+              <HvCheckBox
+                key={c.id}
+                value={c.id}
+                label={c.title}
+                onClick={() => handleClick(c.id)}
+                labelProps={{
+                  // checked labels only scroll to element
+                  style: { color: c.selected ? undefined : theme.colors.atmo4 },
+                  onClick: (event) => {
+                    event.preventDefault();
+                    event.stopPropagation();
+                    handleClick(c.id);
+                  },
+                }}
+              />
+            ))}
+          </HvCheckBoxGroup>
         </HvBox>
       </HvBox>
       <HvContainer maxWidth="md">
         {componentsToShow.map((c) => (
-          <div key={c.id}>{!!c.selected && <Component {...c} />}</div>
+          <div key={c.id} id={c.id} css={{ scrollMarginTop: 64 + 10 }}>
+            {!!c.selected && <Component {...c} />}
+          </div>
         ))}
       </HvContainer>
     </>


### PR DESCRIPTION
- leverage `HvCheckBoxGroup` for handing selection
- put component selection state in `searchParams`
  - state persists across reloads
  - sharable state via link
- improve link scrolling to components
  - `id` to scroll always visible so we don't need to `useTimeout`
  - Component title links/scrolls to component
  - add smooth scrolling to all links (`scrollBehavior: "smooth"`)
  - use `HvButton` for docs (similarly styled)