### PR TITLE
fix(Input): `onChange` event type & forwardRef

### DIFF
--- a/packages/core/src/components/BaseInput/BaseInput.tsx
+++ b/packages/core/src/components/BaseInput/BaseInput.tsx
@@ -1,8 +1,9 @@
-import { RefObject, useContext } from "react";
+import { useContext } from "react";
 import {
   InputBaseComponentProps as MuiInputBaseComponentProps,
   InputProps as MuiInputProps,
   Input as MuiInput,
+  InputBaseProps,
 } from "@mui/material";
 import { HvBaseProps } from "@core/types";
 import { ExtractNames } from "@core/utils";
@@ -91,7 +92,7 @@ export interface HvBaseInputProps
   /** Attributes applied to the input element. */
   inputProps?: MuiInputBaseComponentProps;
   /** Allows passing a ref to the underlying input */
-  inputRef?: RefObject<HTMLElement>;
+  inputRef?: InputBaseProps["inputRef"];
   /** A Jss Object used to override or extend the styles applied to the component. */
   classes?: HvBaseInputClasses;
 }
@@ -142,9 +143,7 @@ export const HvBaseInput = ({
     id
   );
 
-  const onChangeHandler = (
-    event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
-  ) => {
+  const onChangeHandler: MuiInputProps["onChange"] = (event) => {
     onChange?.(event, event.target.value);
   };
 

--- a/packages/core/src/components/ColorPicker/Fields/Fields.tsx
+++ b/packages/core/src/components/ColorPicker/Fields/Fields.tsx
@@ -35,17 +35,15 @@ export const Fields = ({
   classes: classesProp,
 }: FieldsProps) => {
   const { classes, cx } = useClasses(classesProp);
-  const [internalHex, setInternalHex] = useState<string | undefined>(hex);
-  const [internalRed, setInternalRed] = useState<number | undefined>(rgb?.r);
-  const [internalGreen, setInternalGreen] = useState<number | undefined>(
-    rgb?.g
-  );
-  const [internalBlue, setInternalBlue] = useState<number | undefined>(rgb?.b);
+  const [internalHex, setInternalHex] = useState(hex);
+  const [internalRed, setInternalRed] = useState(rgb?.r);
+  const [internalGreen, setInternalGreen] = useState(rgb?.g);
+  const [internalBlue, setInternalBlue] = useState(rgb?.b);
 
-  const hexInputRef = useRef();
-  const redInputRef = useRef();
-  const greenInputRef = useRef();
-  const blueInputRef = useRef();
+  const hexInputRef = useRef<HTMLInputElement>(null);
+  const redInputRef = useRef<HTMLInputElement>(null);
+  const greenInputRef = useRef<HTMLInputElement>(null);
+  const blueInputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
     if (document.activeElement !== hexInputRef.current) {
@@ -97,16 +95,13 @@ export const Fields = ({
     }
   };
 
-  const onChangeHex = (
-    event: React.ChangeEvent<HTMLInputElement>,
-    value: string
-  ) => {
+  const onChangeHex = (event: React.ChangeEvent<any>, value: string) => {
     setInternalHex(value);
     handleChange({ hex: value }, event);
   };
 
   const onChangeRbg = (
-    event: React.ChangeEvent<HTMLInputElement>,
+    event: React.ChangeEvent<any>,
     value: string,
     colorPart: "r" | "g" | "b"
   ) => {
@@ -127,7 +122,7 @@ export const Fields = ({
   return (
     <div className={cx(className, classes.fields)}>
       <HvInput
-        inputRef={hexInputRef}
+        ref={hexInputRef}
         className={classes.double}
         label="HEX"
         value={internalHex?.replace("#", "")}
@@ -136,7 +131,7 @@ export const Fields = ({
         disableClear
       />
       <HvInput
-        inputRef={redInputRef}
+        ref={redInputRef}
         className={classes.single}
         label="R"
         value={`${internalRed}`}
@@ -145,7 +140,7 @@ export const Fields = ({
         disableClear
       />
       <HvInput
-        inputRef={greenInputRef}
+        ref={greenInputRef}
         className={classes.single}
         label="G"
         value={`${internalGreen}`}
@@ -154,7 +149,7 @@ export const Fields = ({
         disableClear
       />
       <HvInput
-        inputRef={blueInputRef}
+        ref={blueInputRef}
         className={classes.single}
         label="B"
         value={`${internalBlue}`}

--- a/packages/core/src/components/Forms/Suggestions/Suggestions.tsx
+++ b/packages/core/src/components/Forms/Suggestions/Suggestions.tsx
@@ -1,5 +1,12 @@
 import { clsx } from "clsx";
-import React, { useContext, useEffect, useRef, useState } from "react";
+import React, {
+  forwardRef,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
+import { useForkRef } from "@mui/material";
 import { HvBaseProps } from "@core/types";
 import { setId } from "@core/utils";
 import {
@@ -34,24 +41,27 @@ export interface HvSuggestionsProps extends HvBaseProps {
   classes?: HvSuggestionsClasses;
 }
 
-export const HvSuggestions = ({
-  id,
-  className,
-  classes,
-  expanded = false,
-  anchorEl,
-  suggestionValues = [],
-  onClose,
-  onSuggestionSelected,
-  ...others
-}: HvSuggestionsProps) => {
+export const HvSuggestions = forwardRef((props: HvSuggestionsProps, extRef) => {
+  const {
+    id,
+    className,
+    classes,
+    expanded = false,
+    anchorEl,
+    suggestionValues = [],
+    onClose,
+    onSuggestionSelected,
+    ...others
+  } = props;
   const { elementId } = useContext(HvFormElementContext);
   const localId = id ?? setId(elementId, "suggestions");
 
   const ref = useRef<HTMLDivElement>(null);
-  const [isOpen, setIsOpen] = useState<boolean>(expanded);
+  const forkedRef = useForkRef(ref, extRef);
 
-  useClickOutside(ref, (event: HvClickOutsideEvent) => {
+  const [isOpen, setIsOpen] = useState(expanded);
+
+  useClickOutside(ref, (event) => {
     setIsOpen(false);
     onClose?.(event);
   });
@@ -63,7 +73,7 @@ export const HvSuggestions = ({
   return (
     <StyledRoot
       id={localId}
-      ref={ref}
+      ref={forkedRef}
       className={clsx(className, suggestionsClasses.root, classes?.root)}
       {...others}
     >
@@ -95,4 +105,4 @@ export const HvSuggestions = ({
       </StyledPopper>
     </StyledRoot>
   );
-};
+});

--- a/packages/core/src/components/TextArea/TextArea.tsx
+++ b/packages/core/src/components/TextArea/TextArea.tsx
@@ -3,7 +3,15 @@ import validationStates, {
   isInvalid,
 } from "@core/components/Forms/FormElement/validationStates";
 import { clsx } from "clsx";
-import { useCallback, useRef, useState, useMemo, useEffect } from "react";
+import {
+  useCallback,
+  useRef,
+  useState,
+  useMemo,
+  useEffect,
+  forwardRef,
+} from "react";
+import { useForkRef } from "@mui/material";
 import { setId } from "@core/utils";
 import isNil from "lodash/isNil";
 import { HvValidationMessages } from "@core/types";
@@ -143,52 +151,52 @@ export interface HvTextAreaProps
 /**
  * A text area is a multiline text input box, with an optional character counter when there is a length limit.
  */
-export const HvTextArea = ({
-  id,
-  className,
-  classes,
-  name,
-  label,
-  description,
-  placeholder,
-  status,
-  statusMessage,
-  validationMessages,
-  maxCharQuantity,
-  minCharQuantity,
-  value: valueProp,
-  inputRef: inputRefProp,
-  rows = 1,
-  defaultValue = "",
-  middleCountLabel = "/",
-  countCharProps = {},
-  inputProps = {},
-  required = false,
-  readOnly = false,
-  disabled = false,
-  autoFocus = false,
-  resizable = false,
-  autoScroll = false,
-  hideCounter = false,
-  blockMax = false,
-  "aria-label": ariaLabel,
-  "aria-labelledby": ariaLabelledBy,
-  "aria-describedby": ariaDescribedBy,
-  "aria-errormessage": ariaErrorMessage,
-  validation,
-  onChange,
-  onBlur,
-  onFocus,
-  ...others
-}: HvTextAreaProps) => {
+export const HvTextArea = forwardRef<any, HvTextAreaProps>((props, ref) => {
+  const {
+    id,
+    className,
+    classes,
+    name,
+    label,
+    description,
+    placeholder,
+    status,
+    statusMessage,
+    validationMessages,
+    maxCharQuantity,
+    minCharQuantity,
+    value: valueProp,
+    inputRef: inputRefProp,
+    rows = 1,
+    defaultValue = "",
+    middleCountLabel = "/",
+    countCharProps = {},
+    inputProps = {},
+    required = false,
+    readOnly = false,
+    disabled = false,
+    autoFocus = false,
+    resizable = false,
+    autoScroll = false,
+    hideCounter = false,
+    blockMax = false,
+    "aria-label": ariaLabel,
+    "aria-labelledby": ariaLabelledBy,
+    "aria-describedby": ariaDescribedBy,
+    "aria-errormessage": ariaErrorMessage,
+    validation,
+    onChange,
+    onBlur,
+    onFocus,
+    ...others
+  } = props;
   const elementId = useUniqueId(id, "hvtextarea");
 
   // Signals that the user has manually edited the input value
   const isDirty = useRef<boolean>(false);
 
-  const inputRefOwn = useRef(null);
-
-  const inputRef = inputRefProp || inputRefOwn;
+  const inputRef = useRef<HTMLTextAreaElement>(null);
+  const forkedRef = useForkRef(ref, inputRefProp, inputRef);
 
   const [focused, setFocused] = useState<boolean>(false);
 
@@ -491,7 +499,7 @@ export const HvTextArea = ({
             : undefined,
           ...inputProps,
         }}
-        inputRef={inputRef}
+        inputRef={forkedRef}
         $resizable={resizable}
         {...others}
       />
@@ -507,4 +515,4 @@ export const HvTextArea = ({
       )}
     </StyledFormElement>
   );
-};
+});


### PR DESCRIPTION
- add `forwardRef` to `HvInput`/`HvTextArea`/`HvSuggestions`
  - deprecate `inputRef` in favour of `ref`
- improve/fix typings
- change `HvInput`'s clear & to trigger internal `onChange`, so that the external `onChange` is triggered with the correct event