### PR TITLE
feat(theme): improve theme.spacing

### DIFF
--- a/docs/guides/theming/Spacing.tsx
+++ b/docs/guides/theming/Spacing.tsx
@@ -1,14 +1,13 @@
 import styled from "@emotion/styled";
 import { HvButton, theme } from "@hitachivantara/uikit-react-core";
 
-export const Spacing = () => {
-  const StyledContainer = styled("div")({
-    flexWrap: "wrap",
-    "& > *": {
-      margin: theme.spacing(["xs", "6px"]),
-    },
-  });
+const StyledContainer = styled("div")({
+  "& > *": {
+    margin: theme.spacing("xs", "6px"),
+  },
+});
 
+export const Spacing = () => {
   return (
     <StyledContainer>
       <HvButton variant="primary">Button 1</HvButton>

--- a/docs/guides/theming/Theming.stories.mdx
+++ b/docs/guides/theming/Theming.stories.mdx
@@ -368,14 +368,20 @@ const MyComponent = () => {
 The NEXT UI Kit provides a spacing helper function named `spacing`. This function helps generate the spacing values for the UI elements when required
 and is contained within the `theme` object provided by the `uikit-react-core` package.
 
-This helper function can receive one of the arguments below and returns the appropriate value in pixels to achieve the desired spacing.
+This helper function receives any number of arguments (or an array of arguments), where each argument is either:
 
-| Argument                                                                            | Result                                                      | Example                       |
-| ----------------------------------------------------------------------------------- | ----------------------------------------------------------- | ----------------------------- |
-| Number                                                                              | The number is multiplied by the theme's spacing base.       | `theme.spacing(5)`            |
-| One of the theme's spacing breakpoints: `xs`, `sm`, `md`, `lg`, or `xl`             | The corresponding breakpoint's spacing value for the theme. | `theme.spacing("sm")`         |
-| Value in pixels                                                                     | The value in pixels.                                        | `theme.spacing("16px")`       |
-| Array of four values: numbers, pixel values, and/or the theme's spacing breakpoints | It will generate the shorthand form of the values.          | `theme.spacing(["sm","0px"])` |
+- A `number`, which is then multiplied by the `8px` base value;
+- A `string`, which is either converted to their breakpoint value (`xs`,`sm`,`md`,`lg`,`xl`) or left as-is.
+
+Examples:
+
+```tsx
+theme.spacing(2); // 16px (2*8px)
+theme.spacing(1, 0); // 8px 0px
+
+theme.spacing("sm"); // 16px
+theme.spacing("sm", "inherit", "42px"); // 16px inherit 42px
+```
 
 The spacing base and breakpoints for each default theme are shown below.
 
@@ -407,13 +413,13 @@ Find below an example on how to use the spacing helper function.
 import styled from "@emotion/styled";
 import { HvButton, theme } from "@hitachivantara/uikit-react-core";
 
-export const Spacing = () => {
-  const StyledContainer = styled("div")({
-    "& > *": {
-      margin: theme.spacing(["xs", "6px"]),
-    },
-  });
+const StyledContainer = styled("div")({
+  "& > *": {
+    margin: theme.spacing("xs", "6px"),
+  },
+});
 
+export const Spacing = () => {
   return (
     <StyledContainer>
       <HvButton variant="primary">Button 1</HvButton>

--- a/docs/guides/theming/WhiteLabeling.tsx
+++ b/docs/guides/theming/WhiteLabeling.tsx
@@ -122,7 +122,7 @@ export const WhiteLabeling = () => {
             onClick={handleChange}
           />
         </HvHeader>
-        <HvContainer style={{ padding: theme.spacing(["md", "md"]) }}>
+        <HvContainer style={{ padding: theme.spacing("md") }}>
           <HvGlobalActions
             title={
               navigationData.find((p) => p.id === selected)?.label ||

--- a/packages/code-editor/src/components/CodeEditor/CodeEditor.stories.tsx
+++ b/packages/code-editor/src/components/CodeEditor/CodeEditor.stories.tsx
@@ -40,9 +40,7 @@ const Header = (props: {
       border: `1px solid ${theme.colors.atmo4}`,
       borderBottom: "none",
       background: theme.colors.atmo1,
-      padding: `${theme.spacing("xs")} ${theme.spacing("xs")} ${theme.spacing(
-        "xs"
-      )} ${theme.spacing("sm")}`,
+      padding: theme.spacing("xs", "xs", "xs", "sm"),
       display: "flex",
       justifyContent: "space-between",
     }),

--- a/packages/core/src/components/AppSwitcher/AppSwitcher.styles.tsx
+++ b/packages/core/src/components/AppSwitcher/AppSwitcher.styles.tsx
@@ -13,7 +13,7 @@ export const { staticClasses, useClasses } = createClasses("HvAppSwitcher", {
     // padding: `${theme.spacing(2) - 4}px 0 ${theme.spacing(2) - 4}px ${
     //   theme.spacing(2) - 4
     // }px`,
-    padding: `${theme.space.sm} 0 ${theme.space.sm} ${theme.space.sm}`,
+    padding: theme.spacing("sm", 0, "sm", "sm"),
   },
   item: {},
   itemSelected: {},

--- a/packages/core/src/components/Banner/BannerContent/BannerContent.styles.tsx
+++ b/packages/core/src/components/Banner/BannerContent/BannerContent.styles.tsx
@@ -14,7 +14,7 @@ export const { useClasses, staticClasses } = createClasses("HvBannerContent", {
   message: {
     display: "flex",
     alignItems: "center",
-    padding: theme.spacing(["xs", 0]),
+    padding: theme.spacing("xs", 0),
     paddingLeft: theme.space.sm,
   },
   action: {

--- a/packages/core/src/components/Calendar/CalendarNavigation/ComposedNavigation/ComposedNavigation.styles.tsx
+++ b/packages/core/src/components/Calendar/CalendarNavigation/ComposedNavigation/ComposedNavigation.styles.tsx
@@ -7,7 +7,7 @@ export const { staticClasses, useClasses } = createClasses(
     navigationContainer: {
       display: "flex",
       justifyContent: "space-between",
-      padding: theme.spacing(["xs", 0]),
+      padding: theme.spacing("xs", 0),
     },
     navigationMonth: {
       minWidth: "160px",

--- a/packages/core/src/components/Carousel/Carousel.styles.ts
+++ b/packages/core/src/components/Carousel/Carousel.styles.ts
@@ -36,7 +36,7 @@ export const { staticClasses, useClasses } = createClasses("HvCarousel", {
     inset: 0,
     zIndex: theme.zIndices.modal,
     "&:not(._)": {
-      padding: theme.spacing(["xs", "xl"]),
+      padding: theme.spacing("xs", "xl"),
     },
   },
   title: {
@@ -93,14 +93,14 @@ export const { staticClasses, useClasses } = createClasses("HvCarousel", {
   counter: {
     color: theme.colors.base_light,
     backgroundColor: theme.colors.base_dark,
-    padding: theme.spacing([0, "sm"]),
+    padding: theme.spacing(0, "sm"),
   },
   slideControls: {
     position: "absolute",
     left: 0,
     right: 0,
     top: `calc(50% - (32px / 2))`,
-    padding: theme.spacing([0, "sm"]),
+    padding: theme.spacing(0, "sm"),
     display: "flex",
     flexDirection: "row",
     alignItems: "center",
@@ -148,7 +148,7 @@ export const { staticClasses, useClasses } = createClasses("HvCarousel", {
     width: "100%",
     overflowX: "auto", // "hidden",
     overflowY: "hidden",
-    padding: theme.spacing(["xs", "2px", "2px"]),
+    padding: theme.spacing("xs", "2px", "2px"),
   },
   thumbnail: {
     height: "unset",

--- a/packages/core/src/components/FilterGroup/FilterContent/FilterContent.styles.tsx
+++ b/packages/core/src/components/FilterGroup/FilterContent/FilterContent.styles.tsx
@@ -16,7 +16,7 @@ export const { staticClasses, useClasses } = createClasses(name, {
     height: 32,
   },
   baseDropdownSelection: {
-    padding: theme.spacing(["0px", "30px", "0px", "0px"]),
+    padding: theme.spacing("0px", "30px", "0px", "0px"),
   },
   root: {
     width: 640,
@@ -36,10 +36,8 @@ export const { staticClasses, useClasses } = createClasses(name, {
   },
   leftSidePanel: {
     display: "inline-block",
-    width: `calc(50% - ${theme.spacing("sm")} - ${theme.spacing("sm")} + 8px)`,
-    height: `calc(100% - ${theme.spacing("sm")} - ${theme.spacing(
-      "sm"
-    )} + 8px)`,
+    width: `calc(50% - ${theme.space.sm} - ${theme.space.sm} + 8px)`,
+    height: `calc(100% - ${theme.space.sm} - ${theme.space.sm} + 8px)`,
     verticalAlign: "top",
     maxHeight: "calc(500px - 75px)",
     minHeight: "calc(370px - 75px)",

--- a/packages/core/src/components/InlineEditor/InlineEditor.styles.tsx
+++ b/packages/core/src/components/InlineEditor/InlineEditor.styles.tsx
@@ -28,7 +28,7 @@ export const { staticClasses, useClasses } = createClasses("HvInlineEditor", {
     color: theme.typography.placeholderText.color,
   },
   button: {
-    padding: theme.spacing(["6px", "8px", "5px", "8px"]),
+    padding: theme.spacing("6px", "8px", "5px", "8px"),
     minHeight: "32px",
 
     boxSizing: "border-box",
@@ -76,7 +76,7 @@ export const { staticClasses, useClasses } = createClasses("HvInlineEditor", {
     minWidth: "32px",
 
     "& svg": {
-      margin: theme.spacing([0, "8px"]),
+      margin: theme.spacing(0, "xs"),
     },
   },
   iconVisible: {

--- a/packages/core/src/components/Input/Input.stories.tsx
+++ b/packages/core/src/components/Input/Input.stories.tsx
@@ -350,7 +350,7 @@ export const ExternalErrorMessage: StoryObj<HvInputProps> = {
         <HvGrid item xs={7}>
           <div
             style={{
-              padding: theme.spacing(["xs", "md"]),
+              padding: theme.spacing("xs", "md"),
               backgroundColor: theme.colors.negative_20,
               color: theme.colors.base_dark,
               height: "100%",

--- a/packages/core/src/components/Pagination/Select.styles.tsx
+++ b/packages/core/src/components/Pagination/Select.styles.tsx
@@ -11,7 +11,7 @@ export const { useClasses } = createClasses("HvPaginationSelect", {
     },
   },
   selection: {
-    padding: theme.spacing([0, "md", 0, "xs"]),
+    padding: theme.spacing(0, "md", 0, "xs"),
   },
   headerOpen: {
     backgroundColor: theme.colors.atmo1,

--- a/packages/core/src/components/Table/TableHeader/TableHeader.styles.tsx
+++ b/packages/core/src/components/Table/TableHeader/TableHeader.styles.tsx
@@ -9,7 +9,7 @@ export const { staticClasses, useClasses } = createClasses("HvTableHeader", {
     height: "var(--cell-height)",
     verticalAlign: "inherit",
     textAlign: "left",
-    padding: theme.spacing([0, "xs", 0, 32]),
+    padding: theme.spacing(0, 1, 0, 4),
     borderBottom: `1px solid ${theme.colors.atmo4}`,
   },
   head: {

--- a/packages/core/src/components/TimeAgo/TimeAgo.stories.tsx
+++ b/packages/core/src/components/TimeAgo/TimeAgo.stories.tsx
@@ -30,7 +30,7 @@ const styles = {
     borderCollapse: "collapse",
     "& th, td": {
       border: `1px solid ${theme.colors.secondary}`,
-      padding: theme.spacing(["5px", "sm"]),
+      padding: theme.spacing("5px", "sm"),
     },
   }),
 };

--- a/packages/core/src/components/TimePicker/TimePicker.styles.ts
+++ b/packages/core/src/components/TimePicker/TimePicker.styles.ts
@@ -44,7 +44,7 @@ export const { useClasses, staticClasses } = createClasses("HvTimePicker", {
     flexDirection: "row",
     justifyContent: "center",
     alignItems: "center",
-    padding: theme.spacing(["xs", 0]),
+    padding: theme.spacing("xs", 0),
     userSelect: "none",
     minWidth: "175px",
   },

--- a/packages/core/src/components/VerticalNavigation/VerticalNavigation.styles.tsx
+++ b/packages/core/src/components/VerticalNavigation/VerticalNavigation.styles.tsx
@@ -20,12 +20,12 @@ export const { staticClasses, useClasses } = createClasses(
       },
       "& > :not(nav:first-of-type)": {
         borderTop: `3px solid ${theme.colors.atmo2}`,
-        padding: theme.spacing(["xs", "sm", "sm", "sm"]),
+        padding: theme.spacing("xs", "sm", "sm", "sm"),
       },
 
       "& > :first-of-type:not(:last-child)": {
         borderTop: "none",
-        padding: theme.spacing(["sm", "sm", "xs", "sm"]),
+        padding: theme.spacing("sm", "sm", "xs", "sm"),
       },
     },
     collapsed: {
@@ -34,11 +34,11 @@ export const { staticClasses, useClasses } = createClasses(
         width: "66px",
       },
       "& > :first-of-type:not(:last-child)": {
-        padding: theme.spacing(["sm", "xs", "xs", "xs"]),
+        padding: theme.spacing("sm", "xs", "xs", "xs"),
       },
 
       "& > :not(nav:first-of-type)": {
-        padding: theme.spacing(["xs", "xs", "sm", "xs"]),
+        padding: theme.spacing("xs", "xs", "sm", "xs"),
       },
     },
 

--- a/packages/styles/src/makeTheme.ts
+++ b/packages/styles/src/makeTheme.ts
@@ -1,7 +1,7 @@
 import * as tokens from "./tokens";
 import { theme } from "./theme";
 import { mergeTheme } from "./utils";
-import { HvCustomTheme, HvTheme, HvThemeStructure } from "./types";
+import type { HvCustomTheme, HvTheme, HvThemeStructure } from "./types";
 
 /**
  * Generate a theme base on the options received.
@@ -13,10 +13,8 @@ import { HvCustomTheme, HvTheme, HvThemeStructure } from "./types";
 export const makeTheme = (
   options: HvCustomTheme | ((theme: HvTheme) => HvCustomTheme)
 ): HvThemeStructure => {
-  const opt: HvCustomTheme =
-    typeof options === "function" ? options(theme) : options;
-
-  const newTheme = mergeTheme(tokens, opt);
+  const customTheme = typeof options === "function" ? options(theme) : options;
+  const newTheme = mergeTheme(tokens, customTheme);
 
   return newTheme;
 };

--- a/packages/styles/src/theme.ts
+++ b/packages/styles/src/theme.ts
@@ -2,14 +2,19 @@ import {
   DeepString,
   HvTheme,
   HvThemeComponents,
-  HvThemeBreakpoint,
   HvThemeTypography,
   HvThemeVars,
   HvThemeTypographyProps,
+  HvThemeUtils,
 } from "./types";
 import * as tokens from "./tokens";
 import type { HvColorAny } from "./tokens";
-import { mapCSSVars } from "./utils";
+import {
+  hasMultipleArgs,
+  mapCSSVars,
+  spacingUtil,
+  spacingUtilOld,
+} from "./utils";
 
 const componentsSpec: DeepString<HvThemeComponents> = {
   actionBar: {
@@ -472,32 +477,21 @@ const themeVars: HvThemeVars = mapCSSVars({
   ...typographySpec,
 });
 
-const spacing = (
-  value:
-    | string
-    | number
-    | HvThemeBreakpoint
-    | (string | number | HvThemeBreakpoint)[]
-): string => {
+const spacing: HvThemeUtils["spacing"] = (...args) => {
+  if (hasMultipleArgs(args)) {
+    return args.map(spacingUtil).join(" ");
+  }
+
+  const [value] = args;
+
   switch (typeof value) {
     case "number":
-      return `calc(${themeVars.space.base} * ${value}px)`;
     case "string":
-      return themeVars.space[value] || value;
+      return spacingUtil(value);
+    // TODO: remove in v6
     case "object":
       return value && value.length > 0
-        ? value
-            .map((x) => {
-              switch (typeof x) {
-                case "number":
-                  return `${x}px`;
-                case "string":
-                  return themeVars.space[x] || x;
-                default:
-                  return "0px";
-              }
-            })
-            .join(" ")
+        ? value.map(spacingUtilOld).join(" ")
         : "0px";
     default:
       return "0px";

--- a/packages/styles/src/themes/ds3.ts
+++ b/packages/styles/src/themes/ds3.ts
@@ -1,8 +1,7 @@
 import { colors } from "../tokens/colors";
 import { makeTheme } from "../makeTheme";
-import { HvTheme } from "../types";
 
-const ds3 = makeTheme((theme: HvTheme) => ({
+const ds3 = makeTheme((theme) => ({
   name: "ds3",
   colors: {
     modes: {
@@ -243,7 +242,7 @@ const ds3 = makeTheme((theme: HvTheme) => ({
   },
   button: {
     borderRadius: theme.radii.base,
-    padding: theme.spacing(["0", "xs"]),
+    padding: theme.spacing("0", "xs"),
     marginIconRight: "0px",
     marginIconLeft: "-8px",
     semanticColor: "rgba(251, 252, 252, 0.3)",

--- a/packages/styles/src/themes/ds5.ts
+++ b/packages/styles/src/themes/ds5.ts
@@ -1,8 +1,7 @@
 import { colors } from "../tokens/colors";
 import { makeTheme } from "../makeTheme";
-import { HvTheme } from "../types";
 
-const ds5 = makeTheme((theme: HvTheme) => ({
+const ds5 = makeTheme((theme) => ({
   name: "ds5",
   colors: {
     modes: {
@@ -186,7 +185,7 @@ const ds5 = makeTheme((theme: HvTheme) => ({
   },
   button: {
     borderRadius: theme.radii.base,
-    padding: theme.spacing(["xs", "sm"]),
+    padding: theme.spacing("xs", "sm"),
     marginIconRight: "0px",
     marginIconLeft: "-8px",
     semanticColor: "rgba(251, 252, 252, 0.3)",

--- a/packages/styles/src/types.ts
+++ b/packages/styles/src/types.ts
@@ -478,15 +478,18 @@ export type HvThemeTypography = {
 // Breakpoints
 export type HvThemeBreakpoint = Exclude<keyof typeof tokens.space, "base">;
 
+export type SpacingValue = number | HvThemeBreakpoint | (string & {});
+
 // Theme utils
 export type HvThemeUtils = {
-  spacing: (
-    value:
-      | string
-      | number
-      | HvThemeBreakpoint
-      | (string | number | HvThemeBreakpoint)[]
-  ) => string;
+  /**
+   * Utility function to generate spacing values from the theme.
+   *
+   * @example
+   * theme.spacing(2) // 16px (2*8px)
+   * theme.spacing("md", "inherit", "42px") // 24px inherit 42px
+   */
+  spacing: (...args: [SpacingValue[]] | SpacingValue[]) => string;
 };
 
 // Theme colors

--- a/packages/styles/src/utils.ts
+++ b/packages/styles/src/utils.ts
@@ -1,4 +1,28 @@
-import { DeepString, HvThemeStructure } from "./types";
+import type { DeepString, HvThemeStructure, SpacingValue } from "./types";
+import { space } from "./tokens/space";
+
+export const spacingUtil = (value: SpacingValue): string => {
+  switch (typeof value) {
+    case "number":
+      return `calc(${space.base} * ${value}px)`;
+    case "string":
+      return space[value] || value;
+    default:
+      return value;
+  }
+};
+
+// TODO: remove in favour or `spacingUtil` in v6
+export const spacingUtilOld = (value: SpacingValue): string => {
+  switch (typeof value) {
+    case "number":
+      return `${value}px`;
+    case "string":
+      return space[value] || value;
+    default:
+      return "0px";
+  }
+};
 
 const toCSSVars = (obj: object, prefix = "--uikit") => {
   const vars = {};
@@ -16,6 +40,12 @@ const toCSSVars = (obj: object, prefix = "--uikit") => {
   }
 
   return vars;
+};
+
+export const hasMultipleArgs = <T extends any>(
+  args: T[] | [T[]]
+): args is T[] => {
+  return args.length > 1;
 };
 
 export const mapCSSVars = <T extends object>(

--- a/packages/viz/src/components/BarChart/stories/customTooltip.ts
+++ b/packages/viz/src/components/BarChart/stories/customTooltip.ts
@@ -13,7 +13,7 @@ const styles: { [key: string]: CSSInterpolation } = {
     boxShadow: theme.colors.shadow,
   },
   container: {
-    padding: theme.spacing(["15px", "sm"]),
+    padding: theme.spacing("15px", "sm"),
     display: "flex",
     flexDirection: "column",
   },

--- a/packages/viz/src/components/ConfusionMatrix/ConfusionMatrix.styles.tsx
+++ b/packages/viz/src/components/ConfusionMatrix/ConfusionMatrix.styles.tsx
@@ -11,7 +11,7 @@ export const { useClasses, staticClasses } = createClasses(
       zIndex: theme.zIndices.sticky,
     },
     tooltipContainer: {
-      padding: theme.spacing(["15px", "sm"]),
+      padding: theme.spacing("15px", "sm"),
       display: "flex",
       flexDirection: "column",
     },


### PR DESCRIPTION
Our `theme.spacing` utility isn't consistent between a single `number` argument and array of `number`.

```ts
theme.spacing(2); // 16px (multiplies value by 8px base)
theme.spacing([2]) // 2px (converts to `px`)
```
This is confusing, and works differently from the previous v4 utility (and MUI's). Furthermore, having to use an array instead of extra arguments is unnecessary, and differs from our previous utility.

This PR:
- allows passing multiple args with behaviour same as passing a single argument
- adds TS completions for the breakpoints

`theme.spacing` with array argument is left as-is

```ts
theme.spacing(2, 4); // 16px 32px
theme.spacing(2, "md", "inherit"); // 16px 16px inherit
```

<img width="152" alt="image" src="https://github.com/lumada-design/hv-uikit-react/assets/638946/5b20e83d-83c2-4302-aa4c-f303db68a7d5">

