### PR TITLE
chore: improve typings across components (remove any's)

### DIFF
--- a/packages/core/src/components/Accordion/Accordion.stories.tsx
+++ b/packages/core/src/components/Accordion/Accordion.stories.tsx
@@ -104,12 +104,12 @@ export const Controlled: StoryObj<HvAccordionProps> = {
       billingAddress: false,
       shippingAddress: false,
     });
-    const handleToggle = (key) => {
+    const handleToggle = (key: keyof typeof expandedState) => {
       const newValue = { ...expandedState };
       newValue[key] = !newValue[key];
       setExpandedState(newValue);
     };
-    const handleAll = (option) => {
+    const handleAll = (option: boolean) => {
       setExpandedState({
         personalInformation: option,
         billingAddress: option,

--- a/packages/core/src/components/Accordion/Accordion.test.tsx
+++ b/packages/core/src/components/Accordion/Accordion.test.tsx
@@ -16,7 +16,7 @@ describe("Accordion", () => {
 
   describe("general structure", () => {
     it("renders the component as expected", () => {
-      const testAttributes = (component) => {
+      const testAttributes = (component: HTMLElement) => {
         expect(component).toBeInTheDocument();
         expect(component).toHaveAttribute("aria-expanded", "false");
         expect(component).toHaveAttribute("aria-disabled", "false");

--- a/packages/core/src/components/AppSwitcher/Action/Action.tsx
+++ b/packages/core/src/components/AppSwitcher/Action/Action.tsx
@@ -31,7 +31,7 @@ export interface HvAppSwitcherActionProps extends HvBaseProps {
   classes?: HvAppSwitcherActionClasses;
 }
 
-const getColor = (color, defaultColor) =>
+const getColor = (color: any, defaultColor: string) =>
   theme.colors[color] || color || defaultColor;
 
 export const HvAppSwitcherAction = ({

--- a/packages/core/src/components/AppSwitcher/AppSwitcher.stories.tsx
+++ b/packages/core/src/components/AppSwitcher/AppSwitcher.stories.tsx
@@ -57,14 +57,18 @@ export const Main: StoryObj<HvAppSwitcherProps> = {
     classes: { control: { disable: true } },
   },
   render: ({ layout }) => {
-    const handlesActionSelectedCallback = (application) => {
-      return (
-        application.url != null &&
-        window.location.href.startsWith(application.url)
-      );
-    };
+    const handlesActionSelectedCallback: HvAppSwitcherProps["isActionSelectedCallback"] =
+      (application) => {
+        return (
+          application.url != null &&
+          window.location.href.startsWith(application.url)
+        );
+      };
 
-    const handleActionClicked = (event, application) => {
+    const handleActionClicked: HvAppSwitcherProps["onActionClickedCallback"] = (
+      event,
+      application
+    ) => {
       if (!application.url) {
         alert(`The clicked application was: ${application.name}`);
       }
@@ -85,9 +89,10 @@ export const Main: StoryObj<HvAppSwitcherProps> = {
 
 export const ManyEntries: StoryObj<HvAppSwitcherProps> = {
   render: () => {
-    const handlesActionSelectedCallback = (application) => {
-      return window.location.href.startsWith(application.url);
-    };
+    const handlesActionSelectedCallback: HvAppSwitcherProps["isActionSelectedCallback"] =
+      (application) => {
+        return window.location.href.startsWith(application.url || "");
+      };
 
     const getDummyApplicationsList = () => {
       const dummyApplicationsList: HvAppSwitcherActionApplication[] = [];
@@ -126,13 +131,17 @@ export const ManyEntries: StoryObj<HvAppSwitcherProps> = {
 
 export const CustomHeader: StoryObj<HvAppSwitcherProps> = {
   render: () => {
-    const [selected, setSelected] = useState(null);
+    const [selected, setSelected] = useState<string>();
 
-    const handleIsActionSelected = (application) => {
-      return application.name === selected;
-    };
+    const handleIsActionSelected: HvAppSwitcherProps["isActionSelectedCallback"] =
+      (application) => {
+        return !!selected && application.name === selected;
+      };
 
-    const handleActionClicked = (event, application) => {
+    const handleActionClicked: HvAppSwitcherProps["onActionClickedCallback"] = (
+      event,
+      application
+    ) => {
       setSelected(application.name);
     };
 

--- a/packages/core/src/components/Banner/Banner.stories.tsx
+++ b/packages/core/src/components/Banner/Banner.stories.tsx
@@ -8,7 +8,7 @@ import {
   HvTypography,
 } from "@core/components";
 import { useState } from "react";
-import { HvBannerContent } from "./BannerContent";
+import { HvBannerContent, HvBannerContentProps } from "./BannerContent";
 
 const StyledBanner = styled(HvBanner)({
   position: "relative",
@@ -98,14 +98,15 @@ export const BannerController: StoryObj<HvBannerProps> = {
     eyes: { include: false },
   },
   render: () => {
-    const SimpleBanner = ({ variant, ...others }) => {
+    const SimpleBanner = ({
+      variant,
+      ...others
+    }: Omit<HvBannerProps, "open">) => {
       const [open, setOpen] = useState(false);
 
       const handleOpen = () => setOpen(true);
 
-      const handleClose = () => {
-        setOpen(false);
-      };
+      const handleClose = () => setOpen(false);
 
       return (
         <>
@@ -211,12 +212,12 @@ export const BannerVariations: StoryObj<HvBannerProps> = {
     },
   },
   render: () => {
-    const actionArray = (id) => [
+    const actionArray = (id: string) => [
       { id: `action${id}_1`, label: "Action 1", disabled: false },
       { id: `action${id}_2`, label: "Action 2", disabled: false },
     ];
 
-    const BannerContent = (props) => (
+    const BannerContent = (props: HvBannerContentProps) => (
       <>
         <br />
         <HvBannerContent {...props} />

--- a/packages/core/src/components/Banner/Banner.tsx
+++ b/packages/core/src/components/Banner/Banner.tsx
@@ -91,7 +91,9 @@ export const HvBanner = ({
     vertical: anchorOrigin,
   };
 
-  const SlideTransition = useCallback(
+  const SlideTransition = useCallback<
+    NonNullable<MuiSnackbarProps["TransitionComponent"]>
+  >(
     (properties) => <Slide {...properties} direction={transitionDirection} />,
     [transitionDirection]
   );

--- a/packages/core/src/components/BaseDropdown/BaseDropdown.tsx
+++ b/packages/core/src/components/BaseDropdown/BaseDropdown.tsx
@@ -1,8 +1,14 @@
-import React, { useMemo, useState, useCallback } from "react";
+import React, {
+  useMemo,
+  useState,
+  useCallback,
+  KeyboardEventHandler,
+} from "react";
 import { createPortal } from "react-dom";
 import { clsx } from "clsx";
 import {
   ClickAwayListener,
+  ClickAwayListenerProps,
   PopperPlacementType,
   PopperProps,
 } from "@mui/material";
@@ -408,7 +414,7 @@ export const HvBaseDropdown = ({
     /**
      *  Handle keyboard inside children container.
      */
-    const handleContainerKeyDown = (event) => {
+    const handleContainerKeyDown: KeyboardEventHandler = (event) => {
       if (isKeypress(event, Esc)) {
         handleToggle(event);
       }
@@ -421,8 +427,8 @@ export const HvBaseDropdown = ({
       }
     };
 
-    const handleOutside = (event) => {
-      const isButtonClick = referenceElement?.contains(event.target);
+    const handleOutside: ClickAwayListenerProps["onClickAway"] = (event) => {
+      const isButtonClick = referenceElement?.contains(event.target as any);
       if (!isButtonClick) {
         onClickOutside?.(event);
         setIsOpen(false);

--- a/packages/core/src/components/BaseInput/validations.ts
+++ b/packages/core/src/components/BaseInput/validations.ts
@@ -1,24 +1,15 @@
+import { HTMLInputTypeAttribute } from "react";
+import { InputBaseComponentProps } from "@mui/material";
 import validationStates from "../Forms/FormElement/validationStates";
+import { HvInputProps } from "..";
 
-/**
- * Checks if the value is a number.
- *
- * @param {Number || String} num - The value to test.
- *
- * @returns {Boolean} - `true` if the value is a number `false` otherwise.
- */
-const isNumeric = (num) =>
+/** Checks if the value is a number. */
+const isNumeric = (num: string) =>
   // to prevent Number( <spaces> ) = 0
   num.trim().length > 0 && !Number.isNaN(Number(num));
 
-/**
- * Checks if the value is an email
- *
- * @param {String} email - The value to test.
- *
- * @returns {Boolean} - `true` if the value is an email `false` otherwise.
- */
-const isEmail = (email) => {
+/** Checks if the value is an email */
+const isEmail = (email: string) => {
   const regexp =
     /^[^\\s]+[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?[.])+[a-z0-9](?:[a-z0-9-]*[a-z0-9])$/i;
   return regexp.test(email);
@@ -30,14 +21,8 @@ export const validationTypes = Object.freeze({
   email: "email",
 });
 
-/**
- * Returns the input's validation type based in the type of the input.
- *
- * @param {String} type - the input type.
- *
- * @returns {String}    - the validation type.
- */
-export const computeValidationType = (type) => {
+/** Returns the input's validation type based in the type of the input. */
+export const computeValidationType = (type: HTMLInputTypeAttribute) => {
   switch (type) {
     case "number":
       return validationTypes.number;
@@ -53,12 +38,12 @@ export const computeValidationType = (type) => {
  * Checks whether any integrated validation, native or not, is active.
  */
 export const hasBuiltInValidations = (
-  required,
-  validationType,
-  minCharQuantity,
-  maxCharQuantity,
-  validation,
-  inputProps
+  required: boolean,
+  validationType: HTMLInputTypeAttribute,
+  minCharQuantity: number | null | undefined,
+  maxCharQuantity: number | null | undefined,
+  validation?: (value: string) => boolean,
+  inputProps?: InputBaseComponentProps
 ) =>
   required ||
   validationType !== validationTypes.none ||
@@ -75,14 +60,11 @@ export const hasBuiltInValidations = (
     inputProps?.type !== "password") ||
   inputProps?.pattern != null;
 
-/**
- * Returns the form element's validation state based in the validity state of the input.
- *
- * @param {Object} inputValidity    - the input validity state (implementing ValidityState interface).
- *
- * @returns {String}                - the validation state.
- */
-export const computeValidationState = (inputValidity, isEmptyValue) => {
+/** Returns the form element's validation state based in the validity state of the input. */
+export const computeValidationState = (
+  inputValidity: HvInputValidity,
+  isEmptyValue: boolean
+) => {
   // to keep 2.x behaviour,
   // consider that if the value is empty (and not required) we're returning to the standBy state.
   // might not make sense, as it makes impossible to say if the user explicitly cleared the input.
@@ -103,13 +85,12 @@ export const computeValidationState = (inputValidity, isEmptyValue) => {
  *
  * For further customization both status and statusMessage should be controlled and
  * set using the onBlur callback that receives both the value and the input validity object.
- *
- * @param {Object} inputValidity    - the input validity state (implementing ValidityState interface).
- * @param {Object} errorMessages    - the available localized error messages.
- *
- * @returns {String}                - the error message.
  */
-export const computeValidationMessage = (inputValidity, errorMessages) => {
+export const computeValidationMessage = (
+  inputValidity: HvInputValidity,
+  /** The available localized error messages. */
+  errorMessages: Record<string, string>
+) => {
   if (inputValidity.valid) {
     return "";
   }
@@ -135,25 +116,15 @@ export const computeValidationMessage = (inputValidity, errorMessages) => {
  *
  * It implements the native browser's ValidityState interface:
  * https://developer.mozilla.org/en-US/docs/Web/API/ValidityState
- *
- * @param {DOMElement} input        - the input being validated.
- * @param {String} value            - the inputted value.
- * @param {Boolean} required        - if the input needs to be filled.
- * @param {Number} minCharQuantity  - the minimum length of the value.
- * @param {Number} maxCharQuantity  - the maximum length of the value.
- * @param {String} validationType   - the input value type.
- * @param {Function} validation     - a custom validation function.
- *
- * @returns {Object}                - the validity state of the input.
  */
 export const validateInput = (
-  input,
-  value,
-  required,
-  minCharQuantity,
-  maxCharQuantity,
-  validationType,
-  validation
+  input: HTMLInputElement | HTMLTextAreaElement | null,
+  value: string,
+  required: boolean,
+  minCharQuantity: any,
+  maxCharQuantity: any,
+  validationType: string,
+  validation: HvInputProps["validation"]
 ): HvInputValidity => {
   // bootstrap validity object using browser's built-in validation
   const inputValidity: HvInputValidity = {

--- a/packages/core/src/components/Box/Box.tsx
+++ b/packages/core/src/components/Box/Box.tsx
@@ -1,8 +1,8 @@
-import { theme } from "@hitachivantara/uikit-styles";
+import { HvTheme, theme } from "@hitachivantara/uikit-styles";
 import { forwardRef } from "react";
 import { PolymorphicComponentRef, PolymorphicRef } from "@core/types";
 
-type SxProps = React.CSSProperties | ((theme) => React.CSSProperties);
+type SxProps = React.CSSProperties | ((theme: HvTheme) => React.CSSProperties);
 
 type HvBoxBaseProps<C extends React.ElementType> = PolymorphicComponentRef<
   C,

--- a/packages/core/src/components/BreadCrumb/BreadCrumb.stories.tsx
+++ b/packages/core/src/components/BreadCrumb/BreadCrumb.stories.tsx
@@ -99,7 +99,7 @@ export const WithCustomComponent: StoryObj<HvBreadCrumbProps> = {
     },
   },
   render: () => {
-    const CustomNavLink = ({ children, to, ariaLabel, ...others }) => (
+    const CustomNavLink = ({ children, to, ariaLabel, ...others }: any) => (
       <a
         href={to}
         aria-label={ariaLabel}

--- a/packages/core/src/components/BreadCrumb/BreadCrumb.tsx
+++ b/packages/core/src/components/BreadCrumb/BreadCrumb.tsx
@@ -32,7 +32,7 @@ export interface HvBreadCrumbProps
   /** Function passed to the component. If defined the component prop is used as the link node. */
   onClick?: (event: MouseEvent<HTMLElement>, data: any) => void;
   /** Props passed down to the DropDownMenu sub-menu component. */
-  dropDownMenuProps?: HvDropDownMenuProps;
+  dropDownMenuProps?: Partial<HvDropDownMenuProps>;
   /** A Jss Object used to override or extend the styles applied to the component. */
   classes?: HvBreadCrumbClasses;
 }

--- a/packages/core/src/components/BreadCrumb/utils.tsx
+++ b/packages/core/src/components/BreadCrumb/utils.tsx
@@ -1,21 +1,21 @@
 import { MoreOptionsHorizontal } from "@hitachivantara/uikit-react-icons";
-import { HvDropDownMenu } from "@core/components";
+import { HvBreadCrumbProps, HvDropDownMenu } from "@core/components";
 import { setId } from "@core/utils";
 
-export const removeExtension = (label) =>
+export const removeExtension = (label: string) =>
   label.includes(".") ? label.substring(0, label.lastIndexOf(".")) : label;
 
 export const pathWithSubMenu = (
-  id,
-  onClick,
-  listRoute,
-  maxVisible,
-  dropDownMenuProps
+  id: string | undefined,
+  onClick: HvBreadCrumbProps["onClick"],
+  listRoute: any,
+  maxVisible: number,
+  dropDownMenuProps?: HvBreadCrumbProps["dropDownMenuProps"]
 ) => {
   const nbrElemToSubMenu = listRoute.length - maxVisible;
   const subMenuList = listRoute.slice(1, nbrElemToSubMenu + 1);
 
-  const handleClick = (event, data) => {
+  const handleClick = (event: any, data: any) => {
     event.preventDefault();
 
     onClick?.(event, data);

--- a/packages/core/src/components/BulkActions/BulkActions.stories.tsx
+++ b/packages/core/src/components/BulkActions/BulkActions.stories.tsx
@@ -2,12 +2,7 @@ import styled from "@emotion/styled";
 import { Add, Delete, Preview, Lock } from "@hitachivantara/uikit-react-icons";
 import { theme } from "@hitachivantara/uikit-styles";
 import { Meta, StoryObj } from "@storybook/react";
-import {
-  HvCheckBox,
-  HvListValue,
-  HvPagination,
-  HvActionGeneric,
-} from "@core/components";
+import { HvCheckBox, HvPagination, HvActionGeneric } from "@core/components";
 import uniqueId from "lodash/uniqueId";
 import { useState } from "react";
 import { HvBulkActions, HvBulkActionsProps } from "./BulkActions";
@@ -47,17 +42,16 @@ type SampleComponentDatum = {
   checked: boolean;
 };
 
-const SampleComponent = ({
-  data,
-  onChange,
-}: {
+type SampleComponentProps = {
   data: SampleComponentDatum[];
   onChange: (
     event: React.ChangeEvent<HTMLInputElement>,
     index: number,
     checked: boolean
   ) => void;
-}) => (
+};
+
+const SampleComponent = ({ data, onChange }: SampleComponentProps) => (
   <StyledRoot>
     {data.map((el, i) => (
       <div key={el.id}>
@@ -93,13 +87,14 @@ export const Main: StoryObj<HvBulkActionsProps> = {
       Array.from(Array(8), (_, i) => addEntry(i))
     );
 
-    const handleSelectAll = (_, checked = false) => {
+    const handleSelectAll = (_: any, checked = false) => {
       setData(data.map((el) => ({ ...el, checked })));
     };
 
-    const handleSelectAllPages = (e) => handleSelectAll(e, true);
+    const handleSelectAllPages: HvBulkActionsProps["onSelectAllPages"] = (e) =>
+      handleSelectAll(e, true);
 
-    const handleChange = (_, i: number, checked: boolean) => {
+    const handleChange: SampleComponentProps["onChange"] = (_, i, checked) => {
       const newData = [...data];
       newData[i].checked = checked;
       setData(newData);
@@ -133,17 +128,21 @@ export const WithActions: StoryObj<HvBulkActionsProps> = {
       Array.from(Array(8), (_, i) => addEntry(i))
     );
 
-    const handleSelectAll = (_, checked = false) => {
+    const handleSelectAll: HvBulkActionsProps["onSelectAll"] = (_, checked) => {
       setData(data.map((el) => ({ ...el, checked })));
     };
 
-    const handleChange = (_, i: number, checked: boolean) => {
+    const handleChange: SampleComponentProps["onChange"] = (_, i, checked) => {
       const newData = [...data];
       newData[i].checked = checked;
       setData(newData);
     };
 
-    const handleAction = (_, __, action: HvListValue | HvActionGeneric) => {
+    const handleAction: HvBulkActionsProps["actionsCallback"] = (
+      _,
+      __,
+      action
+    ) => {
       const selected = data.filter((el) => el.checked);
 
       switch (action.id) {
@@ -227,13 +226,17 @@ export const WithPagination: StoryObj<HvBulkActionsProps> = {
       setData(newData);
     };
 
-    const handleChange = (_, i: number, checked: boolean) => {
+    const handleChange: SampleComponentProps["onChange"] = (_, i, checked) => {
       const newData = [...data];
       newData[i + pageSize * page].checked = checked;
       setData(newData);
     };
 
-    const handleAction = (_, __, action: HvActionGeneric | HvListValue) => {
+    const handleAction: HvBulkActionsProps["actionsCallback"] = (
+      _,
+      __,
+      action
+    ) => {
       const selected = data.filter((el) => el.checked);
 
       switch (action.id) {

--- a/packages/core/src/components/Card/Card.stories.tsx
+++ b/packages/core/src/components/Card/Card.stories.tsx
@@ -28,7 +28,7 @@ import {
   HvToggleButton,
 } from "@core/components";
 import { isKeypress, keyboardCodes } from "@core/utils";
-import { useEffect, useState } from "react";
+import { ReactNode, useEffect, useState } from "react";
 import compressor from "./assets/compressor.png";
 import leaf from "./assets/leaf.png";
 
@@ -303,12 +303,18 @@ export const KPICard: StoryObj<HvCardProps> = {
         "Shaft may be bent, check for bends. Straighten if possible and replace shaft if necessary.",
     };
 
-    const getKpiLabels = (score) => ({
+    const getKpiLabels = (score: string) => ({
       title: "Confidence score",
       indicator: `${score}%`,
     });
 
-    const CardContent = ({ value, icon }) => (
+    const CardContent = ({
+      value,
+      icon,
+    }: {
+      value: string;
+      icon: ReactNode;
+    }) => (
       <HvCardContent>
         <Grid container>
           <HvKpi labels={getKpiLabels(value)} visualIndicator={icon} />
@@ -328,7 +334,7 @@ export const KPICard: StoryObj<HvCardProps> = {
       </HvCardContent>
     );
 
-    const CardFooter = ({ n }) => (
+    const CardFooter = ({ n }: { n: number }) => (
       <HvActionBar aria-label="Leaf">
         <HvCheckBox
           onChange={() => setChecked(n)}
@@ -400,7 +406,7 @@ export const Selectable: StoryObj<HvCardProps> = {
       </HvCardContent>
     );
 
-    const CardClickableContent = ({ children }) => {
+    const CardClickableContent = ({ children }: { children: ReactNode }) => {
       return (
         <StyledButton
           type="button"

--- a/packages/core/src/components/CheckBox/CheckBox.tsx
+++ b/packages/core/src/components/CheckBox/CheckBox.tsx
@@ -104,7 +104,9 @@ export const HvCheckBox = ({
 
   const isStateInvalid = isInvalid(validationState);
 
-  const onChangeCallback = useCallback(
+  const onChangeCallback = useCallback<
+    NonNullable<HvBaseCheckBoxProps["onChange"]>
+  >(
     (event, newChecked) => {
       setIsChecked(() => {
         // This will only run if uncontrolled
@@ -131,21 +133,15 @@ export const HvCheckBox = ({
     ]
   );
 
-  const onFocusVisibleCallback = useCallback(
-    (event) => {
-      setFocusVisible(true);
-      onFocusVisible?.(event);
-    },
-    [onFocusVisible]
-  );
+  const onFocusVisibleCallback: HvBaseCheckBoxProps["onBlur"] = (event) => {
+    setFocusVisible(true);
+    onFocusVisible?.(event);
+  };
 
-  const onBlurCallback = useCallback(
-    (event) => {
-      setFocusVisible(false);
-      onBlur?.(event);
-    },
-    [onBlur]
-  );
+  const onBlurCallback: HvBaseCheckBoxProps["onBlur"] = (event) => {
+    setFocusVisible(false);
+    onBlur?.(event);
+  };
 
   // The error message area will only be created if:
   //   - an external element that provides an error message isn't identified via aria-errormessage AND

--- a/packages/core/src/components/CheckBoxGroup/CheckBoxGroup.stories.tsx
+++ b/packages/core/src/components/CheckBoxGroup/CheckBoxGroup.stories.tsx
@@ -154,7 +154,7 @@ export const Controlled: StoryObj<HvCheckBoxGroupProps> = {
   render: () => {
     const [value, setValue] = useState(["2"]);
 
-    const handleOnChange = (_, newValue) => {
+    const handleOnChange: HvCheckBoxGroupProps["onChange"] = (_, newValue) => {
       setValue(newValue);
     };
 

--- a/packages/core/src/components/CheckBoxGroup/CheckBoxGroup.tsx
+++ b/packages/core/src/components/CheckBoxGroup/CheckBoxGroup.tsx
@@ -14,7 +14,7 @@ import checkBoxGroupClasses, {
   HvCheckBoxGroupClasses,
 } from "./checkBoxGroupClasses";
 
-const computeSelectAllState = (selected, total) => {
+const computeSelectAllState = (selected: number, total: number) => {
   if (selected === 0) {
     return "none";
   }

--- a/packages/core/src/components/ColorPicker/ColorPicker.tsx
+++ b/packages/core/src/components/ColorPicker/ColorPicker.tsx
@@ -1,5 +1,6 @@
 import {
   HvBaseDropdown,
+  HvDropdownProps,
   HvFormElement,
   HvInfoMessage,
   HvLabel,
@@ -156,7 +157,7 @@ export const HvColorPicker = ({
   const hasLabel = label != null;
   const hasDescription = description != null;
 
-  const handleToggle = (_, open: boolean) => {
+  const handleToggle: HvDropdownProps["onToggle"] = (_, open) => {
     setIsOpen(open);
   };
 

--- a/packages/core/src/components/Controls/Controls.stories.tsx
+++ b/packages/core/src/components/Controls/Controls.stories.tsx
@@ -16,13 +16,14 @@ import {
   HvRightControl,
   HvSimpleGrid,
   HvSlider,
+  HvSliderProps,
   HvTableColumnConfig,
   useHvData,
   useHvFilters,
   useHvGlobalFilter,
   useHvSortBy,
 } from "@core/components";
-import { useMemo, useState, useCallback } from "react";
+import { useMemo, useState } from "react";
 import { getColumns, makeData, NewEntry } from "./makedata";
 
 const meta: Meta<typeof HvControls> = {
@@ -298,24 +299,20 @@ export const CustomControls = () => {
     []
   );
 
-  const filterSeverity = useCallback(
-    (rows) =>
+  const columns = useMemo<HvTableColumnConfig<NewEntry, string>[]>(() => {
+    const filterSeverity: HvTableColumnConfig<NewEntry>["filter"] = (rows) =>
       rows.filter(
         (row) =>
           buttons[severitySelection] === "All" ||
           row.original.severity === buttons[severitySelection]
-      ),
-    [buttons, severitySelection]
-  );
+      );
 
-  const sliderTemperature = useCallback(
-    (rows) =>
-      rows.filter((row) => row.original.temperature > temperatureSelection),
-    [temperatureSelection]
-  );
+    const filterTemperature: HvTableColumnConfig<NewEntry>["filter"] = (rows) =>
+      rows.filter(
+        (row) => row.original.temperature > String(temperatureSelection)
+      );
 
-  const columns: HvTableColumnConfig<NewEntry, string>[] = useMemo(
-    () => [
+    return [
       { Header: "Title", accessor: "name" },
       { Header: "Event Type", accessor: "eventType" },
       { Header: "Status", accessor: "status" },
@@ -324,11 +321,10 @@ export const CustomControls = () => {
       {
         Header: "Temperature",
         accessor: "temperature",
-        filter: sliderTemperature,
+        filter: filterTemperature,
       },
-    ],
-    [filterSeverity, sliderTemperature]
-  );
+    ];
+  }, [temperatureSelection, buttons, severitySelection]);
 
   const { rows, setFilter } = useHvData<NewEntry, string>(
     {
@@ -338,12 +334,12 @@ export const CustomControls = () => {
     useHvFilters
   );
 
-  const handleChange = (_, idx) => {
+  const handleChange = (_: any, idx: number) => {
     setSeveritySelection(idx);
     setFilter?.("severity", buttons[idx]);
   };
 
-  const onSliderChange = (values) => {
+  const onSliderChange: HvSliderProps["onChange"] = (values) => {
     setTemperatureSelection(values[0]);
     setFilter?.("temperature", values[0]);
   };
@@ -424,24 +420,20 @@ export const MixedControls = () => {
     []
   );
 
-  const filterSeverity = useCallback(
-    (rows) =>
+  const columns: HvTableColumnConfig<NewEntry, string>[] = useMemo(() => {
+    const filterSeverity: HvTableColumnConfig<NewEntry>["filter"] = (rows) =>
       rows.filter(
         (row) =>
           buttons[severitySelection] === "All" ||
           row.original.severity === buttons[severitySelection]
-      ),
-    [buttons, severitySelection]
-  );
+      );
 
-  const sliderTemperature = useCallback(
-    (rows) =>
-      rows.filter((row) => row.original.temperature > temperatureSelection),
-    [temperatureSelection]
-  );
+    const sliderTemperature: HvTableColumnConfig<NewEntry>["filter"] = (rows) =>
+      rows.filter(
+        (row) => row.original.temperature > String(temperatureSelection)
+      );
 
-  const columns: HvTableColumnConfig<NewEntry, string>[] = useMemo(
-    () => [
+    return [
       { Header: "Title", accessor: "name" },
       { Header: "Event Type", accessor: "eventType" },
       { Header: "Status", accessor: "status" },
@@ -452,9 +444,8 @@ export const MixedControls = () => {
         accessor: "temperature",
         filter: sliderTemperature,
       },
-    ],
-    [filterSeverity, sliderTemperature]
-  );
+    ];
+  }, [temperatureSelection, buttons, severitySelection]);
 
   const { rows, setFilter, setGlobalFilter } = useHvData<NewEntry, string>(
     {
@@ -465,12 +456,12 @@ export const MixedControls = () => {
     useHvGlobalFilter
   );
 
-  const handleChange = (_, idx) => {
+  const handleChange = (_: any, idx: number) => {
     setSeveritySelection(idx);
     setFilter?.("severity", buttons[idx]);
   };
 
-  const onSliderChange = (values) => {
+  const onSliderChange: HvSliderProps["onChange"] = (values) => {
     setTemperatureSelection(values[0]);
     setFilter?.("temperature", values[0]);
   };

--- a/packages/core/src/components/Controls/Controls.tsx
+++ b/packages/core/src/components/Controls/Controls.tsx
@@ -3,7 +3,7 @@ import { HvBaseProps, HvExtraProps } from "@core/types";
 import { HvButton, HvMultiButton } from "@core/components";
 import { setId } from "@core/utils";
 import { useControlled } from "@core/hooks";
-import { Children } from "react";
+import { Children, MouseEvent } from "react";
 import { HvTableInstance } from "@core/components/Table/hooks/useTable";
 import { HvControlsContextProvider } from "./context/ControlsContext";
 import controlsClasses, { HvControlsClasses } from "./controlClasses";
@@ -41,7 +41,7 @@ export interface HvControlsProps extends HvBaseProps {
   /**
    * Callback called when the view switcher button is pressed
    */
-  onViewChange?: (event: Event, id: string) => void;
+  onViewChange?: (event: MouseEvent<HTMLButtonElement>, id: string) => void;
   /**
    * if `true` the button to switch views is not rendered
    */
@@ -67,13 +67,16 @@ export const HvControls = ({
     defaultView
   );
 
-  const onViewChangeHandler = (evt, btnId) => {
+  const onViewChangeHandler = (
+    evt: MouseEvent<HTMLButtonElement>,
+    btnId: any
+  ) => {
     setCurrentView(btnId);
     onViewChange?.(evt, btnId);
   };
 
-  const onSearchHandler = (value) => callbacks?.setGlobalFilter?.(value);
-  const onSortHandler = (value) =>
+  const onSearchHandler = (value: any) => callbacks?.setGlobalFilter?.(value);
+  const onSortHandler = (value: any) =>
     callbacks?.setSortBy?.([
       {
         id: value?.accessor,

--- a/packages/core/src/components/Controls/LeftControl/LeftControl.tsx
+++ b/packages/core/src/components/Controls/LeftControl/LeftControl.tsx
@@ -14,7 +14,7 @@ export interface HvLeftControlProps extends HvBaseProps {
   placeholder?: string;
   /** Callback called when a search action occurs */
   onSearch?: (
-    event: React.ChangeEvent<HTMLInputElement>,
+    event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
     value: string
   ) => void;
   /** Extra props passed to input */
@@ -36,7 +36,7 @@ export const HvLeftControl = ({
 }: HvLeftControlProps) => {
   const { onSearch: onSearchHandler } = useContext(HvControlsContext);
 
-  const onChangeFilter = (e, value) => {
+  const onChangeFilter: HvInputProps["onChange"] = (e, value) => {
     onSearch?.(e, value);
     onSearchHandler?.(value);
   };
@@ -52,7 +52,7 @@ export const HvLeftControl = ({
           id={setId(id, "search-input")}
           type="search"
           placeholder={placeholder}
-          onChange={(e, value) => onChangeFilter(e, value)}
+          onChange={onChangeFilter}
           {...searchProps}
         />
       )}

--- a/packages/core/src/components/Controls/RightControl/RightControl.tsx
+++ b/packages/core/src/components/Controls/RightControl/RightControl.tsx
@@ -42,7 +42,7 @@ export const HvRightControl = ({
 
   const { onSort: onSortHandler } = useContext(HvControlsContext);
 
-  const handleChangeSort = (value) => {
+  const handleChangeSort: HvDropdownProps["onChange"] = (value: any) => {
     onSort?.(value);
     onSortHandler?.(value);
     // this should be changed when dropdown changes his "values" behavior

--- a/packages/core/src/components/DatePicker/DatePicker.stories.tsx
+++ b/packages/core/src/components/DatePicker/DatePicker.stories.tsx
@@ -335,7 +335,7 @@ export const WithSelectionList: StoryObj<HvDatePickerProps> = {
       setEndDate(trueEndDate);
     }, [trueEndDate]);
 
-    const handleClick = (item) => {
+    const handleClick = (item: string) => {
       console.log(item);
       const today = new Date();
       const [d, m, y] = [

--- a/packages/core/src/components/DatePicker/DatePicker.tsx
+++ b/packages/core/src/components/DatePicker/DatePicker.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef, ReactNode } from "react";
 import styled from "@emotion/styled";
 import { Calendar } from "@hitachivantara/uikit-react-icons";
 import { theme } from "@hitachivantara/uikit-styles";
@@ -14,6 +14,7 @@ import {
   HvBaseDropdown,
   HvLabel,
   HvFormStatus,
+  HvBaseDropdownProps,
 } from "@core/components";
 import { useControlled, useLabels, useTheme, useUniqueId } from "@core/hooks";
 import { HvBaseProps } from "@core/types";
@@ -368,7 +369,7 @@ export const HvDatePicker = ({
     }
   };
 
-  const handleToggle = (evt, open) => {
+  const handleToggle: HvBaseDropdownProps["onToggle"] = (evt, open) => {
     /* 
      If evt is null this toggle wasn't triggered by the user.
      instead it was triggered by the baseDropdown useEffect after
@@ -383,7 +384,7 @@ export const HvDatePicker = ({
     focusTarget.current?.focus();
   };
 
-  const handleDateChange = (event, newDate) => {
+  const handleDateChange: HvCalendarProps["onChange"] = (event, newDate) => {
     if (!isDate(newDate)) return;
 
     const autoSave = !showActions && !rangeMode;
@@ -415,11 +416,15 @@ export const HvDatePicker = ({
     }
   };
 
-  const handleInputDateChange = (event, newDate, position) => {
+  const handleInputDateChange: HvCalendarProps["onInputChange"] = (
+    event,
+    newDate,
+    position
+  ) => {
     if (!isDate(newDate)) return;
 
     if (!rangeMode) {
-      handleDateChange(event, newDate);
+      handleDateChange(event as any, newDate);
       return;
     }
 
@@ -472,7 +477,11 @@ export const HvDatePicker = ({
     </HvActionBar>
   );
 
-  const styledTypography = (dateString, variant, text) => {
+  const styledTypography = (
+    dateString: string,
+    variant: any,
+    text: ReactNode
+  ) => {
     const StyledTypography = styled(HvTypography)({
       color: dateString
         ? theme.colors.secondary
@@ -482,7 +491,7 @@ export const HvDatePicker = ({
     return <StyledTypography variant={variant}>{text}</StyledTypography>;
   };
 
-  const renderInput = (dateString) =>
+  const renderInput = (dateString: string) =>
     styledTypography(
       dateString,
       activeTheme?.datePicker.placeholderVariant,

--- a/packages/core/src/components/DatePicker/utils.tsx
+++ b/packages/core/src/components/DatePicker/utils.tsx
@@ -6,7 +6,7 @@ import {
   isSameMonth,
 } from "../Calendar/utils";
 
-export const validateDate = (date) => (isDate(date) && date) || new Date();
+export const validateDate = (date: any) => (isDate(date) && date) || new Date();
 
 export const getFormattedDateRange = (
   date: DateRangeProp,
@@ -22,10 +22,13 @@ export const getFormattedDateRange = (
   return `${startDate.getDate()} - ${endDate?.getDate()} ${monthYear}`;
 };
 
-export const getSingleDateLabel = (date, locale?) =>
+export const getSingleDateLabel = (date: any, locale?: string) =>
   isDate(date) ? getFormattedDate(date, locale) : "";
 
-export const getRangeDateLabel = ({ startDate, endDate }, locale) => {
+export const getRangeDateLabel = (
+  { startDate, endDate }: any,
+  locale: string
+) => {
   if (!(isDate(startDate) && isDate(endDate)))
     return getSingleDateLabel(startDate);
 

--- a/packages/core/src/components/Dialog/Dialog.tsx
+++ b/packages/core/src/components/Dialog/Dialog.tsx
@@ -82,7 +82,7 @@ export const HvDialog = ({
   // the onClose call here to make that check.
   const wrappedClose = useCallback(
     (
-      event,
+      event: any,
       bypassValidation: boolean = false,
       reason?: "escapeKeyDown" | "backdropClick"
     ) => {

--- a/packages/core/src/components/DropDownMenu/DropDownMenu.tsx
+++ b/packages/core/src/components/DropDownMenu/DropDownMenu.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { ChangeEvent, useMemo } from "react";
 import { theme } from "@hitachivantara/uikit-styles";
 import { MoreOptionsVertical } from "@hitachivantara/uikit-react-icons";
 import { useControlled, useUniqueId } from "@core/hooks";
@@ -16,6 +16,7 @@ import {
   HvButton,
   HvButtonVariant,
   HvList,
+  HvListProps,
   HvListValue,
   HvPanel,
 } from "@core/components";
@@ -91,23 +92,25 @@ export const HvDropDownMenu = ({
 
   const listId = setId(id, "list");
 
-  const handleClose = (event) => {
+  const handleClose = (event: ChangeEvent) => {
     // this will only run if uncontrolled
     setOpen(false);
-    onToggle?.(event, false);
+    onToggle?.(event as any, false);
   };
 
   // If the ESCAPE key is pressed inside the list, the close handler must be called.
-  const handleKeyDown = (event) => {
+  const handleKeyDown: HvListProps["onKeyDown"] = (event) => {
     if (isKeypress(event, keyboardCodes.Tab)) {
       const node = event.shiftKey ? focusNodes.prevFocus : focusNodes.nextFocus;
       if (node) setTimeout(() => node.focus(), 0);
-      handleClose(event);
+      handleClose(event as any);
     }
     event.preventDefault();
   };
 
-  const setFocusToContent = (containerRef) => {
+  const setFocusToContent: HvBaseDropdownProps["onContainerCreation"] = (
+    containerRef
+  ) => {
     containerRef?.getElementsByTagName("li")[0]?.focus();
   };
 

--- a/packages/core/src/components/Dropdown/Dropdown.stories.tsx
+++ b/packages/core/src/components/Dropdown/Dropdown.stories.tsx
@@ -12,16 +12,13 @@ import { HvGrid, HvListValue } from "@core/components";
 import { useEffect, useMemo, useState } from "react";
 import { HvDropdown, HvDropdownProps, HvDropdownStatus } from "./Dropdown";
 
-const Decorator = ({ children }) => {
-  return <div style={{ padding: 10, height: 600 }}>{children}</div>;
-};
-
-const meta: Meta<typeof HvDropdown> = {
+export default {
   title: "Components/Dropdown",
   component: HvDropdown,
-  decorators: [(Story) => <Decorator>{Story()}</Decorator>],
-};
-export default meta;
+  decorators: [
+    (Story) => <div style={{ padding: 10, height: 600 }}>{Story()}</div>,
+  ],
+} as Meta<typeof HvDropdown>;
 
 export const Main: StoryObj<HvDropdownProps> = {
   args: {
@@ -67,7 +64,13 @@ const StyledSpan = styled("span")({
   alignItems: "center",
 });
 
-const PriorityIcon = ({ Icon, label }) => (
+const PriorityIcon = ({
+  Icon,
+  label,
+}: {
+  Icon: React.ElementType;
+  label: string;
+}) => (
   <StyledSpan>
     <Icon
       style={{ float: "left", width: 22, height: 22, margin: "5px 5px 5px 0" }}

--- a/packages/core/src/components/Dropdown/Dropdown.tsx
+++ b/packages/core/src/components/Dropdown/Dropdown.tsx
@@ -344,8 +344,8 @@ export const HvDropdown = (props: HvDropdownProps) => {
 
   const dropdownHeaderRef = useRef<HTMLDivElement>();
 
-  const handleToggle = (_e, open) => {
-    onToggle?.(_e, open);
+  const handleToggle: HvBaseDropdownProps["onToggle"] = (event, open) => {
+    onToggle?.(event, open);
 
     setIsOpen(open);
 
@@ -367,15 +367,8 @@ export const HvDropdown = (props: HvDropdownProps) => {
     }
   };
 
-  /**
-   * Applies the selected values to the state
-   *
-   * @param {Array} listValues - An array containing the selected values.
-   * @param {Boolean} commitChanges - If `true` the selection if finally committed the dropdown header text should reflect the new selection
-   * @param {Boolean} toggle -If `true` the dropdown should toggle it's current state
-   * @param {Boolean} notifyChanges -If `true` the dropdown will call onChange.
-   */
-  const handleSelection = (
+  /** Applies the selected values to the state */
+  const handleSelection: HvDropdownListProps["onChange"] = (
     listValues,
     commitChanges,
     toggle,
@@ -400,7 +393,7 @@ export const HvDropdown = (props: HvDropdownProps) => {
     }
     if (notifyChanges) onChange?.(multiSelect ? selected : selected[0]);
     if (toggle) {
-      handleToggle(undefined, false);
+      handleToggle(undefined as any, false);
 
       // focus-ring won't be visible even if using the keyboard:
       // https://github.com/WICG/focus-visible/issues/88
@@ -411,24 +404,26 @@ export const HvDropdown = (props: HvDropdownProps) => {
   /**
    * Handles the `Cancel` action. Both single and ranged modes are handled here.
    */
-  const handleCancel = (evt) => {
-    onCancel?.(evt);
+  const handleCancel: HvDropdownListProps["onCancel"] = (evt) => {
+    onCancel?.(evt as any);
 
-    handleToggle(evt, false);
+    handleToggle(evt as any, false);
 
     // focus-ring won't be visible even if using the keyboard:
     // https://github.com/WICG/focus-visible/issues/88
     dropdownHeaderRef.current?.focus({ preventScroll: true });
   };
 
-  const handleClickOutside = (evt) => {
+  const handleClickOutside: HvBaseDropdownProps["onClickOutside"] = (evt) => {
     onClickOutside?.(evt);
     onCancel?.(evt);
   };
 
-  const setFocusToContent = (containerRef) => {
+  const setFocusToContent: HvBaseDropdownProps["onContainerCreation"] = (
+    containerRef
+  ) => {
     const inputs = containerRef?.getElementsByTagName("input");
-    if (inputs?.length > 0) {
+    if (inputs && inputs.length > 0) {
       inputs[0].focus();
       return;
     }

--- a/packages/core/src/components/Dropdown/List/List.tsx
+++ b/packages/core/src/components/Dropdown/List/List.tsx
@@ -1,4 +1,4 @@
-import { useContext, useEffect, useState } from "react";
+import { MouseEvent, useContext, useEffect, useState } from "react";
 import { clsx } from "clsx";
 import isNil from "lodash/isNil";
 import { setId } from "@core/utils";
@@ -7,6 +7,7 @@ import {
   HvButton,
   HvCheckBox,
   HvInput,
+  HvListProps,
   HvListValue,
   HvTypography,
 } from "@core/components";
@@ -46,11 +47,20 @@ export interface HvDropdownListProps {
    * A function to be executed whenever a item is selected in the list
    * or the Apply button is activated (when `multiSelect` is `true`).
    */
-  onChange: any;
+  onChange: (
+    /** An array containing the selected values */
+    listValues: HvListValue[],
+    /** If `true` the selection if finally committed the dropdown header text should reflect the new selection */
+    commitChanges: boolean,
+    /** If `true` the dropdown should toggle it's current state */
+    toggle: boolean,
+    /** If `true` the dropdown will call onChange */
+    notifyChanges: boolean
+  ) => void;
   /**
    * A function to be executed whenever the Cancel button is activated.
    */
-  onCancel: any;
+  onCancel: (event: MouseEvent) => void;
   /**
    * An object containing all the labels for the dropdown.
    */
@@ -97,7 +107,8 @@ const clone = (values: HvListValue[]) => values.map((value) => ({ ...value }));
 const cleanHidden = (lst: HvListValue[]) =>
   lst.map((item) => ({ ...item, isHidden: false }));
 
-const valuesExist = (values) => !isNil(values) && values?.length > 0;
+const valuesExist = (values: HvListValue[]) =>
+  !isNil(values) && values?.length > 0;
 
 export const HvDropdownList = ({
   id,
@@ -283,7 +294,7 @@ export const HvDropdownList = ({
    *
    * @param listValues - elements selected.
    */
-  const onSelection = (listValues) => {
+  const onSelection: HvListProps["onChange"] = (listValues) => {
     if (!multiSelect) {
       onChange(cleanHidden(listValues), true, true, true);
     } else {

--- a/packages/core/src/components/Dropdown/utils.tsx
+++ b/packages/core/src/components/Dropdown/utils.tsx
@@ -1,37 +1,20 @@
-import { HvListValue } from "@core/components";
+import { HvDropdownLabelsProps, HvListValue } from "@core/components";
 
-/**
- * Filter selected elements.
- *
- * @param {Object} list - the list to filter
- * @returns {Array} - the selected elements
- */
-const getSelected = (list) => list?.filter((elem) => elem.selected) || [];
+/** Filter selected elements. */
+const getSelected = (list: HvListValue[] = []) =>
+  list.filter((elem) => elem.selected);
 
-/**
- * Checks if any element of the list is selected.
- *
- * @param list
- * @returns {boolean}
- */
-const hasSelected = (list) => getSelected(list).length > 0;
+/** Checks if any element of the list is selected. */
+const hasSelected = (list: HvListValue[]) => getSelected(list).length > 0;
 
-/**
- * Gets the selection label according to selection.
- *
- * @param {Object} list - the list to filter the selected elements from
- * @param {Object} labels - the labels to extract the textual values for the label
- * @param {Boolean} multiSelect - if "true" the label will have a different format
- *
- * @returns {Object} - the selection label
- */
+/** Gets the selection label according to selection. */
 const getSelectionLabel = (
-  labels,
-  placeholder,
-  multiSelect,
+  labels: HvDropdownLabelsProps | undefined,
+  placeholder: string,
+  multiSelect: boolean,
   list: HvListValue[] = []
 ) => {
-  const { select } = labels;
+  const { select } = labels || {};
   const selected = getSelected(list);
 
   if (select) return { selected: select };

--- a/packages/core/src/components/FilterGroup/RightPanel/RightPanel.tsx
+++ b/packages/core/src/components/FilterGroup/RightPanel/RightPanel.tsx
@@ -2,6 +2,7 @@ import {
   HvCheckBox,
   HvInput,
   HvList,
+  HvListProps,
   HvPanel,
   HvTypography,
 } from "@core/components";
@@ -86,13 +87,13 @@ export const HvFilterGroupRightPanel = ({
 
   useEffect(() => setSearchStr(""), [activeGroup]);
 
-  const onChangeHandler = (values) => {
+  const onChangeHandler: HvListProps["onChange"] = (values) => {
     const newFilterValues = filterOptions.map((_, i) =>
       activeGroup === i
         ? values.filter((v) => v.selected).map((v) => v.id)
         : [...(filterValues[i] || [])]
     );
-    setFilterValues(newFilterValues);
+    setFilterValues(newFilterValues as any);
   };
 
   const handleSelectAll = useCallback(() => {

--- a/packages/core/src/components/Forms/Adornment/Adornment.stories.tsx
+++ b/packages/core/src/components/Forms/Adornment/Adornment.stories.tsx
@@ -51,7 +51,6 @@ export const InputAdornment: StoryObj<HvAdornmentProps> = {
     const toggleType = () => {
       setPasswordType(!isPassword);
     };
-    const getIcon = (isPass) => (isPass ? <Preview /> : <PreviewOff />);
 
     return (
       <HvFormElement status="standBy">
@@ -64,7 +63,7 @@ export const InputAdornment: StoryObj<HvAdornmentProps> = {
             endAdornment={
               <HvAdornment
                 aria-label="show password"
-                icon={getIcon(isPassword)}
+                icon={isPassword ? <Preview /> : <PreviewOff />}
                 onClick={toggleType}
               />
             }

--- a/packages/core/src/components/Forms/Adornment/Adornment.tsx
+++ b/packages/core/src/components/Forms/Adornment/Adornment.tsx
@@ -9,7 +9,6 @@ import {
 } from "../FormElement";
 import adornmentClasses, { HvAdornmentClasses } from "./adornmentClasses";
 
-const preventDefault = (event) => event.preventDefault();
 const noop = () => {};
 
 export interface HvAdornmentProps
@@ -84,7 +83,7 @@ export const HvAdornment = forwardRef<
           !displayIcon && clsx(adornmentClasses.hideIcon, classes?.hideIcon)
         )}
         onClick={onClick}
-        onMouseDown={preventDefault}
+        onMouseDown={(event) => event.preventDefault()}
         onKeyDown={noop}
         $hideIcon={!displayIcon}
         {...others}

--- a/packages/core/src/components/Forms/FormElement/FormElement.stories.tsx
+++ b/packages/core/src/components/Forms/FormElement/FormElement.stories.tsx
@@ -10,6 +10,7 @@ import {
   HvInfoMessage,
   HvAdornment,
   HvFormStatus,
+  HvBaseInputProps,
 } from "@core/components";
 import { setId } from "@core/utils";
 
@@ -45,8 +46,8 @@ export const Main: StoryObj<HvFormElementProps> = {
       setElementValue(value);
     };
 
-    const onFocusHandler = (event) => {
-      const { type } = event.target;
+    const onFocusHandler: HvFormElementProps["onFocus"] = (event) => {
+      const { type } = event.target as any;
       if (type === "button") return;
       if (
         !event.currentTarget.contains(document.activeElement) ||
@@ -63,22 +64,18 @@ export const Main: StoryObj<HvFormElementProps> = {
       }
     };
 
-    /**
-     * Extra validation is needed because of the close adornment.
-     *
-     * @param event
-     */
-    const onBlurHandler = (event) => {
+    /** Extra validation is needed because of the close adornment. */
+    const onBlurHandler: HvFormElementProps["onBlur"] = (event) => {
       if (
         event.relatedTarget === null ||
         event?.relatedTarget?.id !== setId(inputId, "clear")
       ) {
-        setElement(event.target.value);
+        setElement((event.target as any).value);
         setShowCloseAdornment(false);
       }
     };
 
-    const onMouseLeaveHandler = (event) => {
+    const onMouseLeaveHandler: HvBaseInputProps["onMouseLeave"] = (event) => {
       if (!event.currentTarget.contains(document.activeElement))
         setShowCloseAdornment(false);
     };
@@ -89,8 +86,8 @@ export const Main: StoryObj<HvFormElementProps> = {
 
     return (
       <HvFormElement
-        onBlur={(event) => onBlurHandler(event)}
-        onFocus={(event) => onFocusHandler(event)}
+        onBlur={onBlurHandler}
+        onFocus={onFocusHandler}
         status={elementStatus}
       >
         <HvLabel id="controlled-input-label" label="First name">
@@ -104,7 +101,7 @@ export const Main: StoryObj<HvFormElementProps> = {
             placeholder="Insert your name"
             onChange={(event, value) => setElement(value, false)}
             onMouseEnter={onMouseEnterHandler}
-            onMouseLeave={(event) => onMouseLeaveHandler(event)}
+            onMouseLeave={onMouseLeaveHandler}
             endAdornment={
               <>
                 <HvAdornment

--- a/packages/core/src/components/Forms/FormElement/validationStates.ts
+++ b/packages/core/src/components/Forms/FormElement/validationStates.ts
@@ -1,11 +1,14 @@
+import { HvFormStatus } from ".";
+
 const validationState = Object.freeze({
   standBy: "standBy",
   valid: "valid",
   invalid: "invalid",
 });
 
-export const isValid = (compareState) => compareState === validationState.valid;
-export const isInvalid = (compareState) =>
+export const isValid = (compareState: HvFormStatus) =>
+  compareState === validationState.valid;
+export const isInvalid = (compareState: HvFormStatus) =>
   compareState === validationState.invalid;
 
 export default validationState;

--- a/packages/core/src/components/Forms/Suggestions/Suggestions.stories.tsx
+++ b/packages/core/src/components/Forms/Suggestions/Suggestions.stories.tsx
@@ -1,6 +1,7 @@
 import { Meta, StoryObj } from "@storybook/react";
 import {
   HvBaseInput,
+  HvBaseInputProps,
   HvFormElement,
   HvLabel,
   HvSuggestions,
@@ -35,7 +36,7 @@ export const Main: StoryObj<HvSuggestionsProps> = {
     const [value, setValue] = useState("");
     const inputRef = useRef<HTMLElement>(null);
 
-    const handleChange = (e, val) => {
+    const handleChange: HvBaseInputProps["onChange"] = (e, val) => {
       const matches = suggestions.filter((v) =>
         v.toUpperCase().startsWith(val.toUpperCase())
       );
@@ -45,14 +46,17 @@ export const Main: StoryObj<HvSuggestionsProps> = {
       setValue(val);
     };
 
-    const handleSelection = (e, val) => {
+    const handleSelection: HvSuggestionsProps["onSuggestionSelected"] = (
+      e,
+      val
+    ) => {
       console.log(val);
       setOpen(false);
-      setValue(val.label);
+      setValue(val.label as any);
       inputRef?.current?.focus();
     };
 
-    const handleSuggestionsKey = (evt) => {
+    const handleSuggestionsKey: HvSuggestionsProps["onKeyDown"] = (evt) => {
       if (isKeypress(evt, Esc)) {
         inputRef?.current?.focus();
         setOpen(false);
@@ -101,7 +105,7 @@ export const ServerSideSuggestions: StoryObj<HvSuggestionsProps> = {
     const inputRef = useRef<HTMLElement>(null);
 
     // Server-side mock function
-    const fetchCountries = (input) =>
+    const fetchCountries = (input: string) =>
       new Promise((resolve) => {
         const countries = countryList
           .filter((c) => c.toUpperCase().includes(input.toUpperCase()))
@@ -110,7 +114,7 @@ export const ServerSideSuggestions: StoryObj<HvSuggestionsProps> = {
         setTimeout(() => resolve(countries), 300);
       });
 
-    const handleChange = (e, val) => {
+    const handleChange: HvBaseInputProps["onChange"] = (e, val) => {
       setValue(val);
       setOpen(false);
       if (val.length < 1) return;
@@ -120,14 +124,17 @@ export const ServerSideSuggestions: StoryObj<HvSuggestionsProps> = {
       });
     };
 
-    const handleSelection = (e, val) => {
+    const handleSelection: HvSuggestionsProps["onSuggestionSelected"] = (
+      e,
+      val
+    ) => {
       console.log(val);
       setOpen(false);
-      setValue(val.label);
+      setValue(val.label as any);
       inputRef?.current?.focus();
     };
 
-    const handleSuggestionsKey = (evt) => {
+    const handleSuggestionsKey: HvSuggestionsProps["onKeyDown"] = (evt) => {
       if (isKeypress(evt, Esc)) {
         inputRef?.current?.focus();
         setOpen(false);
@@ -176,7 +183,7 @@ export const OpenWithDownArrow: StoryObj<HvSuggestionsProps> = {
     const [value, setValue] = useState("");
     const inputRef = useRef<HTMLElement>(null);
 
-    const handleChange = (e, val) => {
+    const handleChange: HvBaseInputProps["onChange"] = (e, val) => {
       const matches = suggestions.filter((v) =>
         v.toUpperCase().startsWith(val.toUpperCase())
       );
@@ -186,21 +193,24 @@ export const OpenWithDownArrow: StoryObj<HvSuggestionsProps> = {
       setValue(val);
     };
 
-    const handleSelection = (e, val) => {
+    const handleSelection: HvSuggestionsProps["onSuggestionSelected"] = (
+      e,
+      val
+    ) => {
       console.log(val);
       setOpen(false);
-      setValue(val.label);
+      setValue(val.label as any);
       inputRef?.current?.focus();
     };
 
-    const handleKey = (e) => {
+    const handleKey: HvBaseInputProps["onKeyDown"] = (e) => {
       if (isKeypress(e, keyboardCodes.ArrowDown)) {
         setOpen(true);
         document.getElementById("suggestions-list-item-0")?.focus();
       }
     };
 
-    const handleSuggestionsKey = (evt) => {
+    const handleSuggestionsKey: HvSuggestionsProps["onKeyDown"] = (evt) => {
       if (isKeypress(evt, Esc)) {
         inputRef?.current?.focus();
         setOpen(false);

--- a/packages/core/src/components/Forms/WarningText/WarningText.test.tsx
+++ b/packages/core/src/components/Forms/WarningText/WarningText.test.tsx
@@ -1,16 +1,11 @@
 import { render, screen } from "@testing-library/react";
-import { HvProvider } from "@core/providers";
 import { describe, expect, it } from "vitest";
-import { HvWarningText } from "@core/components";
+import { HvWarningText, HvWarningTextProps } from "@core/components";
 
 const TEXT = "text-content";
 
-const setup = (props) =>
-  render(
-    <HvProvider>
-      <HvWarningText {...props}>{TEXT}</HvWarningText>
-    </HvProvider>
-  );
+const setup = (props: Partial<HvWarningTextProps>) =>
+  render(<HvWarningText {...props}>{TEXT}</HvWarningText>);
 
 describe("WarningText", () => {
   it("should be defined", () => {

--- a/packages/core/src/components/Header/Header.stories.tsx
+++ b/packages/core/src/components/Header/Header.stories.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { StoryObj } from "@storybook/react";
+import { Meta, StoryObj } from "@storybook/react";
 import useMediaQuery from "@mui/material/useMediaQuery";
 import { useTheme } from "@mui/material/styles";
 import { User, Menu, Alert } from "@hitachivantara/uikit-react-icons";
@@ -11,8 +11,9 @@ import {
   HvHeaderActions,
   HvHeaderBrand,
   HvHeaderNavigation,
+  HvHeaderNavigationProps,
 } from "@core/components";
-import HitachiLogo from "./assets/HitachiLogo";
+import { HitachiLogo } from "./assets/HitachiLogo";
 
 const navigationData = [
   {
@@ -80,7 +81,7 @@ export default {
   component: HvHeader,
   subcomponents: { HvHeaderBrand, HvHeaderNavigation, HvHeaderActions },
   decorators: [(Story) => <div style={{ height: 150 }}>{Story()}</div>],
-};
+} as Meta<typeof HvHeader>;
 
 export const Main: StoryObj<HvHeaderProps> = {
   args: {
@@ -94,7 +95,10 @@ export const Main: StoryObj<HvHeaderProps> = {
   },
   render: ({ position }) => {
     const [selected, setSelected] = useState<string>("2");
-    const handleChange = (e, selectedItem) => {
+    const handleChange: HvHeaderNavigationProps["onClick"] = (
+      e,
+      selectedItem
+    ) => {
       if (selectedItem.href) {
         setSelected(selectedItem.id);
       } else if (selectedItem.data?.length) {

--- a/packages/core/src/components/Header/Header.test.tsx
+++ b/packages/core/src/components/Header/Header.test.tsx
@@ -6,7 +6,7 @@ import { HvHeader } from "./Header";
 import { HvHeaderNavigation } from "./Navigation";
 import { HvHeaderBrand } from "./Brand";
 import { HvHeaderActions } from "./Actions";
-import HitachiLogo from "./assets/HitachiLogo";
+import { HitachiLogo } from "./assets/HitachiLogo";
 
 describe("Header", () => {
   it("should render correctly with no data", () => {

--- a/packages/core/src/components/Header/Navigation/MenuBar/MenuBar.tsx
+++ b/packages/core/src/components/Header/Navigation/MenuBar/MenuBar.tsx
@@ -1,5 +1,5 @@
 import { clsx } from "clsx";
-import { useContext } from "react";
+import { MouseEvent, useContext } from "react";
 import { HvHeaderNavigationItemProp } from "@core/components";
 import { HvBaseProps } from "@core/types";
 import { HvMenuItem } from "../MenuItem";

--- a/packages/core/src/components/Header/Navigation/MenuItem/MenuItem.tsx
+++ b/packages/core/src/components/Header/Navigation/MenuItem/MenuItem.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from "react";
+import React, { MouseEvent, useContext } from "react";
 import { HvHeaderNavigationItemProp, HvTypography } from "@core/components";
 import { HvBaseProps } from "@core/types";
 import { isKeypress, keyboardCodes } from "@core/utils";
@@ -46,7 +46,7 @@ export const HvMenuItem = ({ id, item, type, onClick }: MenuItemProps) => {
       : "page"
     : undefined;
 
-  const actionHandler = (event) => {
+  const actionHandler = (event: any) => {
     if (
       event.type === "click" ||
       isKeypress(event, keyboardCodes.Enter) ||

--- a/packages/core/src/components/Header/Navigation/Navigation.tsx
+++ b/packages/core/src/components/Header/Navigation/Navigation.tsx
@@ -2,7 +2,7 @@ import { clsx } from "clsx";
 import { MouseEvent } from "react";
 import { useSelectionPath } from "@core/hooks";
 import { HvBaseProps } from "@core/types";
-import { HvMenuBar } from "./MenuBar";
+import { HvMenuBar, HvMenuBarProps } from "./MenuBar";
 import { StyledNav } from "./Navigation.styles";
 import { FocusProvider } from "./utils/FocusContext";
 import { SelectionContext } from "./utils/SelectionContext";
@@ -37,7 +37,7 @@ export const HvHeaderNavigation = ({
 }: HvHeaderNavigationProps) => {
   const selectionPath = useSelectionPath(data, selected);
 
-  const handleClick = (event, selection) => {
+  const handleClick: HvMenuBarProps["onClick"] = (event, selection) => {
     event.preventDefault();
 
     onClick?.(event, selection);

--- a/packages/core/src/components/Header/assets/HitachiLogo.tsx
+++ b/packages/core/src/components/Header/assets/HitachiLogo.tsx
@@ -1,6 +1,10 @@
+import { SVGProps } from "react";
 import { theme } from "@hitachivantara/uikit-styles";
 
-const HitachiLogo = (props) => {
+export const HitachiLogo = ({
+  style = { width: 72, height: 20 },
+  ...others
+}: SVGProps<SVGSVGElement>) => {
   const color = theme.colors.secondary;
   return (
     <svg
@@ -13,7 +17,8 @@ const HitachiLogo = (props) => {
       xmlSpace="preserve"
       width={80}
       height={16}
-      {...props}
+      style={style}
+      {...others}
     >
       <path
         fill={color}
@@ -45,7 +50,3 @@ const HitachiLogo = (props) => {
     </svg>
   );
 };
-
-export default (props) => (
-  <HitachiLogo style={{ width: 72, height: 20 }} {...props} />
-);

--- a/packages/core/src/components/InlineEditor/InlineEditor.tsx
+++ b/packages/core/src/components/InlineEditor/InlineEditor.tsx
@@ -14,6 +14,7 @@ import {
   HvInput,
   HvButton,
   HvTypography,
+  HvInputProps,
 } from "@core/components";
 import { HvThemeTypographyProps, theme } from "@hitachivantara/uikit-styles";
 import { Edit } from "@hitachivantara/uikit-react-icons";
@@ -98,7 +99,7 @@ export const HvInlineEditor = ({
     setCachedValue(value);
   };
 
-  const handleBlur = (event) => {
+  const handleBlur: HvInputProps["onBlur"] = (event) => {
     setEditMode(false);
 
     const newValue = value || cachedValue; // empty values should be ignored
@@ -106,15 +107,15 @@ export const HvInlineEditor = ({
     onBlur?.(event, newValue);
   };
 
-  const handleKeyDown = (event) => {
+  const handleKeyDown: HvInputProps["onKeyDown"] = (event) => {
     if (isKeypress(event, keyboardCodes.Esc)) {
       setEditMode(false);
       setValue(cachedValue);
     }
-    onKeyDown?.(event);
+    onKeyDown?.(event as any);
   };
 
-  const handleChange = (event, val) => {
+  const handleChange: HvInputProps["onChange"] = (event, val) => {
     setValue(val);
     onChange?.(event, val);
   };

--- a/packages/core/src/components/Input/Input.stories.tsx
+++ b/packages/core/src/components/Input/Input.stories.tsx
@@ -163,11 +163,6 @@ export const ControlledWithButtons: StoryObj<HvInputProps> = {
 
     const [value, setValue] = useState("Initial value");
 
-    // to be possible to change the input value by user action
-    const handleChange = (event, newValue) => {
-      setValue(newValue);
-    };
-
     return (
       <StyledContainer>
         <StyledWrapper>
@@ -198,7 +193,8 @@ export const ControlledWithButtons: StoryObj<HvInputProps> = {
           label="Label"
           placeholder="Enter value"
           value={value}
-          onChange={handleChange}
+          // to be possible to change the input value by user action
+          onChange={(event, newValue) => setValue(newValue)}
         />
       </StyledContainer>
     );
@@ -594,7 +590,7 @@ export const PrefixAndSuffix: StoryObj<HvInputProps> = {
       error: "Invalid subdomain",
     };
 
-    const validateSubdomain = (value) => {
+    const validateSubdomain: HvInputProps["validation"] = (value) => {
       const re = /[^a-zA-Z0-9-]/;
 
       return !re.test(value);

--- a/packages/core/src/components/Input/SearchBox.stories.tsx
+++ b/packages/core/src/components/Input/SearchBox.stories.tsx
@@ -11,6 +11,7 @@ import {
   HvPanel,
   HvTypography,
   HvInput,
+  HvInputProps,
 } from "@core/components";
 import { HvInputSuggestion } from "@core/types";
 import countryNamesArray, { continents, countries } from "./countries";
@@ -35,16 +36,12 @@ export default meta;
 
 export const Main: StoryObj = {
   render: () => {
-    const handleSearch = (_, value: string) => {
-      console.log(value);
-    };
-
     return (
       <HvInput
         type="search"
         aria-label="Select country"
         placeholder="Search"
-        onEnter={handleSearch}
+        onEnter={(_, value) => console.log(value)}
       />
     );
   },
@@ -62,7 +59,7 @@ export const BasicSearch: StoryObj = {
   render: () => {
     const [results, setResults] = useState<string[]>([]);
 
-    const handleSearch = (_evt, val) => {
+    const handleSearch: HvInputProps["onEnter"] = (_evt, val) => {
       setResults([
         `First result related with ${val}`,
         `Second result related with ${val}`,
@@ -125,7 +122,7 @@ export const DynamicSearch: StoryObj = {
       panel: css({ maxWidth: "610px", marginTop: "20px", padding: "5px" }),
     };
 
-    const handleSearch = (_, value: string) => {
+    const handleSearch: HvInputProps["onEnter"] = (_, value) => {
       const newResults: string[] = [];
 
       countryNamesArray
@@ -263,7 +260,7 @@ export const ScopedSearch: StoryObj = {
       []
     );
 
-    const handleSearch = (_, value: string) => {
+    const handleSearch: HvInputProps["onEnter"] = (_, value) => {
       const newResults: string[] = [];
 
       filterByContinent()
@@ -355,7 +352,7 @@ export const SearchAsYouType: StoryObj = {
       }),
     };
 
-    const handleSearch = (_, value: string) => {
+    const handleSearch: HvInputProps["onChange"] = (_, value) => {
       const newResults: string[] = data
         .filter((v) => v.toUpperCase().includes(value.toUpperCase()))
         .map(

--- a/packages/core/src/components/ListContainer/ListContainer.stories.tsx
+++ b/packages/core/src/components/ListContainer/ListContainer.stories.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, CSSProperties } from "react";
+import { useState, useEffect, CSSProperties, MouseEvent } from "react";
 import { Meta, StoryObj } from "@storybook/react";
 import styled from "@emotion/styled";
 import {
@@ -97,11 +97,7 @@ export const Main: StoryObj<HvListContainerProps> = {
 
 export const SingleSelection: StoryObj<HvListContainerProps> = {
   render: () => {
-    const [selectedItem, setSelectedItem] = useState(null);
-
-    const handleListItemClick = (_evt, index) => {
-      setSelectedItem(index);
-    };
+    const [selectedItem, setSelectedItem] = useState(-1);
 
     return (
       <div
@@ -115,44 +111,44 @@ export const SingleSelection: StoryObj<HvListContainerProps> = {
       >
         <HvListContainer interactive condensed aria-label="Stores">
           <HvListItem
-            onClick={(event) => handleListItemClick(event, 0)}
+            onClick={() => setSelectedItem(0)}
             selected={selectedItem === 0}
           >
             98001, Store Manager
           </HvListItem>
           <HvListItem
-            onClick={(event) => handleListItemClick(event, 1)}
+            onClick={() => setSelectedItem(1)}
             selected={selectedItem === 1}
           >
             98002, Store Manager
           </HvListItem>
           <HvListItem
-            onClick={(event) => handleListItemClick(event, 2)}
+            onClick={() => setSelectedItem(2)}
             selected={selectedItem === 2}
           >
             98003, Store Manager
           </HvListItem>
           <HvListItem
-            onClick={(event) => handleListItemClick(event, 3)}
+            onClick={() => setSelectedItem(3)}
             selected={selectedItem === 3}
           >
             98004, Store Manager
           </HvListItem>
           <HvListItem disabled>98005, Store Manager</HvListItem>
           <HvListItem
-            onClick={(event) => handleListItemClick(event, 5)}
+            onClick={() => setSelectedItem(5)}
             selected={selectedItem === 5}
           >
             98001, Store Manager
           </HvListItem>
           <HvListItem
-            onClick={(event) => handleListItemClick(event, 6)}
+            onClick={() => setSelectedItem(6)}
             selected={selectedItem === 6}
           >
             98002, Store Manager
           </HvListItem>
           <HvListItem
-            onClick={(event) => handleListItemClick(event, 7)}
+            onClick={() => setSelectedItem(7)}
             selected={selectedItem === 7}
           >
             98003, Store Manager
@@ -173,7 +169,7 @@ export const MultiSelection: StoryObj<HvListContainerProps> = {
       4: false,
     });
 
-    const handleListItemClick = (_evt, index) => {
+    const handleListItemClick = (_evt: MouseEvent, index: number) => {
       setSelectedItems((previousSelection) => {
         return {
           ...previousSelection,

--- a/packages/core/src/components/Loading/Loading.stories.tsx
+++ b/packages/core/src/components/Loading/Loading.stories.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useState } from "react";
+import { ReactNode, useEffect, useState } from "react";
 import { Meta, StoryObj } from "@storybook/react";
-import { HvButton, HvTypography } from "@core/components";
+import { HvButton, HvButtonProps, HvTypography } from "@core/components";
 import { HvLoading, HvLoadingProps } from "./Loading";
 
 const meta: Meta<typeof HvLoading> = {
@@ -23,7 +23,15 @@ export const Main: StoryObj<HvLoadingProps> = {
   },
 };
 
-const Button = ({ label, variant, color = "base_dark" }) => {
+const Button = ({
+  label,
+  variant,
+  color = "base_dark",
+}: {
+  label: string;
+  variant?: HvButtonProps["variant"];
+  color?: string;
+}) => {
   const [isLoading, setIsLoading] = useState(false);
 
   const activateTimer = () => {
@@ -64,7 +72,13 @@ export const Buttons = () => {
   );
 };
 
-const ButtonDeterminate = ({ label, children }) => (
+const ButtonDeterminate = ({
+  label,
+  children,
+}: {
+  label: string;
+  children: ReactNode;
+}) => (
   <div>
     <HvTypography variant="caption1">{label}</HvTypography>
     <br />
@@ -72,8 +86,14 @@ const ButtonDeterminate = ({ label, children }) => (
   </div>
 );
 
-const Progress = ({ label, inc }) => {
-  const [value, setValue] = useState(0);
+const Progress = ({
+  label,
+  inc,
+}: {
+  label: (val: any) => ReactNode;
+  inc: (val: number) => any;
+}) => {
+  const [value, setValue] = useState<any>(0);
 
   useEffect(() => {
     const interval = setInterval(() => {

--- a/packages/core/src/components/Loading/Loading.tsx
+++ b/packages/core/src/components/Loading/Loading.tsx
@@ -28,7 +28,7 @@ export interface HvLoadingProps extends HvBaseProps {
 export const HvLoading = (props: HvLoadingProps) => {
   const { color, hidden, small, label, classes, className, ...others } = props;
 
-  const getColor = (colorName) => {
+  const getColor = (colorName: string) => {
     return color ? theme.colors[color] || color : theme.colors[colorName];
   };
 

--- a/packages/core/src/components/Login/Login.stories.tsx
+++ b/packages/core/src/components/Login/Login.stories.tsx
@@ -123,10 +123,7 @@ export const CustomBackground: StoryObj<HvLoginProps> = {
     const handleSubmit: FormEventHandler<HTMLFormElement> = (event) => {
       event.preventDefault();
       const formData = new FormData(event.currentTarget);
-      const data = {};
-      formData.forEach((value, key) => {
-        data[key] = value;
-      });
+      const data = Object.fromEntries(formData.entries());
 
       alert(JSON.stringify(data, null, 2));
     };

--- a/packages/core/src/components/MultiButton/MultiButton.stories.tsx
+++ b/packages/core/src/components/MultiButton/MultiButton.stories.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { MouseEvent, useState } from "react";
 import range from "lodash/range";
 import { Meta, StoryObj } from "@storybook/react";
 import { LocationPin, Map } from "@hitachivantara/uikit-react-icons";
@@ -55,10 +55,6 @@ export const OnlyLabels: StoryObj<HvMultiButtonProps> = {
     const [selection, setSelection] = useState(0);
     const buttons = ["Map", "Satellite"];
 
-    const handleChange = (event, idx) => {
-      setSelection(idx);
-    };
-
     return (
       <HvMultiButton style={{ width: "210px" }}>
         {buttons.map((button, i) => (
@@ -66,7 +62,7 @@ export const OnlyLabels: StoryObj<HvMultiButtonProps> = {
             id={button.toLowerCase()}
             key={`${buttons[i]}`}
             selected={selection === i}
-            onClick={(evt) => handleChange(evt, i)}
+            onClick={() => setSelection(i)}
           >
             {button}
           </HvButton>
@@ -84,7 +80,7 @@ export const OnlyIcons: StoryObj<HvMultiButtonProps> = {
       { name: "Location", icon: <LocationPin /> },
     ];
 
-    const handleChange = (event, idx) => {
+    const handleChange = (event: MouseEvent, idx: number) => {
       const newSelection = selection.includes(idx)
         ? selection.filter((v) => v !== idx)
         : [...selection, idx];
@@ -114,7 +110,7 @@ export const Disabled: StoryObj<HvMultiButtonProps> = {
   render: () => {
     const [selection, setSelection] = useState([0]);
 
-    const toggleIndex = (idx) => {
+    const toggleIndex = (idx: number) => {
       const newSelection = selection.includes(idx)
         ? selection.filter((v) => v !== idx)
         : [...selection, idx];
@@ -157,7 +153,7 @@ export const DisabledItem: StoryObj<HvMultiButtonProps> = {
   render: () => {
     const [selection, setSelection] = useState([0]);
 
-    const toggleIndex = (idx) => {
+    const toggleIndex = (idx: number) => {
       const newSelection = selection.includes(idx)
         ? selection.filter((v) => v !== idx)
         : [...selection, idx];
@@ -210,7 +206,7 @@ export const MultipleSelection: StoryObj<HvMultiButtonProps> = {
       "Sunday",
     ];
 
-    const handleChange = (event, idx) => {
+    const handleChange = (event: MouseEvent, idx: number) => {
       const newSelection = selection.includes(idx)
         ? selection.filter((v) => v !== idx)
         : [...selection, idx];
@@ -246,7 +242,7 @@ export const EnforcedSelection: StoryObj<HvMultiButtonProps> = {
   render: () => {
     const [selection, setSelection] = useState([0]);
 
-    const handleChange = (event, idx) => {
+    const handleChange = (event: MouseEvent, idx: number) => {
       if (idx === 0) return; // enforced
       const newSelection = selection.includes(idx)
         ? selection.filter((v) => v !== idx)
@@ -286,7 +282,7 @@ export const MinimumSelection: StoryObj<HvMultiButtonProps> = {
   render: () => {
     const [selection, setSelection] = useState([1, 2]);
 
-    const handleChange = (event, idx) => {
+    const handleChange = (event: MouseEvent, idx: number) => {
       const newSelection = selection.includes(idx)
         ? selection.filter((v) => v !== idx)
         : [...selection, idx];
@@ -326,7 +322,7 @@ export const MaximumSelection: StoryObj<HvMultiButtonProps> = {
   render: () => {
     const [selection, setSelection] = useState<number[]>([]);
 
-    const handleChange = (event, idx) => {
+    const handleChange = (event: MouseEvent, idx: number) => {
       const newSelection = selection.includes(idx)
         ? selection.filter((v) => v !== idx)
         : [...selection, idx];
@@ -375,7 +371,7 @@ export const VerticalOrientation: StoryObj<HvMultiButtonProps> = {
       { name: "Location", icon: <LocationPin />, key: 6 },
     ];
 
-    const handleChange = (event, idx) => {
+    const handleChange = (event: MouseEvent, idx: number) => {
       const newSelection = selection.includes(idx)
         ? selection.filter((v) => v !== idx)
         : [...selection, idx];

--- a/packages/core/src/components/OverflowTooltip/OverflowTooltip.stories.tsx
+++ b/packages/core/src/components/OverflowTooltip/OverflowTooltip.stories.tsx
@@ -1,8 +1,9 @@
+import { ReactNode } from "react";
 import styled from "@emotion/styled";
 import { Meta, StoryObj } from "@storybook/react";
 import { HvOverflowTooltip, HvOverflowTooltipProps } from "@core/components";
 
-const Container = ({ children }) => {
+const Container = ({ children }: { children: ReactNode }) => {
   const StyledContainer = styled("div")({ display: "flex" });
 
   const StyledDiv = styled("div")({

--- a/packages/core/src/components/OverflowTooltip/OverflowTooltip.tsx
+++ b/packages/core/src/components/OverflowTooltip/OverflowTooltip.tsx
@@ -35,7 +35,7 @@ export interface HvOverflowTooltipProps extends HvBaseProps {
   classes?: HvOverflowTooltipClasses;
 }
 
-const isParagraph = (children) => /\s/.test(children);
+const isParagraph = (children = "") => /\s/.test(children);
 
 /**
  * This component generates a tooltip whenever the text is overflowed.

--- a/packages/core/src/components/Pagination/ButtonIconTooltip.tsx
+++ b/packages/core/src/components/Pagination/ButtonIconTooltip.tsx
@@ -1,6 +1,21 @@
-import { HvButton, HvTooltip, HvTypography } from "@core/components";
+import {
+  HvButton,
+  HvButtonProps,
+  HvTooltip,
+  HvTypography,
+} from "@core/components";
+import { ReactNode } from "react";
 
-const ButtonIconTooltip = ({ tooltip, children, ...buttonProps }) => {
+interface ButtonIconTooltipProps extends HvButtonProps {
+  tooltip: ReactNode;
+  children: ReactNode;
+}
+
+const ButtonIconTooltip = ({
+  tooltip,
+  children,
+  ...buttonProps
+}: ButtonIconTooltipProps) => {
   return (
     <HvTooltip title={<HvTypography>{tooltip}</HvTypography>}>
       <div>

--- a/packages/core/src/components/Pagination/Pagination.tsx
+++ b/packages/core/src/components/Pagination/Pagination.tsx
@@ -205,7 +205,7 @@ export const HvPagination = ({
               disabled={pageSize === 0}
               className={classes.pageSizeOptionsSelect}
               aria-label={labels?.pageSizeSelectorDescription}
-              onChange={(_, val: number) => onPageSizeChange?.(val)}
+              onChange={(_: any, val: number) => onPageSizeChange?.(val)}
               value={pageSize}
             >
               {pageSizeOptions.map((option) => (

--- a/packages/core/src/components/Pagination/Select.tsx
+++ b/packages/core/src/components/Pagination/Select.tsx
@@ -1,9 +1,17 @@
 import { useState } from "react";
-import { HvBaseDropdown, HvSelectionList, HvListItem, HvPanel } from "..";
+import {
+  HvBaseDropdown,
+  HvSelectionList,
+  HvListItem,
+  HvPanel,
+  HvSelectionListProps,
+  HvBaseDropdownProps,
+  HvListItemProps,
+} from "..";
 import { useClasses } from "./Select.styles";
 
-export const Option = ({ children, ...others }) => (
-  <HvListItem {...others}>{children}</HvListItem>
+export const Option = ({ ...props }: Partial<HvListItemProps>) => (
+  <HvListItem {...props} />
 );
 
 const HvSelect = ({
@@ -14,20 +22,22 @@ const HvSelect = ({
   value,
   children,
   ...others
-}) => {
+}: any) => {
   const { classes } = useClasses(classesProp);
   const [open, setOpen] = useState(false);
 
-  const handleSelect = (evt, val) => {
+  const handleSelect: HvSelectionListProps["onChange"] = (evt, val) => {
     onChange?.(evt, val);
     setOpen(false);
   };
 
-  const handleToggle = (_evt, s) => {
+  const handleToggle: HvBaseDropdownProps["onToggle"] = (_evt, s) => {
     setOpen(s);
   };
 
-  const setFocusToContent = (containerRef) => {
+  const setFocusToContent: HvBaseDropdownProps["onContainerCreation"] = (
+    containerRef
+  ) => {
     const listItems =
       containerRef != null ? [...containerRef.getElementsByTagName("li")] : [];
     listItems.every((listItem) => {

--- a/packages/core/src/components/Pagination/utils.ts
+++ b/packages/core/src/components/Pagination/utils.ts
@@ -14,7 +14,7 @@ export const usePageInput = (initialPage: number) => {
   const [page, setPage] = useState<number>(initialPage + 1);
 
   const handleChange = useCallback(
-    (evt, newPage: number) => setPage(newPage),
+    (evt: any, newPage: number) => setPage(newPage),
     []
   );
 

--- a/packages/core/src/components/Radio/Radio.stories.tsx
+++ b/packages/core/src/components/Radio/Radio.stories.tsx
@@ -14,17 +14,12 @@ const StyledDiv = styled("div")({
   },
 });
 
-const FlexDecorator = ({ children }) => {
-  return <StyledDiv>{children}</StyledDiv>;
-};
-
-const meta: Meta<typeof HvRadio> = {
+export default {
   title: "Components/Radio/Radio",
   component: HvRadio,
   subcomponents: { HvBaseRadio },
-  decorators: [(Story) => <FlexDecorator>{Story()}</FlexDecorator>],
-};
-export default meta;
+  decorators: [(Story) => <StyledDiv>{Story()}</StyledDiv>],
+} as Meta<typeof HvRadio>;
 
 export const Main: StoryObj<HvRadioProps> = {
   args: {

--- a/packages/core/src/components/Radio/Radio.test.tsx
+++ b/packages/core/src/components/Radio/Radio.test.tsx
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import { fireEvent, render } from "@testing-library/react";
 import { useState } from "react";
 import userEvent from "@testing-library/user-event";
-import { HvRadio } from "./Radio";
+import { HvRadio, HvRadioProps } from "./Radio";
 
 const RadioSample = () => {
   const [checkedValue, setCheckedValue] = useState(null);
@@ -219,7 +219,7 @@ describe("HvRadio", () => {
     });
 
     it("clicking readonly checkbox does not update state", () => {
-      const DisabledSample = ({ onChange }) => {
+      const DisabledSample = ({ onChange }: Partial<HvRadioProps>) => {
         return (
           <>
             <HvRadio

--- a/packages/core/src/components/SelectionList/SelectionList.stories.tsx
+++ b/packages/core/src/components/SelectionList/SelectionList.stories.tsx
@@ -57,7 +57,10 @@ export const Controlled: StoryObj<HvSelectionListProps> = {
     const [value, setValue] = useState(["2"]);
     const [status, setStatus] = useState<HvFormStatus>("standBy");
 
-    const handleOnChange = (_evt, newValue) => {
+    const handleOnChange: HvSelectionListProps["onChange"] = (
+      _evt,
+      newValue
+    ) => {
       setValue(newValue);
 
       if (newValue === "0") {

--- a/packages/core/src/components/SelectionList/SelectionList.tsx
+++ b/packages/core/src/components/SelectionList/SelectionList.tsx
@@ -1,4 +1,10 @@
-import React, { useCallback, useMemo, useRef, useEffect } from "react";
+import React, {
+  useCallback,
+  useMemo,
+  useRef,
+  useEffect,
+  ReactNode,
+} from "react";
 import { clsx } from "clsx";
 import { HvBaseProps } from "@core/types";
 import { useControlled, useUniqueId } from "@core/hooks";
@@ -77,7 +83,10 @@ export interface HvSelectionListProps
   classes?: HvSelectionListClasses;
 }
 
-const getValueFromSelectedChildren = (children, multiple) => {
+const getValueFromSelectedChildren = (
+  children: ReactNode,
+  multiple: boolean
+) => {
   const selectedValues = React.Children.toArray(children)
     .map((child: any) => {
       const childIsControlled = child?.props?.selected !== undefined;
@@ -166,7 +175,7 @@ export const HvSelectionList = ({
   const { ArrowUp, ArrowDown } = keyboardCodes;
 
   useEffect(() => {
-    const handleMeta = (event) => {
+    const handleMeta = (event: KeyboardEvent) => {
       const tempArray: any[] = [];
       if (
         (isKeypress(event, ArrowUp) &&
@@ -177,7 +186,7 @@ export const HvSelectionList = ({
           listContainer.current.contains(event.target))
       ) {
         selectedState.forEach((isSelected, i) => {
-          if (i === event.target.value - 1) {
+          if (i === (event.target as any).value - 1) {
             if (!isSelected) {
               tempArray.push(allValues[i]);
             }

--- a/packages/core/src/components/SimpleGrid/SimpleGrid.styles.tsx
+++ b/packages/core/src/components/SimpleGrid/SimpleGrid.styles.tsx
@@ -2,7 +2,7 @@ import styled from "@emotion/styled";
 import { theme } from "@hitachivantara/uikit-styles";
 import { Spacing, Breakpoint } from ".";
 
-function size(props) {
+function size(props: { size: any; sizes: any }) {
   if (typeof props.size === "number") {
     return props.size;
   }
@@ -10,7 +10,7 @@ function size(props) {
   return props.sizes[props.size] || props.size || props.sizes.md;
 }
 
-function getSortedBreakpoints(breakpoints) {
+function getSortedBreakpoints(breakpoints: Breakpoint[]) {
   if (breakpoints.length === 0) {
     return breakpoints;
   }

--- a/packages/core/src/hooks/useWidth.ts
+++ b/packages/core/src/hooks/useWidth.ts
@@ -4,12 +4,13 @@ import { Breakpoint, useMediaQuery, useTheme } from "@mui/material";
 
 export const useWidth = () => {
   const muiTheme = useTheme();
-  const keys = Object.keys(theme.breakpoints.values).reverse();
+  const keys = Object.keys(theme.breakpoints.values).reverse() as Breakpoint[];
+
   return (
-    keys.reduce((output, key) => {
-      const matches = useMediaQuery(muiTheme.breakpoints.up(key as Breakpoint));
+    keys.reduce<Breakpoint | null>((output, key) => {
+      const matches = useMediaQuery(muiTheme.breakpoints.up(key));
 
       return !output && matches ? key : output;
-    }, "") || "xs"
+    }, null) || "xs"
   );
 };

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -5,6 +5,7 @@
     "baseUrl": "src",
     "rootDir": "src",
     "outDir": "dist",
+    // "noImplicitAny": true,
     "paths": {
       "@core/*": ["./*"]
     }


### PR DESCRIPTION
Improve components' typings by replacing the implicit `any`'s with their actual types (part 1)
Some of the added explicit `any`s are "covering" some type missmatches that we should eventually resolve