### PR TITLE
perf(Icons): move icon logic to hook to reduce size

### DIFF
--- a/app/src/lib/routes.tsx
+++ b/app/src/lib/routes.tsx
@@ -7,6 +7,7 @@ const AssetInventory = lazy(() => import("pages/AssetInventory"));
 const ListView = lazy(() => import("pages/ListView"));
 const Form = lazy(() => import("pages/Form"));
 const DetailsView = lazy(() => import("pages/DetailsView"));
+const Icons = lazy(() => import("pages/Icons"));
 const NotFound = lazy(() => import("pages/NotFound"));
 
 const AppRoutes = () => (
@@ -22,6 +23,7 @@ const AppRoutes = () => (
     <Route path="/preview/list-view" element={<ListView />} />
     <Route path="/preview/form" element={<Form />} />
     <Route path="/preview/details-view" element={<DetailsView />} />
+    <Route path="/icons" element={<Icons />} />
     <Route path="/*" element={<NotFound />} />
   </Routes>
 );

--- a/app/src/pages/Icons.tsx
+++ b/app/src/pages/Icons.tsx
@@ -1,0 +1,16 @@
+import { HvButton } from "@hitachivantara/uikit-react-core";
+import { icons } from "@hitachivantara/uikit-react-icons";
+
+const Icons = () => {
+  return (
+    <div style={{ display: "flex", flexWrap: "wrap" }}>
+      {Object.entries(icons).map(([name, Icon]) => (
+        <HvButton icon key={name} aria-label={name} variant="secondaryGhost">
+          <Icon iconSize="M" />
+        </HvButton>
+      ))}
+    </div>
+  );
+};
+
+export default Icons;

--- a/packages/icons/src/IconBase.tsx
+++ b/packages/icons/src/IconBase.tsx
@@ -1,5 +1,77 @@
 import styled from "@emotion/styled";
-import React, { HTMLAttributes, AllHTMLAttributes } from "react";
+import React, { HTMLAttributes, AllHTMLAttributes, useMemo } from "react";
+import { theme } from "@hitachivantara/uikit-styles";
+
+const getColor = (c: string): string => theme?.colors?.[c] || c;
+
+const getDims = (size: number) => ({ width: size, height: size });
+
+const sizeSelector = (iconSize?: IconSize, hasSpecialSize?: boolean) => {
+  const calcSize = (size: number) => (hasSpecialSize ? size + 8 : size);
+
+  switch (iconSize) {
+    case "XS":
+      return getDims(calcSize(12));
+    // eslint-disable-next-line default-case-last
+    default:
+    case "S":
+      return getDims(calcSize(16));
+    case "M":
+      return getDims(calcSize(32));
+    case "L":
+      return getDims(calcSize(96));
+  }
+};
+
+export function useIconColor(
+  color?: string | string[],
+  semantic?: string,
+  inverted = false,
+  palette: string[] = []
+) {
+  return useMemo(() => {
+    const colorArray =
+      (typeof color === "string" && [getColor(color)]) ||
+      (Array.isArray(color) && color.map?.(getColor)) ||
+      palette;
+
+    if (semantic) {
+      colorArray[0] = theme.colors?.[semantic] || colorArray[0];
+    }
+
+    if (inverted && colorArray[1]) {
+      // eslint-disable-next-line prefer-destructuring
+      colorArray[1] = colorArray[0];
+      colorArray[0] = "none";
+    }
+
+    return colorArray;
+  }, [color, inverted, palette, semantic]);
+}
+
+export function useIconSize(
+  iconSize?: IconSize,
+  height?: number,
+  width?: number,
+  hasSpecialSize = false
+) {
+  return useMemo(() => {
+    if (height && width) return { width, height };
+    return sizeSelector(iconSize, hasSpecialSize);
+  }, [hasSpecialSize, height, iconSize, width]);
+}
+
+export function useIcon(
+  props: IconBaseProps,
+  palette: string[] = [],
+  hasSpecialSize = false
+) {
+  const { color, iconSize, width, height, semantic, inverted } = props;
+  const colorArray = useIconColor(color, semantic, inverted, palette);
+  const size = useIconSize(iconSize, height, width, hasSpecialSize);
+
+  return { size, colorArray };
+}
 
 export type IconSize = "XS" | "S" | "M" | "L";
 
@@ -12,37 +84,23 @@ type HTMLDivProps = Pick<AllHTMLAttributes<HTMLDivElement>, "name"> &
 export interface IconBaseProps extends HTMLDivProps {
   /**
    * A String or Array of strings representing the colors to override in the icon.
-   * Each element inside the array will override a diferent color.
+   * Each element inside the array will override a different color.
    * You can use either an HEX or color name from the palette.
    */
   color?: string | string[];
-  /**
-   * Sets one of the standard sizes of the icons
-   */
+  /** Sets one of the standard sizes of the icons */
   iconSize?: IconSize;
-  /**
-   * A string that will override the viewbox of the svg
-   */
+  /** A string that will override the viewbox of the svg */
   viewbox?: string;
-  /**
-   * A string that will override the height of the svg
-   */
+  /** A string that will override the height of the svg */
   height?: number;
-  /**
-   * A string that will override the width of the svg
-   */
+  /** A string that will override the width of the svg */
   width?: number;
-  /**
-   * Sets one of the standard semantic palette colors of the icon
-   */
+  /** Sets one of the standard semantic palette colors of the icon */
   semantic?: string;
-  /**
-   * Inverts the background-foreground on semantic icons
-   */
+  /** Inverts the background-foreground on semantic icons */
   inverted?: boolean;
-  /**
-   * Props passed down to the svg element.
-   */
+  /** Props passed down to the svg element. */
   svgProps?: React.SVGProps<SVGSVGElement>;
 }
 
@@ -53,22 +111,10 @@ export const StyledIconBase = styled("div")(
       margin: "auto",
       color: "inherit",
     },
-    ...(iconSize === "XS" && {
-      width: 32,
-      height: 32,
-    }),
-    ...(iconSize === "S" && {
-      width: 32,
-      height: 32,
-    }),
-    ...(iconSize === "M" && {
-      width: 48,
-      height: 48,
-    }),
-    ...(iconSize === "L" && {
-      width: 112,
-      height: 112,
-    }),
+    ...(iconSize === "XS" && getDims(32)),
+    ...(iconSize === "S" && getDims(32)),
+    ...(iconSize === "M" && getDims(48)),
+    ...(iconSize === "L" && getDims(112)),
   })
 );
 

