### PR TITLE
fix(Header): aria-current set to true if item has sub levels

### DIFF
--- a/packages/core/src/components/Header/Header.stories.tsx
+++ b/packages/core/src/components/Header/Header.stories.tsx
@@ -12,10 +12,14 @@ import {
   HvHeaderBrand,
   HvHeaderNavigation,
   HvHeaderNavigationProps,
+  HvVerticalNavigation,
+  HvVerticalNavigationTree,
+  HvHeaderNavigationItemProp,
+  theme,
 } from "@hitachivantara/uikit-react-core";
 import { HitachiLogo } from "./assets/HitachiLogo";
 
-const navigationData = [
+const navigationDataMain = [
   {
     id: "1",
     label: "Overview",
@@ -80,7 +84,6 @@ export default {
   title: "Widgets/Header",
   component: HvHeader,
   subcomponents: { HvHeaderBrand, HvHeaderNavigation, HvHeaderActions },
-  decorators: [(Story) => <div style={{ height: 150 }}>{Story()}</div>],
 } as Meta<typeof HvHeader>;
 
 export const Main: StoryObj<HvHeaderProps> = {
@@ -93,10 +96,11 @@ export const Main: StoryObj<HvHeaderProps> = {
       control: "select",
     },
   },
+  decorators: [(Story) => <div style={{ height: 150 }}>{Story()}</div>],
   render: ({ position }) => {
     const [selected, setSelected] = useState<string>("2");
     const handleChange: HvHeaderNavigationProps["onClick"] = (
-      e,
+      event,
       selectedItem
     ) => {
       if (selectedItem.href) {
@@ -124,7 +128,7 @@ export const Main: StoryObj<HvHeaderProps> = {
           <HvHeaderBrand logo={<HitachiLogo />} name="Lumada App" />
           {isLgUp && (
             <HvHeaderNavigation
-              data={navigationData}
+              data={navigationDataMain}
               selected={selected}
               onClick={handleChange}
             />
@@ -145,6 +149,157 @@ export const Main: StoryObj<HvHeaderProps> = {
             )}
           </HvHeaderActions>
         </HvHeader>
+      </div>
+    );
+  },
+};
+
+const navigationDataCombined = [
+  {
+    id: "1",
+    label: "Overview",
+    data: [
+      {
+        id: "1-1",
+        label: "Model Effectiveness 1",
+        href: "/overview/model-effectiveness",
+      },
+      {
+        id: "1-2",
+        label: "Trend Analysis 1-2",
+        href: "/overview/trend-analysis",
+      },
+    ],
+  },
+  {
+    id: "2",
+    label: "Events",
+    href: "/events",
+  },
+  {
+    id: "3",
+    label: "Work Orders",
+    data: [
+      {
+        id: "3-1",
+        label: "Model Effectiveness 3-1",
+        data: [
+          {
+            id: "3-1-1",
+            label: "Another Sub Level 3-1-1",
+            href: "/work-orders/model-effectiveness-3-1-1",
+          },
+          {
+            id: "3-1-2",
+            label: "Another Sub Level 3-1-2",
+            href: "/work-orders/trend-analysis-3-1-2",
+          },
+        ],
+      },
+      {
+        id: "3-2",
+        label: "Trend Analysis 3-2",
+        href: "/work-orders/trend-analysis",
+      },
+    ],
+  },
+  {
+    id: "4",
+    label: "Assets",
+    href: "/assets",
+  },
+  {
+    id: "5",
+    label: "Analytics",
+    data: [
+      {
+        id: "5-1",
+        label: "Model Effectiveness 5-1",
+        href: "/analytics/model-effectiveness",
+      },
+      {
+        id: "5-2",
+        label: "Trend Analysis 5-2",
+        href: "/analytics/trend-analysis",
+      },
+    ],
+  },
+];
+
+export const CombinedNavigation: StoryObj<HvHeaderProps> = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Horizontal and vertical navigation were combined for better organization and distribution of multi-level navigation.",
+      },
+    },
+  },
+  decorators: [(Story) => <div style={{ height: 300 }}>{Story()}</div>],
+  render: () => {
+    const [selectedHeaderItem, setSelectedHeaderItem] =
+      useState<HvHeaderNavigationItemProp>(navigationDataCombined[0]);
+    const [selected, setSelected] = useState(
+      navigationDataCombined[0].data?.[0].id
+    );
+
+    const traverseItem = (item: HvHeaderNavigationItemProp) => {
+      if (item.data) {
+        return traverseItem(item.data[0]);
+      }
+      return item.id;
+    };
+
+    const handleChange: HvHeaderNavigationProps["onClick"] = (event, item) => {
+      setSelectedHeaderItem(item);
+      setSelected(traverseItem(item));
+    };
+
+    const muiTheme = useTheme();
+    const isLgUp = useMediaQuery(muiTheme.breakpoints.up("lg"));
+
+    return (
+      <div>
+        <HvHeader position="relative">
+          {!isLgUp && (
+            <HvButton
+              icon
+              onClick={() => console.log("menu")}
+              style={{ width: 32, height: 32 }}
+            >
+              <Menu />
+            </HvButton>
+          )}
+
+          {isLgUp && (
+            <HvHeaderNavigation
+              data={navigationDataCombined}
+              selected={selectedHeaderItem.id}
+              onClick={handleChange}
+              levels={1}
+            />
+          )}
+        </HvHeader>
+        <div
+          style={{
+            display: "flex",
+            height: `calc(300px - ${theme.header.height})`,
+          }}
+        >
+          <HvVerticalNavigation>
+            <HvVerticalNavigationTree
+              collapsible
+              defaultExpanded
+              selected={selected}
+              onChange={(event, data) => {
+                event.preventDefault();
+
+                setSelected(data.id);
+              }}
+              data={selectedHeaderItem.data ?? [selectedHeaderItem]}
+            />
+          </HvVerticalNavigation>
+        </div>
       </div>
     );
   },

--- a/packages/core/src/components/Header/Navigation/MenuItem/MenuItem.tsx
+++ b/packages/core/src/components/Header/Navigation/MenuItem/MenuItem.tsx
@@ -63,17 +63,20 @@ export const HvHeaderMenuItem = ({
   const { classes, cx } = useClasses(classesProp);
 
   const selectionPath = useContext(SelectionContext);
+
   const { dispatch } = useContext(FocusContext);
 
   const { data } = item;
+
   const hasSubLevel = data && data.length;
+
   const isMenu = type === "menu";
+
   const isSelected = selectionPath?.[isMenu ? 1 : 0] === item.id;
-  const isCurrent = isSelected
-    ? selectionPath?.length > (isMenu ? 2 : 1)
-      ? true
-      : "page"
-    : undefined;
+
+  // true: if the item is part of the selection path but is not the current page the user is seeing, i.e has more sub levels
+  // page: used when the selected item is actually the current page the user is seeing
+  const isCurrent = isSelected ? (hasSubLevel ? true : "page") : undefined;
 
   const actionHandler = (event: any) => {
     if (
@@ -84,6 +87,7 @@ export const HvHeaderMenuItem = ({
       if (event.type === "click") {
         event.currentTarget.blur();
       }
+
       onClick?.(event, item);
     }
   };
@@ -156,7 +160,8 @@ export const HvHeaderMenuItem = ({
           {label}
         </div>
       )}
-      {hasSubLevel && currentLevel < levels && (
+      {/* Limits levels to no more than 2. More than that is not expected and not in DS. */}
+      {hasSubLevel && currentLevel < levels && currentLevel < 2 && (
         <Bar data={data} type="menu">
           {data.map((itm: HvHeaderNavigationItemProp) => (
             <HvHeaderMenuItem

--- a/packages/core/src/components/Header/Navigation/Navigation.tsx
+++ b/packages/core/src/components/Header/Navigation/Navigation.tsx
@@ -23,6 +23,11 @@ export interface HvHeaderNavigationProps
   selected?: string;
   onClick?: (event: MouseEvent, selection: HvHeaderNavigationItemProp) => void;
   classes?: HvHeaderNavigationClasses;
+  /**
+   * The number of levels to show: the first level (1) or the first and second level (2).
+   *
+   * Defaults to `2`.
+   * */
   levels?: 1 | 2;
 }
 
@@ -41,7 +46,10 @@ export const HvHeaderNavigation = (props: HvHeaderNavigationProps) => {
 
   const selectionPath = useSelectionPath(data, selected);
 
-  const handleClick: HvHeaderMenuBarProps["onClick"] = (event, selection) => {
+  const handleClick: HvHeaderMenuBarProps["onClick"] = (
+    event: MouseEvent,
+    selection: HvHeaderNavigationItemProp
+  ) => {
     event.preventDefault();
 
     onClick?.(event, selection);

--- a/packages/core/src/components/Header/Navigation/useSelectionPath.ts
+++ b/packages/core/src/components/Header/Navigation/useSelectionPath.ts
@@ -11,28 +11,34 @@ export interface HvHeaderNavigationItemProp {
 
 const getSelectionPath = (
   data: HvHeaderNavigationItemProp[] | undefined,
-  selectedId: string,
+  selectedId: string | undefined,
   selection: string[] = [],
   idx: number = -1,
   parent: HvHeaderNavigationItemProp[] = []
 ): string[] => {
   data?.forEach((item: HvHeaderNavigationItemProp, i) => {
     const hasData = item.data && item.data.length;
+
     const isSelected = item.id === selectedId;
 
     if (isSelected)
       selection.push(...(idx > -1 ? [parent[idx].id] : []), item.id);
+
     if (hasData) getSelectionPath(item.data, selectedId, selection, i, data);
   });
 
   return selection;
 };
 
-export const useSelectionPath = (data, selectedId): string[] => {
+export const useSelectionPath = (
+  data: HvHeaderNavigationItemProp[],
+  selectedId?: string
+): string[] => {
   const [selectionPath, setSelectionPath] = useState<string[]>([]);
 
   useEffect(() => {
     const path = getSelectionPath(data, selectedId);
+
     setSelectionPath(path);
   }, [data, selectedId]);
 


### PR DESCRIPTION
This PR fixes https://github.com/lumada-design/hv-uikit-react/issues/3525:
- The `aria-current` is now set to `true` if the selected item has sub levels. Otherwise, it's set to `page`.
- The header has been limited to 2 levels since using more levels leads to weird behaviours and it's [not supported in DS](https://designsystem.hitachivantara.com/6c705d900/v/0/p/90fb01-navigation-system/b/07cb30).
- A new story was added to showcase how this can be used. 