### PR TITLE
chore: refactor theme creator

### DIFF
--- a/app/src/generator/Colors/Colors.tsx
+++ b/app/src/generator/Colors/Colors.tsx
@@ -20,13 +20,9 @@ const Colors = (): JSX.Element => {
 
   const colorChangedHandler = (colorName: string, colorValue: string) => {
     updateCustomTheme({
-      ...customTheme,
       colors: {
-        ...customTheme.colors,
         modes: {
-          ...customTheme.colors.modes,
           [selectedMode]: {
-            ...customTheme.colors.modes[selectedMode],
             [colorName]: colorValue,
           },
         },

--- a/app/src/generator/FontFamily/FontFamily.tsx
+++ b/app/src/generator/FontFamily/FontFamily.tsx
@@ -15,7 +15,7 @@ import { extractFontsNames } from "generator/utils";
 import { styles } from "./FontFamily.styles";
 
 const FontFamily = () => {
-  const { customTheme, updateCustomTheme } = useContext(GeneratorContext);
+  const { updateCustomTheme } = useContext(GeneratorContext);
 
   const [fontName, setFontName] = useState("");
   const [fontValues, setFontValues] = useState<HvListValue[]>([
@@ -28,7 +28,6 @@ const FontFamily = () => {
   const onDropdownClickHandler = (font?: string) => {
     if (font) {
       updateCustomTheme({
-        ...customTheme,
         fontFamily: {
           body: font,
         },

--- a/app/src/generator/FontSizes/FontSizes.tsx
+++ b/app/src/generator/FontSizes/FontSizes.tsx
@@ -14,7 +14,7 @@ import { styles } from "./FontSizes.styles";
 
 const FontSizes = () => {
   const { activeTheme } = useTheme();
-  const { customTheme, updateCustomTheme } = useContext(GeneratorContext);
+  const { updateCustomTheme } = useContext(GeneratorContext);
   const [fontSizes, setFontSizes] = useState<HvListValue[]>([]);
   const [fontSize, setFontSize] = useState(""); // base, sm, ...
   const [fontValue, setFontValue] = useState<number>(); // 14, 16, ...
@@ -59,9 +59,7 @@ const FontSizes = () => {
     const fixedValue = value.toFixed(unit === "em" || unit === "rem" ? 1 : 0);
 
     updateCustomTheme({
-      ...customTheme,
       fontSizes: {
-        ...customTheme.fontSizes,
         [fontSize]: `${fixedValue}${unit}`,
       },
     });
@@ -86,9 +84,7 @@ const FontSizes = () => {
     }
 
     updateCustomTheme({
-      ...customTheme,
       fontSizes: {
-        ...customTheme.fontSizes,
         [fontSize]: `${fontValue}${parsedUnit}`,
       },
     });

--- a/app/src/generator/Radii/Radii.tsx
+++ b/app/src/generator/Radii/Radii.tsx
@@ -27,9 +27,7 @@ const Radii = () => {
     const radiiValue = currValues.get(radii) || 0;
 
     updateCustomTheme({
-      ...customTheme,
       radii: {
-        ...customTheme.radii,
         [radii]: radii === "base" ? radiiValue : radiiValue,
       },
     });

--- a/app/src/generator/Sidebar/Sidebar.tsx
+++ b/app/src/generator/Sidebar/Sidebar.tsx
@@ -1,5 +1,4 @@
 import {
-  createTheme,
   HvBaseTheme,
   HvBox,
   HvDropdown,
@@ -13,7 +12,7 @@ import {
   theme,
   useTheme,
 } from "@hitachivantara/uikit-react-core";
-import { lazy, Suspense, useContext, useEffect, useState } from "react";
+import { lazy, Suspense, useContext, useState } from "react";
 import { GeneratorContext } from "generator/GeneratorContext";
 import CodeEditor from "generator/CodeEditor";
 import {
@@ -38,25 +37,19 @@ const Sidebar = () => {
   const { selectedTheme, selectedMode, colorModes, changeTheme, themes } =
     useTheme();
 
-  const { customTheme, updateCustomTheme, open, themeChanges } =
-    useContext(GeneratorContext);
+  const { customTheme, updateCustomTheme, open } = useContext(GeneratorContext);
 
   const [copied, setCopied] = useState(false);
   const [tab, setTab] = useState(0);
 
-  useEffect(() => {
-    const newTheme = createTheme({
-      name: customTheme.name,
-      base: selectedTheme as HvBaseTheme,
-      ...themeChanges,
-    });
-    updateCustomTheme(newTheme, false, false);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [customTheme.name, selectedTheme, themeChanges]);
-
   const handleClose: HvSnackbarProps["onClose"] = (event, reason) => {
     if (reason === "clickaway") return;
     setCopied(false);
+  };
+
+  const handleThemeChange = (base: HvBaseTheme, mode: string) => {
+    updateCustomTheme({ base, name: customTheme.name }, { isBaseChange: true });
+    changeTheme(base, mode);
   };
 
   return (
@@ -84,7 +77,7 @@ const Sidebar = () => {
                 selected: name === selectedTheme,
               }))}
               onChange={(base) => {
-                changeTheme((base as HvListValue)?.value, selectedMode);
+                handleThemeChange((base as HvListValue)?.value, selectedMode);
               }}
             />
             <HvTypography variant="label">Mode:</HvTypography>

--- a/app/src/generator/Sizes/Sizes.tsx
+++ b/app/src/generator/Sizes/Sizes.tsx
@@ -27,9 +27,7 @@ const Sizes = () => {
     const sizeValue = currValues.get(size) || 0;
 
     updateCustomTheme({
-      ...customTheme,
       sizes: {
-        ...customTheme.sizes,
         [size]: sizeValue,
       },
     });

--- a/app/src/generator/Spacing/Spacing.tsx
+++ b/app/src/generator/Spacing/Spacing.tsx
@@ -30,9 +30,7 @@ const Spacing = () => {
         : currValues.get(spacing) || 0;
 
     updateCustomTheme({
-      ...customTheme,
       space: {
-        ...customTheme.space,
         [spacing]:
           spacing === "base"
             ? parseInt(spacingValue.toString(), 10)

--- a/app/src/generator/Typography/Typography.tsx
+++ b/app/src/generator/Typography/Typography.tsx
@@ -89,12 +89,8 @@ const Typography = () => {
     const unit = updatedSizes.get(typographyName)?.unit || "px";
     const fixedValue = value.toFixed(unit === "em" || unit === "rem" ? 1 : 0);
     updateCustomTheme({
-      ...customTheme,
-      ...customTheme,
       typography: {
-        ...customTheme.typography,
         [typographyName]: {
-          ...customTheme.typography[typographyName],
           fontSize: `${fixedValue}${unit}`,
         },
       },

--- a/app/src/generator/Zindices/Zindices.tsx
+++ b/app/src/generator/Zindices/Zindices.tsx
@@ -27,9 +27,7 @@ const Zindices = () => {
     const zIndexValue = currValues.get(zIndex) || 0;
 
     updateCustomTheme({
-      ...customTheme,
       zIndices: {
-        ...customTheme.zIndices,
         [zIndex]: zIndexValue,
       },
     });

--- a/app/src/generator/utils.ts
+++ b/app/src/generator/utils.ts
@@ -35,13 +35,13 @@ export const extractFontsNames = (webfontLink: string): string[] => {
   return fontNames;
 };
 
-export const themeDiff = (a: object, b: object, rootLevel = true): object => {
+export const themeDiff = (a: object, b: object): object => {
   const diff: Record<string, object> = {};
   for (const key in b) {
-    if (rootLevel && (key === "name" || key === "base")) {
-      // eslint-disable-next-line no-continue
-      continue; // ignore 'name' and 'base' at the root level
-    }
+    // if (rootLevel && (key === "name" || key === "base")) {
+    //   // eslint-disable-next-line no-continue
+    //   continue; // ignore 'name' and 'base' at the root level
+    // }
     if (
       typeof b[key as keyof typeof b] === "object" &&
       b[key as keyof typeof b] !== null &&
@@ -50,8 +50,8 @@ export const themeDiff = (a: object, b: object, rootLevel = true): object => {
     ) {
       const nestedDiff = themeDiff(
         a[key as keyof typeof b],
-        b[key as keyof typeof b],
-        false
+        b[key as keyof typeof b]
+        // false
       );
       if (Object.keys(nestedDiff).length > 0) {
         diff[key] = nestedDiff;

--- a/app/src/pages/Instructions/tutorialData.ts
+++ b/app/src/pages/Instructions/tutorialData.ts
@@ -55,7 +55,7 @@ export const tutorialData: StepProps[] = [
   {
     title: "Code Editor",
     content:
-      "All the changes you make to your theme will be available here. You can use the icons to reset or copy the code.",
+      "All the changes you make to your theme will be available here. You can use the icons to reset or copy the code and the usual keyboard shortcuts to undo or redo.",
     orientation: "right",
     size: {
       width: 350,

--- a/packages/core/src/types/generic.ts
+++ b/packages/core/src/types/generic.ts
@@ -34,7 +34,7 @@ export type HvBaseProps<
 > = Omit<HTMLAttributes<E>, K>;
 
 /** This type allows to do a deep partial by applying the Partial type to each key recursively */
-type DeepPartial<T> = Partial<{ [P in keyof T]: DeepPartial<T[P]> }>;
+export type DeepPartial<T> = Partial<{ [P in keyof T]: DeepPartial<T[P]> }>;
 
 /** This type combines the HvExtraProps and DeepPartial types */
 export type HvExtraDeepPartialProps<T> = Partial<{

--- a/packages/styles/src/types.ts
+++ b/packages/styles/src/types.ts
@@ -508,7 +508,7 @@ export type HvCustomTheme = { name: string } & HvThemeComponents &
   Partial<Omit<HvThemeTokens, "colors">> & {
     colors: {
       modes: {
-        [key: string]: HvThemeColorModeStructure;
+        [key: string]: Partial<HvThemeColorModeStructure>;
       };
     };
   };


### PR DESCRIPTION
- refactor of the logic on the Theme Creator 
- removed undo / redo buttons. 
  - this functionality is available on the `Code Editor` since it's no longer readonly
  - if we find we need these controls, we should consider implementing it by using some library that provides us this functionality.