### PR TITLE
test: add coverage config & script

### DIFF
--- a/.config/vite.config.js
+++ b/.config/vite.config.js
@@ -63,5 +63,13 @@ export default defineConfig({
     exclude: ["**/package/**"],
     silent: true,
     testTimeout: 10000,
+    reporters: "default",
+    coverage: {
+      enabled: false,
+      provider: "c8",
+      reporter: "lcov",
+      include: ["src/**/*.ts?(x)"],
+      exclude: ["src/**/stories/*", "src/**/*{test,stories,spec}.ts?(x)"],
+    },
   },
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "@types/react-dom": "^18.0.11",
         "@typescript-eslint/eslint-plugin": "^5.54.1",
         "@typescript-eslint/parser": "^5.54.1",
+        "@vitest/coverage-c8": "^0.31.1",
         "eslint": "^8.35.0",
         "eslint-config-airbnb": "^19.0.4",
         "eslint-config-airbnb-typescript": "^17.0.0",
@@ -58,7 +59,7 @@
         "vite": "^4.1.4",
         "vite-plugin-dts": "2.0.2",
         "vite-tsconfig-paths": "^4.0.5",
-        "vitest": "^0.29.2",
+        "vitest": "^0.31.1",
         "yup": "^1.0.2"
       }
     },
@@ -9650,9 +9651,9 @@
       }
     },
     "node_modules/@types/chai": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.4.tgz",
