### PR TITLE
fix(DropdownMenu): aria expanded set if role exists in base dropdown

### DIFF
--- a/packages/core/src/components/BaseDropdown/BaseDropdown.tsx
+++ b/packages/core/src/components/BaseDropdown/BaseDropdown.tsx
@@ -147,6 +147,7 @@ export const HvBaseDropdown = (props: HvBaseDropdownProps) => {
     onToggle,
     onClickOutside,
     onContainerCreation,
+    "aria-expanded": ariaExpandedProp,
     ...others
   } = useDefaultProps("HvBaseDropdown", props);
   const { classes, cx } = useClasses(classesProp);
@@ -174,6 +175,8 @@ export const HvBaseDropdown = (props: HvBaseDropdownProps) => {
   );
 
   const ariaRole = role || (component == null ? "combobox" : undefined);
+
+  const ariaExpanded = ariaExpandedProp ?? (ariaRole ? !!isOpen : undefined);
 
   const elementId = useUniqueId(id, "hvbasedropdown");
 
@@ -337,6 +340,9 @@ export const HvBaseDropdown = (props: HvBaseDropdownProps) => {
     if (component) {
       return React.cloneElement(component as React.ReactElement, {
         ref: handleDropdownHeaderRef,
+        "aria-controls": isOpen
+          ? setId(elementId, "children-container")
+          : undefined,
       });
     }
 
@@ -482,7 +488,7 @@ export const HvBaseDropdown = (props: HvBaseDropdownProps) => {
       <div
         id={id}
         role={ariaRole}
-        aria-expanded={!!isOpen}
+        aria-expanded={ariaExpanded}
         aria-owns={isOpen ? setId(elementId, "children-container") : undefined}
         className={cx(
           classes.anchor,


### PR DESCRIPTION
Fixes the accessibility problem with the dropdown menu: https://github.com/lumada-design/hv-uikit-react/issues/3537 

[The `aria-expanded` attribute was already defined on the custom button used on the dropdown menu.](https://github.com/lumada-design/hv-uikit-react/blob/master/packages/core/src/components/DropDownMenu/DropDownMenu.tsx#L142) Thus, I decided to remove the `aria-expanded` attribute from the dropdown menu's root container as none of the [authorised roles](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-expanded#associated_roles) seemed appropriate. This was fixed on the base dropdown component by not setting the `aria-expanded` attribute if no role is provided.