### PR TITLE
ci(applitools): run on built artifact

### DIFF
--- a/.github/workflows/tests-applitools.yml
+++ b/.github/workflows/tests-applitools.yml
@@ -27,6 +27,12 @@ jobs:
       - name: Install Dependencies
         uses: ./.github/actions/install-dependencies
 
+      - name: Build Storybook
+        run: npm run build:doc
+        env:
+          NODE_OPTIONS: "--max_old_space_size=8192"
+        shell: bash
+
       - name: Set Applitools App Name
         id: set-app-name
         run: |
@@ -37,7 +43,10 @@ jobs:
           fi
 
       - name: Eyes Storybook
-        run: npm run test:eyes
+        run: |
+          npx concurrently -k -s first -n "SB,TEST" -c "magenta,blue" \
+          "npx http-server dist --port 6006 --silent" \
+          "npx wait-on tcp:6006 && npm run test:eyes -- -u http://localhost:6006" || true
         timeout-minutes: 30
 
       - name: Archive Logs

--- a/.github/workflows/tests-pa11y.yml
+++ b/.github/workflows/tests-pa11y.yml
@@ -19,16 +19,11 @@ jobs:
       - name: Install Dependencies
         uses: ./.github/actions/install-dependencies
 
-      - name: Build Documentation
-        uses: ./.github/actions/build-artifacts
-        with:
-          build-app: false
-
-      - name: Fetch Documentation
-        uses: actions/download-artifact@v3
-        with:
-          name: documentation
-          path: ${{ github.workspace }}/dist
+      - name: Build Storybook
+        run: npm run build:doc
+        env:
+          NODE_OPTIONS: "--max_old_space_size=8192"
+        shell: bash
 
       - name: Run Tests
         run: |


### PR DESCRIPTION
- change applitools workflow to run on built artifact, instead of dev-mode
- also improve pa11y build workflow