### PR TITLE
test(DatePicker): applitools interactions

### DIFF
--- a/packages/core/src/components/DatePicker/DatePicker.stories.tsx
+++ b/packages/core/src/components/DatePicker/DatePicker.stories.tsx
@@ -44,15 +44,6 @@ export const Main: StoryObj<HvDatePickerProps> = {
   argTypes: {
     classes: { control: { disable: true } },
   },
-  parameters: {
-    eyes: {
-      runBefore() {
-        fireEvent.click(screen.getByRole("combobox"));
-
-        return waitFor(() => screen.getByRole("tooltip"));
-      },
-    },
-  },
   decorators: [(Story) => <Decorator>{Story()}</Decorator>],
   render: (args) => {
     return (
@@ -298,6 +289,15 @@ export const NearInvalid: StoryObj<HvDatePickerProps> = {
 };
 
 export const WithValueChange: StoryObj<HvDatePickerProps> = {
+  parameters: {
+    eyes: {
+      runBefore() {
+        fireEvent.click(screen.getByRole("combobox"));
+
+        return waitFor(() => screen.getByRole("tooltip"));
+      },
+    },
+  },
   decorators: [(Story) => <Decorator>{Story()}</Decorator>],
   render: () => {
     const [date, setDate] = useState<Date | undefined>(new Date(2020, 0, 1));


### PR DESCRIPTION
This fixes the reason why the nightly broke today. When I added interactions in the stories for applitools, I forgot the selected date changes every day on the main story 🙃 I remove the interactions in the main story and added them to another one which always have the same selected date.