### PR TITLE
fix(VerticalNavigation): fix invalid 'aria-controls' attribute value

### DIFF
--- a/packages/core/src/components/VerticalNavigation/TreeView/TreeViewItem.tsx
+++ b/packages/core/src/components/VerticalNavigation/TreeView/TreeViewItem.tsx
@@ -463,7 +463,8 @@ export const HvVerticalNavigationTreeViewItem = forwardRef(
                       : true
                     : undefined,
                 "aria-expanded": expandable ? expanded : undefined,
-                "aria-controls": expandable ? setId(id, "group") : undefined,
+                "aria-controls":
+                  isOpen && expandable ? setId(id, "group") : undefined,
                 "aria-label": payload?.label,
               })}
         >


### PR DESCRIPTION
When the VerticalNavigation component is collapsed, the items with children would still have reference to an ID of the hvtreeview which doesn't exist since in this mode a popup is used instead.

![image](https://github.com/lumada-design/hv-uikit-react/assets/17290848/c8efa297-909d-4268-bd83-9e6e6ef13f6e)

`Invalid ARIA attribute value: aria-controls="hvtreeview3-8-group"`