### PR TITLE
chore(ThemeCreator): refactor use of context

### DIFF
--- a/app/src/components/common/Header/Header.tsx
+++ b/app/src/components/common/Header/Header.tsx
@@ -14,13 +14,13 @@ import {
 import logo from "assets/logo.png";
 import { NavigationContext } from "lib/context/NavigationContext";
 import navigation from "lib/navigation";
-import { GeneratorContext } from "generator/GeneratorContext";
+import { useGeneratorContext } from "generator/GeneratorContext";
 
 export const Header = () => {
   const navigate = useNavigate();
   const theme = useTheme();
   const { activePath } = useContext(NavigationContext);
-  const { setOpen, open, setTutorialOpen } = useContext(GeneratorContext);
+  const { setOpen, open, setTutorialOpen } = useGeneratorContext();
 
   const isXs = useMediaQuery(theme.breakpoints.only("xs"));
 

--- a/app/src/components/common/Tutorial/Step.tsx
+++ b/app/src/components/common/Tutorial/Step.tsx
@@ -8,8 +8,8 @@ import {
   HvDialogTitle,
   HvTypography,
 } from "@hitachivantara/uikit-react-core";
-import { GeneratorContext } from "generator/GeneratorContext";
-import { Dispatch, SetStateAction, useContext, useEffect } from "react";
+import { useGeneratorContext } from "generator/GeneratorContext";
+import { Dispatch, SetStateAction, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import { tutorialData } from "./tutorialData";
 import classes from "./tutorialStyles";
@@ -25,7 +25,7 @@ export const Step = ({
   nextHandler: (value: boolean) => void;
   setTutorialOpen: Dispatch<SetStateAction<boolean>> | undefined;
 }) => {
-  const { setOpen, setCurrentStep } = useContext(GeneratorContext);
+  const { setOpen, setCurrentStep } = useGeneratorContext();
   const navigate = useNavigate();
 
   useEffect(() => {

--- a/app/src/generator/CodeEditor/CodeEditor.tsx
+++ b/app/src/generator/CodeEditor/CodeEditor.tsx
@@ -5,14 +5,8 @@ import {
   HvTypography,
   useTheme,
 } from "@hitachivantara/uikit-react-core";
-import { GeneratorContext } from "generator/GeneratorContext";
-import {
-  Dispatch,
-  SetStateAction,
-  useContext,
-  useEffect,
-  useState,
-} from "react";
+import { useGeneratorContext } from "generator/GeneratorContext";
+import { Dispatch, SetStateAction, useEffect, useState } from "react";
 import debounce from "lodash/debounce";
 import JSON5 from "json5";
 import { Download, Reset, Duplicate } from "@hitachivantara/uikit-react-icons";
@@ -31,7 +25,7 @@ const CodeEditor = ({
   const { selectedTheme, selectedMode, changeTheme } = useTheme();
 
   const { customTheme, updateCustomTheme, themeChanges } =
-    useContext(GeneratorContext);
+    useGeneratorContext();
 
   const fileName = `${themeName}.ts`;
 

--- a/app/src/generator/Colors/Colors.tsx
+++ b/app/src/generator/Colors/Colors.tsx
@@ -3,8 +3,7 @@ import {
   HvTypography,
   useTheme,
 } from "@hitachivantara/uikit-react-core";
-import { GeneratorContext } from "generator/GeneratorContext";
-import { useContext } from "react";
+import { useGeneratorContext } from "generator/GeneratorContext";
 import debounce from "lodash/debounce";
 import { HvThemeTokens } from "@hitachivantara/uikit-styles";
 import { styles } from "./Colors.styles";
@@ -12,7 +11,7 @@ import { getColorGroupName, getColors, groupsToShow } from "./utils";
 
 const Colors = (): JSX.Element => {
   const { activeTheme, selectedMode } = useTheme();
-  const { customTheme, updateCustomTheme } = useContext(GeneratorContext);
+  const { customTheme, updateCustomTheme } = useGeneratorContext();
 
   const colors = activeTheme?.colors.modes[selectedMode];
 

--- a/app/src/generator/Content.tsx
+++ b/app/src/generator/Content.tsx
@@ -4,8 +4,7 @@ import { Container, Tutorial } from "components/common";
 import { NavigationProvider } from "lib/context/NavigationContext";
 import navigation from "lib/navigation";
 import Routes from "lib/routes";
-import { useContext } from "react";
-import { GeneratorContext } from "./GeneratorContext";
+import { useGeneratorContext } from "./GeneratorContext";
 
 const Content = () => {
   const { selectedMode } = useTheme();
@@ -16,7 +15,7 @@ const Content = () => {
     setTutorialOpen,
     currentStep,
     setCurrentStep,
-  } = useContext(GeneratorContext);
+  } = useGeneratorContext();
 
   return (
     <div

--- a/app/src/generator/FontFamily/FontFamily.tsx
+++ b/app/src/generator/FontFamily/FontFamily.tsx
@@ -1,4 +1,4 @@
-import { SyntheticEvent, useContext, useState } from "react";
+import { SyntheticEvent, useState } from "react";
 import {
   HvBox,
   HvButton,
@@ -7,7 +7,7 @@ import {
   HvListValue,
   HvSnackbar,
 } from "@hitachivantara/uikit-react-core";
-import { GeneratorContext } from "generator/GeneratorContext";
+import { useGeneratorContext } from "generator/GeneratorContext";
 import { Add } from "@hitachivantara/uikit-react-icons";
 import { css } from "@emotion/css";
 import { SnackbarCloseReason } from "@mui/material";
@@ -15,7 +15,7 @@ import { extractFontsNames } from "generator/utils";
 import { styles } from "./FontFamily.styles";
 
 const FontFamily = () => {
-  const { updateCustomTheme } = useContext(GeneratorContext);
+  const { updateCustomTheme } = useGeneratorContext();
 
   const [fontName, setFontName] = useState("");
   const [fontValues, setFontValues] = useState<HvListValue[]>([

--- a/app/src/generator/FontSizes/FontSizes.tsx
+++ b/app/src/generator/FontSizes/FontSizes.tsx
@@ -1,4 +1,4 @@
-import { useContext, useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import {
   theme,
   useTheme,
@@ -6,7 +6,7 @@ import {
   HvDropdown,
   HvListValue,
 } from "@hitachivantara/uikit-react-core";
-import { GeneratorContext } from "generator/GeneratorContext";
+import { useGeneratorContext } from "generator/GeneratorContext";
 import { css } from "@emotion/css";
 import { FontSize } from "components/common";
 import { extractFontSizeUnit } from "generator/utils";
@@ -14,7 +14,7 @@ import { styles } from "./FontSizes.styles";
 
 const FontSizes = () => {
   const { activeTheme } = useTheme();
-  const { updateCustomTheme } = useContext(GeneratorContext);
+  const { updateCustomTheme } = useGeneratorContext();
   const [fontSizes, setFontSizes] = useState<HvListValue[]>([]);
   const [fontSize, setFontSize] = useState(""); // base, sm, ...
   const [fontValue, setFontValue] = useState<number>(); // 14, 16, ...

--- a/app/src/generator/GeneratorContext.tsx
+++ b/app/src/generator/GeneratorContext.tsx
@@ -11,6 +11,7 @@ import React, {
   Dispatch,
   SetStateAction,
   useCallback,
+  useContext,
 } from "react";
 import merge from "lodash/merge";
 import { themeDiff } from "./utils";
@@ -41,10 +42,9 @@ type GeneratorContextProp = {
   themeChanges?: Partial<HvTheme | HvThemeStructure>;
 };
 
-export const GeneratorContext = createContext<GeneratorContextProp>({
-  customTheme: createTheme({ name: "customTheme", base: "ds5" }),
-  updateCustomTheme: () => {},
-});
+export const GeneratorContext = createContext<GeneratorContextProp | null>(
+  null
+);
 
 const initialTheme = createTheme({ name: "customTheme", base: "ds5" });
 
@@ -147,6 +147,16 @@ const GeneratorProvider = ({ children }: { children: React.ReactNode }) => {
       {children}
     </GeneratorContext.Provider>
   );
+};
+
+export const useGeneratorContext = () => {
+  const context = useContext(GeneratorContext);
+  if (context === null) {
+    throw new Error(
+      "useGeneratorContext must be used within a GeneratorProvider"
+    );
+  }
+  return context;
 };
 
 export default GeneratorProvider;

--- a/app/src/generator/Radii/Radii.tsx
+++ b/app/src/generator/Radii/Radii.tsx
@@ -6,13 +6,13 @@ import {
   useTheme,
 } from "@hitachivantara/uikit-react-core";
 import { HvThemeTokens } from "@hitachivantara/uikit-styles";
-import { useContext, useState } from "react";
-import { GeneratorContext } from "generator/GeneratorContext";
+import { useState } from "react";
+import { useGeneratorContext } from "generator/GeneratorContext";
 import { styles } from "./Radii.styles";
 
 const Radii = () => {
   const { activeTheme } = useTheme();
-  const { customTheme, updateCustomTheme } = useContext(GeneratorContext);
+  const { customTheme, updateCustomTheme } = useGeneratorContext();
   const [currValues, setCurrValues] = useState<Map<string, string | number>>(
     new Map<string, string | number>()
   );

--- a/app/src/generator/Sidebar/Sidebar.tsx
+++ b/app/src/generator/Sidebar/Sidebar.tsx
@@ -12,8 +12,8 @@ import {
   theme,
   useTheme,
 } from "@hitachivantara/uikit-react-core";
-import { lazy, Suspense, useContext, useState } from "react";
-import { GeneratorContext } from "generator/GeneratorContext";
+import { lazy, Suspense, useState } from "react";
+import { useGeneratorContext } from "generator/GeneratorContext";
 import CodeEditor from "generator/CodeEditor";
 import {
   Bold,
@@ -37,7 +37,7 @@ const Sidebar = () => {
   const { selectedTheme, selectedMode, colorModes, changeTheme, themes } =
     useTheme();
 
-  const { customTheme, updateCustomTheme, open } = useContext(GeneratorContext);
+  const { customTheme, updateCustomTheme, open } = useGeneratorContext();
 
   const [copied, setCopied] = useState(false);
   const [tab, setTab] = useState(0);

--- a/app/src/generator/Sizes/Sizes.tsx
+++ b/app/src/generator/Sizes/Sizes.tsx
@@ -6,13 +6,13 @@ import {
   useTheme,
 } from "@hitachivantara/uikit-react-core";
 import { HvThemeTokens } from "@hitachivantara/uikit-styles";
-import { useContext, useState } from "react";
-import { GeneratorContext } from "generator/GeneratorContext";
+import { useState } from "react";
+import { useGeneratorContext } from "generator/GeneratorContext";
 import { styles } from "./Sizes.styles";
 
 const Sizes = () => {
   const { activeTheme } = useTheme();
-  const { customTheme, updateCustomTheme } = useContext(GeneratorContext);
+  const { customTheme, updateCustomTheme } = useGeneratorContext();
   const [currValues, setCurrValues] = useState<Map<string, string>>(
     new Map<string, string>()
   );

--- a/app/src/generator/Spacing/Spacing.tsx
+++ b/app/src/generator/Spacing/Spacing.tsx
@@ -6,13 +6,13 @@ import {
   useTheme,
 } from "@hitachivantara/uikit-react-core";
 import { HvThemeTokens } from "@hitachivantara/uikit-styles";
-import { useContext, useState } from "react";
-import { GeneratorContext } from "generator/GeneratorContext";
+import { useState } from "react";
+import { useGeneratorContext } from "generator/GeneratorContext";
 import { styles } from "./Spacing.styles";
 
 const Spacing = () => {
   const { activeTheme } = useTheme();
-  const { customTheme, updateCustomTheme } = useContext(GeneratorContext);
+  const { customTheme, updateCustomTheme } = useGeneratorContext();
   const [currValues, setCurrValues] = useState<Map<string, string | number>>(
     new Map<string, string | number>()
   );

--- a/app/src/generator/Typography/Typography.tsx
+++ b/app/src/generator/Typography/Typography.tsx
@@ -10,8 +10,8 @@ import {
 } from "@hitachivantara/uikit-react-core";
 import { HvThemeTokens, HvThemeTypography } from "@hitachivantara/uikit-styles";
 import { extractFontSizeUnit } from "generator/utils";
-import { useContext, useEffect, useState } from "react";
-import { GeneratorContext } from "generator/GeneratorContext";
+import { useEffect, useState } from "react";
+import { useGeneratorContext } from "generator/GeneratorContext";
 import debounce from "lodash/debounce";
 import { css } from "@emotion/css";
 import { FontSize } from "components/common";
@@ -30,7 +30,7 @@ const typographyToShow: (keyof HvThemeTypography["typography"])[] = [
 ];
 
 const Typography = () => {
-  const { customTheme, updateCustomTheme } = useContext(GeneratorContext);
+  const { customTheme, updateCustomTheme } = useGeneratorContext();
   const { rootId } = useTheme();
 
   const [updatedHeights, setUpdatedHeights] = useState<Map<string, string>>(

--- a/app/src/generator/Zindices/Zindices.tsx
+++ b/app/src/generator/Zindices/Zindices.tsx
@@ -6,13 +6,13 @@ import {
   useTheme,
 } from "@hitachivantara/uikit-react-core";
 import { HvThemeTokens } from "@hitachivantara/uikit-styles";
-import { useContext, useState } from "react";
-import { GeneratorContext } from "generator/GeneratorContext";
+import { useState } from "react";
+import { useGeneratorContext } from "generator/GeneratorContext";
 import { styles } from "./Zindices.styles";
 
 const Zindices = () => {
   const { activeTheme } = useTheme();
-  const { customTheme, updateCustomTheme } = useContext(GeneratorContext);
+  const { customTheme, updateCustomTheme } = useGeneratorContext();
   const [currValues, setCurrValues] = useState<Map<string, number>>(
     new Map<string, number>()
   );

--- a/app/src/pages/Instructions/Instructions.tsx
+++ b/app/src/pages/Instructions/Instructions.tsx
@@ -23,12 +23,11 @@ import {
   ColorPicker,
   FontSizeBigger,
 } from "@hitachivantara/uikit-react-icons";
-import { GeneratorContext } from "generator/GeneratorContext";
-import { useContext } from "react";
+import { useGeneratorContext } from "generator/GeneratorContext";
 import classes from "./styles";
 
 const Instructions = () => {
-  const { setTutorialOpen } = useContext(GeneratorContext);
+  const { setTutorialOpen } = useGeneratorContext();
 
   const tutorialClickHandler = () => {
     setTutorialOpen?.((prev) => !prev);


### PR DESCRIPTION
Updated the use of the context in the Theme Creator. Created a new hook that deals with validating if the context exists, allowing the `GeneratorContext` to be initialized as null instead of actually unnecessarily creating a new theme just for that purpose. The components that need to use the context use this custom hook instead of having to import `useContext` and `GeneratorContext` everytime.