### PR TITLE
fix: add color contrast ignore rule to the pa11y config

### DIFF
--- a/.config/pa11yci.config.js
+++ b/.config/pa11yci.config.js
@@ -32,7 +32,10 @@ module.exports = (async () => {
         ignoreHTTPSErrors: true,
         args: ["--no-sandbox", "--disable-setuid-sandbox"],
       },
-      ignore: ["color-contrast"],
+      ignore: [
+        "color-contrast",
+        "WCAG2AA.Principle1.Guideline1_4.1_4_3.G18.Fail",
+      ],
     },
     urls: storiesUrls,
   };


### PR DESCRIPTION
we already have `color-contrast` as an ignore rule on our pa11y config file. This adds the actual rule that is being vioated on our color contrast violations.