--- a/packages/icons/src/svgToReact.ts
+++ b/packages/icons/src/svgToReact.ts
@@ -65,7 +65,7 @@ const writeFile = (processedSVG, fileName, subFolder = ".") => {
   });
 
   const exportName = fileName.split(".").join("");
-  const exportString = `export { default as ${exportName} } from "./${fileName}";\n`;
+  const exportString = `export { ${exportName} } from "./${fileName}";\n`;
 
   if (subFolder === ".") {
     fs.appendFile(

--- a/packages/icons/src/utils/converter/generateComponent.ts
+++ b/packages/icons/src/utils/converter/generateComponent.ts
@@ -51,7 +51,6 @@ export const generateComponent = (
   const hasSpecialSize = largerIcons.includes(componentName);
 
   const hasSpecialSizeXS = componentName.endsWith("XS");
-  const calcSize = (size) => (hasSpecialSize ? size + 8 : size);
 
   const themedPalette = colors
     .replace(/"#414141"/g, "theme.colors.secondary")
@@ -62,27 +61,9 @@ export const generateComponent = (
 
   return `
 import { theme } from "@hitachivantara/uikit-styles";
-import { IconBase, IconBaseProps } from "${iconBasePath}";
+import { IconBase, IconBaseProps, useIconColor, useIconSize } from "${iconBasePath}";
 
-const sizeSelector = (iconSize, height, width) => {
-  if (height && width) {
-    return { width, height };
-  }
-
-  switch (iconSize) {
-    case "XS":
-      return { width: ${calcSize(12)}, height: ${calcSize(12)} };
-    default:
-    case "S":
-      return { width: ${calcSize(16)}, height: ${calcSize(16)} };
-    case "M":
-      return { width: ${calcSize(32)}, height: ${calcSize(32)} };
-    case "L":
-      return { width: ${calcSize(96)}, height: ${calcSize(96)} };
-  }
-};
-
-const ${componentName} = ({
+export const ${componentName} = ({
   color,
   iconSize = "${hasSpecialSizeXS ? "XS" : "S"}",
   viewbox = "${defaultSizes.viewBoxRegexp.join(" ")}",
@@ -93,28 +74,13 @@ const ${componentName} = ({
   svgProps,
   ...others
 }: IconBaseProps) => {
-  const getColor = c => theme?.colors?.[c] || c;
-  const colorArray = 
-    (typeof color === "string" && [getColor(color)]) ||
-    (Array.isArray(color) && color.map?.(getColor)) ||
-    [${palette}];
-
-  if (semantic) {
-    colorArray[0] = theme.colors?.[semantic] || colorArray[0];
-  }
-
-  if (inverted && colorArray[1]) {
-    colorArray[1] = colorArray[0];
-    colorArray[0] = "none";
-  }
-
-  const size = sizeSelector(iconSize, height, width);
+  const colorArray = useIconColor(color, semantic, inverted, [${palette}]);
+  const size = useIconSize(iconSize, height, width, ${hasSpecialSize});
 
   return (
-    <IconBase iconSize={iconSize ?? "S"} name="${componentName}" {...others}>
-      ${svgOutput.replace("{...other}", "focusable={false} {...svgProps}")}
+    <IconBase iconSize={iconSize} name="${componentName}" {...others}>
+    ${svgOutput.replace("{...other}", "focusable={false} {...svgProps}")}
     </IconBase>
 )};
-
-export default ${componentName};`;
+`;
 };


### PR DESCRIPTION
- hoist duplicated code in each icon component to `useIconSize` and `useIconColor` hooks
- add page to `app` to test out bundling

Looking at the `dist` folder, and the lazy-loaded Icons app route (that loads all icons) we get the following results:

|               | Before   | After    |
| ------------- | -------- | -------- |
| `dist/esm`    | `4.3M`   | `3.9M`   |
| `pages/Icons` | `478 kB` | `309 kB` |
