### PR TITLE
fix(Typography): change label variant default to `span`

### DIFF
--- a/packages/core/src/components/Typography/Typography.tsx
+++ b/packages/core/src/components/Typography/Typography.tsx
@@ -53,7 +53,7 @@ const HvTypographyMap = {
   title3: "h3",
   title4: "h4",
   body: "p",
-  label: "label",
+  label: "span",
   caption1: "p",
   caption2: "p",
   // LEGACY


### PR DESCRIPTION
`label` should be used to label content. `<HvTypography variant="label">` is being mostly used as a bold variant of `"body"`, not to label content

Changed to `span`, as `p` comes with other associated default styles. `span` has the same default display as `label`