### PR TITLE
fix(GlobalActions): empty space same as container

### DIFF
--- a/packages/core/src/components/GlobalActions/GlobalActions.stories.tsx
+++ b/packages/core/src/components/GlobalActions/GlobalActions.stories.tsx
@@ -119,7 +119,7 @@ export const GlobalVariant: StoryObj<HvGlobalActionsProps> = {
   },
   render: () => {
     const customTitle = (
-      <HvTypography variant="title3" component="h1">
+      <HvTypography variant="title2" component="h1">
         Detail Page Title
       </HvTypography>
     );

--- a/packages/core/src/components/GlobalActions/GlobalActions.styles.tsx
+++ b/packages/core/src/components/GlobalActions/GlobalActions.styles.tsx
@@ -17,16 +17,17 @@ export const { staticClasses, useClasses } = createClasses("HvGlobalActions", {
     zIndex: `calc(${theme.zIndices.banner} - 2)`,
     top: 0,
     left: 0,
+    padding: theme.spacing(1, 0),
+    backdropFilter: "blur(1px)",
+
     "&:before": {
       content: "''",
       display: "flex",
-      width: "100%",
-      height: 72,
-      top: 0,
+      position: "absolute",
+      inset: 0,
       background: theme.colors.atmo2,
       opacity: "75%",
     },
-    backdropFilter: "blur(1px)",
   },
   wrapper: {
     padding: theme.space.sm,
@@ -37,12 +38,11 @@ export const { staticClasses, useClasses } = createClasses("HvGlobalActions", {
     borderRadius: theme.globalActions.borderRadius,
   },
   globalWrapperComplement: {
-    position: "absolute",
+    position: "relative",
     top: 0,
     left: 0,
     background: theme.colors.atmo1,
     width: "100%",
-    marginTop: theme.space.xs,
   },
   globalSectionArea: {
     backgroundColor: theme.globalActions.sectionBackgroundColor,


### PR DESCRIPTION
`GlobalActions` grows according to the content, but its `::before` element which pushes the content down doesn't (has fixed width)

Example:
![image](https://github.com/lumada-design/hv-uikit-react/assets/638946/9dc9fa1d-3b47-4468-a4d0-1fb8a0db37ba)
