### PR TITLE
fix(FilterGroup): fix incorrect counter value

### DIFF
--- a/packages/core/src/components/FilterGroup/Counter/Counter.tsx
+++ b/packages/core/src/components/FilterGroup/Counter/Counter.tsx
@@ -48,8 +48,7 @@ export const HvFilterGroupCounter = ({
 
   let groupsCounter = 0;
   appliedFilters
-    ?.flat()
-    ?.filter((elem) => elem !== undefined)
+    .filter((elem) => elem !== undefined)
     .forEach((fg, i) => {
       groupsCounter += getExistingFiltersById(i, filterValues, filterOptions);
     });


### PR DESCRIPTION
Separating the `flat` function call from the rest of the chained array operations solves the issue. I believe this is related to the fact that `flat` [returns a new array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/flat) instead of modifying the original array in place, whereas `filter` and `forEach` operate on the original array (well `filter` [returns a shallow copy](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/filter) of the original array that shares the same references as the original).