### PR TITLE
chore: refactor Typography section

### DIFF
--- a/app/src/generator/utils.ts
+++ b/app/src/generator/utils.ts
@@ -94,3 +94,9 @@ export const downloadTheme = (filename, text) => {
 
   document.body.removeChild(element);
 };
+
+export const extractFontSizeUnit = (fontSize) => {
+  const unitRegex = /[a-z%]+$/i;
+  const match = fontSize.match(unitRegex);
+  return match ? match[0] : null;
+};


### PR DESCRIPTION
Made some changes to the Typography section:
- in the list of typographies each has the styles of the corresponding typography
- the font size is now a slider with a unit dropdown
-- prevents incorrect values being entered on the input as was possible before
-- the scale of the slider changes depending on the type of unit (`px/pt`: 0-100, `em/rem`: 0-10) and the value is clamped to the new range

https://github.com/lumada-design/hv-uikit-react/assets/7498785/35a976a1-8754-487c-87d6-8f8e1a01e0f1