-      "integrity": "sha512-KnRanxnpfpjUTqTCXslZSEdLfXExwgNxYPdiO2WGUj8+HDjFi8R3k5RVKPeSCzLjCcshCAtVO2QBbVuAV4kTnw==",
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.5.tgz",
+      "integrity": "sha512-mEo1sAde+UCE6b2hxn332f1g1E8WfYRu6p5SvTKr2ZKC1f7gFJXk4h5PyGP9Dt6gCaG8y8XhwnXWC6Iy2cmBng==",
       "dev": true
     },
     "node_modules/@types/chai-subset": {
@@ -10426,20 +10427,34 @@
       }
     },
     "node_modules/@vitest/coverage-c8": {
-      "version": "0.29.8",
-      "resolved": "https://registry.npmjs.org/@vitest/coverage-c8/-/coverage-c8-0.29.8.tgz",
-      "integrity": "sha512-y+sEMQMctWokjnSqm3FCQEYFkjLrYaznsxEZHxcx8z2aftpYg3A5tvI1S5himfdEFo7o+OeHzh40bPSWZHW4oQ==",
+      "version": "0.31.1",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-c8/-/coverage-c8-0.31.1.tgz",
+      "integrity": "sha512-6TkjQpmgYez7e3dbAUoYdRXxWN81BojCmUILJwgCy39uZFG33DsQ0rSRSZC9beAEdCZTpxR63nOvd9hxDQcJ0g==",
       "dev": true,
       "dependencies": {
+        "@ampproject/remapping": "^2.2.1",
         "c8": "^7.13.0",
+        "magic-string": "^0.30.0",
         "picocolors": "^1.0.0",
-        "std-env": "^3.3.1"
+        "std-env": "^3.3.2"
       },
       "funding": {
-        "url": "https://github.com/sponsors/antfu"
+        "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
-        "vitest": ">=0.29.0 <1"
+        "vitest": ">=0.30.0 <1"
+      }
+    },
+    "node_modules/@vitest/coverage-c8/node_modules/magic-string": {
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.0.tgz",
+      "integrity": "sha512-LA+31JYDJLs82r2ScLrlz1GjSgu66ZV518eyWT+S8VhyQn/JL0u9MeBOvQMGYiPk1DBiSN9DDMOcXvigJZaViQ==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.4.13"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@vitest/coverage-c8/node_modules/picocolors": {
@@ -10449,25 +10464,32 @@
       "dev": true
     },
     "node_modules/@vitest/expect": {
-      "version": "0.29.8",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-0.29.8.tgz",
-      "integrity": "sha512-xlcVXn5I5oTq6NiZSY3ykyWixBxr5mG8HYtjvpgg6KaqHm0mvhX18xuwl5YGxIRNt/A5jidd7CWcNHrSvgaQqQ==",
+      "version": "0.31.1",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-0.31.1.tgz",
+      "integrity": "sha512-BV1LyNvhnX+eNYzJxlHIGPWZpwJFZaCcOIzp2CNG0P+bbetenTupk6EO0LANm4QFt0TTit+yqx7Rxd1qxi/SQA==",
       "dev": true,
       "dependencies": {
-        "@vitest/spy": "0.29.8",
-        "@vitest/utils": "0.29.8",
+        "@vitest/spy": "0.31.1",
+        "@vitest/utils": "0.31.1",
         "chai": "^4.3.7"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "0.29.8",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-0.29.8.tgz",
-      "integrity": "sha512-FzdhnRDwEr/A3Oo1jtIk/B952BBvP32n1ObMEb23oEJNO+qO5cBet6M2XWIDQmA7BDKGKvmhUf2naXyp/2JEwQ==",
+      "version": "0.31.1",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-0.31.1.tgz",
+      "integrity": "sha512-imWuc82ngOtxdCUpXwtEzZIuc1KMr+VlQ3Ondph45VhWoQWit5yvG/fFcldbnCi8DUuFi+NmNx5ehMUw/cGLUw==",
       "dev": true,
       "dependencies": {
-        "@vitest/utils": "0.29.8",
+        "@vitest/utils": "0.31.1",
+        "concordance": "^5.0.4",
         "p-limit": "^4.0.0",
         "pathe": "^1.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/runner/node_modules/p-limit": {
@@ -10497,34 +10519,56 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/@vitest/spy": {
-      "version": "0.29.8",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-0.29.8.tgz",
-      "integrity": "sha512-VdjBe9w34vOMl5I5mYEzNX8inTxrZ+tYUVk9jxaZJmHFwmDFC/GV3KBFTA/JKswr3XHvZL+FE/yq5EVhb6pSAw==",
+    "node_modules/@vitest/snapshot": {
+      "version": "0.31.1",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-0.31.1.tgz",
+      "integrity": "sha512-L3w5uU9bMe6asrNzJ8WZzN+jUTX4KSgCinEJPXyny0o90fG4FPQMV0OWsq7vrCWfQlAilMjDnOF9nP8lidsJ+g==",
       "dev": true,
       "dependencies": {
-        "tinyspy": "^1.0.2"
+        "magic-string": "^0.30.0",
+        "pathe": "^1.1.0",
+        "pretty-format": "^27.5.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot/node_modules/magic-string": {
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.0.tgz",
+      "integrity": "sha512-LA+31JYDJLs82r2ScLrlz1GjSgu66ZV518eyWT+S8VhyQn/JL0u9MeBOvQMGYiPk1DBiSN9DDMOcXvigJZaViQ==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.4.13"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "0.31.1",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-0.31.1.tgz",
+      "integrity": "sha512-1cTpt2m9mdo3hRLDyCG2hDQvRrePTDgEJBFQQNz1ydHHZy03EiA6EpFxY+7ODaY7vMRCie+WlFZBZ0/dQWyssQ==",
+      "dev": true,
+      "dependencies": {
+        "tinyspy": "^2.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "0.29.8",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-0.29.8.tgz",
-      "integrity": "sha512-qGzuf3vrTbnoY+RjjVVIBYfuWMjn3UMUqyQtdGNZ6ZIIyte7B37exj6LaVkrZiUTvzSadVvO/tJm8AEgbGCBPg==",
+      "version": "0.31.1",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-0.31.1.tgz",
+      "integrity": "sha512-yFyRD5ilwojsZfo3E0BnH72pSVSuLg2356cN1tCEe/0RtDzxTPYwOomIC+eQbot7m6DRy4tPZw+09mB7NkbMmA==",
       "dev": true,
       "dependencies": {
-        "cli-truncate": "^3.1.0",
-        "diff": "^5.1.0",
+        "concordance": "^5.0.4",
         "loupe": "^2.3.6",
         "pretty-format": "^27.5.1"
-      }
-    },
-    "node_modules/@vitest/utils/node_modules/diff": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-5.1.0.tgz",
-      "integrity": "sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.3.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@wdio/config": {
@@ -12358,6 +12402,12 @@
       "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
       "dev": true
     },
+    "node_modules/blueimp-md5": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/blueimp-md5/-/blueimp-md5-2.19.0.tgz",
+      "integrity": "sha512-DRQrD6gJyy8FbiE4s+bDoXS9hiW3Vbx5uCdwvcCf3zLHL+Iv7LtGHLpr+GZV8rHG8tK766FGYBwRbu8pELTt+w==",
+      "dev": true
+    },
     "node_modules/bmpimagejs": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/bmpimagejs/-/bmpimagejs-1.0.4.tgz",
@@ -14112,6 +14162,25 @@
         "typedarray": "^0.0.6"
       }
     },
+    "node_modules/concordance": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/concordance/-/concordance-5.0.4.tgz",
+      "integrity": "sha512-OAcsnTEYu1ARJqWVGwf4zh4JDfHZEaSNlNccFmt8YjB2l/n19/PF2viLINHc57vO4FKIAFl2FWASIGZZWZ2Kxw==",
+      "dev": true,
+      "dependencies": {
+        "date-time": "^3.1.0",
+        "esutils": "^2.0.3",
+        "fast-diff": "^1.2.0",
+        "js-string-escape": "^1.0.1",
+        "lodash": "^4.17.15",
+        "md5-hex": "^3.0.1",
+        "semver": "^7.3.2",
+        "well-known-symbols": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.18.0 <11 || >=12.14.0 <13 || >=14"
+      }
+    },
     "node_modules/config-chain": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.12.tgz",
@@ -15746,6 +15815,18 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/date-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/date-time/-/date-time-3.1.0.tgz",
+      "integrity": "sha512-uqCUKXE5q1PNBXjPqvwhwJf9SwMoAHBgWJ6DcrnS5o+W2JOiIILl0JEdVD8SGujrNS02GGxgwAg2PN2zONgtjg==",
+      "dev": true,
+      "dependencies": {
+        "time-zone": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/dateformat": {
@@ -18622,6 +18703,12 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true
+    },
+    "node_modules/fast-diff": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.3.0.tgz",
+      "integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==",
       "dev": true
     },
     "node_modules/fast-glob": {
@@ -25357,6 +25444,18 @@
       "resolved": "https://registry.npmjs.org/material-colors/-/material-colors-1.2.6.tgz",
       "integrity": "sha512-6qE4B9deFBIa9YSpOc9O0Sgc43zTeVYbgDT5veRKSlB2+ZuHNoVVxA1L/ckMUayV9Ay9y7Z/SZCLcGteW9i7bg=="
     },
+    "node_modules/md5-hex": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/md5-hex/-/md5-hex-3.0.1.tgz",
+      "integrity": "sha512-BUiRtTtV39LIJwinWBjqVsU9xhdnz7/i889V859IBFpuqGAj6LuOvHv5XLbgZ2R7ptJoJaEcxkv88/h25T7Ciw==",
+      "dev": true,
+      "dependencies": {
+        "blueimp-md5": "^2.10.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/md5.js": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
@@ -26095,15 +26194,15 @@
       }
     },
     "node_modules/mlly": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.2.0.tgz",
-      "integrity": "sha512-+c7A3CV0KGdKcylsI6khWyts/CYrGTrRVo4R/I7u/cUsy0Conxa6LUhiEzVKIw14lc2L5aiO4+SeVe4TeGRKww==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.2.1.tgz",
+      "integrity": "sha512-1aMEByaWgBPEbWV2BOPEMySRrzl7rIHXmQxam4DM8jVjalTQDjpN2ZKOLUrwyhfZQO7IXHml2StcHMhooDeEEQ==",
       "dev": true,
       "dependencies": {
         "acorn": "^8.8.2",
         "pathe": "^1.1.0",
-        "pkg-types": "^1.0.2",
-        "ufo": "^1.1.1"
+        "pkg-types": "^1.0.3",
+        "ufo": "^1.1.2"
       }
     },
     "node_modules/modify-values": {
@@ -29632,13 +29731,13 @@
       }
     },
     "node_modules/pkg-types": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.0.2.tgz",
