### PR TITLE
chore: fix pa11y issues on card, stack, and kpi

### DIFF
--- a/app/src/components/common/Loading/Loading.tsx
+++ b/app/src/components/common/Loading/Loading.tsx
@@ -20,7 +20,7 @@ const ErrorState = (props: ErrorStateProps) => {
       title={errorTitle}
       message={errorMessage}
       action={errorAction}
-      icon={<Info semantic="negative" />}
+      icon={<Info color="negative" />}
     />
   );
 };

--- a/app/src/components/listView/Kpi/Kpi.tsx
+++ b/app/src/components/listView/Kpi/Kpi.tsx
@@ -78,9 +78,9 @@ export const Kpi = ({
           <div className={classes.variation}>
             <Indicator variation={variation} />
             {variation === "up" ? (
-              <TopXS title="Up" semantic="positive" />
+              <TopXS title="Up" color="positive" />
             ) : (
-              <BottomXS title="Up" semantic="negative" />
+              <BottomXS title="Up" color="negative" />
             )}
             <div>
               <HvTypography variant="caption1">vs last 24h.</HvTypography>

--- a/app/src/lib/utils/assetInventory.tsx
+++ b/app/src/lib/utils/assetInventory.tsx
@@ -77,13 +77,13 @@ export const getColumns = (): HvTableColumnConfig<
 export const getStatusIcon = (color: string) => {
   switch (color) {
     case "positive":
-      return <Level0Good semantic="positive" />;
+      return <Level0Good color="positive" />;
     case "neutral":
-      return <Level1 semantic="neutral" />;
+      return <Level1 color="neutral" />;
     case "warning":
-      return <Level2Average semantic="warning" />;
+      return <Level2Average color="warning" />;
     case "negative":
-      return <Level3Bad semantic="negative" />;
+      return <Level3Bad color="negative" />;
     default:
       return undefined;
   }

--- a/app/src/lib/utils/listView.tsx
+++ b/app/src/lib/utils/listView.tsx
@@ -76,13 +76,13 @@ export const makeData = (len = 10): ListViewModel[] => {
 export const getStatusIcon = (status: number) => {
   switch (status) {
     case 0:
-      return <Level0Good semantic="positive" iconSize="XS" />;
+      return <Level0Good color="positive" iconSize="XS" />;
     case 1:
-      return <Level3Bad semantic="negative" iconSize="XS" />;
+      return <Level3Bad color="negative" iconSize="XS" />;
     case 2:
-      return <Level2Average semantic="warning" iconSize="XS" />;
+      return <Level2Average color="warning" iconSize="XS" />;
     default:
-      return <Level1 semantic="neutral" iconSize="XS" />;
+      return <Level1 color="neutral" iconSize="XS" />;
   }
 };
 

--- a/docs/guides/theming/ThemeSample.tsx
+++ b/docs/guides/theming/ThemeSample.tsx
@@ -40,10 +40,10 @@ export const ThemeSample = ({ title }: { title: string }) => {
         <HvCheckBox label="Checkbox" />
         <HvRadio label="Radio" />
         <HvSwitch aria-label="Switch" />
-        <Level0Good semantic="positive" />
-        <Level1 semantic="neutral" />
-        <Level1 semantic="negative" />
-        <Level1 semantic="catastrophic" />
+        <Level0Good color="positive" />
+        <Level1 color="neutral" />
+        <Level1 color="negative" />
+        <Level1 color="catastrophic" />
       </StyledPanel>
       <StyledHvTypography>{title}</StyledHvTypography>
     </StyledContainer>

--- a/packages/core/src/components/Box/Box.tsx
+++ b/packages/core/src/components/Box/Box.tsx
@@ -35,6 +35,7 @@ export const HvBox: HvBoxProps = forwardRef(
       component: Component = "div",
       sx,
       children,
+      classes,
       ...restProps
     } = useDefaultProps("HvBox", props);
 

--- a/packages/core/src/components/Card/Card.stories.tsx
+++ b/packages/core/src/components/Card/Card.stories.tsx
@@ -130,6 +130,8 @@ export const AllComponents: StoryObj<HvCardProps> = {
     const [checked, setChecked] = useState(false);
     const [myActions, setMyActions] = useState<any[]>([]);
 
+    // Note: Fixes an issue with Storybook where the screen will freeze if the state is already
+    // initialized. Thus, we initialized it here in useEffect when the component mounts.
     useEffect(() => {
       setMyActions([
         { id: "post", label: "Upload", icon: <Upload />, disabled: false },
@@ -163,12 +165,10 @@ export const AllComponents: StoryObj<HvCardProps> = {
       <HvCard
         style={{ width: 360 }}
         bgcolor="atmo1"
-        icon={<Level3Bad semantic="negative" />}
+        icon={<Level3Bad color="negative" />}
         statusColor="negative"
         selected={checked}
         selectable
-        // @ts-ignore
-        onClick={(event) => console.log(`my value is ${event.target.value}`)}
       >
         <HvCardHeader
           title="Leaves appear wilted and scorched"
@@ -201,25 +201,25 @@ export const AllComponents: StoryObj<HvCardProps> = {
             </StyledBottomItem>
           </Grid>
         </HvCardContent>
-        <HvCardMedia
-          component="img"
-          alt="leafy leaf"
-          height={160}
-          image={leaf}
-        />
+        <HvCardMedia component="img" alt="Leaves" height={160} image={leaf} />
         <HvActionBar>
           <HvCheckBox
             id="controller"
             onChange={() => setChecked(!checked)}
             checked={checked}
             value="value"
-            inputProps={{ "aria-label": "leaf input" }}
+            inputProps={{
+              "aria-label":
+                "Tick to select the wilted and scorched leaves card.",
+            }}
           />
           <div style={{ flex: 1 }} />
           <HvActionsGeneric
             actions={myActions}
             maxVisibleActions={1}
-            actionsCallback={(e, id, a) => alert(`You have pressed ${a.label}`)}
+            actionsCallback={(e, id, a) =>
+              alert(`You have pressed ${a.label}.`)
+            }
           />
         </HvActionBar>
       </HvCard>
@@ -337,47 +337,65 @@ export const KPICard: StoryObj<HvCardProps> = {
       </HvCardContent>
     );
 
-    const CardFooter = ({ n }: { n: number }) => (
-      <HvActionBar aria-label="Leaf">
+    const CardFooter = ({ n, value }: { n: number; value: string }) => (
+      <HvActionBar>
         <HvCheckBox
           onChange={() => setChecked(n)}
           checked={checked === n}
           value="value"
-          inputProps={{ "aria-label": "leaf input" }}
+          inputProps={{
+            "aria-label": `Tick to select the replace contaminated oil card with confidence score of ${value}%`,
+          }}
         />
         <div style={{ flex: 1 }} />
       </HvActionBar>
     );
 
     return (
-      <Grid container>
-        <Grid item xs={2} sm={3} md={4} lg={4} xl={4}>
-          <StyledCard statusColor="neutral" selectable selected={checked === 1}>
-            <HvCardHeader title="Replace contaminated oil" icon={<Tool />} />
-            <CardContent value="85" icon={<Level1 semantic="neutral" />} />
-            <CardFooter n={1} />
-          </StyledCard>
-        </Grid>
-        <Grid item xs={2} sm={3} md={4} lg={4} xl={4}>
-          <StyledCard statusColor="warning" selectable selected={checked === 2}>
-            <HvCardHeader title="Replace contaminated oil" icon={<Tool />} />
-            <CardContent
-              value="45"
-              icon={<Level2Average semantic="warning" />}
-            />
-            <CardFooter n={2} />
-          </StyledCard>
-        </Grid>
-        <Grid item xs={2} sm={3} md={4} lg={4} xl={4}>
-          <StyledCard
-            statusColor="negative"
-            selectable
-            selected={checked === 3}
-          >
-            <HvCardHeader title="Replace contaminated oil" icon={<Tool />} />
-            <CardContent value="19" icon={<Level3Bad semantic="negative" />} />
-            <CardFooter n={3} />
-          </StyledCard>
+      <Grid container role="grid" aria-label="Select one card">
+        <Grid container role="row">
+          <Grid item xs={2} sm={3} md={4} lg={4} xl={4}>
+            <StyledCard
+              statusColor="neutral"
+              selectable
+              selected={checked === 1}
+              role="gridcell"
+              aria-selected={checked === 1}
+            >
+              <HvCardHeader title="Replace contaminated oil" icon={<Tool />} />
+              <CardContent value="85" icon={<Level1 color="neutral" />} />
+              <CardFooter n={1} value="85" />
+            </StyledCard>
+          </Grid>
+          <Grid item xs={2} sm={3} md={4} lg={4} xl={4}>
+            <StyledCard
+              statusColor="warning"
+              selectable
+              selected={checked === 2}
+              role="gridcell"
+              aria-selected={checked === 2}
+            >
+              <HvCardHeader title="Replace contaminated oil" icon={<Tool />} />
+              <CardContent
+                value="45"
+                icon={<Level2Average color="warning" />}
+              />
+              <CardFooter n={2} value="84" />
+            </StyledCard>
+          </Grid>
+          <Grid item xs={2} sm={3} md={4} lg={4} xl={4}>
+            <StyledCard
+              statusColor="negative"
+              selectable
+              selected={checked === 3}
+              role="gridcell"
+              aria-selected={checked === 3}
+            >
+              <HvCardHeader title="Replace contaminated oil" icon={<Tool />} />
+              <CardContent value="19" icon={<Level3Bad color="negative" />} />
+              <CardFooter n={3} value="19" />
+            </StyledCard>
+          </Grid>
         </Grid>
       </Grid>
     );
@@ -415,7 +433,7 @@ export const Selectable: StoryObj<HvCardProps> = {
         <StyledButton
           type="button"
           onClick={() => setChecked(!checked)}
-          aria-label="Asset Avatar L90 press enter or space to select this card"
+          aria-label="Press enter or space to select the asset avatar L90 card."
           tabIndex={-1}
         >
           {children}
@@ -445,7 +463,9 @@ export const Selectable: StoryObj<HvCardProps> = {
             onChange={() => setChecked(!checked)}
             checked={checked}
             value="value"
-            inputProps={{ "aria-label": "leaf input" }}
+            inputProps={{
+              "aria-label": "Tick to select the asset avatar L90 card.",
+            }}
           />
           <div style={{ width: 32, height: 32 }}>
             <HvToggleButton
@@ -491,11 +511,7 @@ export const SelectableNoFooter: StoryObj<HvCardProps> = {
         </div>
       </HvCardContent>
     );
-    /*
-    `aria-selected` is explicitly unset because cards
-    are normally used in groups, however this being an isolated card
-    the proper role for it is a button/toggle-button with `aria-pressed`
-  */
+
     return (
       <HvCard
         bgcolor="atmo1"
@@ -510,7 +526,6 @@ export const SelectableNoFooter: StoryObj<HvCardProps> = {
           }
         }}
         aria-pressed={selected}
-        aria-selected={undefined}
         onClick={() => setSelected(!selected)}
         statusColor="negative"
       >

--- a/packages/core/src/components/Card/Card.tsx
+++ b/packages/core/src/components/Card/Card.tsx
@@ -54,9 +54,9 @@ export const HvCard = (props: HvCardProps) => {
   } = useDefaultProps("HvCard", props);
 
   const { classes, css, cx } = useClasses(classesProp);
+
   return (
     <HvBox
-      aria-selected={selectable ? selected : undefined}
       className={cx(
         "HvIsCardGridElement",
         classes.root,

--- a/packages/core/src/components/Forms/Adornment/Adornment.stories.tsx
+++ b/packages/core/src/components/Forms/Adornment/Adornment.stories.tsx
@@ -98,11 +98,11 @@ export const DynamicAdornments: StoryObj<HvAdornmentProps> = {
                 <>
                   <HvAdornment
                     showWhen="invalid"
-                    icon={<Fail semantic="negative" />}
+                    icon={<Fail color="negative" />}
                   />
                   <HvAdornment
                     showWhen="valid"
-                    icon={<Success semantic="positive" />}
+                    icon={<Success color="positive" />}
                   />
                 </>
               }

--- a/packages/core/src/components/Forms/FormElement/FormElement.stories.tsx
+++ b/packages/core/src/components/Forms/FormElement/FormElement.stories.tsx
@@ -118,7 +118,7 @@ export const Main: StoryObj<HvFormElementProps> = {
                 />
                 <HvAdornment
                   showWhen="valid"
-                  icon={<Success semantic="positive" />}
+                  icon={<Success color="positive" />}
                 />
               </>
             }
@@ -178,7 +178,7 @@ export const FormElementValid: StoryObj<HvFormElementProps> = {
             endAdornment={
               <HvAdornment
                 showWhen="valid"
-                icon={<Success semantic="positive" />}
+                icon={<Success color="positive" />}
               />
             }
           />

--- a/packages/core/src/components/Forms/WarningText/WarningText.tsx
+++ b/packages/core/src/components/Forms/WarningText/WarningText.tsx
@@ -67,7 +67,7 @@ export const HvWarningText = (props: HvWarningTextProps) => {
   const showWarning = localVisible && !localDisabled;
   const content = showWarning ? children : "";
   const localAdornment = adornment || (
-    <Fail className={classes.defaultIcon} semantic="negative" />
+    <Fail className={classes.defaultIcon} color="negative" />
   );
 
   return (

--- a/packages/core/src/components/Input/Input.tsx
+++ b/packages/core/src/components/Input/Input.tsx
@@ -683,7 +683,7 @@ export const HvInput = forwardRef<InputElement, HvInputProps>((props, ref) => {
       return null;
     }
 
-    return <Success semantic="positive" className={classes.icon} />;
+    return <Success color="positive" className={classes.icon} />;
   }, [showValidationIcon, validationState, classes.icon]);
 
   // useMemo to avoid repetitive cloning of the custom icon

--- a/packages/core/src/components/Kpi/Kpi.stories.tsx
+++ b/packages/core/src/components/Kpi/Kpi.stories.tsx
@@ -98,7 +98,7 @@ export const AverageService: StoryObj<HvKpiProps> = {
         className={css(styles.root)}
         statusColor="positive"
         bgcolor="atmo2"
-        icon={<Level0Good title="Good" semantic="positive" />}
+        icon={<Level0Good title="Good" color="positive" />}
       >
         <div className={css(styles.contentContainer)}>
           <HvTypography className={css(styles.title)} variant="label">
@@ -108,7 +108,7 @@ export const AverageService: StoryObj<HvKpiProps> = {
             <HvTypography className={css(styles.value)} variant="title2">
               12 414
             </HvTypography>
-            <TopXS title="Up" semantic="positive" />
+            <TopXS title="Up" color="positive" />
             <HvTypography>10%</HvTypography>
           </div>
         </div>
@@ -200,8 +200,16 @@ export const IOPS: StoryObj<HvKpiProps> = {
         selectable
         selected={selected}
         onClick={() => setSelected(!selected)}
+        tabIndex={0}
+        role="button"
+        onKeyDown={(event) => {
+          if (event.code === "Enter" || event.code === "Space") {
+            setSelected(!selected);
+          }
+        }}
+        aria-pressed={selected}
         statusColor="negative"
-        icon={<Level2Average title="Bad" semantic="negative" />}
+        icon={<Level2Average title="Bad" color="negative" />}
       >
         <div className={css(styles.contentContainer)}>
           <HvTypography className={css(styles.title)} variant="label">
@@ -330,6 +338,14 @@ export const Selectable: StoryObj<HvKpiProps> = {
         selectable
         selected={selected}
         onClick={() => setSelected(!selected)}
+        tabIndex={0}
+        role="button"
+        onKeyDown={(event) => {
+          if (event.code === "Enter" || event.code === "Space") {
+            setSelected(!selected);
+          }
+        }}
+        aria-pressed={selected}
         statusColor="sema0"
       >
         <div className={css(styles.contentContainer)}>
@@ -441,6 +457,14 @@ export const SelectableSemantic: StoryObj<HvKpiProps> = {
         selectable
         selected={selected}
         onClick={() => setSelected(!selected)}
+        tabIndex={0}
+        role="button"
+        onKeyDown={(event) => {
+          if (event.code === "Enter" || event.code === "Space") {
+            setSelected(!selected);
+          }
+        }}
+        aria-pressed={selected}
         statusColor="negative"
       >
         <div className={css(styles.contentContainer)}>
@@ -564,7 +588,7 @@ export const Gauge: StoryObj<HvKpiProps> = {
         className={css(styles.root)}
         statusColor="positive"
         bgcolor="atmo2"
-        icon={<Level0Good title="Good" semantic="positive" />}
+        icon={<Level0Good title="Good" color="positive" />}
       >
         <div className={css(styles.contentContainer)}>
           <HvTypography className={css(styles.title)} variant="label">
@@ -681,7 +705,7 @@ export const StatusTrain: StoryObj<HvKpiProps> = {
           className={css(styles.root)}
           statusColor="positive"
           bgcolor="atmo2"
-          icon={<Level0Good semantic="positive" />}
+          icon={<Level0Good color="positive" />}
         >
           <div className={css(styles.contentContainer)}>
             <HvTypography variant="label">Alarms</HvTypography>
@@ -694,7 +718,7 @@ export const StatusTrain: StoryObj<HvKpiProps> = {
           className={css(styles.root)}
           statusColor="negative"
           bgcolor="atmo2"
-          icon={<Level3Bad semantic="negative" />}
+          icon={<Level3Bad color="negative" />}
         >
           <div className={css(styles.contentContainer)}>
             <HvTypography variant="label">Transport</HvTypography>
@@ -779,6 +803,14 @@ export const Small: StoryObj<HvKpiProps> = {
           selectable
           selected={selected}
           onClick={() => setSelected(!selected)}
+          tabIndex={0}
+          role="button"
+          onKeyDown={(event) => {
+            if (event.code === "Enter" || event.code === "Space") {
+              setSelected(!selected);
+            }
+          }}
+          aria-pressed={selected}
           classes={{
             semanticBar: css(styles.semanticBar),
             selectable: css(styles.selectable),
@@ -786,7 +818,7 @@ export const Small: StoryObj<HvKpiProps> = {
           }}
         >
           <div className={css(styles.contentContainer)}>
-            <Level3Bad semantic="negative" />
+            <Level3Bad color="negative" />
             <div className={css(styles.textContainer)}>
               <div className={css(styles.valueContainer)}>
                 <HvTypography variant="title2">7</HvTypography>

--- a/packages/core/src/components/Stack/Stack.stories.tsx
+++ b/packages/core/src/components/Stack/Stack.stories.tsx
@@ -182,12 +182,7 @@ export const WithNavigation = () => {
           divider={false}
           dividerProps={{ variant: "middle", light: true }}
         >
-          <HvCard
-            bgcolor="atmo1"
-            statusColor="negative"
-            style={{ width: 275 }}
-            selectable
-          >
+          <HvCard bgcolor="atmo1" statusColor="negative" style={{ width: 275 }}>
             <HvCardHeader title="Card 1" icon={<Tool />} />
             <HvCardContent>
               <div style={{ marginTop: "20px" }}>
@@ -216,12 +211,7 @@ export const WithNavigation = () => {
               <div style={{ flex: 1 }} />
             </HvActionBar>
           </HvCard>
-          <HvCard
-            bgcolor="atmo1"
-            statusColor="positive"
-            style={{ width: 275 }}
-            selectable
-          >
+          <HvCard bgcolor="atmo1" statusColor="positive" style={{ width: 275 }}>
             <HvCardHeader title="Card 2" icon={<Tool />} />
             <HvCardContent>
               <div style={{ marginTop: "20px" }}>
@@ -243,12 +233,7 @@ export const WithNavigation = () => {
               <div style={{ flex: 1 }} />
             </HvActionBar>
           </HvCard>
-          <HvCard
-            bgcolor="atmo1"
-            statusColor="sema15"
-            style={{ width: 275 }}
-            selectable
-          >
+          <HvCard bgcolor="atmo1" statusColor="sema15" style={{ width: 275 }}>
             <HvCardHeader title="Card 3" icon={<Tool />} />
             <HvCardContent>
               <div style={{ marginTop: "20px" }}>
@@ -274,7 +259,6 @@ export const WithNavigation = () => {
             bgcolor="atmo1"
             statusColor="neutral_20"
             style={{ width: 275 }}
-            selectable
           >
             <HvCardHeader title="Card 4" icon={<Tool />} />
             <HvCardContent>

--- a/templates/AssetInventory/utils.tsx
+++ b/templates/AssetInventory/utils.tsx
@@ -27,13 +27,13 @@ export const getColumns = (): HvTableColumnConfig<
 export const getStatusIcon = (color: string) => {
   switch (color) {
     case "positive":
-      return <Level0Good semantic="positive" />;
+      return <Level0Good color="positive" />;
     case "neutral":
-      return <Level1 semantic="neutral" />;
+      return <Level1 color="neutral" />;
     case "warning":
-      return <Level2Average semantic="warning" />;
+      return <Level2Average color="warning" />;
     case "negative":
-      return <Level3Bad semantic="negative" />;
+      return <Level3Bad color="negative" />;
     default:
       return undefined;
   }

--- a/templates/ListView/Kpi/Kpi.tsx
+++ b/templates/ListView/Kpi/Kpi.tsx
@@ -78,9 +78,9 @@ export const Kpi = ({
           <div className={classes.variation}>
             <Indicator variation={variation} />
             {variation === "up" ? (
-              <TopXS title="Up" semantic="positive" />
+              <TopXS title="Up" color="positive" />
             ) : (
-              <BottomXS title="Up" semantic="negative" />
+              <BottomXS title="Up" color="negative" />
             )}
             <div>
               <HvTypography variant="caption1">vs last 24h.</HvTypography>

--- a/templates/ListView/utils.tsx
+++ b/templates/ListView/utils.tsx
@@ -15,13 +15,13 @@ import {
 export const getStatusIcon = (status: number) => {
   switch (status) {
     case 0:
-      return <Level0Good semantic="positive" iconSize="XS" />;
+      return <Level0Good color="positive" iconSize="XS" />;
     case 1:
-      return <Level3Bad semantic="negative" iconSize="XS" />;
+      return <Level3Bad color="negative" iconSize="XS" />;
     case 2:
-      return <Level2Average semantic="warning" iconSize="XS" />;
+      return <Level2Average color="warning" iconSize="XS" />;
     default:
-      return <Level1 semantic="neutral" iconSize="XS" />;
+      return <Level1 color="neutral" iconSize="XS" />;
   }
 };
 


### PR DESCRIPTION
- Pa11y issues fixed on the card component.
   - Consequently the Pa11y issues with the KPI and stack components were also fixed.
- `semantic` prop updated to `color` for icons since the former is deprecated. 