### PR TITLE
chore: remove unused ie11 polyfills

### DIFF
--- a/packages/core/src/components/BulkActions/BulkActions.tsx
+++ b/packages/core/src/components/BulkActions/BulkActions.tsx
@@ -166,11 +166,6 @@ export const HvBulkActions = (props: HvBulkActionsProps) => {
             [`& .${staticClasses.selectAll}:focus-within div`]: {
               backgroundColor: hexToRgbA(baseColor, 0.3),
             },
-
-            // IE fallback code (using focus-within-polyfill)
-            [`& .${staticClasses.selectAll}.focus-within div`]: {
-              backgroundColor: hexToRgbA(baseColor, 0.3),
-            },
           }),
         className
       )}

--- a/packages/core/src/components/CheckBoxGroup/CheckBoxGroup.styles.tsx
+++ b/packages/core/src/components/CheckBoxGroup/CheckBoxGroup.styles.tsx
@@ -22,10 +22,6 @@ export const { staticClasses, useClasses } = createClasses("HvCheckBoxGroup", {
     "&>*:focus-within": {
       zIndex: 1,
     },
-    // IE fallback code (using focus-within-polyfill)
-    "&>*.focus-within": {
-      zIndex: 1,
-    },
   },
   horizontal: {
     flexDirection: "row",

--- a/packages/core/src/components/DropDownMenu/DropDownMenu.styles.tsx
+++ b/packages/core/src/components/DropDownMenu/DropDownMenu.styles.tsx
@@ -14,7 +14,7 @@ export const { staticClasses, useClasses } = createClasses("HvDropDownMenu", {
   root: {
     display: "inline-block",
     width: "auto",
-    "&.focus-visible $icon": {
+    "&:focus-visible $icon": {
       ...outlineStyles,
     },
   },

--- a/packages/core/src/components/FilterGroup/RightPanel/RightPanel.styles.tsx
+++ b/packages/core/src/components/FilterGroup/RightPanel/RightPanel.styles.tsx
@@ -24,10 +24,6 @@ export const { staticClasses, useClasses } = createClasses(name, {
     "&:focus-within": {
       zIndex: 1,
     },
-    // IE fallback code (using focus-within-polyfill)
-    "&.focus-within": {
-      zIndex: 1,
-    },
   },
   selectAll: {
     width: "100%",

--- a/packages/core/src/components/List/List.styles.tsx
+++ b/packages/core/src/components/List/List.styles.tsx
@@ -34,10 +34,6 @@ export const StyledSelectAllCheckBox = styled((props: HvCheckBoxProps) => (
   "&:focus-within": {
     zIndex: 1,
   },
-  // IE fallback code (using focus-within-polyfill)
-  "&.focus-within": {
-    zIndex: 1,
-  },
 });
 
 export const StyledMultiSelectCheckBox = styled((props: HvCheckBoxProps) => (
@@ -53,12 +49,6 @@ export const StyledMultiSelectCheckBox = styled((props: HvCheckBoxProps) => (
     },
 
     "&:focus-within": {
-      backgroundColor: "transparent",
-      outline: "none",
-      boxShadow: "none",
-    },
-    // IE fallback code (using focus-within-polyfill)
-    "&.focus-within": {
       backgroundColor: "transparent",
       outline: "none",
       boxShadow: "none",
@@ -100,12 +90,6 @@ export const StyledSingleSelectRadio = styled((props: HvRadioProps) => (
       outline: "none",
       boxShadow: "none",
     },
-    // IE fallback code (using focus-within-polyfill)
-    "&.focus-within": {
-      backgroundColor: "transparent",
-      outline: "none",
-      boxShadow: "none",
-    },
   },
   [`& .${radioClasses.label}`]: {
     display: "inline-block",
@@ -122,9 +106,6 @@ export const StyledListItem = styled(
   [`& .${listItemClasses.selected}`]: {
     ...($applySelected && {
       "&:not(:hover):not(.HvIsFocused):not(:focus-within)": {
-        backgroundColor: "transparent",
-      },
-      "&:not(:hover):not(.HvIsFocused):not(.focus-within)": {
         backgroundColor: "transparent",
       },
     }),

--- a/packages/core/src/components/RadioGroup/RadioGroup.styles.tsx
+++ b/packages/core/src/components/RadioGroup/RadioGroup.styles.tsx
@@ -22,10 +22,6 @@ export const { staticClasses, useClasses } = createClasses("HvRadioGroup", {
     "&>*:focus-within": {
       zIndex: 1,
     },
-    // IE fallback code (using focus-within-polyfill)
-    "&>*.focus-within": {
-      zIndex: 1,
-    },
   },
   horizontal: {
     flexDirection: "row",

--- a/packages/core/src/components/SelectionList/SelectionList.styles.tsx
+++ b/packages/core/src/components/SelectionList/SelectionList.styles.tsx
@@ -32,10 +32,6 @@ export const { staticClasses, useClasses } = createClasses("HvSelectionList", {
     "&>*:focus-within": {
       zIndex: 1,
     },
-    // IE fallback code (using focus-within-polyfill)
-    "&>*.focus-within": {
-      zIndex: 1,
-    },
   },
   invalid: { borderBottom: `1px solid ${theme.colors.negative}` },
 });

--- a/packages/core/src/components/VerticalNavigation/TreeView/TreeViewItem.styles.tsx
+++ b/packages/core/src/components/VerticalNavigation/TreeView/TreeViewItem.styles.tsx
@@ -95,14 +95,8 @@ export const StyledContent = styled(HvTypography)({
   // focus
   [`:not(.${treeViewItemClasses.disabled}>&):not(.${treeViewItemClasses.selected}>&):focus-visible`]:
     hover(),
-  [`:not(.${treeViewItemClasses.disabled}>&):not(.${treeViewItemClasses.selected}>&).focus-visible`]:
-    hover(),
 
   [`*:focus-visible .${treeViewItemClasses.focused}>&`]: {
-    ...outlineStyles,
-  },
-
-  [` .focus-visible .${treeViewItemClasses.focused}>&`]: {
     ...outlineStyles,
   },
 
@@ -119,10 +113,6 @@ export const StyledContent = styled(HvTypography)({
   },
 
   "&:focus-visible": {
-    ...outlineStyles,
-  },
-
-  "&.focus-visible": {
     ...outlineStyles,
   },
 

--- a/packages/core/src/components/VerticalNavigation/TreeView/descendants.tsx
+++ b/packages/core/src/components/VerticalNavigation/TreeView/descendants.tsx
@@ -23,17 +23,6 @@ type Item = {
   [key: string]: unknown;
 };
 
-// To replace with .findIndex() once we stop IE11 support.
-function findIndex(array, comp) {
-  for (let i = 0; i < array.length; i += 1) {
-    if (comp(array[i])) {
-      return i;
-    }
-  }
-
-  return -1;
-}
-
 function binaryFindElement(array, element) {
   let start = 0;
   let end = array.length - 1;
@@ -120,8 +109,7 @@ export function useDescendant(descendant) {
   // index on the following render and we will re-register descendants
   // so that everything is up-to-date before the user interacts with a
   // collection.
-  const index = findIndex(
-    descendants,
+  const index = descendants.findIndex(
     (item) => item.element === descendant.element
   );
 


### PR DESCRIPTION
Remove remaining `.focus-within` and `.focus-visible` polyfill classes.

We don't support IE11 anymore. And even if we did, these class polyfills aren't being applied