-      "integrity": "sha512-hM58GKXOcj8WTqUXnsQyJYXdeAPbythQgEF3nTcEo+nkD49chjQ9IKm/QJy9xf6JakXptz86h7ecP2024rrLaQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.0.3.tgz",
+      "integrity": "sha512-nN7pYi0AQqJnoLPC9eHFQ8AcyaixBUOwvqc5TDnIKCMEE6I0y8P7OKA7fPexsXGCGxQDl/cmrLAp26LhcwxZ4A==",
       "dev": true,
       "dependencies": {
         "jsonc-parser": "^3.2.0",
-        "mlly": "^1.1.1",
+        "mlly": "^1.2.0",
         "pathe": "^1.1.0"
       }
     },
@@ -35284,6 +35383,15 @@
         "readable-stream": "3"
       }
     },
+    "node_modules/time-zone": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/time-zone/-/time-zone-1.0.0.tgz",
+      "integrity": "sha512-TIsDdtKo6+XrPtiTm1ssmMngN1sAhyKnTO2kunQWqNPWIVvCm15Wmw4SWInwTVgJ5u/Tr04+8Ei9TNcw4x4ONA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/timers-browserify": {
       "version": "2.0.12",
       "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.12.tgz",
@@ -35326,9 +35434,9 @@
       "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
     },
     "node_modules/tinybench": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.4.0.tgz",
-      "integrity": "sha512-iyziEiyFxX4kyxSp+MtY1oCH/lvjH3PxFN8PGCDeqcZWAJ/i+9y+nL85w99PxVzrIvew/GSkSbDYtiGVa85Afg==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.5.0.tgz",
+      "integrity": "sha512-kRwSG8Zx4tjF9ZiyH4bhaebu+EDz1BOx9hOigYHlUW4xxI/wKIUQUqo018UlU4ar6ATPBsaMrdbKZ+tmPdohFA==",
       "dev": true
     },
     "node_modules/tinycolor2": {
@@ -35337,18 +35445,18 @@
       "integrity": "sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw=="
     },
     "node_modules/tinypool": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-0.4.0.tgz",
-      "integrity": "sha512-2ksntHOKf893wSAH4z/+JbPpi92esw8Gn9N2deXX+B0EO92hexAVI9GIZZPx7P5aYo5KULfeOSt3kMOmSOy6uA==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-0.5.0.tgz",
+      "integrity": "sha512-paHQtnrlS1QZYKF/GnLoOM/DN9fqaGOFbCbxzAhwniySnzl9Ebk8w73/dd34DAhe/obUbPAOldTyYXQZxnPBPQ==",
       "dev": true,
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/tinyspy": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-1.1.1.tgz",
-      "integrity": "sha512-UVq5AXt/gQlti7oxoIg5oi/9r0WpF7DGEVwXgqWSMmyN16+e3tl5lIvTaOpJ3TAtu5xFzWccFRM4R5NaWHF+4g==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-2.1.0.tgz",
+      "integrity": "sha512-7eORpyqImoOvkQJCSkL0d0mB4NHHIFAy4b1u8PHdDa7SjGS2njzl6/lyGoZLm+eyYEtlUmFGE0rFj66SWxZgQQ==",
       "dev": true,
       "engines": {
         "node": ">=14.0.0"
@@ -35921,9 +36029,9 @@
       }
     },
     "node_modules/ufo": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.1.1.tgz",
