### PR TITLE
build(icons): split `svgo` optimizer from converter & improve docs

### DIFF
--- a/packages/icons/README.md
+++ b/packages/icons/README.md
@@ -12,4 +12,16 @@ npm install @hitachivantara/uikit-react-icons
 
 ## Adding New Icons
 
-To add new icons, you should copy the `.svg` to the `assets` directory and execute `npm run build`.
+1. Copy the `.svg` to the `assets` directory.
+2. Run `npm run optimize` to optimize the icons (using `svgo`).
+3. Run `npm run build` to convert the SVGs to React components & build the package.
+
+## File structure
+
+```sh
+icons/
+├── assets # optimized `.svg` assets
+├── bin    # `.tsx` icon components
+├── dist   # built artifacts (by `vite build`)
+└── src    # .svg to React component generator scripts
+```

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -25,9 +25,9 @@
   "scripts": {
     "prebuild": "npm run convert",
     "build": "vite build",
+    "optimize": "svgo -r -f assets assets",
     "preconvert": "npx rimraf bin",
     "convert": "run-s convert:*",
-    "convert:optimize": "svgo --config=./svgo.config.js -r -f assets assets",
     "convert:svg": "tsx src/svgToReact.ts dir --input assets --output bin --force",
     "convert:copy": "npx cpy \"src/IconBase*\" \"bin\"",
     "clean": "npx rimraf dist bin package",


### PR DESCRIPTION
- move `svgo` optimizer out of `npm run convert` (to `npm run optimize`)
  - improves performance (less stuff to "build")
  - `svgo` rarely needs to be run (only when adding new icons)
  - `svgo` changes need to be manually reviewed, as it changes source-code files
- improve icons package docs (file structure & adding icons)