### PR TITLE
feat(Carousel): add customisable controls/thumbnail position

### DIFF
--- a/packages/core/src/components/Carousel/Carousel.stories.tsx
+++ b/packages/core/src/components/Carousel/Carousel.stories.tsx
@@ -159,11 +159,11 @@ export const Embedded: StoryObj<HvCarouselProps> = {
         </HvCardMedia>
         <HvCardContent>
           <div style={{ paddingTop: "20px" }}>
-            <HvTypography variant="highlightText">ID</HvTypography>
+            <HvTypography variant="label">ID</HvTypography>
             <HvTypography>2101cad3-7cd4-1000-bdp95-d8c497176e7c</HvTypography>
           </div>
           <div style={{ marginTop: "20px" }}>
-            <HvTypography variant="highlightText">Last connected</HvTypography>
+            <HvTypography variant="label">Last connected</HvTypography>
             <HvTypography>Aug 30, 2017 12:27:53 PM</HvTypography>
           </div>
         </HvCardContent>

--- a/packages/core/src/components/Carousel/Carousel.styles.ts
+++ b/packages/core/src/components/Carousel/Carousel.styles.ts
@@ -1,4 +1,3 @@
-import { CSSProperties } from "react";
 import { theme } from "@hitachivantara/uikit-styles";
 import { createClasses } from "@core/utils";
 
@@ -47,23 +46,18 @@ export const { staticClasses, useClasses } = createClasses("HvCarousel", {
   actions: {
     display: "flex",
     justifyContent: "flex-end",
-    height: 0,
-    zIndex: 1,
+    right: 0,
 
     position: "relative",
-    top: theme.carousel.actionsOffsetTop,
   },
   closeButton: {},
 
-  mainContainer: {
-    display: "flex",
-    flexDirection: theme.carousel
-      .mainContainerFlexDirection as CSSProperties["flexDirection"],
-  },
+  mainContainer: {},
 
   controls: {
     display: "flex",
     alignItems: "center",
+    position: "relative",
     height: 32,
     justifyContent: theme.carousel.controlsJustifyContent,
     backgroundColor: theme.carousel.controlsBackgroundColor,

--- a/packages/core/src/components/Carousel/Carousel.tsx
+++ b/packages/core/src/components/Carousel/Carousel.tsx
@@ -19,6 +19,7 @@ import {
   HvButton,
   HvContainer,
   HvTypography,
+  useTheme,
 } from "../..";
 
 import { HvCarouselControls } from "./CarouselControls";
@@ -58,6 +59,8 @@ export interface HvCarouselProps
   showFullscreen?: boolean;
   /** Whether to hide the thumbnails. Hidden by default in "xs" mode */
   hideThumbnails?: boolean;
+  controlsPosition?: "top" | "bottom";
+  thumbnailsPosition?: "top" | "bottom";
   /** Carousel configuration options. @see https://www.embla-carousel.com/api/options/ */
   carouselOptions?: EmblaOptionsType;
   /** */
@@ -78,21 +81,29 @@ export const HvCarousel = (props: HvCarouselProps) => {
     thumbnailWidth = 90,
     title,
     children,
-    actions,
+    actions: actionsProp,
     xs,
     showDots: showDotsProp,
     showCounter: showCounterProp,
     showSlideControls,
     showFullscreen: showFullscreenProp,
     hideThumbnails: hideThumbnailsProp,
+    controlsPosition: controlsPositionProp,
+    thumbnailsPosition: thumbnailsPositionProp,
     carouselOptions,
     renderThumbnail,
     onChange,
     ...others
   } = props;
-  const { classes, cx } = useClasses(classesProp);
+  const { activeTheme } = useTheme();
+  const { classes, css, cx } = useClasses(classesProp);
   const thumbnailsRef = useRef<HTMLDivElement>(null);
   const [isFullscreen, setIsFullscreen] = useState(false);
+
+  const isDs3 = activeTheme?.name === "ds3";
+  const actionsPosition = isDs3 ? "header" : "controls";
+  const controlsPosition = controlsPositionProp ?? (isDs3 ? "bottom" : "top");
+  const thumbnailsPosition = thumbnailsPositionProp ?? "bottom";
 
   const [containerRef, controller] = useCarousel({
     align: "start",
@@ -162,6 +173,59 @@ export const HvCarousel = (props: HvCarouselProps) => {
   const showThumbnails = !hideThumbnails && !!renderThumbnail;
   const showDots = showDotsProp ?? numSlides <= 5;
 
+  const actions = (
+    <div
+      className={cx(
+        classes.actions,
+        actionsPosition === "header"
+          ? css({ position: "relative", top: -40, height: 0 })
+          : css({ position: "absolute" })
+      )}
+    >
+      {actionsProp}
+      {showFullscreen && (
+        <HvButton
+          icon
+          variant="secondaryGhost"
+          onClick={() => setIsFullscreen((curr) => !curr)}
+          className={classes.closeButton}
+        >
+          {isFullscreen ? (
+            <Close aria-label="Close" />
+          ) : (
+            <Fullscreen aria-label="Fullscreen" />
+          )}
+        </HvButton>
+      )}
+    </div>
+  );
+
+  const controls = (
+    <HvCarouselControls
+      classes={classes}
+      showDots={showDots}
+      page={selectedIndex}
+      pages={numSlides}
+      canPrevious={canPrev}
+      canNext={canNext}
+      onPreviousClick={handlePrevious}
+      onNextClick={handleNext}
+      actions={actionsPosition === "controls" && actions}
+    />
+  );
+
+  const thumbnails = showThumbnails && (
+    <HvCarouselThumbnails
+      classes={classes}
+      ref={thumbnailsRef}
+      page={selectedIndex}
+      pages={numSlides}
+      width={thumbnailWidth}
+      onThumbnailClick={(evt, i) => handleScroll(i)}
+      renderThumbnail={renderThumbnail}
+    />
+  );
+
   return (
     <HvContainer
       className={cx(classes.root, className, {
@@ -175,94 +239,57 @@ export const HvCarousel = (props: HvCarouselProps) => {
           {title}
         </HvTypography>
       )}
-      <div className={classes.actions}>
-        {showFullscreen && (
-          <HvButton
-            icon
-            variant="secondaryGhost"
-            onClick={() => setIsFullscreen((curr) => !curr)}
-            className={classes.closeButton}
-          >
-            {isFullscreen ? (
-              <Close aria-label="Close" />
-            ) : (
-              <Fullscreen aria-label="Fullscreen" />
-            )}
-          </HvButton>
-        )}
-        {actions}
-      </div>
 
-      <div className={classes.mainContainer}>
-        <HvCarouselControls
-          classes={classes}
-          showDots={showDots}
-          page={selectedIndex}
-          pages={numSlides}
-          canPrevious={canPrev}
-          canNext={canNext}
-          onPreviousClick={handlePrevious}
-          onNextClick={handleNext}
-        />
+      {actionsPosition === "header" && actions}
+      {thumbnailsPosition === "top" && thumbnails}
+      {controlsPosition === "top" && controls}
+      <div
+        className={cx(classes.main, {
+          [classes.mainXs]: xs,
+          [classes.mainFullscreen]: isFullscreen,
+        })}
+      >
+        {showCounter && (
+          <div className={classes.counterContainer}>
+            <span className={classes.counter}>
+              {`${selectedIndex + 1}/${numSlides}`}
+            </span>
+          </div>
+        )}
+
+        {showSlideControls && (
+          <div className={classes.slideControls}>
+            <HvButton
+              icon
+              disabled={!canPrev}
+              variant="secondary"
+              aria-label="Backwards"
+              onClick={handlePrevious}
+            >
+              <Backwards iconSize="XS" />
+            </HvButton>
+            <HvButton
+              icon
+              disabled={!canNext}
+              variant="secondary"
+              aria-label="Forwards"
+              onClick={handleNext}
+            >
+              <Forwards iconSize="XS" />
+            </HvButton>
+          </div>
+        )}
 
         <div
-          className={cx(classes.main, {
-            [classes.mainXs]: xs,
-            [classes.mainFullscreen]: isFullscreen,
-          })}
+          ref={containerRef}
+          style={{ height }}
+          className={classes.slidesViewport}
         >
-          {showCounter && (
-            <div className={classes.counterContainer}>
-              <span className={classes.counter}>
-                {`${selectedIndex + 1}/${numSlides}`}
-              </span>
-            </div>
-          )}
-
-          {showSlideControls && (
-            <div className={classes.slideControls}>
-              <HvButton
-                icon
-                disabled={!canPrev}
-                variant="secondary"
-                aria-label="Backwards"
-                onClick={handlePrevious}
-              >
-                <Backwards iconSize="XS" />
-              </HvButton>
-              <HvButton
-                icon
-                disabled={!canNext}
-                variant="secondary"
-                aria-label="Forwards"
-                onClick={handleNext}
-              >
-                <Forwards iconSize="XS" />
-              </HvButton>
-            </div>
-          )}
-
-          <div
-            ref={containerRef}
-            style={{ height }}
-            className={classes.slidesViewport}
-          >
-            <div className={classes.slidesContainer}>{children}</div>
-          </div>
+          <div className={classes.slidesContainer}>{children}</div>
         </div>
       </div>
-
-      {showThumbnails && (
-        <HvCarouselThumbnails
-          classes={classes}
-          ref={thumbnailsRef}
-          page={selectedIndex}
-          pages={numSlides}
-          width={thumbnailWidth}
-          onThumbnailClick={(evt, i) => handleScroll(i)}
-          renderThumbnail={renderThumbnail}
-        />
-      )}
+      {controlsPosition === "bottom" && controls}
+      {thumbnailsPosition === "bottom" && thumbnails}
     </HvContainer>
   );
 };

--- a/packages/core/src/components/Carousel/Carousel.tsx
+++ b/packages/core/src/components/Carousel/Carousel.tsx
@@ -13,10 +13,16 @@ import {
   Close,
   Fullscreen,
 } from "@hitachivantara/uikit-react-icons";
-import { HvButton, HvContainer, HvStack, HvTypography } from "@core/components";
-import { HvBaseProps } from "@core/types";
-import { ExtractNames } from "@core/utils";
+import {
+  ExtractNames,
+  HvBaseProps,
+  HvButton,
+  HvContainer,
+  HvTypography,
+} from "../..";
 
+import { HvCarouselControls } from "./CarouselControls";
+import { HvCarouselThumbnails } from "./CarouselThumbnails";
 import { staticClasses, useClasses } from "./Carousel.styles";
 
 const clamp = (num: number, max: number, min = 0) =>
@@ -188,44 +194,16 @@ export const HvCarousel = (props: HvCarouselProps) => {
       </div>
 
       <div className={classes.mainContainer}>
-        <div className={classes.controls}>
-          {showDots ? (
-            <div className={classes.dots}>
-              {Array.from(Array(numSlides)).map((el, index) => (
-                <span
-                  key={`circle-${index}`}
-                  className={cx(classes.dot, {
-                    [classes.dotSelected]: index === selectedIndex,
-                  })}
-                />
-              ))}
-            </div>
-          ) : (
-            <>
-              <HvButton
-                icon
-                disabled={!canPrev}
-                variant="secondaryGhost"
-                aria-label="Backwards"
-                onClick={handlePrevious}
-              >
-                <Backwards iconSize="XS" />
-              </HvButton>
-              <div className={classes.pageCounter}>
-                {`${selectedIndex + 1} / ${numSlides}`}
-              </div>
-              <HvButton
-                icon
-                disabled={!canNext}
-                variant="secondaryGhost"
-                aria-label="Forwards"
-                onClick={handleNext}
-              >
-                <Forwards iconSize="XS" />
-              </HvButton>
-            </>
-          )}
-        </div>
+        <HvCarouselControls
+          classes={classes}
+          showDots={showDots}
+          page={selectedIndex}
+          pages={numSlides}
+          canPrevious={canPrev}
+          canNext={canNext}
+          onPreviousClick={handlePrevious}
+          onNextClick={handleNext}
+        />
 
         <div
           className={cx(classes.main, {
@@ -275,24 +253,15 @@ export const HvCarousel = (props: HvCarouselProps) => {
       </div>
 
       {showThumbnails && (
-        <div ref={thumbnailsRef} className={classes.panel}>
-          <HvStack direction="row" spacing="xs">
-            {Array.from(Array(numSlides)).map((doc, i) => (
-              <HvButton
-                icon
-                variant="secondaryGhost"
-                key={`button-${i}`}
-                style={{ width: thumbnailWidth }}
-                className={cx(classes.thumbnail, {
-                  [classes.thumbnailSelected]: i === selectedIndex,
-                })}
-                onClick={() => handleScroll(i)}
-              >
-                {renderThumbnail(i)}
-              </HvButton>
-            ))}
-          </HvStack>
-        </div>
+        <HvCarouselThumbnails
+          classes={classes}
+          ref={thumbnailsRef}
+          page={selectedIndex}
+          pages={numSlides}
+          width={thumbnailWidth}
+          onThumbnailClick={(evt, i) => handleScroll(i)}
+          renderThumbnail={renderThumbnail}
+        />
       )}
     </HvContainer>
   );

--- a/packages/core/src/components/Carousel/CarouselControls.tsx
+++ b/packages/core/src/components/Carousel/CarouselControls.tsx
@@ -1,0 +1,77 @@
+import { MouseEventHandler, ReactNode } from "react";
+import { Backwards, Forwards } from "@hitachivantara/uikit-react-icons";
+import { HvBaseProps } from "@core/types";
+import { HvButton, HvPaginationProps } from "..";
+import { HvCarouselClasses, HvCarouselProps } from ".";
+import { useClasses } from "./Carousel.styles";
+
+interface HvCarouselControlsProps
+  extends HvBaseProps<HTMLDivElement>,
+    Pick<HvPaginationProps, "page" | "pages" | "canPrevious" | "canNext">,
+    Pick<HvCarouselProps, "showDots"> {
+  classes?: HvCarouselClasses;
+  actions?: ReactNode;
+  onPreviousClick?: MouseEventHandler<HTMLButtonElement>;
+  onNextClick?: MouseEventHandler<HTMLButtonElement>;
+}
+
+export const HvCarouselControls = (props: HvCarouselControlsProps) => {
+  const {
+    classes: classesProp,
+    className,
+    showDots,
+    page,
+    pages,
+    canPrevious,
+    canNext,
+    actions,
+    onPreviousClick,
+    onNextClick,
+  } = props;
+  const { classes, cx } = useClasses(classesProp, false);
+
+  const selectedIndex = page || 0;
+  const numSlides = pages;
+
+  return (
+    <div className={cx(classes.controls, className)}>
+      {showDots ? (
+        <div className={classes.dots}>
+          {Array.from(Array(numSlides)).map((el, index) => (
+            <span
+              key={`circle-${index}`}
+              className={cx(classes.dot, {
+                [classes.dotSelected]: index === selectedIndex,
+              })}
+            />
+          ))}
+        </div>
+      ) : (
+        <>
+          <HvButton
+            icon
+            disabled={!canPrevious}
+            variant="secondaryGhost"
+            aria-label="Backwards"
+            onClick={onPreviousClick}
+          >
+            <Backwards iconSize="XS" />
+          </HvButton>
+          <div className={classes.pageCounter}>
+            {`${selectedIndex + 1} / ${numSlides}`}
+          </div>
+          <HvButton
+            icon
+            disabled={!canNext}
+            variant="secondaryGhost"
+            aria-label="Forwards"
+            onClick={onNextClick}
+          >
+            <Forwards iconSize="XS" />
+          </HvButton>
+        </>
+      )}
+      {actions}
+    </div>
+  );
+};

--- a/packages/core/src/components/Carousel/CarouselSlide/CarouselSlide.tsx
+++ b/packages/core/src/components/Carousel/CarouselSlide/CarouselSlide.tsx
@@ -20,6 +20,7 @@ export interface HvCarouselSlideProps
  */
 export const HvCarouselSlide = ({
   classes: classesProp = {},
+  className,
   children,
   size: flexBasis = "100%",
   src,
@@ -28,7 +29,13 @@ export const HvCarouselSlide = ({
 }: HvCarouselSlideProps) => {
   const { classes, css, cx } = useClasses(classesProp);
   return (
-    <div className={cx(css({ flex: `0 0 ${flexBasis}` }), classes.slide)}>
+    <div
+      className={cx(
+        css({ flex: `0 0 ${flexBasis}` }),
+        classes.slide,
+        className
+      )}
+    >
       {children ?? (
         <img className={classes.image} src={src} alt={alt} {...props} />
       )}

--- a/packages/core/src/components/Carousel/CarouselThumbnail.tsx
+++ b/packages/core/src/components/Carousel/CarouselThumbnail.tsx
@@ -1,0 +1,30 @@
+import { HvButton, HvButtonProps } from "../..";
+import { useClasses } from "./Carousel.styles";
+
+interface HvCarouselThumbnailProps extends HvButtonProps {
+  selected?: boolean;
+}
+
+export const HvCarouselThumbnail = (props: HvCarouselThumbnailProps) => {
+  const {
+    classes: classesProp,
+    className,
+    selected,
+    children,
+    ...others
+  } = props;
+  const { classes, cx } = useClasses(classesProp);
+
+  return (
+    <HvButton
+      icon
+      variant="secondaryGhost"
+      className={cx(classes.thumbnail, {
+        [classes.thumbnailSelected]: selected,
+      })}
+      {...others}
+    >
+      {children}
+    </HvButton>
+  );
+};

--- a/packages/core/src/components/Carousel/CarouselThumbnails.tsx
+++ b/packages/core/src/components/Carousel/CarouselThumbnails.tsx
@@ -1,0 +1,55 @@
+import { CSSProperties, MouseEvent, forwardRef } from "react";
+import { HvBaseProps } from "@core/types";
+import { HvPaginationProps, HvStack } from "..";
+import { HvCarouselClasses, HvCarouselProps } from ".";
+import { useClasses } from "./Carousel.styles";
+import { HvCarouselThumbnail } from "./CarouselThumbnail";
+
+interface HvCarouselThumbnailsProps
+  extends HvBaseProps<HTMLDivElement, "children">,
+    Pick<HvPaginationProps, "page" | "pages" | "canPrevious" | "canNext">,
+    Pick<HvCarouselProps, "showDots" | "renderThumbnail"> {
+  width?: CSSProperties["width"];
+  classes?: HvCarouselClasses;
+  onThumbnailClick?: (
+    event: MouseEvent<HTMLButtonElement>,
+    index: number
+  ) => void;
+}
+
+export const HvCarouselThumbnails = forwardRef<
+  HTMLDivElement,
+  HvCarouselThumbnailsProps
+>((props, ref) => {
+  const {
+    classes: classesProp,
+    className,
+    page,
+    pages,
+    width,
+    renderThumbnail,
+    onThumbnailClick,
+    ...others
+  } = props;
+  const { classes, cx } = useClasses(classesProp);
+
+  const selectedIndex = page || 0;
+  const numSlides = pages;
+
+  return (
+    <div ref={ref} className={cx(classes.panel, className)} {...others}>
+      <HvStack direction="row" spacing="xs">
+        {Array.from(Array(numSlides)).map((doc, i) => (
+          <HvCarouselThumbnail
+            key={`thumbnail-${i}`}
+            style={{ width }}
+            selected={i === selectedIndex}
+            onClick={(event) => onThumbnailClick?.(event, i)}
+          >
+            {renderThumbnail?.(i)}
+          </HvCarouselThumbnail>
+        ))}
+      </HvStack>
+    </div>
+  );
+});

--- a/packages/core/src/utils/classes.ts
+++ b/packages/core/src/utils/classes.ts
@@ -55,11 +55,19 @@ export function createClasses<Name extends string, ClassName extends string>(
 
   const staticClasses = getClasses(Object.keys(styles) as ClassName[], name);
 
-  function useClasses(classesProp: Partial<Record<ClassName, string>> = {}) {
+  /**
+   * Hook that takes in a component's `classesProp` overrides, and returns the
+   * concatenated static/internal/override `classes`, and the cached `cx` and `css` utilities.
+   */
+  function useClasses(
+    classesProp: Partial<Record<ClassName, string>> = {},
+    /** Whether to add the static classes. Disable when included by `classesProp` */
+    addStatic = true
+  ) {
     const { cx, css } = useCss();
 
     const mergeClasses = (key: string) =>
-      cx(`${name}-${key}`, css(styles[key]), classesProp?.[key]);
+      cx(addStatic && `${name}-${key}`, css(styles[key]), classesProp?.[key]);
 
     const classes = Object.fromEntries(
       Object.keys(styles).map((key) => [key, mergeClasses(key)])

--- a/packages/styles/src/theme.ts
+++ b/packages/styles/src/theme.ts
@@ -385,7 +385,6 @@ const componentsSpec: DeepString<HvThemeComponents> = {
   carousel: {
     xsControlsDisplay: "string",
     counterContainerDisplay: "string",
-    actionsOffsetTop: "string",
     mainContainerFlexDirection: "string",
     controlsBorder: "string",
     controlsBackgroundColor: "string",

--- a/packages/styles/src/themes/ds3.ts
+++ b/packages/styles/src/themes/ds3.ts
@@ -601,7 +601,6 @@ const ds3 = makeTheme((theme: HvTheme) => ({
   carousel: {
     xsControlsDisplay: "none",
     counterContainerDisplay: "block",
-    actionsOffsetTop: `calc(-32px - ${theme.space.xs})`,
     mainContainerFlexDirection: "column-reverse",
     controlsBorder: "none",
     controlsBackgroundColor: "transparent",

--- a/packages/styles/src/themes/ds5.ts
+++ b/packages/styles/src/themes/ds5.ts
@@ -544,7 +544,6 @@ const ds5 = makeTheme((theme: HvTheme) => ({
   carousel: {
     xsControlsDisplay: "flex",
     counterContainerDisplay: "none",
-    actionsOffsetTop: 0,
     mainContainerFlexDirection: "column",
     controlsBorder: `1px solid ${theme.colors.atmo4}`,
     controlsBackgroundColor: theme.colors.atmo2,

--- a/packages/styles/src/types.ts
+++ b/packages/styles/src/types.ts
@@ -394,7 +394,6 @@ export type HvThemeComponents = {
   carousel: {
     xsControlsDisplay: CSSProperties["display"];
     counterContainerDisplay: CSSProperties["display"];
-    actionsOffsetTop: CSSProperties["top"];
     mainContainerFlexDirection: CSSProperties["flexDirection"];
     controlsBorder: CSSProperties["border"];
     controlsJustifyContent: CSSProperties["justifyContent"];


### PR DESCRIPTION
- break down `HvCarousel` into sub-components
  - makes it easier to build a custom carousel, if the current `HvCarousel` doesn't suit some use-case
- add `controlsPosition` & `thumbnailsPosition` props to configure thumbnail/controls position