-      "integrity": "sha512-MvlCc4GHrmZdAllBc0iUDowff36Q9Ndw/UzqmEKyrfSzokTd9ZCy1i+IIk5hrYKkjoYVQyNbrw7/F8XJ2rEwTg==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.1.2.tgz",
+      "integrity": "sha512-TrY6DsjTQQgyS3E3dBaOXf0TpPD8u9FVrVYmKVegJuFw51n/YB9XPt+U6ydzFG5ZIN7+DIjPbNmXoBj9esYhgQ==",
       "dev": true
     },
     "node_modules/uglify-js": {
@@ -36681,14 +36789,14 @@
       }
     },
     "node_modules/vite-node": {
-      "version": "0.29.8",
-      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-0.29.8.tgz",
-      "integrity": "sha512-b6OtCXfk65L6SElVM20q5G546yu10/kNrhg08afEoWlFRJXFq9/6glsvSVY+aI6YeC1tu2TtAqI2jHEQmOmsFw==",
+      "version": "0.31.1",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-0.31.1.tgz",
+      "integrity": "sha512-BajE/IsNQ6JyizPzu9zRgHrBwczkAs0erQf/JRpgTIESpKvNj9/Gd0vxX905klLkb0I0SJVCKbdrl5c6FnqYKA==",
       "dev": true,
       "dependencies": {
         "cac": "^6.7.14",
         "debug": "^4.3.4",
-        "mlly": "^1.1.0",
+        "mlly": "^1.2.0",
         "pathe": "^1.1.0",
         "picocolors": "^1.0.0",
         "vite": "^3.0.0 || ^4.0.0"
@@ -36697,10 +36805,10 @@
         "vite-node": "vite-node.mjs"
       },
       "engines": {
-        "node": ">=v14.16.0"
+        "node": ">=v14.18.0"
       },
       "funding": {
-        "url": "https://github.com/sponsors/antfu"
+        "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/vite-node/node_modules/debug": {
@@ -36875,44 +36983,45 @@
       }
     },
     "node_modules/vitest": {
-      "version": "0.29.8",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-0.29.8.tgz",
-      "integrity": "sha512-JIAVi2GK5cvA6awGpH0HvH/gEG9PZ0a/WoxdiV3PmqK+3CjQMf8c+J/Vhv4mdZ2nRyXFw66sAg6qz7VNkaHfDQ==",
+      "version": "0.31.1",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-0.31.1.tgz",
+      "integrity": "sha512-/dOoOgzoFk/5pTvg1E65WVaobknWREN15+HF+0ucudo3dDG/vCZoXTQrjIfEaWvQXmqScwkRodrTbM/ScMpRcQ==",
       "dev": true,
       "dependencies": {
-        "@types/chai": "^4.3.4",
+        "@types/chai": "^4.3.5",
         "@types/chai-subset": "^1.3.3",
         "@types/node": "*",
-        "@vitest/expect": "0.29.8",
-        "@vitest/runner": "0.29.8",
-        "@vitest/spy": "0.29.8",
-        "@vitest/utils": "0.29.8",
-        "acorn": "^8.8.1",
+        "@vitest/expect": "0.31.1",
+        "@vitest/runner": "0.31.1",
+        "@vitest/snapshot": "0.31.1",
+        "@vitest/spy": "0.31.1",
+        "@vitest/utils": "0.31.1",
+        "acorn": "^8.8.2",
         "acorn-walk": "^8.2.0",
         "cac": "^6.7.14",
         "chai": "^4.3.7",
+        "concordance": "^5.0.4",
         "debug": "^4.3.4",
-        "local-pkg": "^0.4.2",
+        "local-pkg": "^0.4.3",
+        "magic-string": "^0.30.0",
         "pathe": "^1.1.0",
         "picocolors": "^1.0.0",
-        "source-map": "^0.6.1",
-        "std-env": "^3.3.1",
-        "strip-literal": "^1.0.0",
-        "tinybench": "^2.3.1",
-        "tinypool": "^0.4.0",
-        "tinyspy": "^1.0.2",
+        "std-env": "^3.3.2",
+        "strip-literal": "^1.0.1",
+        "tinybench": "^2.5.0",
+        "tinypool": "^0.5.0",
         "vite": "^3.0.0 || ^4.0.0",
-        "vite-node": "0.29.8",
+        "vite-node": "0.31.1",
         "why-is-node-running": "^2.2.2"
       },
       "bin": {
         "vitest": "vitest.mjs"
       },
       "engines": {
-        "node": ">=v14.16.0"
+        "node": ">=v14.18.0"
       },
       "funding": {
-        "url": "https://github.com/sponsors/antfu"
+        "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
         "@edge-runtime/vm": "*",
@@ -36977,20 +37086,23 @@
         }
       }
     },
+    "node_modules/vitest/node_modules/magic-string": {
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.0.tgz",
+      "integrity": "sha512-LA+31JYDJLs82r2ScLrlz1GjSgu66ZV518eyWT+S8VhyQn/JL0u9MeBOvQMGYiPk1DBiSN9DDMOcXvigJZaViQ==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.4.13"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/vitest/node_modules/picocolors": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
       "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
       "dev": true
-    },
-    "node_modules/vitest/node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/vm-browserify": {
       "version": "1.1.2",
@@ -38092,6 +38204,15 @@
         "watchpack-chokidar2": "^2.0.1"
       }
     },
+    "node_modules/well-known-symbols": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/well-known-symbols/-/well-known-symbols-2.0.0.tgz",
+      "integrity": "sha512-ZMjC3ho+KXo0BfJb7JgtQ5IBuvnShdlACNkKkdsqBmYw3bPAaJfPeYUo6tLUaT5tG/Gkh7xkpBhKRQ9e7pyg9Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/whatwg-encoding": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-2.0.0.tgz",
@@ -38721,7 +38842,6 @@
       "devDependencies": {
         "@types/react": "^18.0.28",
         "@types/react-dom": "^18.0.11",
-        "@vitest/coverage-c8": "^0.29.7",
         "npm-run-all": "^4.1.5",
         "tsc-alias": "^1.8.2"
       },
@@ -38763,7 +38883,6 @@
         "@types/react": "^18.0.28",
         "@types/react-color": "^2.17.5",
         "@types/react-dom": "^18.0.11",
-        "@vitest/coverage-c8": "^0.29.7",
         "npm-run-all": "^4.1.5",
         "tsc-alias": "^1.8.2"
       },
@@ -38877,7 +38996,6 @@
       "devDependencies": {
         "@types/react": "^18.0.28",
         "@types/react-dom": "^18.0.11",
-        "@vitest/coverage-c8": "^0.29.7",
         "npm-run-all": "^4.1.5",
         "tsc-alias": "^1.8.2"
       },
@@ -41604,7 +41722,6 @@
         "@monaco-editor/react": "^4.5.1",
         "@types/react": "^18.0.28",
         "@types/react-dom": "^18.0.11",
-        "@vitest/coverage-c8": "^0.29.7",
         "clsx": "^1.2.1",
         "npm-run-all": "^4.1.5",
         "tsc-alias": "^1.8.2"
