### PR TITLE
refactor: use hasOwnProperty instead of hasOwn

### DIFF
--- a/app/src/generator/utils.ts
+++ b/app/src/generator/utils.ts
@@ -46,7 +46,7 @@ export const themeDiff = (a: object, b: object): object => {
         diff[key] = nestedDiff;
       }
     } else if (
-      !Object.hasOwn(a, key) ||
+      !Object.prototype.hasOwnProperty.call(a, key) ||
       a[key as keyof typeof b] !== b[key as keyof typeof b]
     ) {
       diff[key as keyof typeof b] = b[key as keyof typeof b];

--- a/docs/foundation/colors/Colors.tsx
+++ b/docs/foundation/colors/Colors.tsx
@@ -19,7 +19,7 @@ import { themeColors } from "./themeColors";
 function groupColors(colorsJson) {
   const colorsMap = new Map();
   for (const key in colorsJson) {
-    if (Object.hasOwn(colorsJson, key)) {
+    if (Object.prototype.hasOwnProperty.call(colorsJson, key)) {
       colorsMap.set(key, colorsJson[key]);
     }
   }

--- a/packages/core/src/utils/classes.ts
+++ b/packages/core/src/utils/classes.ts
@@ -22,7 +22,7 @@ const deepRenameKeys = <T extends object>(
 ): T => {
   const result: any = {};
   for (const key in obj) {
-    if (Object.hasOwn(obj, key)) {
+    if (Object.prototype.hasOwnProperty.call(obj, key)) {
       const newKey = mapFn(key);
       const value = obj[key];
       result[newKey] =


### PR DESCRIPTION
- Instead of `Object.hasOwn` we now use `Object.prototype.hasOwnProperty.call` since the former was only introduced in Chrome 93 and we support lower versions. I did not use `obj.hasOwnProperty(key)` since this was leading to a ESLint error.
- This fixes the pa11y tests. Nothing was being tested since it uses Chrome 91. 

💡 Maybe we should think about using the [eslint-plugin-compat](https://github.com/amilajack/eslint-plugin-compat) to prevent using stuff that is not compatible with the browsers we support. I tested this plugin and it seems great but I decided not to add it since there's currently a [bug](https://github.com/amilajack/eslint-plugin-compat/issues/404) where nothing inside an if statement is reported as an error 😅 