### PR TITLE
docs: layout page added

### DIFF
--- a/docs/guides/layout/Layout.stories.mdx
+++ b/docs/guides/layout/Layout.stories.mdx
@@ -1,0 +1,108 @@
+import { Meta, Story, Canvas } from "@storybook/addon-docs";
+import {
+  ContainerSample,
+  SimpleGridSample,
+  GridSample,
+  getBreakpoints,
+} from "./Layout";
+
+<Meta title="Guides/Layout" />
+
+# Layout <a id="layout" />
+
+When building UIs you should always strive for **responsive layouts** to enable your pages to adapt to different screen sizes and orientations,
+ensuring overall consistency across platforms and environments.
+
+The NEXT UI Kit provides the following components to help you create responsive layouts:
+
+- [Container](#container)
+- [Grid](#grid)
+- [Simple Grid](#simple-grid)
+
+Using these components together or individually will enable you to create beautiful responsive layouts in your applications.
+
+One underlying concept for all these components are **breakpoints**. While the container and grid components use internally the breakpoints defined by
+Design System, the simple grid component enables you to create your own breakpoints. These breakpoints are specific screen sizes at which the layouts
+should adjust themselves to suit the screen resolution and orientation.
+
+Design System has the following breakpoints:
+
+<table>
+  <thead>
+    <tr>
+      <th style={{ width: 150 }}>Breakpoint</th>
+      <th style={{ width: 150 }}>Width (px)</th>
+      <th style={{ width: 150 }}>Gutters (px)</th>
+      <th style={{ width: 150 }}>Number of columns</th>
+    </tr>
+  </thead>
+  <tbody>
+    {Object.entries(getBreakpoints()).map((entry) => {
+      return (
+        <tr key={entry[0]}>
+          <td>{entry[0]}</td>
+          <td>{entry[1].value}</td>
+          <td>{entry[1].gutter}</td>
+          <td>{entry[1].column}</td>
+        </tr>
+      );
+    })}
+  </tbody>
+</table>
+
+Whenever the screen resolution goes above or below a breakpoint, the layout should adapt itself to suit the screen size and for the content to be accessible.
+
+## Container <a id="container" />
+
+The [Container](/docs/components-container--main) is one of the most basic layout components we provide to our community, and it enables you to center content horizontally on the page.
+
+This component is very useful when your content can't grow beyond a specific breakpoint. In this case, you can use `maxWidth` to specify the breakpoint
+to which the content is bounded. The content will automatically grow or shrink according with the size of the screen and breakpoint used ensuring that
+it doesn't grow beyond the specified width.
+
+If necessary, multiple nested containers can be used as shown in the example below.
+
+<Canvas>
+  <Story name="Container" story={ContainerSample} />
+</Canvas>
+
+For more information, please go to the [container's API](/docs/components-container--main).
+
+## Grid <a id="grid" />
+
+The [Grid](/docs/components-grid-grid--main) component enables you to create responsive grid layouts with a variable amount of columns. The grid items will also adapt themselves
+to suit the screen sizes.
+
+By default this component is based on a 12-column grid layout. This can be easily changed through the `columns` property. If this property is set to
+`auto`, the Design System directives will be used where the number of columns will update depending on the breakpoint.
+
+The grid component also enables you to span items across columns if needed. Thus, with this component you'll be able to create a variety of layouts depending
+on your needs.
+
+Below is an example on how to use the grid component where the Design System directives were used and some grid items were spanned across multiple columns.
+
+<Canvas>
+  <Story name="Grid" story={GridSample} />
+</Canvas>
+
+Learn more about this component [here](/docs/components-grid-grid--main).
+
+## Simple Grid <a id="simple-grid" />
+
+The [Simple Grid](/docs/components-grid-simple-grid--main) component is an alternative to the grid component mentioned above and it provides an easy way of creating responsive grids where each item takes an equal amount
+of space. The items will grow or shrink whenever the screen size changes.
+
+This component should be used whenever you need to create grids where items should be distributed across a specific number of columns with the same width.
+
+This component also enables you to create your own breakpoints and define the spacing and number of columns for each one. Thus, contrary to the grid component,
+the simple grid does not rely on the Design System breakpoints. Furthermore, you can only define the number of columns per row and not the span of each grid item
+enabling you to create much simpler grids than the grid component.
+
+In the example below a grid with three columns was created to distribute the cards across them, and when the screen width goes under the Design System
+`sm` (600px) breakpoint the grid only has two columns.
+
+<Canvas>
+  <Story name="SimpleGrid" story={SimpleGridSample} />
+</Canvas>
+
+More information about can be found [here](/docs/components-grid-simple-grid--main).

--- a/docs/guides/layout/Layout.tsx
+++ b/docs/guides/layout/Layout.tsx
@@ -1,0 +1,156 @@
+import { css } from "@emotion/css";
+import {
+  HvCard,
+  HvCardContent,
+  HvCardHeader,
+  HvContainer,
+  HvGlobalActions,
+  HvGrid,
+  HvSimpleGrid,
+  HvTypography,
+  ds5,
+  theme,
+  useTheme,
+} from "@hitachivantara/uikit-react-core";
+import { HvBarChart } from "@hitachivantara/uikit-react-viz";
+
+export const getBreakpoints = () => {
+  const gutters = {
+    xs: 16,
+    sm: 16,
+    md: 32,
+    lg: 32,
+    xl: 32,
+  };
+  const columns = {
+    xs: 4,
+    sm: 8,
+    md: 12,
+    lg: 12,
+    xl: 12,
+  };
+
+  return Object.entries(ds5.breakpoints.values).reduce((acc, curr) => {
+    const [key, value] = curr;
+    acc[key] = {
+      value,
+      gutter: gutters[key],
+      column: columns[key],
+    };
+    return acc;
+  }, {});
+};
+
+export const ContainerSample = () => {
+  return (
+    <HvContainer maxWidth="lg">
+      <HvGlobalActions title="Details" />
+      <HvContainer maxWidth="md">
+        <HvTypography variant="body">
+          Lorem ipsum dolor sit amet consectetur adipisicing elit. Corrupti
+          quasi sed perferendis optio eos excepturi possimus atque aperiam
+          impedit expedita dolores, est nulla, aut iure, deleniti recusandae
+          corporis eaque provident?
+        </HvTypography>
+        <HvTypography variant="body">
+          Lorem ipsum dolor sit amet consectetur adipisicing elit. Velit culpa
+          error vitae fugit minima. Distinctio tempore ipsa voluptatum, vel
+          alias possimus aut, itaque corrupti nesciunt accusantium commodi nulla
+          minima voluptates.
+        </HvTypography>
+      </HvContainer>
+    </HvContainer>
+  );
+};
+
+export const SimpleGridSample = () => {
+  const { activeTheme } = useTheme();
+
+  return (
+    <HvSimpleGrid
+      cols={3}
+      breakpoints={[
+        {
+          maxWidth: activeTheme.breakpoints.values.sm,
+          cols: 2,
+        },
+      ]}
+    >
+      {Array.from({ length: 9 }).map((v, i) => {
+        return (
+          <HvCard key={`simple-grid-card-${i}`} bgcolor="atmo1">
+            <HvCardHeader title={`Card ${i}`} />
+            <HvCardContent>
+              <HvTypography>
+                Lorem ipsum dolor sit amet consectetur adipisicing elit.
+              </HvTypography>
+            </HvCardContent>
+          </HvCard>
+        );
+      })}
+    </HvSimpleGrid>
+  );
+};
+
+export const GridSample = () => {
+  return (
+    <HvGrid columns="auto" container>
+      <HvGrid item xs={4} sm={8} md={12}>
+        <HvGlobalActions title="Dashboard" />
+      </HvGrid>
+      {Array.from({ length: 4 }).map((v, i) => {
+        return (
+          <HvGrid item xs={4} sm={4} md={3} lg={3} key={`grid-card-${i}`}>
+            <HvCard bgcolor="atmo1">
+              <HvCardHeader title={`KPI ${i}`} />
+              <HvCardContent>
+                <HvTypography>
+                  Lorem ipsum dolor sit amet consectetur adipisicing elit.
+                </HvTypography>
+              </HvCardContent>
+            </HvCard>
+          </HvGrid>
+        );
+      })}
+      <HvGrid item xs={4} sm={8} md={12}>
+        <HvCard
+          bgcolor="atmo1"
+          classes={{
+            semanticBar: css({
+              height: 0,
+            }),
+          }}
+        >
+          <HvCardContent
+            classes={{
+              content: css({
+                paddingTop: theme.space.sm,
+              }),
+            }}
+          >
+            <HvBarChart
+              data={{
+                Group: ["Group 1", "Group 2", "Group 3"],
+                "Sales Target": [2300, 1000, 7800],
+                "Sales Per Rep": [6000, 3900, 1000],
+                "Monthly Sales": [3700, 6700, 1100],
+                Target: [2100, 7700, 3000],
+                Cash: [500, 7600, 7800],
+              }}
+              groupBy="Group"
+              measures={[
+                "Sales Target",
+                "Sales Per Rep",
+                "Monthly Sales",
+                "Target",
+                "Cash",
+              ]}
+              horizontal
+              grid={{ bottom: 0 }}
+            />
+          </HvCardContent>
+        </HvCard>
+      </HvGrid>
+    </HvGrid>
+  );
+};

--- a/packages/core/src/components/Container/Container.tsx
+++ b/packages/core/src/components/Container/Container.tsx
@@ -45,6 +45,7 @@ export interface HvContainerProps
   classes?: HvContainerClasses;
 }
 
+/** The container enables you to center your content horizontally and bound it to a specific breakpoint. */
 export const HvContainer = forwardRef<HTMLDivElement, HvContainerProps>(
   (props, ref) => {
     const {

--- a/packages/core/src/components/Grid/Grid.tsx
+++ b/packages/core/src/components/Grid/Grid.tsx
@@ -190,19 +190,19 @@ function getNumberOfColumns(columns: HvGridProps["columns"]) {
 
 /**
  * The grid creates visual consistency between layouts while allowing flexibility
- * across a wide variety of designs. This component is based in a 12-column grid layout.
+ * across a wide variety of designs. This component is based on a 12-column grid layout.
  *
- * It is is based in the [Material UI Grid](https://mui.com/material-ui/react-grid/).
+ * It's based on the [Material UI Grid](https://mui.com/material-ui/react-grid/).
  *
  * The definitions were set following the Design System directives:
  *
  * | Breakpoint | Width (in px) | Gutters (in px) | Number of columns |
  * | ---------- | ------------- | --------------- | ----------------- |
- * | xs         | [0-575[       | 16              | 4                 |
- * | sm         | [576-767[     | 16              | 8                 |
- * | md         | [768-991[     | 32              | 12                |
- * | lg         | [992-1199[    | 32              | 12                |
- * | xl         | [1200-...[    | 32              | 12                |
+ * | xs         | [0-600[       | 16              | 4                 |
+ * | sm         | [600-960[     | 16              | 8                 |
+ * | md         | [960-1270[     | 32              | 12                |
+ * | lg         | [1270-1920[    | 32              | 12                |
+ * | xl         | [1920-...[    | 32              | 12                |
  *
  * However, the number of columns is set to 12 for all breakpoints, as it serves most
  * of the use cases and simplifies the implementation.

--- a/packages/core/src/components/SimpleGrid/SimpleGrid.styles.tsx
+++ b/packages/core/src/components/SimpleGrid/SimpleGrid.styles.tsx
@@ -6,7 +6,9 @@ import { createClasses } from "@core/utils/classes";
 
 import { Spacing, Breakpoint } from "./types";
 
-export const { staticClasses, useClasses } = createClasses("HvSimpleGrid", {});
+export const { staticClasses, useClasses } = createClasses("HvSimpleGrid", {
+  root: {},
+});
 
 function size(props: { size: any; sizes: any }) {
   if (typeof props.size === "number") {

--- a/packages/core/src/components/SimpleGrid/SimpleGrid.tsx
+++ b/packages/core/src/components/SimpleGrid/SimpleGrid.tsx
@@ -1,9 +1,19 @@
 import { HvBaseProps } from "@core/types/generic";
 import { useDefaultProps } from "@core/hooks/useDefaultProps";
+import { ExtractNames } from "@core/utils/classes";
 
 import { Breakpoint, Spacing } from "./types";
-import { getContainerStyle, useClasses } from "./SimpleGrid.styles";
+import {
+  getContainerStyle,
+  staticClasses,
+  useClasses,
+} from "./SimpleGrid.styles";
 
+export { staticClasses as simpleGridClasses };
+
+export type HvSimpleGridClasses = ExtractNames<typeof useClasses>;
+
+/** Grid component that enables you to create columns of equal width and define your own breakpoints and responsive behavior. */
 export interface HvSimpleGridProps extends HvBaseProps {
   /**
    * Spacing with pre-defined values according the values defined in the theme
@@ -23,6 +33,8 @@ export interface HvSimpleGridProps extends HvBaseProps {
    * Number of how many columns the content will be displayed
    */
   cols?: number;
+  /** A Jss Object used to override or extend the styles applied to the component. */
+  classes?: HvSimpleGridClasses;
 }
 
 export const HvSimpleGrid = (props: HvSimpleGridProps) => {
@@ -32,15 +44,19 @@ export const HvSimpleGrid = (props: HvSimpleGridProps) => {
     spacing = "sm",
     cols,
     className,
+    classes: classesProp,
     ...others
   } = useDefaultProps("HvSimpleGrid", props);
 
-  const { cx, css } = useClasses();
+  const { classes, cx, css } = useClasses(classesProp);
 
   const containerStyle = getContainerStyle({ breakpoints, spacing, cols });
 
   return (
-    <div className={cx(css(containerStyle), className)} {...others}>
+    <div
+      className={cx(css(containerStyle), classes.root, className)}
+      {...others}
+    >
       {children}
     </div>
   );


### PR DESCRIPTION
- Layout page added to the docs.
- The grid docs page was updated because the wrong breakpoints values were used.
- `classes` prop extracted from the simple grid component because it was added to the root component.