@@ -41622,7 +41739,6 @@
         "@types/react-color": "^2.17.5",
         "@types/react-dom": "^18.0.11",
         "@types/react-table": "^7.7.14",
-        "@vitest/coverage-c8": "^0.29.7",
         "attr-accept": "^2.2.2",
         "clsx": "^1.2.1",
         "dayjs": "^1.11.7",
@@ -41716,7 +41832,6 @@
         "@hitachivantara/uikit-react-core": "^5.11.0",
         "@types/react": "^18.0.28",
         "@types/react-dom": "^18.0.11",
-        "@vitest/coverage-c8": "^0.29.7",
         "clsx": "^1.2.1",
         "npm-run-all": "^4.1.5",
         "tsc-alias": "^1.8.2",
@@ -45868,9 +45983,9 @@
       }
     },
     "@types/chai": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.4.tgz",
-      "integrity": "sha512-KnRanxnpfpjUTqTCXslZSEdLfXExwgNxYPdiO2WGUj8+HDjFi8R3k5RVKPeSCzLjCcshCAtVO2QBbVuAV4kTnw==",
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.5.tgz",
+      "integrity": "sha512-mEo1sAde+UCE6b2hxn332f1g1E8WfYRu6p5SvTKr2ZKC1f7gFJXk4h5PyGP9Dt6gCaG8y8XhwnXWC6Iy2cmBng==",
       "dev": true
     },
     "@types/chai-subset": {
@@ -46518,16 +46633,27 @@
       }
     },
     "@vitest/coverage-c8": {
-      "version": "0.29.8",
-      "resolved": "https://registry.npmjs.org/@vitest/coverage-c8/-/coverage-c8-0.29.8.tgz",
-      "integrity": "sha512-y+sEMQMctWokjnSqm3FCQEYFkjLrYaznsxEZHxcx8z2aftpYg3A5tvI1S5himfdEFo7o+OeHzh40bPSWZHW4oQ==",
+      "version": "0.31.1",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-c8/-/coverage-c8-0.31.1.tgz",
+      "integrity": "sha512-6TkjQpmgYez7e3dbAUoYdRXxWN81BojCmUILJwgCy39uZFG33DsQ0rSRSZC9beAEdCZTpxR63nOvd9hxDQcJ0g==",
       "dev": true,
       "requires": {
+        "@ampproject/remapping": "^2.2.1",
         "c8": "^7.13.0",
+        "magic-string": "^0.30.0",
         "picocolors": "^1.0.0",
-        "std-env": "^3.3.1"
+        "std-env": "^3.3.2"
       },
       "dependencies": {
+        "magic-string": {
+          "version": "0.30.0",
+          "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.0.tgz",
+          "integrity": "sha512-LA+31JYDJLs82r2ScLrlz1GjSgu66ZV518eyWT+S8VhyQn/JL0u9MeBOvQMGYiPk1DBiSN9DDMOcXvigJZaViQ==",
+          "dev": true,
+          "requires": {
+            "@jridgewell/sourcemap-codec": "^1.4.13"
+          }
+        },
         "picocolors": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
@@ -46537,23 +46663,24 @@
       }
     },
     "@vitest/expect": {
-      "version": "0.29.8",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-0.29.8.tgz",
-      "integrity": "sha512-xlcVXn5I5oTq6NiZSY3ykyWixBxr5mG8HYtjvpgg6KaqHm0mvhX18xuwl5YGxIRNt/A5jidd7CWcNHrSvgaQqQ==",
+      "version": "0.31.1",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-0.31.1.tgz",
+      "integrity": "sha512-BV1LyNvhnX+eNYzJxlHIGPWZpwJFZaCcOIzp2CNG0P+bbetenTupk6EO0LANm4QFt0TTit+yqx7Rxd1qxi/SQA==",
       "dev": true,
       "requires": {
-        "@vitest/spy": "0.29.8",
-        "@vitest/utils": "0.29.8",
+        "@vitest/spy": "0.31.1",
+        "@vitest/utils": "0.31.1",
         "chai": "^4.3.7"
       }
     },
     "@vitest/runner": {
-      "version": "0.29.8",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-0.29.8.tgz",
-      "integrity": "sha512-FzdhnRDwEr/A3Oo1jtIk/B952BBvP32n1ObMEb23oEJNO+qO5cBet6M2XWIDQmA7BDKGKvmhUf2naXyp/2JEwQ==",
+      "version": "0.31.1",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-0.31.1.tgz",
+      "integrity": "sha512-imWuc82ngOtxdCUpXwtEzZIuc1KMr+VlQ3Ondph45VhWoQWit5yvG/fFcldbnCi8DUuFi+NmNx5ehMUw/cGLUw==",
       "dev": true,
       "requires": {
-        "@vitest/utils": "0.29.8",
+        "@vitest/utils": "0.31.1",
+        "concordance": "^5.0.4",
         "p-limit": "^4.0.0",
         "pathe": "^1.1.0"
       },
@@ -46575,33 +46702,46 @@
         }
       }
     },
