### PR TITLE
fix(TimePicker): fix a11y issues

### DIFF
--- a/packages/core/src/components/TimePicker/TimePicker.stories.tsx
+++ b/packages/core/src/components/TimePicker/TimePicker.stories.tsx
@@ -26,7 +26,6 @@ const makeDecorator = (styles: CSSProperties) => (Story) =>
 export const Main: StoryObj<HvTimePickerProps> = {
   args: {
     label: "Time Picker",
-    "aria-label": "Time Picker",
     description: "",
     placeholder: "Select a date",
   },
@@ -74,7 +73,6 @@ export const Form: StoryObj<HvTimePickerProps> = {
         <HvTimePicker
           name="scheduleTime"
           label="Time Picker"
-          aria-label="Time Picker"
           defaultValue={{ hours: 5, minutes: 30, seconds: 14 }}
           onChange={console.log}
         />
@@ -110,27 +108,11 @@ export const Variants: StoryObj<HvTimePickerProps> = {
 
     return (
       <div className={css(styles.root)}>
-        <HvTimePicker
-          required
-          label="Required"
-          aria-label="Required"
-          defaultValue={value}
-        />
-        <HvTimePicker
-          disabled
-          label="Disabled"
-          aria-label="Disabled"
-          defaultValue={value}
-        />
-        <HvTimePicker
-          readOnly
-          label="Read-only"
-          aria-label="Read only"
-          defaultValue={value}
-        />
+        <HvTimePicker required label="Required" defaultValue={value} />
+        <HvTimePicker disabled label="Disabled" defaultValue={value} />
+        <HvTimePicker readOnly label="Read-only" defaultValue={value} />
         <HvTimePicker
           label="Invalid"
-          aria-label="Invalid"
           status="invalid"
           statusMessage="This is an invalid time"
           defaultValue={value}
@@ -166,7 +148,6 @@ export const Controlled: StoryObj<HvTimePickerProps> = {
         <br />
         <HvTimePicker
           label="Time Picker"
-          aria-label="Time Picker"
           defaultValue={value}
           onChange={setValue}
         />
@@ -197,7 +178,6 @@ export const Format12Hours: StoryObj<HvTimePickerProps> = {
       <HvTimePicker
         timeFormat="12"
         label="Time Picker"
-        aria-label="Time Picker"
         defaultValue={{ hours: 19, minutes: 30, seconds: 14 }}
       />
     );

--- a/packages/core/src/components/TimePicker/TimePicker.tsx
+++ b/packages/core/src/components/TimePicker/TimePicker.tsx
@@ -189,7 +189,7 @@ export const HvTimePicker = (props: HvTimePickerProps) => {
     },
   };
   const state = useTimeFieldState(stateProps);
-  const { labelProps, fieldProps } = useTimeField(
+  const { labelProps, fieldProps, descriptionProps } = useTimeField(
     {
       ...stateProps,
       id,
@@ -246,7 +246,10 @@ export const HvTimePicker = (props: HvTimePickerProps) => {
             <HvLabel label={label} className={classes.label} {...labelProps} />
           )}
           {description && (
-            <HvInfoMessage className={classes.description}>
+            <HvInfoMessage
+              className={classes.description}
+              {...descriptionProps}
+            >
               {description}
             </HvInfoMessage>
           )}
@@ -299,6 +302,8 @@ export const HvTimePicker = (props: HvTimePickerProps) => {
         }}
         aria-haspopup="dialog"
         aria-label={ariaLabel}
+        aria-labelledby={fieldProps["aria-labelledby"]}
+        aria-describedby={fieldProps["aria-describedby"]}
         aria-invalid={isStateInvalid ? true : undefined}
         aria-errormessage={errorMessageId}
         disablePortal={disablePortal}


### PR DESCRIPTION
- Missing `aria-labelledby` and `aria-describedby` added to the base dropdown on the time picker component. This was leading to accessibility issues on the query builder.
- I removed the `aria-label` from the time picker stories because since the `label` is set it shouldn't necessary to have both. They were previously added to fix the accessibility issues on the time picker stories. This PR fixes these previous issues without having the need to set both the `aria-label` and `label`. 