### PR TITLE
fix(breadcrumb): remove startCase

### DIFF
--- a/docs/foundation/colors/Colors.tsx
+++ b/docs/foundation/colors/Colors.tsx
@@ -1,5 +1,4 @@
 import React, { useState, useEffect } from "react";
-import startCase from "lodash/startCase";
 import capitalize from "lodash/capitalize";
 import {
   HvProvider,
@@ -46,7 +45,7 @@ const ColorsGroup = ({
           <StyledGroup>
             <div>
               <StyledGroupName variant="title2">
-                {capitalize(startCase(group))}
+                {capitalize(group)}
               </StyledGroupName>
               <StyledColors>
                 {Object.values(themeColors[selectedTheme][group]).map(

--- a/packages/core/src/components/BreadCrumb/BreadCrumb.stories.tsx
+++ b/packages/core/src/components/BreadCrumb/BreadCrumb.stories.tsx
@@ -137,11 +137,11 @@ export const WithLongLabels: StoryObj<HvBreadCrumbProps> = {
   },
   render: (args) => {
     const longData = [
-      { label: "Label 1 with some long text", path: "route1" },
-      { label: "Label 2 with some long text", path: "route2" },
-      { label: "Label 3 with some long text", path: "route3" },
-      { label: "Label 4 with some long text", path: "route4" },
-      { label: "Label 5 with some long text", path: "route5" },
+      { label: "Label 1 With Some Long Text", path: "route1" },
+      { label: "Label 2 With Some Long Text", path: "route2" },
+      { label: "Label 3 With Some Long Text", path: "route3" },
+      { label: "Label 4 With Some Long Text", path: "route4" },
+      { label: "Label 5 With Some Long Text", path: "route5" },
     ];
 
     return (

--- a/packages/core/src/components/BreadCrumb/BreadCrumb.tsx
+++ b/packages/core/src/components/BreadCrumb/BreadCrumb.tsx
@@ -1,6 +1,5 @@
 import { clsx } from "clsx";
 import isNil from "lodash/isNil";
-import startCase from "lodash/startCase";
 import { isValidElement, MouseEvent } from "react";
 import { HvBaseProps } from "@core/types/generic";
 import { HvDropDownMenuProps } from "@core/components";
@@ -123,7 +122,7 @@ export const HvBreadCrumb = ({
                     )}
                     variant="body"
                   >
-                    {startCase(removeExtension(elem.label))}
+                    {removeExtension(elem.label)}
                   </StyledTypography>
                 )) || (
                   <HvPage

--- a/packages/core/src/components/BreadCrumb/Page/Page.tsx
+++ b/packages/core/src/components/BreadCrumb/Page/Page.tsx
@@ -4,7 +4,6 @@ import {
   HvTypography,
 } from "@core/components";
 import { ExtractNames } from "@core/utils";
-import startCase from "lodash/startCase";
 import { MouseEvent } from "react";
 import { staticClasses, useClasses } from "./Page.styles";
 
@@ -42,7 +41,7 @@ export const HvPage = ({
       className={cx(classes.link, classes.label, classes.a)}
       {...others}
     >
-      <HvOverflowTooltip data={startCase(elem.label)} />
+      <HvOverflowTooltip data={elem.label} />
     </HvTypography>
   );
 };


### PR DESCRIPTION
- This is the same fix @zettca did previously but I'm also removing `startCase` in the colors doc page to fix applitools (indefinitely reading stories problem).