### PR TITLE
docs: fix storybook horizontal scrollbar

### DIFF
--- a/.storybook/theme/styles/docs.ts
+++ b/.storybook/theme/styles/docs.ts
@@ -1,6 +1,8 @@
 export const getDocsStyles = (theme) => {
   return {
     ".sbdocs.sbdocs-wrapper": {
+      overflow: "hidden",
+
       ".sbdocs": {
         fontFamily: "'Open Sans',sans-serif !important",
       },
@@ -10,17 +12,21 @@ export const getDocsStyles = (theme) => {
         maxWidth: "90% !important",
       },
 
-      ".sbdocs-preview": {
-        overflow: "visible",
-
-        "& > div": {
-          overflow: "visible",
-
-          "& > div": {
+      // This is necessary for the chart tooltips to not be hidden
+      "div[id*='anchor--visualizations-bar-chart'], div[id*='anchor--visualizations-line-chart']":
+        {
+          ".sbdocs-preview": {
             overflow: "visible",
+
+            "& > div": {
+              overflow: "visible",
+
+              "& > div": {
+                overflow: "visible",
+              },
+            },
           },
         },
-      },
 
       "a.sbdocs": {
         color: "#2064B4",


### PR DESCRIPTION
When doing the line and bar charts I added `overflow: visible` in the Storybook CSS to avoid hiding the chart tooltips. However I did not notice at the time this added an horizontal scrollbar to the docs. Moreover, I just noticed now that the Global Actions stories were overflowing. 
I fixed this and now the `overflow: visible` CSS is only applied to the line and bar charts stories (to avoid any side effects in other components' stories) and the horizontal scrollbar no longer appears.