### PR TITLE
fix(VerticalNavigation): expand/collapse icon with long labels

### DIFF
--- a/packages/core/src/components/VerticalNavigation/TreeView/TreeViewItem.styles.tsx
+++ b/packages/core/src/components/VerticalNavigation/TreeView/TreeViewItem.styles.tsx
@@ -28,13 +28,17 @@ export const StyledGroup = styled("ul")({
 export const StyledLabel = styled(
   "div",
   transientOptions
-)(({ $expandable }: { $expandable: boolean }) => ({
+)(({ $expandable, $hasIcon }: { $expandable: boolean; $hasIcon: boolean }) => ({
   display: "flex",
   flexGrow: 1,
   maxWidth: "100%",
-  ...($expandable && {
+  ...(($hasIcon || $expandable) && {
     maxWidth: "calc(100% - 32px)",
   }),
+  ...($expandable &&
+    $hasIcon && {
+      maxWidth: "calc(100% - 64px)",
+    }),
 }));
 
 export const StyledNode = styled("li")({

--- a/packages/core/src/components/VerticalNavigation/TreeView/TreeViewItem.tsx
+++ b/packages/core/src/components/VerticalNavigation/TreeView/TreeViewItem.tsx
@@ -475,8 +475,11 @@ export const HvVerticalNavigationTreeViewItem = forwardRef(
           />
 
           {isOpen && (
-            <StyledLabel $expandable={!!expandable}>{label}</StyledLabel>
+            <StyledLabel $hasIcon={useIcons} $expandable={!!expandable}>
+              {label}
+            </StyledLabel>
           )}
+
           {isOpen && expandable && (expanded ? <DropUpXS /> : <DropDownXS />)}
         </StyledContent>
       ),


### PR DESCRIPTION
Fixes: https://github.com/lumada-design/hv-uikit-react/issues/3510

Before:

<img width="247" alt="Screenshot 2023-08-01 at 11 41 32" src="https://github.com/lumada-design/hv-uikit-react/assets/43220251/492d7ee7-184d-46ec-b159-4b0504e0a7d9">

After:

<img width="247" alt="Screenshot 2023-08-01 at 11 41 43" src="https://github.com/lumada-design/hv-uikit-react/assets/43220251/19bb4d13-a5ac-4517-9671-f3ee1144ceec">
