### PR TITLE
chore: fix theme creator app not considering the removal of customisations from the code editor

### DIFF
--- a/app/src/components/common/IconButton.tsx
+++ b/app/src/components/common/IconButton.tsx
@@ -15,7 +15,7 @@ export interface IconButtonProps extends Omit<HvButtonProps, "icon"> {
 /** An `HvButton` of type icon wrapped in a tooltip  */
 export const IconButton = ({ label, icon, ...others }: IconButtonProps) => {
   return (
-    <HvTooltip title={<HvTypography>{label}</HvTypography>}>
+    <HvTooltip enterDelay={500} title={<HvTypography>{label}</HvTypography>}>
       <span>
         <HvButton icon variant="secondaryGhost" aria-label={label} {...others}>
           {icon}

--- a/app/src/generator/CodeEditor/CodeEditor.tsx
+++ b/app/src/generator/CodeEditor/CodeEditor.tsx
@@ -61,10 +61,11 @@ const CodeEditor = ({
   const codeChangedHandler = (code?: string) => {
     if (!code) return;
 
-    const snippet = code.substring(
-      code.indexOf("({") + 1,
-      code.indexOf("});") + 1
-    );
+    const snippet = code
+      .substring(code.indexOf("({") + 1, code.indexOf("});") + 1)
+      .replaceAll("\n", "")
+      .replaceAll(" ", "")
+      .replaceAll(",}", "}");
 
     const themeJson = snippet.replace(
       /(['"])?([a-zA-Z0-9_]+)(['"])?:/g,
@@ -73,19 +74,21 @@ const CodeEditor = ({
 
     try {
       const parsed = JSON.parse(themeJson);
-      if (
-        customTheme.base !== parsed.base &&
-        (parsed.base === "ds3" || parsed.base === "ds5")
-      ) {
-        changeTheme(parsed.base, selectedMode);
-        updateCustomTheme(
-          { base: parsed.base },
-          {
-            isBaseChange: true,
-          }
-        );
+      if (customTheme.base !== parsed.base) {
+        if (parsed.base === "ds3" || parsed.base === "ds5") {
+          changeTheme(parsed.base, selectedMode);
+          updateCustomTheme(
+            { ...parsed },
+            {
+              isBaseChange: true,
+              isCodeEdit: true,
+            }
+          );
+        } else {
+          console.log("invalid base theme");
+        }
       } else {
-        updateCustomTheme({ ...parsed });
+        updateCustomTheme({ ...parsed }, { isCodeEdit: true });
       }
     } catch {
       console.log("error processing theme JSON");
@@ -97,7 +100,10 @@ const CodeEditor = ({
   return (
     <HvBox css={{ position: "relative" }}>
       <HvBox className={styles.codeEditorTools}>
-        <HvTooltip title={<HvTypography>Download</HvTypography>}>
+        <HvTooltip
+          enterDelay={500}
+          title={<HvTypography>Download</HvTypography>}
+        >
           <HvButton
             variant="secondaryGhost"
             component="a"

--- a/app/src/generator/Colors/Colors.tsx
+++ b/app/src/generator/Colors/Colors.tsx
@@ -79,6 +79,7 @@ const Colors = (): JSX.Element => {
                 return (
                   <HvTooltip
                     key={c}
+                    enterDelay={500}
                     title={
                       <div className={styles.tooltip}>
                         <HvTypography variant="label">{c}</HvTypography>

--- a/app/src/generator/Typography/Typography.tsx
+++ b/app/src/generator/Typography/Typography.tsx
@@ -118,12 +118,8 @@ const Typography = () => {
     setUpdatedSizes(map);
 
     updateCustomTheme({
-      ...customTheme,
-      ...customTheme,
       typography: {
-        ...customTheme.typography,
         [typographyName]: {
-          ...customTheme.typography[typographyName],
           fontSize: `${fontSize}${unit}`,
         },
       },
@@ -203,11 +199,8 @@ const Typography = () => {
     lineHeight: keyof HvThemeTokens["lineHeights"]
   ) => {
     updateCustomTheme({
-      ...customTheme,
       typography: {
-        ...customTheme.typography,
         [typographyName]: {
-          ...customTheme.typography[typographyName],
           lineHeight: customTheme?.lineHeights[lineHeight],
         },
       },
@@ -223,11 +216,8 @@ const Typography = () => {
     fontWeight: keyof HvThemeTokens["fontWeights"]
   ) => {
     updateCustomTheme({
-      ...customTheme,
       typography: {
-        ...customTheme.typography,
         [typographyName]: {
-          ...customTheme.typography[typographyName],
           fontWeight: customTheme?.fontWeights[fontWeight],
         },
       },
@@ -243,11 +233,8 @@ const Typography = () => {
     colorValue: string
   ) => {
     updateCustomTheme({
-      ...customTheme,
       typography: {
-        ...customTheme.typography,
         [typographyName]: {
-          ...customTheme.typography[typographyName],
           color: colorValue,
         },
       },


### PR DESCRIPTION
whenever we were manually **removing** anything from the Code Editor those changes weren't being taken into consideration since we're diffing with the current changes with the previous changes and merging the result:

```
const diff = themeDiff(prev, changes);
return merge({}, prev, diff);
```

but the previous versions include what we're removing so they're never actually removed. I added a `isCodeEdit`prop because editing the code manually is actually different from making changes using the other controls.