### PR TITLE
chore: use json5 library to parse the code editor theme

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -21,6 +21,7 @@
     "i18next-browser-languagedetector": "^7.0.2",
     "i18next-http-backend": "^2.2.1",
     "js-cookie": "^3.0.5",
+    "json5": "^2.2.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-google-charts": "^4.0.0",

--- a/app/src/generator/CodeEditor/CodeEditor.tsx
+++ b/app/src/generator/CodeEditor/CodeEditor.tsx
@@ -15,6 +15,7 @@ import {
   useState,
 } from "react";
 import debounce from "lodash/debounce";
+import JSON5 from "json5";
 import { Download, Reset, Duplicate } from "@hitachivantara/uikit-react-icons";
 import { getThemeCode } from "generator/utils";
 import { HvCodeEditor } from "@hitachivantara/uikit-react-code-editor";
@@ -61,19 +62,13 @@ const CodeEditor = ({
   const codeChangedHandler = (code?: string) => {
     if (!code) return;
 
-    const snippet = code
-      .substring(code.indexOf("({") + 1, code.indexOf("});") + 1)
-      .replaceAll("\n", "")
-      .replaceAll(" ", "")
-      .replaceAll(",}", "}");
-
-    const themeJson = snippet.replace(
-      /(['"])?([a-zA-Z0-9_]+)(['"])?:/g,
-      '"$2": '
+    const snippet = code.substring(
+      code.indexOf("({") + 1,
+      code.indexOf("});") + 1
     );
 
     try {
-      const parsed = JSON.parse(themeJson);
+      const parsed = JSON5.parse(snippet);
       if (customTheme.base !== parsed.base) {
         if (parsed.base === "ds3" || parsed.base === "ds5") {
           changeTheme(parsed.base, selectedMode);

--- a/package-lock.json
+++ b/package-lock.json
@@ -86,6 +86,7 @@
         "i18next-browser-languagedetector": "^7.0.2",
         "i18next-http-backend": "^2.2.1",
         "js-cookie": "^3.0.5",
+        "json5": "^2.2.3",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-google-charts": "^4.0.0",
@@ -24409,7 +24410,6 @@
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
       "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
-      "dev": true,
       "bin": {
         "json5": "lib/cli.js"
       },
@@ -58209,8 +58209,7 @@
     "json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
-      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
-      "dev": true
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="
     },
     "jsonc-parser": {
       "version": "3.2.0",
@@ -67799,6 +67798,7 @@
         "i18next-browser-languagedetector": "^7.0.2",
         "i18next-http-backend": "^2.2.1",
         "js-cookie": "^3.0.5",
+        "json5": "^2.2.3",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-google-charts": "^4.0.0",


### PR DESCRIPTION
Using the `json5` library will prevent us from needing to do several manual validations on the parsing of the theme to a JSON object (like including comments, trailing commas, etc)