### PR TITLE
fix(breadcrumb): allow special characters

### DIFF
--- a/packages/core/src/components/BreadCrumb/BreadCrumb.tsx
+++ b/packages/core/src/components/BreadCrumb/BreadCrumb.tsx
@@ -1,6 +1,5 @@
 import { clsx } from "clsx";
 import isNil from "lodash/isNil";
-import startCase from "lodash/startCase";
 import { isValidElement, MouseEvent } from "react";
 import { HvBaseProps } from "@core/types/generic";
 import { HvDropDownMenuProps } from "@core/components";
@@ -123,7 +122,7 @@ export const HvBreadCrumb = ({
                     )}
                     variant="body"
                   >
-                    {startCase(removeExtension(elem.label))}
+                    {removeExtension(elem.label)}
                   </StyledTypography>
                 )) || (
                   <HvPage

--- a/packages/core/src/components/BreadCrumb/Page/Page.tsx
+++ b/packages/core/src/components/BreadCrumb/Page/Page.tsx
@@ -4,7 +4,6 @@ import {
   HvTypography,
 } from "@core/components";
 import { ExtractNames } from "@core/utils";
-import startCase from "lodash/startCase";
 import { MouseEvent } from "react";
 import { staticClasses, useClasses } from "./Page.styles";
 
@@ -42,7 +41,7 @@ export const HvPage = ({
       className={cx(classes.link, classes.label, classes.a)}
       {...others}
     >
-      <HvOverflowTooltip data={startCase(elem.label)} />
+      <HvOverflowTooltip data={elem.label} />
     </HvTypography>
   );
 };


### PR DESCRIPTION
- remove `startCase` to allow special characters to be passed. still converts to start-case