### PR TITLE
fix(DropdownMenu): pa11y issues

### DIFF
--- a/packages/core/src/components/DropDownMenu/DropDownMenu.tsx
+++ b/packages/core/src/components/DropDownMenu/DropDownMenu.tsx
@@ -145,7 +145,7 @@ export const HvDropDownMenu = (props: HvDropDownMenuProps) => {
         >
           {icon || (
             <MoreOptionsVertical
-              role="presentation"
+              aria-hidden
               color={disabled ? "secondary_60" : undefined}
             />
           )}


### PR DESCRIPTION
- `role="presentation"` replaced by `aria-hidden` on the dropdown menu component to fix a bunch of these accessibility issues we have on various stories. `aria-hidden` seemed more appropriate since the icon is unimportant and not needed for the accessibility tree.

<img width="917" alt="Screenshot 2023-08-24 at 12 13 41" src="https://github.com/lumada-design/hv-uikit-react/assets/43220251/8d78093f-071c-4d8c-bab1-beb800228c15">

