### PR TITLE
chore: added the possibility to set the depth on the header navigation

### DIFF
--- a/packages/core/src/components/Header/Navigation/MenuBar/MenuBar.tsx
+++ b/packages/core/src/components/Header/Navigation/MenuBar/MenuBar.tsx
@@ -11,6 +11,8 @@ export interface HvMenuBarProps extends HvBaseProps<HTMLDivElement, "onClick"> {
   data: HvHeaderNavigationItemProp[];
   type: string;
   onClick?: (event: MouseEvent, selection: HvHeaderNavigationItemProp) => void;
+  maxDepth: number;
+  currentDepth: number;
 }
 
 export const HvMenuBar = ({
@@ -18,6 +20,8 @@ export const HvMenuBar = ({
   data = [],
   onClick,
   type = "menubar",
+  maxDepth,
+  currentDepth,
   className,
 }: HvMenuBarProps) => {
   const selectionPath = useContext(SelectionContext);
@@ -40,7 +44,14 @@ export const HvMenuBar = ({
     >
       <MenuBarUl id={id} onFocus={() => {}}>
         {data.map((item: HvHeaderNavigationItemProp) => (
-          <HvMenuItem key={item.id} item={item} type={type} onClick={onClick} />
+          <HvMenuItem
+            key={item.id}
+            item={item}
+            type={type}
+            onClick={onClick}
+            maxDepth={maxDepth}
+            currentDepth={currentDepth}
+          />
         ))}
       </MenuBarUl>
     </MenuBarRoot>

--- a/packages/core/src/components/Header/Navigation/MenuItem/MenuItem.tsx
+++ b/packages/core/src/components/Header/Navigation/MenuItem/MenuItem.tsx
@@ -11,6 +11,8 @@ export interface MenuItemProps extends HvBaseProps<HTMLDivElement, "onClick"> {
   item: HvHeaderNavigationItemProp;
   type?: string;
   onClick?: (event: MouseEvent, selection: HvHeaderNavigationItemProp) => void;
+  maxDepth: number;
+  currentDepth: number;
 }
 
 // Traverse the tree of items and return the first href it finds
@@ -38,7 +40,14 @@ const traverseItem = (node: HvHeaderNavigationItemProp) => {
   return { href, target };
 };
 
-export const HvMenuItem = ({ id, item, type, onClick }: MenuItemProps) => {
+export const HvMenuItem = ({
+  id,
+  item,
+  type,
+  onClick,
+  maxDepth,
+  currentDepth,
+}: MenuItemProps) => {
   const selectionPath = useContext(SelectionContext);
   const { dispatch } = useContext(FocusContext);
 
@@ -128,7 +137,15 @@ export const HvMenuItem = ({ id, item, type, onClick }: MenuItemProps) => {
           {label}
         </MenuItemLabel>
       )}
-      {hasSubLevel && <HvMenuBar data={data} onClick={onClick} type="menu" />}
+      {hasSubLevel && currentDepth < maxDepth && (
+        <HvMenuBar
+          data={data}
+          onClick={onClick}
+          type="menu"
+          maxDepth={maxDepth}
+          currentDepth={currentDepth + 1}
+        />
+      )}
     </MenuItemLi>
   );
 };

--- a/packages/core/src/components/Header/Navigation/Navigation.tsx
+++ b/packages/core/src/components/Header/Navigation/Navigation.tsx
@@ -25,6 +25,7 @@ export interface HvHeaderNavigationProps
   selected?: string;
   onClick?: (event: MouseEvent, selection: HvHeaderNavigationItemProp) => void;
   classes?: HvHeaderNavigationClasses;
+  maxDepth?: 0 | 1;
 }
 
 export const HvHeaderNavigation = ({
@@ -33,6 +34,7 @@ export const HvHeaderNavigation = ({
   onClick,
   className,
   classes,
+  maxDepth = 1,
   ...others
 }: HvHeaderNavigationProps) => {
   const selectionPath = useSelectionPath(data, selected);
@@ -54,7 +56,13 @@ export const HvHeaderNavigation = ({
           )}
           {...others}
         >
-          <HvMenuBar data={data} type="menubar" onClick={handleClick} />
+          <HvMenuBar
+            data={data}
+            type="menubar"
+            onClick={handleClick}
+            maxDepth={maxDepth}
+            currentDepth={0}
+          />
         </StyledNav>
       </FocusProvider>
     </SelectionContext.Provider>


### PR DESCRIPTION
With this PR we wanted to fix an issue with the accessibilty we are having on the App Shell side.
On the App Shell we only send to the header the first level of the data structure, because we only want to display the first level of menus, since the rest will be displayed on the VerticalNavigation.

This was causing some issues with the aria-current property, as it was always being set as page when in reality most of the times it should actually show true  but since the data structure was limited to the first level the logic to calculate the aria-current wasn’t working properly.

We added a new property called maxDepth to control how many levels should be displayed. The values are:
0 - Top level only
1 - 2 levels - This is the default value
I’ve decided to only have these two options because more than this will cause the header to have a weird behavior and I don’t think its supported at all, but if it is let me know and I’ll change it.

These changes on the App Shell side we will be able to have the correct aria-current value on the navigation.