### PR TITLE
fix(icons): replace name attribute with data-name

### DIFF
--- a/packages/core/src/components/DropDownMenu/DropDownMenu.tsx
+++ b/packages/core/src/components/DropDownMenu/DropDownMenu.tsx
@@ -142,6 +142,7 @@ export const HvDropDownMenu = ({
         >
           {icon || (
             <MoreOptionsVertical
+              role="presentation"
               color={disabled ? "secondary_60" : undefined}
             />
           )}

--- a/packages/icons/src/utils/converter/generateComponent.ts
+++ b/packages/icons/src/utils/converter/generateComponent.ts
@@ -78,7 +78,7 @@ export const ${componentName} = ({
   const size = useIconSize(iconSize, height, width, ${hasSpecialSize});
 
   return (
-    <IconBase iconSize={iconSize} name="${componentName}" {...others}>
+    <IconBase iconSize={iconSize} data-name="${componentName}" {...others}>
     ${svgOutput.replace("{...other}", "focusable={false} {...svgProps}")}
     </IconBase>
 )};


### PR DESCRIPTION
The [`name` attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes) should only be used in form elements. Our `div` icon components are adding the icon name to the `name` attribute.

Replaced `name` with `data-name` in case it's being used for testing, although this should probably be tested in a better way (select by label, role, or testid)