### PR TITLE
ci(applitools): run applitools on dev server

### DIFF
--- a/.github/workflows/tests-applitools.yml
+++ b/.github/workflows/tests-applitools.yml
@@ -27,12 +27,6 @@ jobs:
       - name: Install Dependencies
         uses: ./.github/actions/install-dependencies
 
-      - name: Build Storybook
-        run: npm run build:doc
-        env:
-          NODE_OPTIONS: "--max_old_space_size=8192"
-        shell: bash
-
       - name: Set Applitools App Name
         id: set-app-name
         run: |
@@ -43,10 +37,7 @@ jobs:
           fi
 
       - name: Eyes Storybook
-        run: |
-          npx concurrently -k -s first -n "SB,TEST" -c "magenta,blue" \
-          "npx http-server dist --port 6006 --silent" \
-          "npx wait-on tcp:6006 && npm run test:eyes -- -u http://localhost:6006" || true
+        run: npm run test:eyes
         timeout-minutes: 30
 
       - name: Archive Logs


### PR DESCRIPTION
Going back to running applitools on a dev server since using a build leads to weird behaviours: missing CSS on baselines. 