-    "@vitest/spy": {
-      "version": "0.29.8",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-0.29.8.tgz",
-      "integrity": "sha512-VdjBe9w34vOMl5I5mYEzNX8inTxrZ+tYUVk9jxaZJmHFwmDFC/GV3KBFTA/JKswr3XHvZL+FE/yq5EVhb6pSAw==",
+    "@vitest/snapshot": {
+      "version": "0.31.1",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-0.31.1.tgz",
+      "integrity": "sha512-L3w5uU9bMe6asrNzJ8WZzN+jUTX4KSgCinEJPXyny0o90fG4FPQMV0OWsq7vrCWfQlAilMjDnOF9nP8lidsJ+g==",
       "dev": true,
       "requires": {
-        "tinyspy": "^1.0.2"
-      }
-    },
-    "@vitest/utils": {
-      "version": "0.29.8",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-0.29.8.tgz",
-      "integrity": "sha512-qGzuf3vrTbnoY+RjjVVIBYfuWMjn3UMUqyQtdGNZ6ZIIyte7B37exj6LaVkrZiUTvzSadVvO/tJm8AEgbGCBPg==",
-      "dev": true,
-      "requires": {
-        "cli-truncate": "^3.1.0",
-        "diff": "^5.1.0",
-        "loupe": "^2.3.6",
+        "magic-string": "^0.30.0",
+        "pathe": "^1.1.0",
         "pretty-format": "^27.5.1"
       },
       "dependencies": {
-        "diff": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/diff/-/diff-5.1.0.tgz",
-          "integrity": "sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw==",
-          "dev": true
+        "magic-string": {
+          "version": "0.30.0",
+          "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.0.tgz",
+          "integrity": "sha512-LA+31JYDJLs82r2ScLrlz1GjSgu66ZV518eyWT+S8VhyQn/JL0u9MeBOvQMGYiPk1DBiSN9DDMOcXvigJZaViQ==",
+          "dev": true,
+          "requires": {
+            "@jridgewell/sourcemap-codec": "^1.4.13"
+          }
         }
+      }
+    },
+    "@vitest/spy": {
+      "version": "0.31.1",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-0.31.1.tgz",
+      "integrity": "sha512-1cTpt2m9mdo3hRLDyCG2hDQvRrePTDgEJBFQQNz1ydHHZy03EiA6EpFxY+7ODaY7vMRCie+WlFZBZ0/dQWyssQ==",
+      "dev": true,
+      "requires": {
+        "tinyspy": "^2.1.0"
+      }
+    },
+    "@vitest/utils": {
+      "version": "0.31.1",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-0.31.1.tgz",
+      "integrity": "sha512-yFyRD5ilwojsZfo3E0BnH72pSVSuLg2356cN1tCEe/0RtDzxTPYwOomIC+eQbot7m6DRy4tPZw+09mB7NkbMmA==",
+      "dev": true,
+      "requires": {
+        "concordance": "^5.0.4",
+        "loupe": "^2.3.6",
+        "pretty-format": "^27.5.1"
       }
     },
     "@wdio/config": {
@@ -48060,6 +48200,12 @@
       "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
       "dev": true
     },
+    "blueimp-md5": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/blueimp-md5/-/blueimp-md5-2.19.0.tgz",
+      "integrity": "sha512-DRQrD6gJyy8FbiE4s+bDoXS9hiW3Vbx5uCdwvcCf3zLHL+Iv7LtGHLpr+GZV8rHG8tK766FGYBwRbu8pELTt+w==",
+      "dev": true
+    },
     "bmpimagejs": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/bmpimagejs/-/bmpimagejs-1.0.4.tgz",
@@ -49411,6 +49557,22 @@
         "typedarray": "^0.0.6"
       }
     },
+    "concordance": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/concordance/-/concordance-5.0.4.tgz",
+      "integrity": "sha512-OAcsnTEYu1ARJqWVGwf4zh4JDfHZEaSNlNccFmt8YjB2l/n19/PF2viLINHc57vO4FKIAFl2FWASIGZZWZ2Kxw==",
+      "dev": true,
+      "requires": {
+        "date-time": "^3.1.0",
+        "esutils": "^2.0.3",
+        "fast-diff": "^1.2.0",
+        "js-string-escape": "^1.0.1",
+        "lodash": "^4.17.15",
+        "md5-hex": "^3.0.1",
+        "semver": "^7.3.2",
+        "well-known-symbols": "^2.0.0"
+      }
+    },
     "config-chain": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.12.tgz",
@@ -50638,6 +50800,15 @@
             "webidl-conversions": "^7.0.0"
           }
         }
+      }
+    },
+    "date-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/date-time/-/date-time-3.1.0.tgz",
+      "integrity": "sha512-uqCUKXE5q1PNBXjPqvwhwJf9SwMoAHBgWJ6DcrnS5o+W2JOiIILl0JEdVD8SGujrNS02GGxgwAg2PN2zONgtjg==",
+      "dev": true,
+      "requires": {
+        "time-zone": "^1.0.0"
       }
     },
     "dateformat": {
@@ -52879,6 +53050,12 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true
+    },
+    "fast-diff": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.3.0.tgz",
+      "integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==",
       "dev": true
     },
     "fast-glob": {
@@ -58067,6 +58244,15 @@
       "resolved": "https://registry.npmjs.org/material-colors/-/material-colors-1.2.6.tgz",
       "integrity": "sha512-6qE4B9deFBIa9YSpOc9O0Sgc43zTeVYbgDT5veRKSlB2+ZuHNoVVxA1L/ckMUayV9Ay9y7Z/SZCLcGteW9i7bg=="
     },
+    "md5-hex": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/md5-hex/-/md5-hex-3.0.1.tgz",
+      "integrity": "sha512-BUiRtTtV39LIJwinWBjqVsU9xhdnz7/i889V859IBFpuqGAj6LuOvHv5XLbgZ2R7ptJoJaEcxkv88/h25T7Ciw==",
+      "dev": true,
+      "requires": {
+        "blueimp-md5": "^2.10.0"
+      }
+    },
     "md5.js": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
@@ -58685,15 +58871,15 @@
       }
     },
     "mlly": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.2.0.tgz",
