### PR TITLE
fix: pa11y issues in color picker and base dropdown components

### DIFF
--- a/packages/core/src/components/BaseDropdown/BaseDropdown.tsx
+++ b/packages/core/src/components/BaseDropdown/BaseDropdown.tsx
@@ -345,9 +345,6 @@ export const HvBaseDropdown = (props: HvBaseDropdownProps) => {
     if (component) {
       return React.cloneElement(component as React.ReactElement, {
         ref: handleDropdownHeaderRef,
-        "aria-controls": isOpen
-          ? setId(elementId, "children-container")
-          : undefined,
       });
     }
 
@@ -366,9 +363,6 @@ export const HvBaseDropdown = (props: HvBaseDropdownProps) => {
         })}
         role={ariaRole === "combobox" ? "textbox" : undefined}
         style={disabled || readOnly ? { pointerEvents: "none" } : undefined}
-        aria-controls={
-          isOpen ? setId(elementId, "children-container") : undefined
-        }
         aria-label={others["aria-label"] ?? undefined}
         aria-labelledby={others["aria-labelledby"] ?? undefined}
         aria-required={required ?? undefined}
@@ -497,6 +491,9 @@ export const HvBaseDropdown = (props: HvBaseDropdownProps) => {
         role={ariaRole}
         aria-expanded={ariaExpanded}
         aria-owns={isOpen ? setId(elementId, "children-container") : undefined}
+        aria-controls={
+          isOpen ? setId(elementId, "children-container") : undefined
+        }
         aria-required={required ?? undefined}
         aria-readonly={readOnly ?? undefined}
         className={cx(

--- a/packages/core/src/components/ColorPicker/ColorPicker.stories.tsx
+++ b/packages/core/src/components/ColorPicker/ColorPicker.stories.tsx
@@ -56,6 +56,7 @@ export const WithoutSavedColors: StoryObj<HvColorPickerProps> = {
     return (
       <div style={{ width: "134px" }}>
         <HvColorPicker
+          aria-label="Color"
           expanded
           showSavedColors={false}
           onChange={(color) => console.log(color)}
@@ -79,6 +80,7 @@ export const OnlyRecommendedColors: StoryObj<HvColorPickerProps> = {
     return (
       <div style={{ width: "134px" }}>
         <HvColorPicker
+          aria-label="Color"
           expanded
           showSavedColors={false}
           showCustomColors={false}
@@ -103,6 +105,7 @@ export const IconOnly: StoryObj<HvColorPickerProps> = {
     return (
       <div style={{ width: "134px" }}>
         <HvColorPicker
+          aria-label="Color"
           iconOnly
           expanded
           onChange={(color) => console.log(color)}
@@ -126,6 +129,7 @@ export const IconOnlyWithoutSavedColors: StoryObj<HvColorPickerProps> = {
     return (
       <div style={{ width: "134px" }}>
         <HvColorPicker
+          aria-label="Color"
           iconOnly
           expanded
           showSavedColors={false}
@@ -151,6 +155,7 @@ export const IconOnlyRecommendedColors: StoryObj<HvColorPickerProps> = {
     return (
       <div style={{ width: "134px" }}>
         <HvColorPicker
+          aria-label="Color"
           iconOnly
           expanded
           showSavedColors={false}
@@ -177,6 +182,7 @@ export const CustomizedColorPicker: StoryObj<HvColorPickerProps> = {
     return (
       <div style={{ width: "240px" }}>
         <HvColorPicker
+          aria-label="Color"
           expanded
           showLabels={false}
           showSavedColors={false}
@@ -241,6 +247,7 @@ export const ControlledColorPicker: StoryObj<HvColorPickerProps> = {
         </div>
         <div style={{ width: "134px" }}>
           <HvColorPicker
+            aria-label="Color"
             expanded
             showSavedColors={false}
             onChange={(value) => {

--- a/packages/core/src/components/ColorPicker/ColorPicker.tsx
+++ b/packages/core/src/components/ColorPicker/ColorPicker.tsx
@@ -91,7 +91,9 @@ export interface HvColorPickerProps {
   /** Callback fired when a new saved color is removed. */
   onSavedColorRemoved?: (color?: string) => void;
   /** Aria label to apply to delete saved color button. */
-  deleteSavedColorButtonArialLabel?: string;
+  deleteSavedColorButtonArialLabel?: string; // TODO: fix typo "ArialLabel" in next version
+  /** Aria label to apply to add saved color button. */
+  addSavedColorButtonAriaLabel?: string;
 }
 
 const DEFAULT_LABELS: HvColorPickerProps["labels"] = {
@@ -149,6 +151,7 @@ export const HvColorPicker = (props: HvColorPickerProps) => {
     onSavedColorAdded,
     onSavedColorRemoved,
     deleteSavedColorButtonArialLabel = "Delete saved color",
+    addSavedColorButtonAriaLabel = "Add current color to saved colors",
   } = useDefaultProps("HvColorPicker", props);
 
   const { classes, css, cx } = useClasses(classesProp);
@@ -330,7 +333,8 @@ export const HvColorPicker = (props: HvColorPickerProps) => {
                 onAddColor={handleAddColor}
                 onClickColor={handleSelect}
                 onRemoveColor={handleRemoveColor}
-                deleteButtonArialLabel={deleteSavedColorButtonArialLabel}
+                deleteButtonAriaLabel={deleteSavedColorButtonArialLabel}
+                addButtonAriaLabel={addSavedColorButtonAriaLabel}
               />
             )}
             {recommendedColorsPosition === "bottom" && (

--- a/packages/core/src/components/ColorPicker/SavedColors/SavedColors.tsx
+++ b/packages/core/src/components/ColorPicker/SavedColors/SavedColors.tsx
@@ -18,7 +18,8 @@ interface SavedColorsProps {
   onClickColor: (color: { hex: string; source: string }) => void;
   onAddColor: () => void;
   onRemoveColor: (color: string, index: number) => void;
-  deleteButtonArialLabel?: string;
+  deleteButtonAriaLabel?: string;
+  addButtonAriaLabel?: string;
   classes?: HvColorPickerSavedColorsClasses;
 }
 
@@ -27,7 +28,8 @@ export const SavedColors = ({
   onClickColor,
   onAddColor,
   onRemoveColor,
-  deleteButtonArialLabel,
+  deleteButtonAriaLabel,
+  addButtonAriaLabel,
   classes: classesProp,
 }: SavedColorsProps) => {
   const { classes } = useClasses(classesProp);
@@ -46,8 +48,9 @@ export const SavedColors = ({
         variant="secondarySubtle"
         icon
         onClick={onAddColor}
+        aria-label={addButtonAriaLabel}
       >
-        <Add />
+        <Add aria-hidden />
       </HvButton>
       {colors.map((color, index) => (
         <div
@@ -69,9 +72,9 @@ export const SavedColors = ({
               variant="secondarySubtle"
               onClick={() => onRemoveColor(color, index)}
               tabIndex={0}
-              aria-label={deleteButtonArialLabel}
+              aria-label={deleteButtonAriaLabel}
             >
-              <CloseXS iconSize="XS" />
+              <CloseXS aria-hidden iconSize="XS" />
             </HvButton>
           </div>
         </div>

--- a/packages/core/src/components/Tag/Tag.tsx
+++ b/packages/core/src/components/Tag/Tag.tsx
@@ -44,7 +44,7 @@ export interface HvTagProps
   /** The role of the element with an attributed event. */
   role?: string;
   /** Aria properties to apply to delete button in tag */
-  deleteButtonArialLabel?: string;
+  deleteButtonArialLabel?: string; // TODO: fix typo "ArialLabel" in next version
   /** Props to apply to delete button */
   deleteButtonProps?: HvButtonProps;
   /** A Jss Object used to override or extend the styles applied to the component. */


### PR DESCRIPTION
Color picker and base dropdown pa11y issues fixed:
   - The base dropdown component was also fixed since it was leading to accessibility issues on the color picker component. The `aria-controls` was transferred to the base dropdown root. This also fixes some pa11y issues on other stories.