### PR TITLE
fix(Table): a11y issues fixed 

### DIFF
--- a/docs/guides/visualizations/Visualizations.stories.mdx
+++ b/docs/guides/visualizations/Visualizations.stories.mdx
@@ -10,12 +10,13 @@ The NEXT UI Kit offers a set of visualizations that enables you to visual displa
 At the moment, the following visualizations are available and we are continuously working on expanding the selection we offer:
 
 - [KPI](/docs/visualizations-kpi--main)
+- [Table](/docs/visualizations-table--main)
 - [Line chart](/docs/visualizations-line-chart--main)
 - [Bar chart](/docs/visualizations-bar-chart--main)
 - [Donut chart](/docs/visualizations-donut-chart--main)
 - [Confusion matrix](/docs/visualizations-confusion-matrix--main)
 
-The KPI component is available on the `uikit-react-core` package while all the other visualizations are in the `uikit-react-viz` package.
+The KPI and Table components are available on the `uikit-react-core` package while all the other visualizations are in the `uikit-react-viz` package.
 
 All the information below is only applicable to the visualizations from the `uikit-react-viz` package.
 

--- a/packages/core/src/components/Table/TableHeader/TableHeader.tsx
+++ b/packages/core/src/components/Table/TableHeader/TableHeader.tsx
@@ -15,7 +15,7 @@ import { theme } from "@hitachivantara/uikit-styles";
 import { HvTypography, HvTypographyProps } from "@core/components/Typography";
 import { useTheme } from "@core/hooks/useTheme";
 import { ExtractNames } from "@core/utils/classes";
-import { HvButton } from "@core/components/Button";
+import { HvButton, HvButtonProps } from "@core/components/Button";
 
 import TableContext from "../TableContext";
 import TableSectionContext from "../TableSectionContext";
@@ -71,6 +71,8 @@ export interface HvTableHeaderProps
   resizerProps?: HTMLAttributes<HTMLDivElement>;
   /** A Jss Object used to override or extend the styles applied to the component. */
   classes?: HvTableHeaderClasses;
+  /** Extra props to be passed onto the sort button in the header. */
+  sortButtonProps?: HvButtonProps;
 }
 
 const defaultComponent = "th";
@@ -102,6 +104,7 @@ export const HvTableHeader = forwardRef<HTMLElement, HvTableHeaderProps>(
       resizerProps = {},
       resizable = false,
       resizing = false,
+      sortButtonProps,
       ...others
     },
     externalRef
