### PR TITLE
chore(POC): add useDefaultProps & usage in Avatar/ActionBar

### DIFF
--- a/packages/core/src/components/ActionBar/ActionBar.styles.tsx
+++ b/packages/core/src/components/ActionBar/ActionBar.styles.tsx
@@ -5,7 +5,7 @@ export const { staticClasses, useClasses } = createClasses("HvActionBar", {
   root: {
     width: "100%",
     padding: theme.space.sm,
-    borderTop: theme.actionBar.borderTop,
+    borderTop: `1px solid ${theme.colors.atmo3}`,
     display: "flex",
     alignItems: "center",
     justifyContent: "flex-end",

--- a/packages/core/src/components/ActionBar/ActionBar.tsx
+++ b/packages/core/src/components/ActionBar/ActionBar.tsx
@@ -1,5 +1,6 @@
 import { HvBaseProps } from "@core/types";
 import { ExtractNames } from "@core/utils";
+import { useDefaultProps } from "@core/hooks";
 import { staticClasses, useClasses } from "./ActionBar.styles";
 
 export { staticClasses as actionBarClasses };
@@ -12,7 +13,12 @@ export interface HvActionBarProps extends HvBaseProps {
 }
 
 export const HvActionBar = (props: HvActionBarProps) => {
-  const { classes: classesProp, className, children, ...others } = props;
+  const {
+    classes: classesProp,
+    className,
+    children,
+    ...others
+  } = useDefaultProps("actionBar", props);
   const { classes, cx } = useClasses(classesProp);
 
   return (

--- a/packages/core/src/components/Avatar/Avatar.tsx
+++ b/packages/core/src/components/Avatar/Avatar.tsx
@@ -4,7 +4,7 @@ import { AvatarProps as MuiAvatarProps } from "@mui/material/Avatar";
 import { clsx } from "clsx";
 import { CSSProperties, HTMLAttributes } from "react";
 import { HvBaseProps } from "@core/types";
-import { useImageLoaded } from "@core/hooks";
+import { useDefaultProps, useImageLoaded } from "@core/hooks";
 import { decreaseSize } from "@core/utils";
 import {
   StyledAvatar,
@@ -72,26 +72,27 @@ const getColor = (color: string, defaultColor: string): string =>
  * Avatars can be used to represent a user or a brand.
  * They can show an image, an icon or the initial letters of a name, for example.
  */
-export const HvAvatar = ({
-  className,
-  style,
-  classes,
-  children: childrenProp,
-  component = "div",
-  size = "sm",
-  backgroundColor = "secondary",
-  color = "atmo1",
-  src,
-  srcSet,
-  sizes,
-  alt,
-  imgProps,
-  status,
-  badge,
-  variant = "circular",
-  avatarProps,
-  ...others
-}: HvAvatarProps) => {
+export const HvAvatar = (props: HvAvatarProps) => {
+  const {
+    className,
+    style,
+    classes,
+    children: childrenProp,
+    component = "div",
+    size = "sm",
+    backgroundColor = "secondary",
+    color = "atmo1",
+    src,
+    srcSet,
+    sizes,
+    alt,
+    imgProps,
+    status,
+    badge,
+    variant = "circular",
+    avatarProps,
+    ...others
+  } = useDefaultProps("avatar", props);
   let children: React.ReactNode;
 
   // Use a hook instead of onError on the img element to support server-side rendering.

--- a/packages/core/src/hooks/index.ts
+++ b/packages/core/src/hooks/index.ts
@@ -1,5 +1,7 @@
 export * from "./useClickOutside";
 export * from "./useControlled";
+export * from "./useCss";
+export * from "./useDefaultProps";
 export { default as useForkRef } from "./useForkRef";
 export * from "./useImageLoaded";
 export * from "./useSelectionPath";

--- a/packages/core/src/hooks/useDefaultProps.ts
+++ b/packages/core/src/hooks/useDefaultProps.ts
@@ -1,0 +1,46 @@
+import { useMemo } from "react";
+import { useCss, useTheme } from ".";
+
+/** Filter out `undefined` entries from `props` object. */
+export function filterProps(props: Record<string, any>) {
+  return Object.keys(props).reduce((acc, key) => {
+    if (props[key] !== undefined) {
+      acc[key] = props[key];
+    }
+    return acc;
+  }, {} as typeof props);
+}
+
+/** Adds to `props` the default props defined in the theme, for the given `componentName`. */
+export function useDefaultProps<T extends Record<string, any>>(
+  /** Name of the theme component key to inject defaultProps */
+  componentName: string, // keyof HvThemeComponents,
+  props: Partial<T>
+): T {
+  const { activeTheme } = useTheme();
+  const { css, cx } = useCss();
+
+  const themeDefaultProps = activeTheme?.components?.[componentName];
+
+  const classes = useMemo(() => {
+    const themeClasses = themeDefaultProps?.classes || {};
+    const propsClasses = props?.classes || {};
+    const classKeys = [
+      ...Object.keys(themeClasses),
+      ...Object.keys(propsClasses),
+    ];
+    return classKeys.reduce((acc, key) => {
+      acc[key] = cx(
+        themeClasses[key] && css(themeClasses[key]),
+        propsClasses[key]
+      );
+      return acc;
+    }, {} as Record<string, string>);
+  }, [css, cx, props?.classes, themeDefaultProps?.classes]);
+
+  return {
+    ...themeDefaultProps,
+    ...filterProps(props),
+    classes,
+  };
+}

--- a/packages/styles/src/themes/ds3.ts
+++ b/packages/styles/src/themes/ds3.ts
@@ -227,6 +227,17 @@ const ds3 = makeTheme((theme: HvTheme) => ({
       textDecoration: "underline",
     },
   },
+  components: {
+    avatar: {
+      size: "lg",
+      variant: "square",
+    },
+    actionBar: {
+      classes: {
+        root: { borderTop: `3px solid ${theme.colors.atmo2}` },
+      },
+    },
+  },
   actionBar: {
     borderTop: `3px solid ${theme.colors.atmo2}`,
   },

--- a/packages/styles/src/themes/ds5.ts
+++ b/packages/styles/src/themes/ds5.ts
@@ -170,6 +170,12 @@ const ds5 = makeTheme((theme: HvTheme) => ({
       textDecoration: "underline",
     },
   },
+  components: {
+    avatar: {
+      size: "lg",
+      variant: "square",
+    },
+  },
   actionBar: {
     borderTop: `1px solid ${theme.colors.atmo3}`,
   },

--- a/packages/styles/src/types.ts
+++ b/packages/styles/src/types.ts
@@ -18,7 +18,13 @@ interface CSSProperties extends CSS.Properties<string | number> {}
 
 export type HvThemeTokens = typeof flattenTokens;
 
-// Theme components
+/** Theme components props */
+export type HvThemeComponentsProps = {
+  /** Component properties to override */
+  components?: Record<string, Record<string, any>>;
+};
+
+/** Theme components */
 export type HvThemeComponents = {
   actionBar: {
     borderTop: string;
@@ -492,6 +498,7 @@ export type HvThemeStructure = {
   name: string;
   base?: HvBaseTheme;
 } & HvThemeComponents &
+  HvThemeComponentsProps &
   HvThemeTypography &
   Omit<HvThemeTokens, "colors"> & {
     colors: {
@@ -503,6 +510,7 @@ export type HvThemeStructure = {
 
 // Custom theme
 export type HvCustomTheme = { name: string } & HvThemeComponents &
+  HvThemeComponentsProps &
   HvThemeTypography &
   Partial<Omit<HvThemeTokens, "colors">> & {
     colors: {


### PR DESCRIPTION
- add `useDefaultProps` hook to allow overriding component props at theme level
  - example `HvAvatar` usage for `size`/`variant` props
- add special logic for `classes` prop, so that users can pass `CSSInterpolation` and the name is computed
  - example `HvActionBar` usage for DS3 vs DS5 theming via `classes`