### PR TITLE
fix(a11y): tooltip labels

### DIFF
--- a/packages/core/src/components/Avatar/Avatar.tsx
+++ b/packages/core/src/components/Avatar/Avatar.tsx
@@ -1,4 +1,4 @@
-import { CSSProperties, HTMLAttributes } from "react";
+import { CSSProperties, HTMLAttributes, forwardRef } from "react";
 import { useDefaultProps } from "@core/hooks/useDefaultProps";
 
 import { User } from "@hitachivantara/uikit-react-icons";
@@ -74,7 +74,7 @@ const getColor = (color: string, defaultColor: string): string =>
  * Avatars can be used to represent a user or a brand.
  * They can show an image, an icon or the initial letters of a name, for example.
  */
-export const HvAvatar = (props: HvAvatarProps) => {
+export const HvAvatar = forwardRef<any, HvAvatarProps>((props, ref) => {
   const {
     className,
     style,
@@ -157,7 +157,7 @@ export const HvAvatar = (props: HvAvatarProps) => {
   const badgeColor = getColor(badge || "", theme.colors.positive);
 
   return (
-    <div className={classes.container} {...others}>
+    <div ref={ref} className={classes.container} {...others}>
       <div
         className={cx(classes.status, classes[variant], classes[size])}
         style={statusInlineStyle}
@@ -182,4 +182,4 @@ export const HvAvatar = (props: HvAvatarProps) => {
       </div>
     </div>
   );
-};
+});

--- a/packages/core/src/components/Button/Button.tsx
+++ b/packages/core/src/components/Button/Button.tsx
@@ -112,7 +112,6 @@ export const HvButton: <C extends React.ElementType = "button">(
     return (
       <Component
         ref={ref}
-        type="button"
         className={cx(
           classes.root,
           css(getVariantStyles(variant)),
@@ -125,6 +124,7 @@ export const HvButton: <C extends React.ElementType = "button">(
           },
           className
         )}
+        {...(Component === "button" && { type: "button" })}
         {...(disabled && {
           disabled: true,
           tabIndex: -1,

--- a/packages/core/src/components/Carousel/Carousel.stories.tsx
+++ b/packages/core/src/components/Carousel/Carousel.stories.tsx
@@ -145,8 +145,8 @@ export const Embedded: StoryObj<HvCarouselProps> = {
 
     return (
       <HvCard bgcolor="atmo1" style={{ width: 350 }}>
-        <HvCardHeader title="Image Carousel" aria-label="Compressor" />
-        <HvCardMedia>
+        <HvCardHeader title="Image Carousel" />
+        <HvCardMedia role="none">
           <HvCarousel xs height={400}>
             {images.map(({ src, name }) => (
               <HvCarouselSlide

--- a/packages/core/src/components/DropDownMenu/DropDownMenu.tsx
+++ b/packages/core/src/components/DropDownMenu/DropDownMenu.tsx
@@ -142,6 +142,7 @@ export const HvDropDownMenu = (props: HvDropDownMenuProps) => {
           aria-expanded={open}
           disabled={disabled}
           aria-label="Dropdown menu"
+          aria-haspopup="menu"
         >
           {icon || (
             <MoreOptionsVertical
@@ -151,7 +152,6 @@ export const HvDropDownMenu = (props: HvDropDownMenuProps) => {
           )}
         </HvButton>
       }
-      aria-haspopup="menu"
       placement={placement}
       variableWidth
       disablePortal={disablePortal}

--- a/packages/core/src/components/GlobalActions/GlobalActions.stories.tsx
+++ b/packages/core/src/components/GlobalActions/GlobalActions.stories.tsx
@@ -1,6 +1,5 @@
 import { Backwards } from "@hitachivantara/uikit-react-icons";
 import { Meta, StoryObj } from "@storybook/react";
-import uniqueId from "lodash/uniqueId";
 import {
   HvButton,
   HvTypography,
@@ -29,7 +28,7 @@ export const Main: StoryObj<HvGlobalActionsProps> = {
   },
   decorators: [(Story) => <div style={{ height: 300 }}>{Story()}</div>],
   render: (args) => {
-    const BackButton = () => (
+    const backButton = (
       <HvButton aria-label="Back" icon onClick={() => alert("Back!")}>
         <Backwards />
       </HvButton>
@@ -37,12 +36,10 @@ export const Main: StoryObj<HvGlobalActionsProps> = {
 
     return (
       <HvContainer>
-        <HvGlobalActions backButton={<BackButton />} {...args}>
+        <HvGlobalActions backButton={backButton} {...args}>
           <HvButton variant="primary">Approve & Share</HvButton>
           <HvButton variant="secondarySubtle">Reset</HvButton>
           <HvDropDownMenu
-            id={`dropdownItem-${uniqueId()}`}
-            aria-label="dropdownMenu-Items"
             placement="left"
             dataList={[
               { label: "Action 2" },
@@ -57,8 +54,6 @@ export const Main: StoryObj<HvGlobalActionsProps> = {
             <HvButton variant="secondarySubtle">Remove</HvButton>
             <HvButton variant="secondarySubtle">Share</HvButton>
             <HvDropDownMenu
-              id={`dropdownItem-${uniqueId()}`}
-              aria-label="dropdownMenu-Items"
               placement="left"
               dataList={[
                 { label: "Action 2" },
@@ -113,8 +108,6 @@ export const Main: StoryObj<HvGlobalActionsProps> = {
             <HvButton variant="secondarySubtle">Remove</HvButton>
             <HvButton variant="secondarySubtle">Share</HvButton>
             <HvDropDownMenu
-              id={`dropdownItem-${uniqueId()}`}
-              aria-label="dropdownMenu-Items"
               placement="left"
               dataList={[
                 { label: "Action 2" },
@@ -161,8 +154,6 @@ export const Main: StoryObj<HvGlobalActionsProps> = {
             <HvButton variant="secondarySubtle">Remove</HvButton>
             <HvButton variant="secondarySubtle">Share</HvButton>
             <HvDropDownMenu
-              id={`dropdownItem-${uniqueId()}`}
-              aria-label="dropdownMenu-Items"
               placement="left"
               dataList={[
                 { label: "Action 2" },
@@ -217,18 +208,16 @@ export const SampleWithAdditionalActions: StoryObj<HvGlobalActionsProps> = {
     },
   },
   render: () => {
-    const BackButton = () => (
+    const backButton = (
       <HvButton aria-label="Back" icon onClick={() => alert("Back!")}>
         <Backwards />
       </HvButton>
     );
 
     return (
-      <HvGlobalActions title="Detail Page Title" backButton={<BackButton />}>
+      <HvGlobalActions title="Detail Page Title" backButton={backButton}>
         <HvButton variant="secondaryGhost">Primary</HvButton>
         <HvDropDownMenu
-          id={`dropdownItem-${uniqueId()}`}
-          aria-label="dropdownMenu-Items"
           placement="left"
           dataList={[
             { label: "Action 2" },
@@ -251,8 +240,6 @@ export const SampleWithAdditionalActionsAndNoBackButton: StoryObj<HvGlobalAction
         <HvGlobalActions title="Detail Page Title" backButton={false}>
           <HvButton variant="secondaryGhost">Primary</HvButton>
           <HvDropDownMenu
-            id={`dropdownItem-${uniqueId()}`}
-            aria-label="dropdownMenu-Items"
             placement="left"
             dataList={[
               { label: "Action 2" },
@@ -279,20 +266,20 @@ export const SampleWithCustomTitleAndAdditionalActions: StoryObj<HvGlobalActions
       },
     },
     render: () => {
-      const CustomTitle = (
+      const customTitle = (
         <HvTypography variant="title3" component="h1">
           A Custom Title
         </HvTypography>
       );
 
-      const BackButton = () => (
+      const backButton = (
         <HvButton aria-label="Back" icon onClick={() => alert("Back!")}>
           <Backwards />
         </HvButton>
       );
 
       return (
-        <HvGlobalActions title={CustomTitle} backButton={<BackButton />}>
+        <HvGlobalActions title={customTitle} backButton={backButton}>
           <HvButton variant="primary">Primary</HvButton>
           <HvButton variant="secondarySubtle">Secondary</HvButton>
           <HvButton variant="secondarySubtle">Secondary</HvButton>
@@ -317,8 +304,6 @@ export const SectionGlobalActions: StoryObj<HvGlobalActionsProps> = {
       <HvGlobalActions title="Section Title" variant="section">
         <HvButton variant="secondaryGhost">Primary</HvButton>
         <HvDropDownMenu
-          id={`dropdownItem-${uniqueId()}`}
-          aria-label="dropdownMenu-Items"
           placement="left"
           dataList={[
             { label: "Action 2" },

--- a/packages/core/src/components/Input/SearchBox.stories.tsx
+++ b/packages/core/src/components/Input/SearchBox.stories.tsx
@@ -373,7 +373,7 @@ export const SearchAsYouType: StoryObj = {
           onChange={handleSearch}
           inputProps={{ autoComplete: "off" }}
         />
-        <HvPanel className={classes.panel}>
+        <HvPanel className={classes.panel} tabIndex={0}>
           <HvTypography variant="label">Countries of Europe</HvTypography>
           {results.map((element, i) => (
             <div key={i} className={classes.result}>

--- a/packages/core/src/components/OverflowTooltip/OverflowTooltip.stories.tsx
+++ b/packages/core/src/components/OverflowTooltip/OverflowTooltip.stories.tsx
@@ -36,6 +36,7 @@ export default meta;
 
 export const Main: StoryObj<HvOverflowTooltipProps> = {
   args: {
+    open: true,
     placement: "top-start",
     data: "This is a very long text that should be cut because it so long that it doesn't fit",
     paragraphOverflow: false,
@@ -44,10 +45,6 @@ export const Main: StoryObj<HvOverflowTooltipProps> = {
     classes: { control: { disable: true } },
   },
   render: (args) => {
-    return (
-      <HvOverflowTooltip open {...args}>
-        List
-      </HvOverflowTooltip>
-    );
+    return <HvOverflowTooltip {...args} />;
   },
 };

--- a/packages/core/src/components/OverflowTooltip/OverflowTooltip.tsx
+++ b/packages/core/src/components/OverflowTooltip/OverflowTooltip.tsx
@@ -97,7 +97,7 @@ export const HvOverflowTooltip = (props: HvOverflowTooltipProps) => {
     ]
   );
 
-  return open || isOverflowing ? (
+  return (
     <HvTooltip
       id={id}
       disableHoverListener={!isOverflowing}
@@ -108,11 +108,12 @@ export const HvOverflowTooltip = (props: HvOverflowTooltipProps) => {
           {data}
         </HvTypography>
       }
+      // unset since `content` *is* the label
+      aria-label={null as any}
+      aria-labelledby={null as any}
       {...tooltipsProps}
     >
       {content}
     </HvTooltip>
-  ) : (
-    content
   );
 };

--- a/packages/core/src/components/TextArea/TextArea.stories.tsx
+++ b/packages/core/src/components/TextArea/TextArea.stories.tsx
@@ -133,14 +133,6 @@ export const LimitedBlocking: StoryObj<HvTextAreaProps> = {
     },
   },
   render: () => {
-    const [textLength, setTextLength] = useState<number>(0);
-
-    const setCounter = (_, data) => {
-      setTextLength(data.length);
-
-      return data;
-    };
-
     return (
       <HvTextArea
         id="limited-blocking"
@@ -150,10 +142,6 @@ export const LimitedBlocking: StoryObj<HvTextAreaProps> = {
         placeholder="Enter value"
         maxCharQuantity={10}
         blockMax
-        onChange={setCounter}
-        countCharProps={{
-          "aria-label": `You have inserted ${textLength} characters`,
-        }}
       />
     );
   },

--- a/packages/core/src/components/Tooltip/Tooltip.stories.tsx
+++ b/packages/core/src/components/Tooltip/Tooltip.stories.tsx
@@ -4,7 +4,6 @@ import {
   HvAvatar,
   HvBox,
   HvButton,
-  HvCheckBox,
   HvTooltip,
   HvTooltipProps,
   HvTypography,
@@ -114,17 +113,11 @@ export const CustomElements: StoryObj<HvTooltipProps> = {
         </HvButton>
       </HvTooltip>
       <HvTooltip title="Wrapped HvAvatar">
-        <div>
-          <HvAvatar
-            alt="Ryan"
-            src="https://avatars.githubusercontent.com/u/80?v=4"
-          />
-        </div>
-      </HvTooltip>
-      <HvTooltip title="Wrapped HvCheckBox">
-        <div>
-          <HvCheckBox label="Value" />
-        </div>
+        <HvAvatar
+          role="img"
+          alt="Ryan"
+          src="https://avatars.githubusercontent.com/u/80?v=4"
+        />
       </HvTooltip>
       <HvTooltip placement="left" title="Left placement link">
         <HvTypography
@@ -204,13 +197,13 @@ export const CustomContent: StoryObj<HvTooltipProps> = {
         }}
       >
         <HvTooltip open title={longTextTooltip}>
-          <HvTypography>Long text tooltip</HvTypography>
+          <HvButton variant="secondaryGhost">Long text tooltip</HvButton>
         </HvTooltip>
         <HvTooltip open title={multilineContent1} useSingle={false}>
-          <HvTypography>Multiline content 1</HvTypography>
+          <HvButton variant="secondaryGhost">Multiline content 1</HvButton>
         </HvTooltip>
         <HvTooltip open title={multilineContent2} useSingle={false}>
-          <HvTypography>Multiline content 2</HvTypography>
+          <HvButton variant="secondaryGhost">Multiline content 2</HvButton>
         </HvTooltip>
       </HvBox>
     );

--- a/packages/core/src/components/Tooltip/Tooltip.styles.tsx
+++ b/packages/core/src/components/Tooltip/Tooltip.styles.tsx
@@ -22,6 +22,7 @@ export const popperSx = (useSingle: boolean) => {
       opacity: 1,
     },
     [`& .${MuitooltipClasses.tooltip}`]: {
+      fontFamily: theme.fontFamily.body,
       ...theme.typography.body,
       display: "flex",
       width: "fit-content",


### PR DESCRIPTION
HvTooltip (actually MuiTooltip) passes aria-label to the tooltip target We shouldn't be wrapping it around divs

- Explicitly remove `aria-label` from OverflowTooltip, as it's incorrect & redundant
- Add roles to elements in HvTooltip samples
- Also remove some redundant/incorrect `aria-labels`