@@ -183,6 +186,8 @@ export const HvTableHeader = forwardRef<HTMLElement, HvTableHeaderProps>(
               className={classes.sortButton}
               icon
               overrideIconColors={false}
+              aria-label="Sort"
+              {...sortButtonProps}
             >
               <Sort className={classes.sortIcon} />
             </HvButton>

--- a/packages/core/src/components/Table/renderers/ProgressColumnCell/ProgressColumnCell.tsx
+++ b/packages/core/src/components/Table/renderers/ProgressColumnCell/ProgressColumnCell.tsx
@@ -9,6 +9,7 @@ export interface HvProgressColumnCellProp {
   total: number;
   /** The color of the bar. */
   color?: "primary" | "secondary";
+  "aria-labelledby"?: string;
 }
 
 export const normalizeProgressBar = (value: number, max: number) => {
@@ -19,6 +20,7 @@ export const HvProgressColumnCell = ({
   partial,
   total,
   color = "primary",
+  "aria-labelledby": ariaLabelledBy,
 }: HvProgressColumnCellProp): JSX.Element => {
   const { classes } = useClasses();
 
@@ -38,6 +40,7 @@ export const HvProgressColumnCell = ({
           color={color}
           variant="determinate"
           value={percentage}
+          aria-labelledby={ariaLabelledBy}
         />
       </div>
     </div>

--- a/packages/core/src/components/Table/renderers/SwitchColumnCell/SwitchColumnCell.tsx
+++ b/packages/core/src/components/Table/renderers/SwitchColumnCell/SwitchColumnCell.tsx
@@ -40,10 +40,10 @@ export const HvSwitchColumnCell = ({
         </HvTypography>
       )}
       <HvBaseSwitch
-        aria-label={switchLabel}
         checked={checked}
         value={value}
         {...switchProps}
+        inputProps={{ "aria-label": switchLabel, ...switchProps?.inputProps }}
       />
       {trueLabel != null && (
         <HvTypography

--- a/packages/core/src/components/Table/renderers/renderers.tsx
+++ b/packages/core/src/components/Table/renderers/renderers.tsx
@@ -176,6 +176,8 @@ export function hvTagColumn<
   };
 }
 
+// TODO - Review accessibility on the next renderers because they all differ
+
 export function hvSwitchColumn<
   D extends object = Record<string, unknown>,
   H extends HvTableHeaderRenderer | undefined = HvTableHeaderRenderer
@@ -213,7 +215,7 @@ export function hvDropdownColumn<
   H extends HvTableHeaderRenderer | undefined = HvTableHeaderRenderer
 >(
   col: HvTableColumnConfig<D, H>,
-  id: string,
+  id: string | undefined,
   placeholder: string,
   disabledPlaceholder: string,
   onChange?: (identifier: string, value: HvListValue) => void
@@ -229,7 +231,7 @@ export function hvDropdownColumn<
           onChange={(val) => onChange?.(row.id, val)}
           disabled={dsbld}
           dropdownProps={{
-            "aria-labelledby": setId(id, column.id),
+            "aria-labelledby": setId(id, column.id) || column.id || id, // TODO - to be reviewed because it doesn't make much sense
           }}
         />
       );
@@ -253,13 +255,18 @@ export function hvProgressColumn<
 ): HvTableColumnConfig<D, H> {
   return {
     Cell: (cellProps: HvCellProps<D, H>) => {
-      const { row } = cellProps;
+      const { row, column } = cellProps;
       const partial = getPartial?.(row) || 0;
       const total = getTotal?.(row);
 
       if (total) {
         return (
-          <HvProgressColumnCell partial={partial} total={total} color={color} />
+          <HvProgressColumnCell
+            partial={partial}
+            total={total}
+            color={color}
+            aria-labelledby={column.id}
+          />
         );
       }
 

--- a/packages/core/src/components/Table/stories/Table.stories.tsx
+++ b/packages/core/src/components/Table/stories/Table.stories.tsx
@@ -124,7 +124,7 @@ const StyledResponsiveTableHeader = styled(HvTableHeader)({
 // #endregion Responsive table styled components
 
 export default {
-  title: "Guides/Table",
+  title: "Visualizations/Table",
   component: HvTable,
   subcomponents: {
     HvTableContainer,

--- a/packages/core/src/components/Table/stories/Table.stories.tsx
+++ b/packages/core/src/components/Table/stories/Table.stories.tsx
@@ -203,7 +203,7 @@ export const NoData: StoryObj<HvTableProps> = {
               <HvTableCell colSpan={100} style={{ height: 96 }}>
                 <HvEmptyState
                   message="No data to display."
-                  icon={<Ban role="presentation" />}
+                  icon={<Ban role="none" />}
                 />
               </HvTableCell>
             </HvTableRow>
@@ -256,6 +256,7 @@ export const SimpleTable: StoryObj<HvTableProps> = {
               <HvTableRow key={el.id} hover selected={checkedIdx === idx}>
                 <HvTableCell variant="checkbox">
                   <HvCheckBox
+                    aria-label="Tick to select the row"
                     checked={checkedIdx === idx}
                     onClick={toggleChecked(idx)}
                   />
@@ -376,7 +377,7 @@ export const ResponsiveTable = () => {
             ))}
           </StyledResponsiveTableRow>
         </StyledResponsiveHead>
-        <StyledResponsiveBody $breakpoints={muiTheme.breakpoints}>
+        <StyledResponsiveBody tabIndex={0} $breakpoints={muiTheme.breakpoints}>
           {data.map((row) => {
             return (
               <StyledResponsiveTableRow
@@ -442,6 +443,7 @@ export const ListRow = () => {
                 <HvTableRow key={el.id} hover selected={checkedIdx === idx}>
                   <HvTableCell variant="listcheckbox">
                     <HvCheckBox
+                      aria-label="Tick to select the row"
                       checked={checkedIdx === idx}
                       onClick={toggleChecked(idx)}
                     />

--- a/packages/core/src/components/Table/stories/TableHooks/TableHooks.stories.mdx
+++ b/packages/core/src/components/Table/stories/TableHooks/TableHooks.stories.mdx
@@ -1,7 +1,7 @@
 import { Meta, Canvas, Story } from "@storybook/addon-docs";
 import { UseHvHooksStory } from "./TableHooks.stories";
 
-<Meta title="Guides/Table/Table Hooks" />
+<Meta title="Visualizations/Table/Table Hooks" />
 
 # Table Hooks
 

--- a/packages/core/src/components/Table/stories/TableHooks/TableHooks.stories.tsx
+++ b/packages/core/src/components/Table/stories/TableHooks/TableHooks.stories.tsx
@@ -533,7 +533,7 @@ const UseHvBulkActions = () => {
         <HvTableCell colSpan={100} style={{ height: 96 }}>
           <HvEmptyState
             message="No data to display."
-            icon={<Ban role="presentation" />}
+            icon={<Ban role="none" />}
           />
         </HvTableCell>
       </HvTableRow>
@@ -655,7 +655,7 @@ const EmptyStateRow = useCallback(
       <HvTableCell colSpan={100} style={{ height: 96 }}>
         <HvEmptyState
           message="No data to display."
-          icon={<Ban role="presentation" />}
+          icon={<Ban role="none" />}
         />
       </HvTableCell>
     </HvTableRow>
@@ -1215,7 +1215,7 @@ const UseHvTableSticky = () => {
             </HvTableRow>
           ))}
         </HvTableHead>
-        <HvTableBody {...getTableBodyProps()}>
+        <HvTableBody tabIndex={0} {...getTableBodyProps()}>
           {rows.map((row) => {
             prepareRow(row);
 
@@ -1300,7 +1300,7 @@ return (
           </HvTableRow>
         ))}
       </HvTableHead>
-      <HvTableBody {...getTableBodyProps()}>
+      <HvTableBody tabIndex={0} {...getTableBodyProps()}>
         {rows.map((row) => {
           prepareRow(row);
 

--- a/packages/core/src/components/Table/stories/TableHooks/UseHvBulkActions.stories.mdx
+++ b/packages/core/src/components/Table/stories/TableHooks/UseHvBulkActions.stories.mdx
@@ -1,7 +1,7 @@
 import { Meta, Canvas, Story } from "@storybook/addon-docs";
 import { UseHvBulkActionsStory } from "./TableHooks.stories";
 
-<Meta title="Guides/Table/Table Hooks/Hooks/useHvBulkActions" />
+<Meta title="Visualizations/Table/Table Hooks/Hooks/useHvBulkActions" />
 
 # useHvBulkActions
 

--- a/packages/core/src/components/Table/stories/TableHooks/UseHvGroupBy.stories.mdx
+++ b/packages/core/src/components/Table/stories/TableHooks/UseHvGroupBy.stories.mdx
@@ -1,7 +1,7 @@
 import { Meta, Canvas, Story } from "@storybook/addon-docs";
 import { UseHvGroupByStory } from "./TableHooks.stories";
 
-<Meta title="Guides/Table/Table Hooks/Hooks/useHvGroupBy" />
+<Meta title="Visualizations/Table/Table Hooks/Hooks/useHvGroupBy" />
 
 # useHvGroupBy
 

--- a/packages/core/src/components/Table/stories/TableHooks/UseHvHeaderGroups.stories.mdx
+++ b/packages/core/src/components/Table/stories/TableHooks/UseHvHeaderGroups.stories.mdx
@@ -1,7 +1,7 @@
 import { Meta, Canvas, Story } from "@storybook/addon-docs";
 import { UseHvHeaderGroupsStory } from "./TableHooks.stories";
 
-<Meta title="Guides/Table/Table Hooks/Hooks/useHvHeaderGroups" />
+<Meta title="Visualizations/Table/Table Hooks/Hooks/useHvHeaderGroups" />
 
 # useHvHeaderGroups
 

--- a/packages/core/src/components/Table/stories/TableHooks/UseHvPagination.stories.mdx
+++ b/packages/core/src/components/Table/stories/TableHooks/UseHvPagination.stories.mdx
@@ -1,7 +1,7 @@
 import { Meta, Canvas, Story } from "@storybook/addon-docs";
 import { UseHvPaginationStory } from "./TableHooks.stories";
 
-<Meta title="Guides/Table/Table Hooks/Hooks/useHvPagination" />
+<Meta title="Visualizations/Table/Table Hooks/Hooks/useHvPagination" />
 
 # useHvPagination
 

--- a/packages/core/src/components/Table/stories/TableHooks/UseHvRowExpand.stories.mdx
+++ b/packages/core/src/components/Table/stories/TableHooks/UseHvRowExpand.stories.mdx
@@ -1,7 +1,7 @@
 import { Meta, Canvas, Story } from "@storybook/addon-docs";
 import { UseHvRowExpandStory } from "./TableHooks.stories";
 
-<Meta title="Guides/Table/Table Hooks/Hooks/useHvRowExpand" />
+<Meta title="Visualizations/Table/Table Hooks/Hooks/useHvRowExpand" />
 
 # useHvRowExpand
 

--- a/packages/core/src/components/Table/stories/TableHooks/UseHvRowSelection.stories.mdx
+++ b/packages/core/src/components/Table/stories/TableHooks/UseHvRowSelection.stories.mdx
@@ -4,7 +4,7 @@ import {
   UseHvSelectionControlledStory,
 } from "./TableHooks.stories";
 
-<Meta title="Guides/Table/Table Hooks/Hooks/useHvRowSelection" />
+<Meta title="Visualizations/Table/Table Hooks/Hooks/useHvRowSelection" />
 
 # useHvRowSelection
 

--- a/packages/core/src/components/Table/stories/TableHooks/UseHvSortBy.stories.mdx
+++ b/packages/core/src/components/Table/stories/TableHooks/UseHvSortBy.stories.mdx
@@ -1,7 +1,7 @@
 import { Meta, Canvas, Story } from "@storybook/addon-docs";
 import { UseHvSortByStory } from "./TableHooks.stories";
 
-<Meta title="Guides/Table/Table Hooks/Hooks/useHvSortBy" />
+<Meta title="Visualizations/Table/Table Hooks/Hooks/useHvSortBy" />
 
 # useHvSortBy
 

--- a/packages/core/src/components/Table/stories/TableHooks/UseHvTableSticky.stories.mdx
+++ b/packages/core/src/components/Table/stories/TableHooks/UseHvTableSticky.stories.mdx
@@ -1,7 +1,7 @@
 import { Meta, Canvas, Story } from "@storybook/addon-docs";
 import { UseHvTableStickyStory } from "./TableHooks.stories";
 
-<Meta title="Guides/Table/Table Hooks/Hooks/useHvTableSticky" />
+<Meta title="Visualizations/Table/Table Hooks/Hooks/useHvTableSticky" />
 
 # useHvTableSticky
 

--- a/packages/core/src/components/Table/stories/TableRenderers/DateColumnRenderer.stories.mdx
+++ b/packages/core/src/components/Table/stories/TableRenderers/DateColumnRenderer.stories.mdx
@@ -1,7 +1,7 @@
 import { Meta, Canvas, Story } from "@storybook/addon-docs";
 import { DateColumnRendererStory } from "./TableRenderers.stories";
 
-<Meta title="Guides/Table/Table Renderers/Renderers/Date Column Renderer" />
+<Meta title="Visualizations/Table/Table Renderers/Renderers/Date Column Renderer" />
 
 # Date Column Renderer
 

--- a/packages/core/src/components/Table/stories/TableRenderers/DropdownColumnRenderer.stories.mdx
+++ b/packages/core/src/components/Table/stories/TableRenderers/DropdownColumnRenderer.stories.mdx
@@ -1,7 +1,7 @@
 import { Meta, Canvas, Story } from "@storybook/addon-docs";
 import { DropdownColumnRendererStory } from "./TableRenderers.stories";
 
-<Meta title="Guides/Table/Table Renderers/Renderers/Dropdown Column Renderer" />
+<Meta title="Visualizations/Table/Table Renderers/Renderers/Dropdown Column Renderer" />
 
 # Dropdown Column Renderer
 

--- a/packages/core/src/components/Table/stories/TableRenderers/ExpandColumnRenderer.stories.mdx
+++ b/packages/core/src/components/Table/stories/TableRenderers/ExpandColumnRenderer.stories.mdx
@@ -1,7 +1,7 @@
 import { Meta, Canvas, Story } from "@storybook/addon-docs";
 import { ExpandColumnRendererStory } from "./TableRenderers.stories";
 
-<Meta title="Guides/Table/Table Renderers/Renderers/Expand Column Renderer" />
+<Meta title="Visualizations/Table/Table Renderers/Renderers/Expand Column Renderer" />
 
 # Expand Column Renderer
 

--- a/packages/core/src/components/Table/stories/TableRenderers/NumberColumnRenderer.stories.mdx
+++ b/packages/core/src/components/Table/stories/TableRenderers/NumberColumnRenderer.stories.mdx
@@ -1,7 +1,7 @@
 import { Meta, Canvas, Story } from "@storybook/addon-docs";
 import { NumberColumnRendererStory } from "./TableRenderers.stories";
 
-<Meta title="Guides/Table/Table Renderers/Renderers/Number Column Renderer" />
+<Meta title="Visualizations/Table/Table Renderers/Renderers/Number Column Renderer" />
 
 # Number Column Renderer
 

--- a/packages/core/src/components/Table/stories/TableRenderers/ProgressColumnRenderer.stories.mdx
+++ b/packages/core/src/components/Table/stories/TableRenderers/ProgressColumnRenderer.stories.mdx
@@ -1,7 +1,7 @@
 import { Meta, Canvas, Story } from "@storybook/addon-docs";
 import { ProgressColumnRendererStory } from "./TableRenderers.stories";
 
-<Meta title="Guides/Table/Table Renderers/Renderers/Progress Column Renderer" />
+<Meta title="Visualizations/Table/Table Renderers/Renderers/Progress Column Renderer" />
 
 # Progress Column Renderer
 

--- a/packages/core/src/components/Table/stories/TableRenderers/SwitchColumnRenderer.stories.mdx
+++ b/packages/core/src/components/Table/stories/TableRenderers/SwitchColumnRenderer.stories.mdx
@@ -1,7 +1,7 @@
 import { Meta, Canvas, Story } from "@storybook/addon-docs";
 import { SwitchColumnRendererStory } from "./TableRenderers.stories";
 
-<Meta title="Guides/Table/Table Renderers/Renderers/Switch Column Renderer" />
+<Meta title="Visualizations/Table/Table Renderers/Renderers/Switch Column Renderer" />
 
 # Switch Column Renderer
 

--- a/packages/core/src/components/Table/stories/TableRenderers/TableRenderers.stories.mdx
+++ b/packages/core/src/components/Table/stories/TableRenderers/TableRenderers.stories.mdx
@@ -1,7 +1,7 @@
 import { Meta, Canvas, Story } from "@storybook/addon-docs";
 import { AllColumnRenderersStory } from "./TableRenderers.stories";
 
-<Meta title="Guides/Table/Table Renderers" />
+<Meta title="Visualizations/Table/Table Renderers" />
 
 # Table Renderers
 

--- a/packages/core/src/components/Table/stories/TableRenderers/TableRenderers.stories.tsx
+++ b/packages/core/src/components/Table/stories/TableRenderers/TableRenderers.stories.tsx
@@ -33,10 +33,7 @@ import { makeRenderersData, NewRendererEntry } from "../storiesUtils";
 const EmptyRow = ({ height }) => (
   <HvTableRow>
     <HvTableCell colSpan={100} style={{ height }}>
-      <HvEmptyState
-        message="No data to display"
-        icon={<Ban role="presentation" />}
-      />
+      <HvEmptyState message="No data to display" icon={<Ban role="none" />} />
     </HvTableCell>
   </HvTableRow>
 );
@@ -48,6 +45,7 @@ const AllColumnRenderers = () => {
         Header: "isDisabled",
         accessor: "isDisabled",
         style: { minWidth: 130 },
+        id: "disabled-header",
       },
       "default",
       "yes",
@@ -57,27 +55,44 @@ const AllColumnRenderers = () => {
       }
     ),
     hvExpandColumn<NewRendererEntry, string>(
-      { Header: "Title", accessor: "name", style: { maxWidth: 100 } },
+      {
+        Header: "Title",
+        accessor: "name",
+        style: { maxWidth: 100 },
+        id: "title-header",
+      },
       "expand",
       "collapse",
       () => true
     ),
     hvDateColumn<NewRendererEntry, string>(
-      { Header: "Time", accessor: "createdDate", style: { minWidth: 50 } },
+      {
+        Header: "Time",
+        accessor: "createdDate",
+        style: { minWidth: 50 },
+        id: "time-header",
+      },
       "YYYY/MM/DD HH:mm"
     ),
     hvNumberColumn<NewRendererEntry, string>({
       Header: "Quantity",
       accessor: "eventQuantity",
       style: { minWidth: 20 },
+      id: "quantity-header",
     }),
     hvTextColumn<NewRendererEntry, string>({
       Header: "Event Type",
       accessor: "eventType",
       style: { maxWidth: 160 },
+      id: "event-type-header",
     }),
     hvTagColumn<NewRendererEntry, string, NewRendererEntry["status"]>(
-      { Header: "Status", accessor: "status", style: { width: 20 } },
+      {
+        Header: "Status",
+        accessor: "status",
+        style: { width: 20 },
+        id: "status-header",
+      },
       "status_name",
       "status_color",
       "status_text_color",
@@ -90,14 +105,15 @@ const AllColumnRenderers = () => {
         accessor: "riskScore",
         style: { width: 125 },
         disableSortBy: true,
+        id: "probability-header",
       },
       (row) => row.original.riskScore,
       () => 100,
       "secondary"
     ),
     hvDropdownColumn<NewRendererEntry, string>(
-      { Header: "Severity", accessor: "severity" },
-      "Severity-id-101",
+      { Header: "Severity", accessor: "severity", id: "severity-header" },
+      undefined,
       "Select severity...",
       "Select severity...",
       () => console.log("select me")
@@ -141,7 +157,7 @@ const AllColumnRenderers = () => {
         <React.Fragment key={row.id}>
           <HvTableRow
             {...row.getRowProps({
-              "aria-rowindex": index,
+              "aria-rowindex": index + 1,
             })}
           >
             {row.cells.map((cell) => (
@@ -183,7 +199,11 @@ const AllColumnRenderers = () => {
           <HvTableHead>
             <HvTableRow>
               {headers.map((col) => (
-                <HvTableHeader {...col.getHeaderProps()} key={col.Header}>
+                <HvTableHeader
+                  {...col.getHeaderProps()}
+                  key={col.Header}
+                  id={col.id}
+                >
                   {col.render("Header")}
                 </HvTableHeader>
               ))}
@@ -210,6 +230,7 @@ const getColumns = () => [
       Header: "isDisabled",
       accessor: "isDisabled",
       style: { minWidth: 130 },
+      id: "disabled-header"
     },
     "default",
     "yes",
@@ -219,27 +240,29 @@ const getColumns = () => [
     }
   ),
   hvExpandColumn<NewRendererEntry, string>(
-    { Header: "Title", accessor: "name", style: { maxWidth: 100 } },
+    { Header: "Title", accessor: "name", style: { maxWidth: 100 }, id: "title-header" },
     "expand",
     "collapse",
     () => true
   ),
   hvDateColumn<NewRendererEntry, string>(
-    { Header: "Time", accessor: "createdDate", style: { minWidth: 50 } },
+    { Header: "Time", accessor: "createdDate", style: { minWidth: 50 }, id: "time-header" },
     "YYYY/MM/DD HH:mm"
   ),
   hvNumberColumn<NewRendererEntry, string>({
     Header: "Quantity",
     accessor: "eventQuantity",
     style: { minWidth: 20 },
+    id: "quantity-header"
   }),
   hvTextColumn<NewRendererEntry, string>({
     Header: "Event Type",
     accessor: "eventType",
     style: { maxWidth: 160 },
+    id: "event-type-header"
   }),
   hvTagColumn<NewRendererEntry, string, NewRendererEntry["status"]>(
-    { Header: "Status", accessor: "status", style: { width: 20 } },
+    { Header: "Status", accessor: "status", style: { width: 20 }, id: "status-header" },
     "status_name",
     "status_color",
     "status_text_color",
@@ -252,14 +275,15 @@ const getColumns = () => [
       accessor: "riskScore",
       style: { width: 125 },
       disableSortBy: true,
+      id: "probability-header"
     },
     (row) => row.original.riskScore,
     () => 100,
     "secondary"
   ),
   hvDropdownColumn<NewRendererEntry, string>(
-    { Header: "Severity", accessor: "severity" },
-    "Severity-id-101",
+    { Header: "Severity", accessor: "severity", id: "severity-header" },
+    undefined,
     "Select severity...",
     "Select severity...",
     () => console.log("select me")
@@ -279,7 +303,7 @@ const EmptyRow = () => (
     <HvTableCell colSpan={100} style={{ height: 100 }}>
       <HvEmptyState
         message="No data to display"
-        icon={<Ban role="presentation" />}
+        icon={<Ban role="none" />}
       />
     </HvTableCell>
   </HvTableRow>
@@ -314,7 +338,7 @@ const rowRenderer = (pages: HvRowInstance<NewRendererEntry, string>[]) => {
       <React.Fragment key={row.id}>
         <HvTableRow
           {...row.getRowProps({
-            "aria-rowindex": index,
+            "aria-rowindex": index + 1,
           })}
         >
           {row.cells.map((cell) => (
@@ -356,7 +380,7 @@ return (
         <HvTableHead>
           <HvTableRow>
             {headers.map((col) => (
-              <HvTableHeader {...col.getHeaderProps()} key={col.Header}>
+              <HvTableHeader {...col.getHeaderProps()} key={col.Header} id={col.id}>
                 {col.render("Header")}
               </HvTableHeader>
             ))}
@@ -420,7 +444,7 @@ const TextColumnRenderer = () => {
         <React.Fragment key={row.id}>
           <HvTableRow
             {...row.getRowProps({
-              "aria-rowindex": index,
+              "aria-rowindex": index + 1,
             })}
           >
             {row.cells.map((cell) => (
@@ -490,7 +514,7 @@ const EmptyRow = () => (
     <HvTableCell colSpan={100} style={{ height: 100 }}>
       <HvEmptyState
         message="No data to display"
-        icon={<Ban role="presentation" />}
+        icon={<Ban role="none" />}
       />
     </HvTableCell>
   </HvTableRow>
@@ -523,7 +547,7 @@ const rowRenderer = (pages: HvRowInstance<NewRendererEntry, string>[]) => {
       <React.Fragment key={row.id}>
         <HvTableRow
           {...row.getRowProps({
-            "aria-rowindex": index,
+            "aria-rowindex": index + 1,
           })}
         >
           {row.cells.map((cell) => (
@@ -615,7 +639,7 @@ const NumberColumnRenderer = () => {
         <React.Fragment key={row.id}>
           <HvTableRow
             {...row.getRowProps({
-              "aria-rowindex": index,
+              "aria-rowindex": index + 1,
             })}
           >
             {row.cells.map((cell) => (
@@ -685,7 +709,7 @@ const EmptyRow = () => (
     <HvTableCell colSpan={100} style={{ height: 50 }}>
       <HvEmptyState
         message="No data to display"
-        icon={<Ban role="presentation" />}
+        icon={<Ban role="none" />}
       />
     </HvTableCell>
   </HvTableRow>
@@ -718,7 +742,7 @@ const rowRenderer = (pages: HvRowInstance<NewRendererEntry, string>[]) => {
       <React.Fragment key={row.id}>
         <HvTableRow
           {...row.getRowProps({
-            "aria-rowindex": index,
+            "aria-rowindex": index + 1,
           })}
         >
           {row.cells.map((cell) => (
@@ -809,7 +833,7 @@ const DateColumnRenderer = () => {
         <React.Fragment key={row.id}>
           <HvTableRow
             {...row.getRowProps({
-              "aria-rowindex": index,
+              "aria-rowindex": index + 1,
             })}
           >
             {row.cells.map((cell) => (
@@ -878,7 +902,7 @@ const EmptyRow = () => (
     <HvTableCell colSpan={100} style={{ height: 50 }}>
       <HvEmptyState
         message="No data to display"
-        icon={<Ban role="presentation" />}
+        icon={<Ban role="none" />}
       />
     </HvTableCell>
   </HvTableRow>
@@ -911,7 +935,7 @@ const rowRenderer = (pages: HvRowInstance<NewRendererEntry, string>[]) => {
       <React.Fragment key={row.id}>
         <HvTableRow
           {...row.getRowProps({
-            "aria-rowindex": index,
+            "aria-rowindex": index + 1,
           })}
         >
           {row.cells.map((cell) => (
@@ -1011,7 +1035,7 @@ const ExpandColumnRenderer = () => {
         <React.Fragment key={row.id}>
           <HvTableRow
             {...row.getRowProps({
-              "aria-rowindex": index,
+              "aria-rowindex": index + 1,
             })}
           >
             {row.cells.map((cell) => (
@@ -1105,7 +1129,7 @@ const EmptyRow = () => (
     <HvTableCell colSpan={100} style={{ height: 50 }}>
       <HvEmptyState
         message="No data to display"
-        icon={<Ban role="presentation" />}
+        icon={<Ban role="none" />}
       />
     </HvTableCell>
   </HvTableRow>
@@ -1140,7 +1164,7 @@ const rowRenderer = (pages: HvRowInstance<NewRendererEntry, string>[]) => {
       <React.Fragment key={row.id}>
         <HvTableRow
           {...row.getRowProps({
-            "aria-rowindex": index,
+            "aria-rowindex": index + 1,
           })}
         >
           {row.cells.map((cell) => (
@@ -1265,7 +1289,7 @@ const SwitchColumnRenderer = () => {
         <React.Fragment key={row.id}>
           <HvTableRow
             {...row.getRowProps({
-              "aria-rowindex": index,
+              "aria-rowindex": index + 1,
             })}
           >
             {row.cells.map((cell) => (
@@ -1351,7 +1375,7 @@ const EmptyRow = () => (
     <HvTableCell colSpan={100} style={{ height: 50 }}>
       <HvEmptyState
         message="No data to display"
-        icon={<Ban role="presentation" />}
+        icon={<Ban role="none" />}
       />
     </HvTableCell>
   </HvTableRow>
@@ -1384,7 +1408,7 @@ const rowRenderer = (pages: HvRowInstance<NewRendererEntry, string>[]) => {
       <React.Fragment key={row.id}>
         <HvTableRow
           {...row.getRowProps({
-            "aria-rowindex": index,
+            "aria-rowindex": index + 1,
           })}
         >
           {row.cells.map((cell) => (
@@ -1480,7 +1504,7 @@ const TagColumnRenderer = () => {
         <React.Fragment key={row.id}>
           <HvTableRow
             {...row.getRowProps({
-              "aria-rowindex": index,
+              "aria-rowindex": index + 1,
             })}
           >
             {row.cells.map((cell) => (
@@ -1554,7 +1578,7 @@ const EmptyRow = () => (
     <HvTableCell colSpan={100} style={{ height: 50 }}>
       <HvEmptyState
         message="No data to display"
-        icon={<Ban role="presentation" />}
+        icon={<Ban role="none" />}
       />
     </HvTableCell>
   </HvTableRow>
@@ -1587,7 +1611,7 @@ const rowRenderer = (pages: HvRowInstance<NewRendererEntry, string>[]) => {
       <React.Fragment key={row.id}>
         <HvTableRow
           {...row.getRowProps({
-            "aria-rowindex": index,
+            "aria-rowindex": index + 1,
           })}
         >
           {row.cells.map((cell) => (
@@ -1644,6 +1668,7 @@ const ProgressColumnRenderer = () => {
           accessor: "riskScore",
           style: { width: 125 },
           disableSortBy: true,
+          id: "probability-header",
         },
         (row) => row.original.riskScore,
         () => 100,
@@ -1683,7 +1708,7 @@ const ProgressColumnRenderer = () => {
         <React.Fragment key={row.id}>
           <HvTableRow
             {...row.getRowProps({
-              "aria-rowindex": index,
+              "aria-rowindex": index + 1,
             })}
           >
             {row.cells.map((cell) => (
@@ -1711,7 +1736,11 @@ const ProgressColumnRenderer = () => {
           <HvTableHead>
             <HvTableRow>
               {headers.map((col) => (
-                <HvTableHeader {...col.getHeaderProps()} key={col.Header}>
+                <HvTableHeader
+                  {...col.getHeaderProps()}
+                  key={col.Header}
+                  id={col.id}
+                >
                   {col.render("Header")}
                 </HvTableHeader>
               ))}
@@ -1740,6 +1769,7 @@ const columns = useMemo(() => {
         accessor: "riskScore",
         style: { width: 125 },
         disableSortBy: true,
+        id: "probability-header"
       },
       (row) => row.original.riskScore,
       () => 100,
@@ -1757,7 +1787,7 @@ const EmptyRow = () => (
     <HvTableCell colSpan={100} style={{ height: 100 }}>
       <HvEmptyState
         message="No data to display"
-        icon={<Ban role="presentation" />}
+        icon={<Ban role="none" />}
       />
     </HvTableCell>
   </HvTableRow>
@@ -1790,7 +1820,7 @@ const rowRenderer = (pages: HvRowInstance<NewRendererEntry, string>[]) => {
       <React.Fragment key={row.id}>
         <HvTableRow
           {...row.getRowProps({
-            "aria-rowindex": index,
+            "aria-rowindex": index + 1,
           })}
         >
           {row.cells.map((cell) => (
@@ -1818,7 +1848,7 @@ return (
         <HvTableHead>
           <HvTableRow>
             {headers.map((col) => (
-              <HvTableHeader {...col.getHeaderProps()} key={col.Header}>
+              <HvTableHeader {...col.getHeaderProps()} key={col.Header} id={col.id}>
                 {col.render("Header")}
               </HvTableHeader>
             ))}
@@ -1846,8 +1876,8 @@ const DropdownColumnRenderer = () => {
   const columns = useMemo(() => {
     return [
       hvDropdownColumn<NewRendererEntry, string>(
-        { Header: "Severity", accessor: "severity" },
-        "Severity-id-101",
+        { Header: "Severity", accessor: "severity", id: "severity-header" },
+        undefined,
         "Select severity...",
         "Select severity...",
         (id, value) => {
@@ -1897,7 +1927,7 @@ const DropdownColumnRenderer = () => {
         <React.Fragment key={row.id}>
           <HvTableRow
             {...row.getRowProps({
-              "aria-rowindex": index,
+              "aria-rowindex": index + 1,
             })}
           >
             {row.cells.map((cell) => (
@@ -1925,7 +1955,11 @@ const DropdownColumnRenderer = () => {
           <HvTableHead>
             <HvTableRow>
               {headers.map((col) => (
-                <HvTableHeader {...col.getHeaderProps()} key={col.Header}>
+                <HvTableHeader
+                  {...col.getHeaderProps()}
+                  key={col.Header}
+                  id={col.id}
+                >
                   {col.render("Header")}
                 </HvTableHeader>
               ))}
@@ -1953,8 +1987,8 @@ const [data, setData] = useState(initialData);
 const columns = useMemo(() => {
   return [
     hvDropdownColumn<NewRendererEntry, string>(
-      { Header: "Severity", accessor: "severity" },
-      "Severity-id-101",
+      { Header: "Severity", accessor: "severity", id: "severity-header" },
+      undefined,
       "Select severity...",
       "Select severity...",
       (id, value) => {
@@ -1982,7 +2016,7 @@ const EmptyRow = () => (
     <HvTableCell colSpan={100} style={{ height: 100 }}>
       <HvEmptyState
         message="No data to display"
-        icon={<Ban role="presentation" />}
+        icon={<Ban role="none" />}
       />
     </HvTableCell>
   </HvTableRow>
@@ -2015,7 +2049,7 @@ const rowRenderer = (pages: HvRowInstance<NewRendererEntry, string>[]) => {
       <React.Fragment key={row.id}>
         <HvTableRow
           {...row.getRowProps({
-            "aria-rowindex": index,
+            "aria-rowindex": index + 1,
           })}
         >
           {row.cells.map((cell) => (
@@ -2043,7 +2077,7 @@ return (
         <HvTableHead>
           <HvTableRow>
             {headers.map((col) => (
-              <HvTableHeader {...col.getHeaderProps()} key={col.Header}>
+              <HvTableHeader {...col.getHeaderProps()} key={col.Header} id={col.id}>
                 {col.render("Header")}
               </HvTableHeader>
             ))}

--- a/packages/core/src/components/Table/stories/TableRenderers/TagColumnRenderer.stories.mdx
+++ b/packages/core/src/components/Table/stories/TableRenderers/TagColumnRenderer.stories.mdx
@@ -1,7 +1,7 @@
 import { Meta, Canvas, Story } from "@storybook/addon-docs";
 import { TagColumnRendererStory } from "./TableRenderers.stories";
 
-<Meta title="Guides/Table/Table Renderers/Renderers/Tag Column Renderer" />
+<Meta title="Visualizations/Table/Table Renderers/Renderers/Tag Column Renderer" />
 
 # Tag Column Renderer
 

--- a/packages/core/src/components/Table/stories/TableRenderers/TextColumnRenderer.stories.mdx
+++ b/packages/core/src/components/Table/stories/TableRenderers/TextColumnRenderer.stories.mdx
@@ -1,7 +1,7 @@
 import { Meta, Canvas, Story } from "@storybook/addon-docs";
 import { TextColumnRendererStory } from "./TableRenderers.stories";
 
-<Meta title="Guides/Table/Table Renderers/Renderers/Text Column Renderer" />
+<Meta title="Visualizations/Table/Table Renderers/Renderers/Text Column Renderer" />
 
 # Text Column Renderer
 

--- a/packages/core/src/components/Table/stories/TableSamples/AlternativeLayout.stories.mdx
+++ b/packages/core/src/components/Table/stories/TableSamples/AlternativeLayout.stories.mdx
@@ -1,7 +1,7 @@
 import { Meta, Canvas, Story } from "@storybook/addon-docs";
 import { AlternativeLayoutStory } from "./TableSamples.stories";
 
-<Meta title="Guides/Table/Table Samples/Alternative Layout" />
+<Meta title="Visualizations/Table/Table Samples/Alternative Layout" />
 
 # Alternative Layout
 

--- a/packages/core/src/components/Table/stories/TableSamples/ColumnResize.stories.mdx
+++ b/packages/core/src/components/Table/stories/TableSamples/ColumnResize.stories.mdx
@@ -1,7 +1,7 @@
 import { Meta, Canvas, Story } from "@storybook/addon-docs";
 import { ColumnResizeStory } from "./TableSamples.stories";
 
-<Meta title="Guides/Table/Table Samples/Column Resize" />
+<Meta title="Visualizations/Table/Table Samples/Column Resize" />
 
 # Column Resize
 

--- a/packages/core/src/components/Table/stories/TableSamples/EmptyCells.stories.mdx
+++ b/packages/core/src/components/Table/stories/TableSamples/EmptyCells.stories.mdx
@@ -1,7 +1,7 @@
 import { Meta, Canvas, Story } from "@storybook/addon-docs";
 import { EmptyCellsStory } from "./TableSamples.stories";
 
-<Meta title="Guides/Table/Table Samples/Empty Cells" />
+<Meta title="Visualizations/Table/Table Samples/Empty Cells" />
 
 # Empty Cells
 

--- a/packages/core/src/components/Table/stories/TableSamples/LockedSelection.stories.mdx
+++ b/packages/core/src/components/Table/stories/TableSamples/LockedSelection.stories.mdx
@@ -1,7 +1,7 @@
 import { Meta, Canvas, Story } from "@storybook/addon-docs";
 import { LockedSelectionStory } from "./TableSamples.stories";
 
-<Meta title="Guides/Table/Table Samples/Locked Selection" />
+<Meta title="Visualizations/Table/Table Samples/Locked Selection" />
 
 # Locked Selection
 

--- a/packages/core/src/components/Table/stories/TableSamples/ServerSide.stories.mdx
+++ b/packages/core/src/components/Table/stories/TableSamples/ServerSide.stories.mdx
@@ -1,7 +1,7 @@
 import { Meta, Canvas, Story } from "@storybook/addon-docs";
 import { ServerSideStory } from "./TableSamples.stories";
 
-<Meta title="Guides/Table/Table Samples/Server Side" />
+<Meta title="Visualizations/Table/Table Samples/Server Side" />
 
 # Server Side
 

--- a/packages/core/src/components/Table/stories/TableSamples/TableSamples.stories.mdx
+++ b/packages/core/src/components/Table/stories/TableSamples/TableSamples.stories.mdx
@@ -1,7 +1,7 @@
 import { Meta, Canvas, Story } from "@storybook/addon-docs";
 import { CompleteStory } from "./TableSamples.stories";
 
-<Meta title="Guides/Table/Table Samples" />
+<Meta title="Visualizations/Table/Table Samples" />
 
 # Complete Table
 

--- a/packages/core/src/components/Table/stories/TableSamples/TableSamples.stories.tsx
+++ b/packages/core/src/components/Table/stories/TableSamples/TableSamples.stories.tsx
@@ -55,10 +55,7 @@ import LoadingContainer from "./LoadingContainer";
 const EmptyRow = ({ height }) => (
   <HvTableRow>
     <HvTableCell colSpan={100} style={{ height }}>
-      <HvEmptyState
-        message="No data to display"
-        icon={<Ban role="presentation" />}
-      />
+      <HvEmptyState message="No data to display" icon={<Ban role="none" />} />
     </HvTableCell>
   </HvTableRow>
 );
@@ -193,7 +190,7 @@ const Complete = () => {
       return (
         <HvTableRow
           {...row.getRowProps({
-            "aria-rowindex": index,
+            "aria-rowindex": index + 1,
           })}
         >
           {row.cells.map((cell) => (
@@ -382,7 +379,7 @@ const rowRenderer = (pageRows: HvRowInstance<AssetEvent, string>[]) => {
     return (
       <HvTableRow
         {...row.getRowProps({
-          "aria-rowindex": index,
+          "aria-rowindex": index + 1,
         })}
       >
         {row.cells.map((cell) => (

--- a/packages/core/src/components/Table/stories/storiesUtils.tsx
+++ b/packages/core/src/components/Table/stories/storiesUtils.tsx
@@ -2,8 +2,6 @@ import React, { useCallback, useRef, useState } from "react";
 
 import range from "lodash/range";
 
-import { Random } from "@core/utils/Random";
-
 import { HvTableColumnConfig } from "../hooks/useTable";
 
 export interface NewRendererEntry {
@@ -46,8 +44,6 @@ export interface AssetEvent {
 // If a Cell gets a value, it has to return a react element
 const getCell = (value: string) => value as unknown as React.ReactElement;
 
-const rand = new Random();
-
 const formatDate = (date: Date) => date.toISOString().split("T")[0];
 
 const getOption = (opts: string[], i: number) => opts[i % opts.length];
@@ -81,32 +77,26 @@ const getDropdownOptions = (options: string[] = [], selected = "") => {
 };
 
 const makeEvent = (i: number): AssetEvent => {
-  const r = rand.next();
-  const [dateMax, dateMin] = [2018, 2023].map((y) => new Date(y, 0).getTime());
-
   return {
     id: `${i + 1}`,
     name: `Event ${i + 1}`,
-    createdDate: formatDate(new Date(rand.next(dateMax, dateMin))),
+    createdDate: formatDate(new Date("2020-03-20")),
     eventType: "Anomaly detection",
     status: getOption(["Closed", "Open"], i),
-    riskScore: rand.next(100, 10),
+    riskScore: (i % 100) + 1,
     severity: getOption(["Critical", "Major", "Average", "Minor"], i),
-    priority: (r > 0.66 && "High") || (r > 0.33 && "Medium") || "Low",
+    priority: getOption(["High", "Medium", "Low"], i),
   };
 };
 
 const newRendererEntry = (i: number): NewRendererEntry => {
-  const [dateMax, dateMin] = [2018, 2022].map((y) => new Date(y, 0).getTime());
   let eventTypeText = generateEmptyString("Anomaly detection", i);
   eventTypeText = generateLongString(eventTypeText, i);
+
   return {
     id: `${i + 1}`,
     name: `Event ${i + 1}`,
-    createdDate: generateEmptyDate(
-      formatDate(new Date(rand.next(dateMax, dateMin))),
-      i
-    ),
+    createdDate: generateEmptyDate(formatDate(new Date("2020-03-20")), i),
     eventQuantity: generateLargeNumber(i),
     eventType: eventTypeText,
     status: {
@@ -114,7 +104,7 @@ const newRendererEntry = (i: number): NewRendererEntry => {
       status_color: getTagColor(getOption(["Closed", "Open"], i)),
       status_text_color: "black",
     },
-    riskScore: rand.next(100, 10),
+    riskScore: (i % 100) + 1,
     isDisabled: generateBooleanState(i),
     severity: getDropdownOptions(
       ["Critical", "Major", "Average", "Minor"],
@@ -124,18 +114,16 @@ const newRendererEntry = (i: number): NewRendererEntry => {
 };
 
 const controlledSelectedEntry = (i: number): AssetEvent => {
-  const r = rand.next();
-  const [dateMax, dateMin] = [2018, 2022].map((y) => new Date(y, 0).getTime());
   return {
     id: `${i + 1}`,
     name: `Event ${i + 1}`,
-    createdDate: formatDate(new Date(rand.next(dateMax, dateMin))),
+    createdDate: formatDate(new Date("2020-03-20")),
     eventType: "Anomaly detection",
     status: getOption(["Closed", "Open"], i),
-    riskScore: rand.next(100, 10),
+    riskScore: (i % 100) + 1,
     severity: getOption(["Critical", "Major", "Average", "Minor"], i),
-    priority: (r > 0.66 && "High") || (r > 0.33 && "Medium") || "Low",
-    selected: r < 0.66,
+    priority: getOption(["High", "Medium", "Low"], i),
+    selected: i < 3,
   };
 };
 


### PR DESCRIPTION
- The table samples were switched to the "Visualizations" tab. Because of this pa11y now tests the table samples which was not happening previously. Applitools was not testing the table also.
   - This change increased the number of accessibility issues to more than 200 😅
- Several accessibility issues were fixed on the table (not all of them) and we now have 15 issues on our report 🎉
   - There's only one issue remaining for the table regarding the table header group.
   - The renderers should be reviewed on a next major because they use different logic for accessibility:
      - The switch was using a `switchLabel` but the dropdown an `id`. For the progress line I ended up only using the column id to simplify things.

<img width="1601" alt="Screenshot 2023-09-01 at 10 41 31" src="https://github.com/lumada-design/hv-uikit-react/assets/43220251/65a933bd-99ce-4f49-8247-b8dfb0f71b72">