-      "integrity": "sha512-+c7A3CV0KGdKcylsI6khWyts/CYrGTrRVo4R/I7u/cUsy0Conxa6LUhiEzVKIw14lc2L5aiO4+SeVe4TeGRKww==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.2.1.tgz",
+      "integrity": "sha512-1aMEByaWgBPEbWV2BOPEMySRrzl7rIHXmQxam4DM8jVjalTQDjpN2ZKOLUrwyhfZQO7IXHml2StcHMhooDeEEQ==",
       "dev": true,
       "requires": {
         "acorn": "^8.8.2",
         "pathe": "^1.1.0",
-        "pkg-types": "^1.0.2",
-        "ufo": "^1.1.1"
+        "pkg-types": "^1.0.3",
+        "ufo": "^1.1.2"
       }
     },
     "modify-values": {
@@ -61433,13 +61619,13 @@
       }
     },
     "pkg-types": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.0.2.tgz",
-      "integrity": "sha512-hM58GKXOcj8WTqUXnsQyJYXdeAPbythQgEF3nTcEo+nkD49chjQ9IKm/QJy9xf6JakXptz86h7ecP2024rrLaQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.0.3.tgz",
+      "integrity": "sha512-nN7pYi0AQqJnoLPC9eHFQ8AcyaixBUOwvqc5TDnIKCMEE6I0y8P7OKA7fPexsXGCGxQDl/cmrLAp26LhcwxZ4A==",
       "dev": true,
       "requires": {
         "jsonc-parser": "^3.2.0",
-        "mlly": "^1.1.1",
+        "mlly": "^1.2.0",
         "pathe": "^1.1.0"
       }
     },
@@ -65877,6 +66063,12 @@
         "readable-stream": "3"
       }
     },
+    "time-zone": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/time-zone/-/time-zone-1.0.0.tgz",
+      "integrity": "sha512-TIsDdtKo6+XrPtiTm1ssmMngN1sAhyKnTO2kunQWqNPWIVvCm15Wmw4SWInwTVgJ5u/Tr04+8Ei9TNcw4x4ONA==",
+      "dev": true
+    },
     "timers-browserify": {
       "version": "2.0.12",
       "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.12.tgz",
@@ -65913,9 +66105,9 @@
       "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
     },
     "tinybench": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.4.0.tgz",
-      "integrity": "sha512-iyziEiyFxX4kyxSp+MtY1oCH/lvjH3PxFN8PGCDeqcZWAJ/i+9y+nL85w99PxVzrIvew/GSkSbDYtiGVa85Afg==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.5.0.tgz",
+      "integrity": "sha512-kRwSG8Zx4tjF9ZiyH4bhaebu+EDz1BOx9hOigYHlUW4xxI/wKIUQUqo018UlU4ar6ATPBsaMrdbKZ+tmPdohFA==",
       "dev": true
     },
     "tinycolor2": {
@@ -65924,15 +66116,15 @@
       "integrity": "sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw=="
     },
     "tinypool": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-0.4.0.tgz",
-      "integrity": "sha512-2ksntHOKf893wSAH4z/+JbPpi92esw8Gn9N2deXX+B0EO92hexAVI9GIZZPx7P5aYo5KULfeOSt3kMOmSOy6uA==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-0.5.0.tgz",
+      "integrity": "sha512-paHQtnrlS1QZYKF/GnLoOM/DN9fqaGOFbCbxzAhwniySnzl9Ebk8w73/dd34DAhe/obUbPAOldTyYXQZxnPBPQ==",
       "dev": true
     },
     "tinyspy": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-1.1.1.tgz",
-      "integrity": "sha512-UVq5AXt/gQlti7oxoIg5oi/9r0WpF7DGEVwXgqWSMmyN16+e3tl5lIvTaOpJ3TAtu5xFzWccFRM4R5NaWHF+4g==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-2.1.0.tgz",
+      "integrity": "sha512-7eORpyqImoOvkQJCSkL0d0mB4NHHIFAy4b1u8PHdDa7SjGS2njzl6/lyGoZLm+eyYEtlUmFGE0rFj66SWxZgQQ==",
       "dev": true
     },
     "tmp": {
@@ -66358,9 +66550,9 @@
       "dev": true
     },
     "ufo": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.1.1.tgz",
