### PR TITLE
Revert "fix(breadcrumb): allow special characters on labels (#3469)"

### DIFF
--- a/.config/applitools.config.js
+++ b/.config/applitools.config.js
@@ -9,6 +9,7 @@ module.exports = {
 
   puppeteerOptions: {
     args: ["--no-sandbox", "--disable-setuid-sandbox"],
+    ignoreHTTPSErrors: true,
   },
 
   appName: process.env.APPLITOOLS_APP_NAME,
@@ -24,9 +25,5 @@ module.exports = {
 
   include: ({ kind }) => !isExcludedPath(kind),
 
-  testConcurrency: 10,
-
-  disableBrowserFetching: true,
-
-  showLogs: true,
+  testConcurrency: 20,
 };

--- a/packages/core/src/components/BreadCrumb/BreadCrumb.tsx
+++ b/packages/core/src/components/BreadCrumb/BreadCrumb.tsx
@@ -1,5 +1,6 @@
 import { clsx } from "clsx";
 import isNil from "lodash/isNil";
+import startCase from "lodash/startCase";
 import { isValidElement, MouseEvent } from "react";
 import { HvBaseProps } from "@core/types/generic";
 import { HvDropDownMenuProps } from "@core/components";
@@ -122,7 +123,7 @@ export const HvBreadCrumb = ({
                     )}
                     variant="body"
                   >
-                    {removeExtension(elem.label)}
+                    {startCase(removeExtension(elem.label))}
                   </StyledTypography>
                 )) || (
                   <HvPage

--- a/packages/core/src/components/BreadCrumb/Page/Page.tsx
+++ b/packages/core/src/components/BreadCrumb/Page/Page.tsx
@@ -4,6 +4,7 @@ import {
   HvTypography,
 } from "@core/components";
 import { ExtractNames } from "@core/utils";
+import startCase from "lodash/startCase";
 import { MouseEvent } from "react";
 import { staticClasses, useClasses } from "./Page.styles";
 
@@ -41,7 +42,7 @@ export const HvPage = ({
       className={cx(classes.link, classes.label, classes.a)}
       {...others}
     >
-      <HvOverflowTooltip data={elem.label} />
+      <HvOverflowTooltip data={startCase(elem.label)} />
     </HvTypography>
   );
 };

--- a/packages/core/src/components/Carousel/Carousel.stories.tsx
+++ b/packages/core/src/components/Carousel/Carousel.stories.tsx
@@ -18,6 +18,11 @@ export default {
   title: "Widgets/Carousel",
   component: HvCarousel,
   subcomponents: { HvCarouselSlide },
+  parameters: {
+    eyes: {
+      waitBeforeCapture: 5000,
+    },
+  },
 } as Meta<typeof HvCarousel>;
 
 export const Main: StoryObj<HvCarouselProps> = {


### PR DESCRIPTION
- reverts #3469 which for some reason is making Applitools break
- reverts some Applitools settings
- waitFor Carousel images to load