### PR TITLE
fix(VerticalNavigation): arial labels added to navigation slider buttons

### DIFF
--- a/packages/core/src/components/VerticalNavigation/Header/Header.tsx
+++ b/packages/core/src/components/VerticalNavigation/Header/Header.tsx
@@ -97,7 +97,7 @@ export const HvVerticalNavigationHeader = ({
       {...others}
     >
       {isOpen && headerTitle && slider && (
-        <HvButton icon onClick={backButtonClickHandler} {...backButtonProps}>
+        <HvButton icon onClick={backButtonClickHandler} aria-label="Back" {...backButtonProps}>
           <Backwards iconSize="XS" />
         </HvButton>
       )}

--- a/packages/core/src/components/VerticalNavigation/Navigation/Navigation.tsx
+++ b/packages/core/src/components/VerticalNavigation/Navigation/Navigation.tsx
@@ -93,6 +93,8 @@ export interface HvVerticalNavigationTreeProps
    * target - the behavior when opening an url.
    */
   data?: NavigationData[];
+  /** Aria label to apply to the navigate to submenu button on the navigation slider list items. */
+  sliderForwardButtonAriaLabel?: string;
 }
 
 const createListHierarchy = (
@@ -199,6 +201,8 @@ export const HvVerticalNavigationTree = ({
   selected: selectedProp,
   defaultSelected,
   onChange,
+
+  sliderForwardButtonAriaLabel = "Navigate to submenu",
 
   ...others
 }: HvVerticalNavigationTreeProps) => {
@@ -399,6 +403,7 @@ export const HvVerticalNavigationTree = ({
           selected={selected}
           onNavigateToTarget={navigateToTargetHandler}
           onNavigateToChild={navigateToChildHandler}
+          forwardButtonAriaLabel={sliderForwardButtonAriaLabel}
         />
       ) : (
         <HvVerticalNavigationTreeView

--- a/packages/core/src/components/VerticalNavigation/NavigationSlider/NavigationSlider.tsx
+++ b/packages/core/src/components/VerticalNavigation/NavigationSlider/NavigationSlider.tsx
@@ -50,6 +50,8 @@ export interface HvVerticalNavigationSliderProps {
     event: React.MouseEvent<HTMLButtonElement>,
     item: NavigationData
   ) => void;
+  /** Aria label to apply to the navigate to submenu button on the list items. */
+  forwardButtonAriaLabel?: string;
 }
 
 export const HvVerticalNavigationSlider = ({
@@ -59,6 +61,7 @@ export const HvVerticalNavigationSlider = ({
   selected,
   onNavigateToTarget,
   onNavigateToChild,
+  forwardButtonAriaLabel = "Navigate to submenu",
 }: HvVerticalNavigationSliderProps) => {
   return (
     <HvListContainer interactive id={id}>
@@ -89,6 +92,7 @@ export const HvVerticalNavigationSlider = ({
                   onClick={(event) => {
                     onNavigateToChild?.(event, item);
                   }}
+                  aria-label={forwardButtonAriaLabel}
                 >
                   <DropRightXS />
                 </HvButton>


### PR DESCRIPTION
Fixes: https://github.com/lumada-design/hv-uikit-react/issues/3357

- The missing `aria-label` attributes were added to the back and navigate to submenu buttons. 
- The default values can be overridden using the `backButtonProps` prop on the `HvVerticalNavigationHeader` component and the `sliderForwardButtonAriaLabel` prop on the `HvVerticalNavigationTree` component, respectively. 