### PR TITLE
feat(ConfusionMatrix): confusion matrix added

### DIFF
--- a/.config/pa11yci.config.js
+++ b/.config/pa11yci.config.js
@@ -13,6 +13,7 @@ const filterStories = (stories) => {
     "Visualizations/Bar Chart",
     "Visualizations/Line Chart",
     "Visualizations/Donut Chart",
+    "Visualizations/Confusion Matrix",
   ];
 
   return Object.values(stories).reduce((acc, story) => {

--- a/docs/overview/migration/MigrationV5.stories.mdx
+++ b/docs/overview/migration/MigrationV5.stories.mdx
@@ -63,8 +63,6 @@ migrate your application at the moment since their development is still in progr
 
 The following components are missing:
 
-- From `@hitachivantara/uikit-react-viz`:
-  - Confusion matrix
 - From `@hitachivantara/uikit-react-lab`:
   - Navigation anchors
   - Notification panel

--- a/docs/overview/status/data.json
+++ b/docs/overview/status/data.json
@@ -227,7 +227,7 @@
     {
       "name": "Confusion Matrix",
       "features": "",
-      "status": "⌛",
+      "status": "✅",
       "notes": ""
     },
     {

--- a/packages/viz/src/components/BarChart/BarChart.tsx
+++ b/packages/viz/src/components/BarChart/BarChart.tsx
@@ -73,19 +73,21 @@ export const HvBarChart = ({
   legend,
   tooltip,
   classes,
+  height,
+  width,
 }: HvBarChartProps) => {
   const chartData = useData({ data, groupBy, sortBy, splitBy, measures });
 
   const chartDataset = useDataset(chartData);
 
   const chartYAxis = useYAxis({
-    yAxis,
+    axes: Array.isArray(yAxis) || yAxis == null ? yAxis : [yAxis],
     defaultType: horizontal ? "categorical" : "continuous",
   });
 
   const chartXAxis = useXAxis({
-    xAxis,
-    defaultType: horizontal ? "continuous" : "categorical",
+    type: horizontal ? "continuous" : "categorical",
+    ...xAxis,
   });
 
   const chartSlider = useDataZoom({
@@ -140,5 +142,5 @@ export const HvBarChart = ({
     chartTooltip,
   ]);
 
-  return <HvBaseChart options={options} />;
+  return <HvBaseChart options={options} width={width} height={height} />;
 };

--- a/packages/viz/src/components/ConfusionMatrix/ConfusionMatrix.stories.tsx
+++ b/packages/viz/src/components/ConfusionMatrix/ConfusionMatrix.stories.tsx
@@ -1,0 +1,255 @@
+import { theme } from "@hitachivantara/uikit-react-core";
+import {
+  HvConfusionMatrix,
+  HvConfusionMatrixProps,
+} from "@hitachivantara/uikit-react-viz";
+import { Meta, StoryObj } from "@storybook/react";
+
+const meta: Meta<typeof HvConfusionMatrix> = {
+  title: "Visualizations/Confusion Matrix",
+  component: HvConfusionMatrix,
+  parameters: { eyes: { include: false } },
+  decorators: [
+    (Story) => (
+      <div
+        style={{
+          backgroundColor: theme.colors.atmo1,
+          padding: 20,
+        }}
+      >
+        {Story()}
+      </div>
+    ),
+  ],
+};
+export default meta;
+
+const mockData = {
+  prediction: [
+    "Beaver",
+    "Beaver",
+    "Beaver",
+    "Beaver",
+    "Lion",
+    "Lion",
+    "Lion",
+    "Lion",
+    "Seal",
+    "Seal",
+    "Seal",
+    "Seal",
+    "Dog",
+    "Dog",
+    "Dog",
+    "Dog",
+  ],
+  expected: [
+    "Beaver",
+    "Lion",
+    "Seal",
+    "Dog",
+    "Beaver",
+    "Lion",
+    "Seal",
+    "Dog",
+    "Beaver",
+    "Lion",
+    "Seal",
+    "Dog",
+    "Beaver",
+    "Lion",
+    "Seal",
+    "Dog",
+  ],
+  matches: [95, 15, 1, 20, 10, 97, 8, 40, 6, 12, 100, 16, 2, 9, 12, 90],
+};
+
+export const Main: StoryObj<HvConfusionMatrixProps> = {
+  args: {
+    format: "square",
+  },
+  argTypes: {
+    measure: { control: { disable: true } },
+    splitBy: { control: { disable: true } },
+    data: { control: { disable: true } },
+    delta: { control: { disable: true } },
+    xAxis: { control: { disable: true } },
+    yAxis: { control: { disable: true } },
+    tooltip: { control: { disable: true } },
+    valuesProps: { control: { disable: true } },
+    classes: { control: { disable: true } },
+    groupBy: { control: { disable: true } },
+    sortBy: { control: { disable: true } },
+    legend: { control: { disable: true } },
+    grid: { control: { disable: true } },
+  },
+  render: ({ data, measure, groupBy, splitBy, sortBy, ...others }) => {
+    return (
+      <HvConfusionMatrix
+        data={{
+          prediction: mockData.prediction,
+          expected: mockData.expected,
+          matches: mockData.matches,
+        }}
+        measure="matches"
+        groupBy="prediction"
+        splitBy="expected"
+        {...others}
+      />
+    );
+  },
+};
+
+export const DeltaConfusionMatrix: StoryObj<HvConfusionMatrixProps> = {
+  render: () => {
+    return (
+      <HvConfusionMatrix
+        data={{
+          prediction: mockData.prediction,
+          expected: mockData.expected,
+          matches: mockData.matches,
+          baseline: [
+            90, 15, 1, 20, 10, 100, 8, 40, 4, 12, 90, 16, 2, 21, 12, 90,
+          ],
+        }}
+        delta="baseline"
+        measure="matches"
+        groupBy="prediction"
+        splitBy="expected"
+      />
+    );
+  },
+};
+
+export const SemanticConfusionMatrix: StoryObj<HvConfusionMatrixProps> = {
+  render: () => {
+    return (
+      <HvConfusionMatrix
+        data={{
+          prediction: mockData.prediction,
+          expected: mockData.expected,
+          matches: [
+            0, 0.15, 0, 0, 0, 0.97, 0, 0, 0.6, 0.12, 0, 0, 0.2, 0.9, 0, 0,
+          ],
+        }}
+        colorScale={[
+          {
+            label: "Good",
+            color: "positive",
+            max: 1,
+            min: 0.75,
+          },
+          {
+            label: "Caution",
+            color: "warning",
+            max: 0.75,
+            min: 0.3,
+          },
+          {
+            label: "Bad",
+            color: "negative",
+            max: 0.3,
+            min: 0,
+          },
+          {
+            label: "Neutral",
+            color: "atmo2",
+            value: 0,
+          },
+        ]}
+        measure="matches"
+        groupBy="prediction"
+        splitBy="expected"
+      />
+    );
+  },
+};
+
+export const CustomConfusionMatrix: StoryObj<HvConfusionMatrixProps> = {
+  render: () => {
+    return (
+      <HvConfusionMatrix
+        data={{
+          prediction: mockData.prediction,
+          expected: mockData.expected,
+          matches: mockData.matches,
+        }}
+        measure="matches"
+        groupBy="prediction"
+        splitBy="expected"
+        width={800}
+        height={800}
+        colorScale={["purple", "blue"]}
+        yAxis={{
+          name: "Expected Values",
+          nameProps: {
+            color: "red",
+            fontSize: 14,
+          },
+        }}
+        xAxis={{
+          name: "X Values",
+          position: "bottom",
+          nameProps: {
+            color: "red",
+            fontSize: 14,
+          },
+        }}
+        valuesProps={{
+          color: "white",
+          fontSize: 20,
+          fontStyle: "italic",
+        }}
+      />
+    );
+  },
+};
+
+export const ConfusionMatrixWithoutValues: StoryObj<HvConfusionMatrixProps> = {
+  render: () => {
+    return (
+      <HvConfusionMatrix
+        data={{
+          prediction: mockData.prediction,
+          expected: mockData.expected,
+          matches: mockData.matches,
+        }}
+        measure="matches"
+        groupBy="prediction"
+        splitBy="expected"
+        valuesProps={{ show: false }}
+      />
+    );
+  },
+};
+
+export const LandscapeFormat: StoryObj<HvConfusionMatrixProps> = {
+  render: () => {
+    const base = ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j"];
+    const prediction = base.reduce((acc: string[], curr: string) => {
+      acc.push(...Array.from(Array(base.length), () => curr));
+      return acc;
+    }, []);
+    const expected = Array.from(
+      Array(base.length * base.length),
+      () => base
+    ).flat();
+    const matches = Array.from(Array(base.length * base.length), () =>
+      Math.random().toFixed(2)
+    ).flat();
+
+    return (
+      <HvConfusionMatrix
+        data={{
+          prediction,
+          expected,
+          matches,
+        }}
+        measure="matches"
+        groupBy="prediction"
+        splitBy="expected"
+        format="landscape"
+      />
+    );
+  },
+};

--- a/packages/viz/src/components/ConfusionMatrix/ConfusionMatrix.styles.tsx
+++ b/packages/viz/src/components/ConfusionMatrix/ConfusionMatrix.styles.tsx
@@ -1,0 +1,25 @@
+import { createClasses, theme } from "@hitachivantara/uikit-react-core";
+
+export const { useClasses, staticClasses } = createClasses(
+  "HvConfusionMatrix",
+  {
+    tooltipRoot: {
+      backgroundColor: theme.colors.atmo1,
+      width: "fit-content",
+      minWidth: 150,
+      boxShadow: theme.colors.shadow,
+      zIndex: theme.zIndices.sticky,
+    },
+    tooltipContainer: {
+      padding: theme.spacing(["15px", "sm"]),
+      display: "flex",
+      flexDirection: "column",
+    },
+    tooltipText: {
+      fontFamily: theme.fontFamily.body,
+      fontWeight: theme.fontWeights.normal,
+      fontSize: theme.fontSizes.sm,
+      color: theme.colors.secondary,
+    },
+  }
+);

--- a/packages/viz/src/components/ConfusionMatrix/ConfusionMatrix.tsx
+++ b/packages/viz/src/components/ConfusionMatrix/ConfusionMatrix.tsx
@@ -1,0 +1,271 @@
+import { useMemo } from "react";
+
+import { Arrayable, ExtractNames } from "@hitachivantara/uikit-react-core";
+
+import * as echarts from "echarts/core";
+import { HeatmapChart } from "echarts/charts";
+import {
+  VisualMapComponent,
+  GridComponent,
+  TooltipComponent,
+} from "echarts/components";
+
+import {
+  HvVisualMapHookProps,
+  useData,
+  useGrid,
+  useTooltip,
+  useVisualMap,
+  useXAxis,
+  useYAxis,
+} from "@viz/hooks";
+import { getGroupKey } from "@viz/utils";
+
+import { HvBaseChart } from "../BaseChart";
+import { useClasses } from "./ConfusionMatrix.styles";
+import {
+  HvChartCommonProps,
+  HvChartXAxis,
+  HvChartYAxis,
+} from "../../types/common";
+import { HvChartTooltip } from "../../types/tooltip";
+import { HvConfusionMatrixMeasure } from "../../types/measures";
+import { useColorScale, useGridLayout, useSeries } from "./utils";
+import {
+  HvConfusionMatrixFormat,
+  HvConfusionMatrixColorScale,
+  HvConfusionMatrixValuesProps,
+} from "./types";
+
+// Register chart components
+echarts.use([
+  HeatmapChart,
+  VisualMapComponent,
+  GridComponent,
+  TooltipComponent,
+]);
+
+export type HvConfusionMatrixClasses = ExtractNames<typeof useClasses>;
+
+export interface HvConfusionMatrixProps
+  extends Omit<HvChartCommonProps, "tooltip"> {
+  /** Column to measure. */
+  measure: HvConfusionMatrixMeasure;
+  /** Columns to use to split the measure. */
+  splitBy?: Arrayable<string>;
+  /**
+   * Column to use for the delta confusion matrix.
+   *
+   * It can be set to `true` in case the `measure` already has the calculations for the delta confusion matrix.
+   */
+  delta?: boolean | string;
+  /** Options for the xAxis, i.e. the horizontal axis. */
+  xAxis?: HvChartXAxis;
+  /** Options for the yAxis, i.e. the vertical axis. */
+  yAxis?: HvChartYAxis;
+  /** Tooltip options. */
+  tooltip?: Omit<HvChartTooltip, "type">;
+  /** Format of the confusion matrix. Defaults to `square`. */
+  format?: HvConfusionMatrixFormat;
+  /** Properties to customize the prediction values. */
+  valuesProps?: HvConfusionMatrixValuesProps;
+  /** A Jss Object used to override or extend the styles applied to the component. */
+  classes?: HvConfusionMatrixClasses;
+  /**
+   * Color scale of the confusion matrix.
+   *
+   * If an array of two strings is provided, the first and second values are the lower and upper ends of the scale, respectively.
+   * An array of objects can also be used to create a custom scale.
+   * If `delta` is not provided, a default color scale is used when `colorScale` is not defined: `[base-light, cat3]`.
+   */
+  colorScale?: [string, string] | HvConfusionMatrixColorScale[];
+}
+
+/**
+ * Confusion Matrix is a table displaying the performance of a predictive model.
+ * Typically the columns show the predicted class and the rows the expected class.
+ * The main diagonal counts the positive matches while the cells outside it count the mismatches between predicted and expected.
+ */
+export const HvConfusionMatrix = ({
+  legend,
+  groupBy,
+  measure,
+  sortBy,
+  splitBy,
+  grid,
+  data: dataProp,
+  tooltip,
+  xAxis,
+  yAxis,
+  colorScale: colorScaleProp,
+  delta,
+  valuesProps,
+  width,
+  height,
+  format = "square",
+  classes: classesProp,
+}: HvConfusionMatrixProps) => {
+  const { classes } = useClasses(classesProp);
+
+  const groupByKey = getGroupKey(groupBy);
+
+  const chartData = useData({
+    data: dataProp,
+    groupBy,
+    measures: [measure],
+    sortBy: sortBy ?? groupBy, // automatically orders x axis to create the confusion matrix
+    splitBy,
+    delta: typeof delta === "string" ? delta : undefined,
+  });
+
+  const colorScale = useColorScale({
+    delta: !!delta,
+    data: chartData,
+    custom: colorScaleProp,
+    filterKey: groupByKey,
+  });
+
+  const chartVisualMap = useVisualMap({
+    show: colorScale?.pieces != null,
+    type: colorScale?.pieces != null ? "piecewise" : "continuous",
+    ...(colorScale as Pick<
+      HvVisualMapHookProps,
+      "max" | "min" | "colorScale" | "pieces"
+    >),
+    ...legend,
+  });
+
+  const chartTooltip = useTooltip({
+    component: (params) => {
+      const value = params?.series?.[0].value;
+      const fmtValue =
+        typeof measure !== "string" && measure.valueFormatter
+          ? measure.valueFormatter(value)
+          : tooltip?.valueFormatter
+          ? tooltip?.valueFormatter(value)
+          : value;
+      const ftmTitle = tooltip?.titleFormatter
+        ? tooltip.titleFormatter(params?.title)
+        : params?.title;
+
+      const content = `${ftmTitle} - ${params?.series?.[0].name}: ${fmtValue}`;
+
+      return `
+        <div class="${classes.tooltipRoot}">
+            <div class="${classes.tooltipContainer}">
+                <div>
+                    <p class="${classes.tooltipText}">${content}</p>
+                </div>
+            </div>
+        </div>`;
+    },
+    ...tooltip,
+  });
+
+  const chartYAxis = useYAxis({
+    axes: [
+      {
+        type: "categorical",
+        name: "True Label",
+        position: "left",
+        ...yAxis,
+        nameProps: {
+          location: "center",
+          padding:
+            yAxis?.nameProps?.location == null ||
+            yAxis?.nameProps?.location === "center"
+              ? yAxis?.position === "right"
+                ? [50, 0, 0, 0]
+                : [0, 0, 50, 0]
+              : undefined,
+          ...yAxis?.nameProps,
+        },
+        data: chartData
+          .columnNames()
+          .filter((p) => p !== groupByKey)
+          .reverse(),
+      },
+    ],
+  });
+
+  const chartXAxis = useXAxis({
+    name: "Predicted Value",
+    position: "top",
+    ...xAxis,
+    nameProps: {
+      location: "center",
+      padding:
+        xAxis?.nameProps?.location == null ||
+        xAxis?.nameProps?.location === "center"
+          ? xAxis?.position === "bottom"
+            ? [30, 0, 0, 0]
+            : [0, 0, 30, 0]
+          : undefined,
+      ...xAxis?.nameProps,
+    },
+    data: chartData.array(groupByKey),
+  });
+
+  const chartSeries = useSeries({
+    data: chartData,
+    filterKey: groupByKey,
+    valuesProps,
+    delta: !!(delta && colorScale == null),
+  });
+
+  const chartGridLayout = useGridLayout({
+    data: chartData,
+    format,
+    filterKey: groupByKey,
+    visualMapVisible: chartVisualMap.visualMap.show,
+    visualMapYPosition: chartVisualMap.visualMap.top,
+    xAxisPosition: chartXAxis.xAxis.position,
+  });
+
+  const chartGrid = useGrid({
+    // If sizes are provided, the grid size should automatically adapt to the values provided
+    width: width != null ? undefined : chartGridLayout.size.width,
+    height: height != null ? undefined : chartGridLayout.size.height,
+    ...chartGridLayout.padding,
+    ...grid,
+  });
+
+  const size = useMemo(() => {
+    return {
+      width,
+      // Echarts has a problem were the height is always set to 300px
+      // Thus, we need to update the height to make sure the chart is not cut out
+      height:
+        height ??
+        chartGridLayout.size.height +
+          chartGridLayout.padding.bottom +
+          chartGridLayout.padding.top,
+    };
+  }, [
+    chartGridLayout.padding.bottom,
+    chartGridLayout.padding.top,
+    chartGridLayout.size.height,
+    height,
+    width,
+  ]);
+
+  const options = useMemo(() => {
+    return {
+      ...chartVisualMap,
+      ...chartTooltip,
+      ...chartGrid,
+      ...chartXAxis,
+      ...chartYAxis,
+      ...chartSeries,
+    };
+  }, [
+    chartVisualMap,
+    chartTooltip,
+    chartGrid,
+    chartYAxis,
+    chartSeries,
+    chartXAxis,
+  ]);
+
+  return <HvBaseChart options={options} {...size} />;
+};

--- a/packages/viz/src/components/ConfusionMatrix/index.ts
+++ b/packages/viz/src/components/ConfusionMatrix/index.ts
@@ -1,0 +1,2 @@
+export * from "./types";
+export * from "./ConfusionMatrix";

--- a/packages/viz/src/components/ConfusionMatrix/types.ts
+++ b/packages/viz/src/components/ConfusionMatrix/types.ts
@@ -1,0 +1,23 @@
+export interface HvConfusionMatrixColorScale {
+  /** You can use either an HEX or color name from the palette. */
+  color: string;
+  label: string;
+  max?: number;
+  min?: number;
+  value?: number;
+}
+
+export interface HvConfusionMatrixValuesProps {
+  /** Whether to show the prediction values inside the confusion matrix or not. Defaults to `true`. */
+  show?: boolean;
+  /** Prediction values label color. You can use either an HEX or color name from the palette. */
+  color?: string;
+  /** Prediction values label font style. */
+  fontStyle?: "normal" | "italic";
+  /** Prediction values label font weight. */
+  fontWeight?: number;
+  /** Prediction values label font size. */
+  fontSize?: number;
+}
+
+export type HvConfusionMatrixFormat = "square" | "landscape";

--- a/packages/viz/src/components/ConfusionMatrix/utils.ts
+++ b/packages/viz/src/components/ConfusionMatrix/utils.ts
@@ -1,0 +1,216 @@
+import { useMemo, useCallback } from "react";
+
+import type ColumnTable from "arquero/dist/types/table/column-table";
+
+import { useTheme } from "@hitachivantara/uikit-react-core";
+
+import { HvChartXAxis } from "@viz/types/common";
+
+import {
+  HvConfusionMatrixColorScale,
+  HvConfusionMatrixFormat,
+  HvConfusionMatrixValuesProps,
+} from "./types";
+
+export const useColorScale = ({
+  data,
+  delta,
+  custom,
+  filterKey,
+}: {
+  data: ColumnTable;
+  delta: boolean;
+  filterKey: string;
+  custom?: [string, string] | HvConfusionMatrixColorScale[];
+}) => {
+  const { activeTheme, selectedMode } = useTheme();
+
+  const colorScale = useMemo(() => {
+    if (custom == null && delta) {
+      return;
+    }
+
+    if (custom && typeof custom[0] === "object") {
+      return {
+        pieces: (custom as HvConfusionMatrixColorScale[]).reduce(
+          (acc: HvConfusionMatrixColorScale[], curr) => {
+            acc.push({
+              ...curr,
+              color:
+                activeTheme?.colors.modes[selectedMode][curr.color] ||
+                curr.color,
+            });
+            return acc;
+          },
+          []
+        ),
+      };
+    }
+
+    const flatData = data
+      .columnNames()
+      .filter((p) => p !== filterKey)
+      .reduce((acc: number[], c: string) => {
+        acc.push(...data.array(c));
+        return acc;
+      }, []);
+    const max = Math.max(...flatData);
+    const min = Math.min(...flatData);
+
+    return {
+      colorScale: custom || [
+        activeTheme?.colors.modes[selectedMode].base_light || "",
+        activeTheme?.colors.modes[selectedMode].cat3 || "",
+      ],
+      max,
+      min,
+    };
+  }, [activeTheme?.colors.modes, custom, data, filterKey, delta, selectedMode]);
+
+  return colorScale;
+};
+
+export const useSeries = ({
+  data,
+  filterKey,
+  delta,
+  valuesProps,
+}: {
+  data: ColumnTable;
+  filterKey: string;
+  delta: boolean;
+  valuesProps?: HvConfusionMatrixValuesProps;
+}) => {
+  const { activeTheme, selectedMode } = useTheme();
+
+  const getDeltaColor = useCallback(
+    (value: number, diagonal: boolean) => {
+      if ((diagonal && value > 0) || (!diagonal && value < 0)) {
+        return activeTheme?.colors.modes[selectedMode].positive;
+      }
+      if ((diagonal && value < 0) || (!diagonal && value > 0)) {
+        return activeTheme?.colors.modes[selectedMode].negative;
+      }
+
+      return activeTheme?.colors.modes[selectedMode].base_light;
+    },
+    [activeTheme?.colors.modes, selectedMode]
+  );
+
+  const chartSeries = useMemo(() => {
+    return {
+      series: {
+        id: `series~${filterKey}`,
+        type: "heatmap",
+        label: {
+          show: true,
+          ...valuesProps,
+          ...(valuesProps?.color && {
+            color:
+              activeTheme?.colors.modes[selectedMode][valuesProps.color] ||
+              valuesProps.color,
+          }),
+        },
+        emphasis: {
+          disabled: true,
+        },
+        data: data
+          .columnNames()
+          .filter((p) => p !== filterKey)
+          .reduce((acc: (string | number)[][], c: string, j) => {
+            const row: (string | number)[][] = data
+              .array(c)
+              .reduce((racc, rv, i) => {
+                racc.push({
+                  value: [data.array(filterKey)[i], c, rv != null ? rv : "-"],
+                  ...(delta && {
+                    visualMap: false,
+                    itemStyle: {
+                      color: getDeltaColor(rv, i === j),
+                    },
+                  }),
+                });
+                return racc;
+              }, []);
+
+            acc.push(...row);
+            return acc;
+          }, []),
+      },
+    };
+  }, [
+    activeTheme?.colors.modes,
+    data,
+    delta,
+    filterKey,
+    getDeltaColor,
+    selectedMode,
+    valuesProps,
+  ]);
+
+  return chartSeries;
+};
+
+const SQUARE_SIZE = 52;
+
+export const useGridLayout = ({
+  data,
+  filterKey,
+  format,
+  xAxisPosition,
+  visualMapVisible,
+  visualMapYPosition,
+}: {
+  xAxisPosition: HvChartXAxis["position"];
+  data: ColumnTable;
+  filterKey: string;
+  format: HvConfusionMatrixFormat;
+  visualMapVisible: boolean;
+  visualMapYPosition: "top" | "center" | "bottom";
+}) => {
+  const size = useMemo(() => {
+    const nCols = data.array(filterKey).length;
+    const nRows = data.columnNames().filter((p) => p !== filterKey).length;
+    const itemHeight = format === "square" ? SQUARE_SIZE : SQUARE_SIZE / 2;
+
+    return {
+      padding: {
+        bottom:
+          xAxisPosition === "bottom" ||
+          (visualMapVisible && visualMapYPosition === "bottom")
+            ? 60
+            : 20,
+        top:
+          xAxisPosition === "top" ||
+          (visualMapVisible && visualMapYPosition === "top")
+            ? 60
+            : 20,
+        ...(visualMapVisible &&
+          visualMapYPosition === "bottom" &&
+          xAxisPosition === "bottom" && {
+            bottom: 100,
+          }),
+        ...(visualMapVisible &&
+          visualMapYPosition === "top" &&
+          xAxisPosition === "top" && {
+            top: 100,
+          }),
+        left: 80,
+        right: 80,
+      },
+      size: {
+        height: Math.max(itemHeight * nRows, itemHeight * 8),
+        width: Math.max(SQUARE_SIZE * nCols, SQUARE_SIZE * 8),
+      },
+    };
+  }, [
+    data,
+    filterKey,
+    format,
+    visualMapVisible,
+    visualMapYPosition,
+    xAxisPosition,
+  ]);
+
+  return size;
+};

--- a/packages/viz/src/components/DonutChart/DonutChart.stories.tsx
+++ b/packages/viz/src/components/DonutChart/DonutChart.stories.tsx
@@ -35,7 +35,21 @@ const meta: Meta<typeof HvDonutChart> = {
 export default meta;
 
 export const Main: StoryObj<HvDonutChartProps> = {
-  render: () => {
+  args: {
+    type: "regular",
+  },
+  argTypes: {
+    measure: { control: { disable: true } },
+    slicesNameFormatter: { control: { disable: true } },
+    data: { control: { disable: true } },
+    groupBy: { control: { disable: true } },
+    sortBy: { control: { disable: true } },
+    tooltip: { control: { disable: true } },
+    legend: { control: { disable: true } },
+    grid: { control: { disable: true } },
+    classes: { control: { disable: true } },
+  },
+  render: ({ data, groupBy, measure, ...others }) => {
     return (
       <HvDonutChart
         data={{
@@ -44,6 +58,7 @@ export const Main: StoryObj<HvDonutChartProps> = {
         }}
         groupBy="Type"
         measure="Music"
+        {...others}
       />
     );
   },

--- a/packages/viz/src/components/DonutChart/DonutChart.tsx
+++ b/packages/viz/src/components/DonutChart/DonutChart.tsx
@@ -58,6 +58,8 @@ export const HvDonutChart = ({
   measure: measures,
   sortBy,
   grid,
+  width,
+  height,
   type = "regular",
   slicesNameFormatter,
 }: HvDonutChartProps) => {
@@ -100,5 +102,5 @@ export const HvDonutChart = ({
     };
   }, [chartSeries, chartDataset, chartLegend, chartTooltip, chartGrid]);
 
-  return <HvBaseChart options={options} />;
+  return <HvBaseChart options={options} width={width} height={height} />;
 };

--- a/packages/viz/src/components/LineChart/LineChart.tsx
+++ b/packages/viz/src/components/LineChart/LineChart.tsx
@@ -80,14 +80,18 @@ export const HvLineChart = ({
   legend,
   classes,
   tooltip,
+  width,
+  height,
 }: HvLineChartProps) => {
   const chartData = useData({ data, groupBy, measures, splitBy, sortBy });
 
   const chartDataset = useDataset(chartData);
 
-  const chartYAxis = useYAxis({ yAxis });
+  const chartYAxis = useYAxis({
+    axes: Array.isArray(yAxis) || yAxis == null ? yAxis : [yAxis],
+  });
 
-  const chartXAxis = useXAxis({ xAxis, scale: true });
+  const chartXAxis = useXAxis({ ...xAxis, scale: true });
 
   const chartSlider = useDataZoom({
     showHorizontal: horizontalRangeSlider?.show,
@@ -141,5 +145,5 @@ export const HvLineChart = ({
     chartTooltip,
   ]);
 
-  return <HvBaseChart options={options} />;
+  return <HvBaseChart options={options} width={width} height={height} />;
 };

--- a/packages/viz/src/components/index.ts
+++ b/packages/viz/src/components/index.ts
@@ -1,3 +1,4 @@
 export * from "./LineChart";
 export * from "./BarChart";
 export * from "./DonutChart";
+export * from "./ConfusionMatrix";

--- a/packages/viz/src/hooks/index.ts
+++ b/packages/viz/src/hooks/index.ts
@@ -7,4 +7,5 @@ export * from "./useData";
 export * from "./useDataset";
 export * from "./useSeries";
 export * from "./useLegend";
+export * from "./useVisualMap";
 export * from "./tooltip";

--- a/packages/viz/src/hooks/tooltip/useTooltip.tsx
+++ b/packages/viz/src/hooks/tooltip/useTooltip.tsx
@@ -29,7 +29,7 @@ interface EChartsTooltipParams {
 }
 
 interface HvTooltipHookProps {
-  measures:
+  measures?:
     | Arrayable<HvLineChartMeasures | HvBarChartMeasures>
     | HvDonutChartMeasure;
   trigger?: "item" | "axis";
@@ -44,7 +44,7 @@ interface HvTooltipHookProps {
 }
 
 export const useTooltip = ({
-  measures,
+  measures = [],
   classes,
   component,
   show = true,
@@ -75,7 +75,6 @@ export const useTooltip = ({
             : horizontal
             ? params[0].dimensionNames[params[0].encode.x[0]]
             : params[0].dimensionNames[params[0].encode.y[0]],
-
           measures
         );
 
@@ -181,9 +180,14 @@ export const useTooltip = ({
           series: params.map((p) => {
             return {
               color: p.color,
-              name: p.seriesType === "pie" ? p.name : p.seriesName,
+              name:
+                p.seriesType === "heatmap"
+                  ? String(p.value[p.encode.y[0]])
+                  : p.seriesType === "pie"
+                  ? p.name
+                  : p.seriesName,
               value:
-                p.seriesType === "pie"
+                p.seriesType === "pie" || p.seriesType === "heatmap"
                   ? p.value[p.encode.value[0]]
                   : horizontal
                   ? p.value[p.encode.x[0]]

--- a/packages/viz/src/hooks/useData.tsx
+++ b/packages/viz/src/hooks/useData.tsx
@@ -24,6 +24,7 @@ interface HvDataHookProps {
     | HvDonutChartMeasure;
   splitBy?: HvAxisChartCommonProps["splitBy"];
   sortBy?: HvChartCommonProps["sortBy"];
+  delta?: string;
 }
 
 export const useData = ({
@@ -32,6 +33,7 @@ export const useData = ({
   measures,
   sortBy,
   splitBy,
+  delta,
 }: HvDataHookProps): internal.ColumnTable => {
   const groupByKey = getGroupKey(groupBy);
 
@@ -113,6 +115,22 @@ export const useData = ({
       ...Object.keys(measuresFields),
     ];
 
+    // --- Confusion matrix ---
+    // Recalculate the measures columns according to the delta column
+    if (delta) {
+      const deltaExpression = Object.keys(measuresFields).reduce(
+        (acc, curr) => {
+          return {
+            ...acc,
+            [curr]: `d => d.${curr} - d.${delta}`,
+          };
+        },
+        {}
+      );
+
+      tableData = tableData.derive(deltaExpression);
+    }
+
     // remove unneeded fields
     tableData = tableData.select(...allFields);
 
@@ -158,7 +176,7 @@ export const useData = ({
     }
 
     return tableData;
-  }, [data, groupBy, groupByKey, splitBy, measures, sortBy]);
+  }, [data, groupBy, splitBy, measures, sortBy, delta, groupByKey]);
 
   return chartData;
 };

--- a/packages/viz/src/hooks/useGrid.tsx
+++ b/packages/viz/src/hooks/useGrid.tsx
@@ -9,9 +9,18 @@ interface HvGridHookProps {
   bottom?: HvChartGrid["bottom"];
   left?: HvChartGrid["left"];
   right?: HvChartGrid["right"];
+  width?: number | string;
+  height?: number | string;
 }
 
-export const useGrid = ({ top, left, right, bottom }: HvGridHookProps) => {
+export const useGrid = ({
+  top,
+  left,
+  right,
+  bottom,
+  width,
+  height,
+}: HvGridHookProps) => {
   const option = useMemo<Pick<EChartsOption, "grid">>(() => {
     return {
       // if no value is defined we shouldn't pass anything because echarts doesn't behave well otherwise
@@ -28,9 +37,15 @@ export const useGrid = ({ top, left, right, bottom }: HvGridHookProps) => {
         ...(right != null && {
           right,
         }),
+        ...(width != null && {
+          width,
+        }),
+        ...(height != null && {
+          height,
+        }),
       },
     };
-  }, [top, left, right, bottom]);
+  }, [top, left, right, bottom, height, width]);
 
   return option;
 };

--- a/packages/viz/src/hooks/useVisualMap.tsx
+++ b/packages/viz/src/hooks/useVisualMap.tsx
@@ -1,0 +1,69 @@
+import { useMemo } from "react";
+
+import type { EChartsOption } from "echarts-for-react/lib/types";
+
+import { getLegendIcon } from "@viz/utils";
+import { HvChartLegend } from "@viz/types";
+
+export interface HvVisualMapHookProps {
+  show?: boolean;
+  pieces?: Record<string, string | number>[];
+  max?: number;
+  min?: number;
+  colorScale?: string[];
+  type?: "continuous" | "piecewise";
+  // Uses the same props as the legend
+  position?: HvChartLegend["position"];
+  direction?: HvChartLegend["direction"];
+}
+
+export const useVisualMap = ({
+  show = true,
+  direction = "horizontal",
+  type = "continuous",
+  pieces,
+  max,
+  min,
+  colorScale,
+  position: positionProp,
+}: HvVisualMapHookProps) => {
+  const option = useMemo<Pick<EChartsOption, "visualMap">>(() => {
+    return {
+      visualMap: {
+        type,
+        show,
+        ...(pieces && {
+          pieces,
+        }),
+        ...(type === "piecewise" && {
+          itemSymbol: getLegendIcon("square"),
+          itemGap: 20,
+          itemHeight: 16,
+          itemWidth: 16,
+        }),
+        ...(colorScale && {
+          max,
+          min,
+          inRange: {
+            color: colorScale,
+          },
+        }),
+        orient: direction,
+        top: positionProp?.y || "top",
+        left: positionProp?.x || "center",
+      },
+    };
+  }, [
+    colorScale,
+    direction,
+    max,
+    min,
+    pieces,
+    positionProp?.x,
+    positionProp?.y,
+    show,
+    type,
+  ]);
+
+  return option;
+};

--- a/packages/viz/src/hooks/useXAxis.tsx
+++ b/packages/viz/src/hooks/useXAxis.tsx
@@ -2,37 +2,87 @@ import { useMemo } from "react";
 
 import type { EChartsOption } from "echarts-for-react/lib/types";
 
-import { getAxisType } from "@viz/utils";
-import { HvAxisChartCommonProps } from "@viz/types/common";
-import { HvChartAxisType } from "@viz/types";
+import { useTheme } from "@hitachivantara/uikit-react-core";
 
-interface HvXAxisHookProps {
-  xAxis: HvAxisChartCommonProps["xAxis"];
-  defaultType?: HvChartAxisType;
+import { getAxisType } from "@viz/utils";
+import { HvChartXAxis } from "@viz/types/common";
+
+interface HvXAxisHookProps extends HvChartXAxis {
   scale?: boolean;
+  data?: string[];
 }
 
 export const useXAxis = ({
-  xAxis,
-  defaultType = "categorical",
+  id,
+  type = "categorical",
+  labelFormatter,
+  labelRotation,
+  name,
+  maxValue,
+  minValue,
   scale = false,
+  data,
+  position,
+  nameProps,
 }: HvXAxisHookProps) => {
+  const { activeTheme, selectedMode } = useTheme();
+
   const option = useMemo<Pick<EChartsOption, "xAxis">>(() => {
+    const nameStyleKeys = nameProps
+      ? Object.keys(nameProps).filter((key) => key !== "location")
+      : undefined;
+    const nameStyle =
+      nameProps && nameStyleKeys
+        ? nameStyleKeys.reduce((acc, curr) => {
+            return {
+              ...acc,
+              [curr]:
+                curr === "color"
+                  ? activeTheme?.colors.modes[selectedMode][
+                      nameProps[curr] as string
+                    ] || nameProps[curr]
+                  : nameProps[curr],
+            };
+          }, {})
+        : undefined;
+
     return {
       xAxis: {
-        id: xAxis?.id,
-        type: getAxisType(xAxis?.type) ?? getAxisType(defaultType),
-        name: xAxis?.name,
+        id,
+        type: getAxisType(type),
+        name,
         scale,
         axisLabel: {
-          rotate: xAxis?.labelRotation ?? 0,
-          formatter: xAxis?.labelFormatter,
+          rotate: labelRotation ?? 0,
+          formatter: labelFormatter,
         },
-        max: xAxis?.maxValue === "max" ? "dataMax" : xAxis?.maxValue,
-        min: xAxis?.minValue === "min" ? "dataMin" : xAxis?.minValue,
+        max: maxValue === "max" ? "dataMax" : maxValue,
+        min: minValue === "min" ? "dataMin" : minValue,
+        ...(nameProps?.location && {
+          nameLocation: nameProps.location,
+        }),
+        ...(nameStyle && {
+          nameTextStyle: nameStyle,
+        }),
+        ...(data && { data }),
+        ...(position && { position }),
       },
     };
-  }, [xAxis, scale, defaultType]);
+  }, [
+    nameProps,
+    id,
+    type,
+    name,
+    scale,
+    labelRotation,
+    labelFormatter,
+    maxValue,
+    minValue,
+    data,
+    position,
+    activeTheme?.colors.modes,
+    selectedMode,
+  ]);
 
   return option;
 };

--- a/packages/viz/src/types/axis.ts
+++ b/packages/viz/src/types/axis.ts
@@ -6,6 +6,8 @@
  */
 export type HvChartAxisType = "continuous" | "categorical" | "time";
 
+export type HvChartAxisNameLocation = "start" | "end" | "center";
+
 /** Axis definition */
 export interface HvChartAxis {
   id?: string;
@@ -19,6 +21,21 @@ export interface HvChartAxis {
   labelRotation?: number;
   /** Name used for the axis. */
   name?: string;
+  /** Properties to customize the axis name. */
+  nameProps?: {
+    /** Location. */
+    location?: HvChartAxisNameLocation;
+    /** Padding. */
+    padding?: number | number[];
+    /** Color. You can use either an HEX or color name from the palette. */
+    color?: string;
+    /** Font size. */
+    fontSize?: number;
+    /** Font style. */
+    fontStyle?: "normal" | "italic";
+    /** Font weight. */
+    fontWeight?: number;
+  };
   /** Maximum value on the axis. Set this property to `max` to use the maximum data value. */
   maxValue?:
     | string

--- a/packages/viz/src/types/common.ts
+++ b/packages/viz/src/types/common.ts
@@ -8,7 +8,7 @@ import { HvChartLegend } from "./legend";
 import { HvChartHorizontalRangeSlider } from "./slider";
 import { HvChartAxis } from "./axis";
 
-// Note: These types should not be exported for now since they can change over time.
+// Note: These types should not be exported at the moment since they can change over time.
 
 /** Props common among all charts.  */
 export interface HvChartCommonProps {
@@ -24,6 +24,20 @@ export interface HvChartCommonProps {
   legend?: HvChartLegend;
   /** Grid options. */
   grid?: HvChartGrid;
+  /** Chart width. */
+  width?: number;
+  /** Chart height. */
+  height?: number;
+}
+
+export interface HvChartXAxis extends HvChartAxis {
+  /** Position of the axis. */
+  position?: "top" | "bottom";
+}
+
+export interface HvChartYAxis extends HvChartAxis {
+  /** Position of the axis. */
+  position?: "left" | "right";
 }
 
 /** Axis charts (line and bar) common props  */
@@ -31,9 +45,9 @@ export interface HvAxisChartCommonProps {
   /** Columns to use to split the measures. */
   splitBy?: Arrayable<string>;
   /** Options for the xAxis, i.e. the horizontal axis. */
-  xAxis?: HvChartAxis;
+  xAxis?: HvChartXAxis;
   /** Options for the yAxis, i.e. the vertical axis. */
-  yAxis?: HvChartAxis | [HvChartAxis, HvChartAxis];
+  yAxis?: HvChartYAxis | [HvChartYAxis, HvChartYAxis];
   /** Stack name to use when all the series should be stacked together. If not provided, the series are not stacked. */
   stack?: string;
   /** Ranger slider options for the horizontal axis. */

--- a/packages/viz/src/types/index.ts
+++ b/packages/viz/src/types/index.ts
@@ -5,13 +5,18 @@ export type {
   HvChartTooltipType,
 } from "./tooltip";
 export type { HvChartGrid } from "./grid";
-export type { HvChartAxis, HvChartAxisType } from "./axis";
+export type {
+  HvChartAxis,
+  HvChartAxisType,
+  HvChartAxisNameLocation,
+} from "./axis";
 export type {
   HvBarChartMeasures,
   HvLineChartMeasures,
   HvDonutChartMeasure,
   HvChartSampling,
   HvChartAggregation,
+  HvConfusionMatrixMeasure,
 } from "./measures";
 export type { HvChartOrder, HvChartSortBy } from "./sort";
 export type { HvChartLegend } from "./legend";

--- a/packages/viz/src/types/measures.ts
+++ b/packages/viz/src/types/measures.ts
@@ -51,8 +51,12 @@ export interface BarFullMeasures extends BaseMeasures, AxisMeasures {}
 
 export interface DonutFullMeasures extends BaseMeasures {}
 
+export interface ConfusionMatrixMeasure extends BaseMeasures {}
+
 export type HvLineChartMeasures = string | LineFullMeasures;
 
 export type HvBarChartMeasures = string | BarFullMeasures;
 
 export type HvDonutChartMeasure = string | DonutFullMeasures;
+
+export type HvConfusionMatrixMeasure = string | ConfusionMatrixMeasure;

--- a/packages/viz/src/types/tooltip.ts
+++ b/packages/viz/src/types/tooltip.ts
@@ -5,9 +5,9 @@ export type HvChartTooltipType = (typeof tooltipType)[number];
 export interface HvChartTooltipParams {
   title?: string | number;
   series?: {
+    color?: string;
     name?: string;
     value?: string | number;
-    color?: string;
   }[];
 }
 

--- a/packages/viz/src/utils/registerTheme.ts
+++ b/packages/viz/src/utils/registerTheme.ts
@@ -16,6 +16,7 @@ export const registerTheme = (
   const customAxis = {
     nameTextStyle: {
       ...baseText,
+      color: themeStructure?.colors.modes[mode].secondary_80,
     },
     axisLine: {
       show: true,
@@ -94,6 +95,22 @@ export const registerTheme = (
     line: {
       lineStyle: {
         width: 2,
+      },
+    },
+    visualMap: {
+      textStyle: {
+        ...baseText,
+      },
+    },
+    heatmap: {
+      label: {
+        fontWeight: baseText.fontWeight,
+        fontSize: baseText.fontSize,
+        fontFamily: baseText.fontFamily,
+      },
+      itemStyle: {
+        borderColor: themeStructure?.colors.modes[mode].atmo3,
+        borderWidth: 1,
       },
     },
   });


### PR DESCRIPTION
- Confusion matrix component created.
   -  Formats available: `square` (default) or `landscape`.
   -  The confusion matrix uses a default color scale but it can be overwritten. If it's a delta matrix, the `positive`/`negative` colors are used. 
   - Leverages the visual roles to create the confusion matrix. 
      - Should we enable users to provide the matrix and rows/columns values directly in the future?
- More customisations added to the charts: chart width and height, axis position, and axis name customisations.