-      "integrity": "sha512-MvlCc4GHrmZdAllBc0iUDowff36Q9Ndw/UzqmEKyrfSzokTd9ZCy1i+IIk5hrYKkjoYVQyNbrw7/F8XJ2rEwTg==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.1.2.tgz",
+      "integrity": "sha512-TrY6DsjTQQgyS3E3dBaOXf0TpPD8u9FVrVYmKVegJuFw51n/YB9XPt+U6ydzFG5ZIN7+DIjPbNmXoBj9esYhgQ==",
       "dev": true
     },
     "uglify-js": {
@@ -66976,14 +67168,14 @@
       }
     },
     "vite-node": {
-      "version": "0.29.8",
-      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-0.29.8.tgz",
-      "integrity": "sha512-b6OtCXfk65L6SElVM20q5G546yu10/kNrhg08afEoWlFRJXFq9/6glsvSVY+aI6YeC1tu2TtAqI2jHEQmOmsFw==",
+      "version": "0.31.1",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-0.31.1.tgz",
+      "integrity": "sha512-BajE/IsNQ6JyizPzu9zRgHrBwczkAs0erQf/JRpgTIESpKvNj9/Gd0vxX905klLkb0I0SJVCKbdrl5c6FnqYKA==",
       "dev": true,
       "requires": {
         "cac": "^6.7.14",
         "debug": "^4.3.4",
-        "mlly": "^1.1.0",
+        "mlly": "^1.2.0",
         "pathe": "^1.1.0",
         "picocolors": "^1.0.0",
         "vite": "^3.0.0 || ^4.0.0"
@@ -67084,34 +67276,35 @@
       }
     },
     "vitest": {
-      "version": "0.29.8",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-0.29.8.tgz",
-      "integrity": "sha512-JIAVi2GK5cvA6awGpH0HvH/gEG9PZ0a/WoxdiV3PmqK+3CjQMf8c+J/Vhv4mdZ2nRyXFw66sAg6qz7VNkaHfDQ==",
+      "version": "0.31.1",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-0.31.1.tgz",
+      "integrity": "sha512-/dOoOgzoFk/5pTvg1E65WVaobknWREN15+HF+0ucudo3dDG/vCZoXTQrjIfEaWvQXmqScwkRodrTbM/ScMpRcQ==",
       "dev": true,
       "requires": {
-        "@types/chai": "^4.3.4",
+        "@types/chai": "^4.3.5",
         "@types/chai-subset": "^1.3.3",
         "@types/node": "*",
-        "@vitest/expect": "0.29.8",
-        "@vitest/runner": "0.29.8",
-        "@vitest/spy": "0.29.8",
-        "@vitest/utils": "0.29.8",
-        "acorn": "^8.8.1",
+        "@vitest/expect": "0.31.1",
+        "@vitest/runner": "0.31.1",
+        "@vitest/snapshot": "0.31.1",
+        "@vitest/spy": "0.31.1",
+        "@vitest/utils": "0.31.1",
+        "acorn": "^8.8.2",
         "acorn-walk": "^8.2.0",
         "cac": "^6.7.14",
         "chai": "^4.3.7",
+        "concordance": "^5.0.4",
         "debug": "^4.3.4",
-        "local-pkg": "^0.4.2",
+        "local-pkg": "^0.4.3",
+        "magic-string": "^0.30.0",
         "pathe": "^1.1.0",
         "picocolors": "^1.0.0",
-        "source-map": "^0.6.1",
-        "std-env": "^3.3.1",
-        "strip-literal": "^1.0.0",
-        "tinybench": "^2.3.1",
-        "tinypool": "^0.4.0",
-        "tinyspy": "^1.0.2",
+        "std-env": "^3.3.2",
+        "strip-literal": "^1.0.1",
+        "tinybench": "^2.5.0",
+        "tinypool": "^0.5.0",
         "vite": "^3.0.0 || ^4.0.0",
-        "vite-node": "0.29.8",
+        "vite-node": "0.31.1",
         "why-is-node-running": "^2.2.2"
       },
       "dependencies": {
@@ -67130,16 +67323,19 @@
             "ms": "2.1.2"
           }
         },
+        "magic-string": {
+          "version": "0.30.0",
+          "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.0.tgz",
+          "integrity": "sha512-LA+31JYDJLs82r2ScLrlz1GjSgu66ZV518eyWT+S8VhyQn/JL0u9MeBOvQMGYiPk1DBiSN9DDMOcXvigJZaViQ==",
+          "dev": true,
+          "requires": {
+            "@jridgewell/sourcemap-codec": "^1.4.13"
+          }
+        },
         "picocolors": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
           "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
-          "dev": true
-        },
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
           "dev": true
         }
       }
@@ -68056,6 +68252,12 @@
           }
         }
       }
+    },
+    "well-known-symbols": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/well-known-symbols/-/well-known-symbols-2.0.0.tgz",
+      "integrity": "sha512-ZMjC3ho+KXo0BfJb7JgtQ5IBuvnShdlACNkKkdsqBmYw3bPAaJfPeYUo6tLUaT5tG/Gkh7xkpBhKRQ9e7pyg9Q==",
+      "dev": true
     },
     "whatwg-encoding": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "build:doc": "build-storybook --docs -o dist --quiet",
     "test": "npm run test -w packages --if-present",
     "test:pa11y": "pa11y-ci -c .config/pa11yci.config.js",
+    "coverage": "npm run coverage -w packages --if-present",
     "prettier": "prettier --check .",
     "prettier:fix": "prettier --write .",
     "lint": "eslint . --ext .ts,.tsx --cache",
@@ -51,6 +52,7 @@
     "@types/react-dom": "^18.0.11",
     "@typescript-eslint/eslint-plugin": "^5.54.1",
     "@typescript-eslint/parser": "^5.54.1",
+    "@vitest/coverage-c8": "^0.31.1",
     "eslint": "^8.35.0",
     "eslint-config-airbnb": "^19.0.4",
     "eslint-config-airbnb-typescript": "^17.0.0",
@@ -77,7 +79,7 @@
     "vite": "^4.1.4",
     "vite-plugin-dts": "2.0.2",
     "vite-tsconfig-paths": "^4.0.5",
-    "vitest": "^0.29.2",
+    "vitest": "^0.31.1",
     "yup": "^1.0.2"
   },
   "husky": {

--- a/packages/code-editor/package.json
+++ b/packages/code-editor/package.json
@@ -45,7 +45,6 @@
   "devDependencies": {
     "@types/react": "^18.0.28",
     "@types/react-dom": "^18.0.11",
-    "@vitest/coverage-c8": "^0.29.7",
     "npm-run-all": "^4.1.5",
     "tsc-alias": "^1.8.2"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -67,7 +67,6 @@
     "@types/react": "^18.0.28",
     "@types/react-color": "^2.17.5",
     "@types/react-dom": "^18.0.11",
-    "@vitest/coverage-c8": "^0.29.7",
     "npm-run-all": "^4.1.5",
     "tsc-alias": "^1.8.2"
   },

--- a/packages/lab/package.json
+++ b/packages/lab/package.json
@@ -49,7 +49,6 @@
   "devDependencies": {
     "@types/react": "^18.0.28",
     "@types/react-dom": "^18.0.11",
-    "@vitest/coverage-c8": "^0.29.7",
     "npm-run-all": "^4.1.5",
     "tsc-alias": "^1.8.2"
   },


### PR DESCRIPTION
add `npm run coverage` & required configuration to have a coverage report generated.
disabled by default in `npm test`