### PR TITLE
fix(Theme): link shadow constant to theme header shadow property

### DIFF
--- a/packages/styles/src/themes/ds5.ts
+++ b/packages/styles/src/themes/ds5.ts
@@ -215,7 +215,7 @@ const ds5 = makeTheme((theme: HvTheme) => ({
     secondLevelSelectedItemBorderTopThickness: "0px",
     secondLevelSelectedItemBorderBottomColor: theme.colors.secondary,
     secondLevelSelectedItemBorderBottomThickness: "4px",
-    shadow: "none",
+    shadow: theme.colors.shadow,
     secondLevelItemColor: theme.colors.secondary,
     secondLevelSelectedItemColor: theme.colors.secondary,
     secondLevelSelectedItemBackgroundColor: "transparent",


### PR DESCRIPTION
DS3 theme has on the header-shadow property the shadow constant set while that same property on DS5 is set to "none" causing the header to not have a shadow as defined on DS mocks.