### PR TITLE
docs: args tables reviewed

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -45,8 +45,4 @@ export const parameters = {
   },
 };
 
-export const argTypes = {
-  classes: { control: { disable: true }, if: { arg: "classes" } },
-};
-
 export const decorators = [withThemeProvider];

--- a/packages/core/src/components/Accordion/Accordion.stories.tsx
+++ b/packages/core/src/components/Accordion/Accordion.stories.tsx
@@ -57,6 +57,7 @@ export const Main: StoryObj<HvAccordionProps> = {
   argTypes: {
     classes: { control: { disable: true } },
     containerProps: { control: { disable: true } },
+    children: { control: { disable: true } },
   },
   render: (args) => {
     return (

--- a/packages/core/src/components/Accordion/Accordion.tsx
+++ b/packages/core/src/components/Accordion/Accordion.tsx
@@ -24,19 +24,11 @@ export { staticClasses as accordionClasses };
 export type HvAccordionClasses = ExtractNames<typeof useClasses>;
 
 export interface HvAccordionProps
-  extends HvBaseProps<HTMLDivElement, "onChange"> {
+  extends HvBaseProps<HTMLDivElement, "onChange" | "children"> {
   /**
-   * Id to be applied to the root node of the accordion.
+   * Content to be rendered
    */
-  id?: string;
-  /**
-   * Class names to be applied to the accordion.
-   */
-  className?: string;
-  /**
-   * A Jss Object used to override or extend the styles applied.
-   */
-  classes?: HvAccordionClasses;
+  children: React.ReactNode;
   /**
    * The accordion label button.
    */
@@ -70,9 +62,9 @@ export interface HvAccordionProps
    */
   labelVariant?: HvTypographyVariants;
   /**
-   * Content to be rendered
+   * A Jss Object used to override or extend the styles applied.
    */
-  children: React.ReactNode;
+  classes?: HvAccordionClasses;
 }
 
 /**

--- a/packages/core/src/components/ActionBar/ActionBar.stories.tsx
+++ b/packages/core/src/components/ActionBar/ActionBar.stories.tsx
@@ -32,7 +32,6 @@ const meta: Meta<typeof HvActionBar> = {
 export default meta;
 
 export const Main: StoryObj<HvActionBarProps> = {
-  args: {},
   argTypes: {
     classes: { control: { disable: true } },
   },
@@ -51,10 +50,6 @@ export const Main: StoryObj<HvActionBarProps> = {
 };
 
 export const DualAction: StoryObj<HvActionBarProps> = {
-  args: {},
-  argTypes: {
-    classes: { control: { disable: true } },
-  },
   parameters: {
     docs: {
       description: {

--- a/packages/core/src/components/Banner/Banner.stories.tsx
+++ b/packages/core/src/components/Banner/Banner.stories.tsx
@@ -34,7 +34,6 @@ export const Main: StoryObj<HvBannerProps> = {
   },
   argTypes: {
     classes: { control: { disable: true } },
-    ref: { control: { disable: true } },
     customIcon: { control: { disable: true } },
     bannerContentProps: { control: { disable: true } },
     actions: { control: { disable: true } },

--- a/packages/core/src/components/Banner/Banner.tsx
+++ b/packages/core/src/components/Banner/Banner.tsx
@@ -61,6 +61,8 @@ export interface HvBannerProps
   bannerContentProps?: HvBannerContentProps;
   /** A Jss Object used to override or extend the styles applied to the component. */
   classes?: HvBannerClasses;
+  /** @ignore */
+  ref?: MuiSnackbarProps["ref"];
 }
 
 /**

--- a/packages/core/src/components/Carousel/Carousel.tsx
+++ b/packages/core/src/components/Carousel/Carousel.tsx
@@ -62,11 +62,13 @@ export interface HvCarouselProps
   showFullscreen?: boolean;
   /** Whether to hide the thumbnails. Hidden by default in "xs" mode */
   hideThumbnails?: boolean;
+  /** Controls position. */
   controlsPosition?: "top" | "bottom";
+  /** Thumbnails position. */
   thumbnailsPosition?: "top" | "bottom";
   /** Carousel configuration options. @see https://www.embla-carousel.com/api/options/ */
   carouselOptions?: EmblaOptionsType;
-  /** */
+  /** Function that renders the thumbnail.  */
   renderThumbnail?: (index: number) => React.ReactNode;
   /** The callback fired when the active slide changes. */
   onChange?: (index: number) => void;

--- a/packages/core/src/components/CheckBox/CheckBox.stories.tsx
+++ b/packages/core/src/components/CheckBox/CheckBox.stories.tsx
@@ -33,7 +33,8 @@ export const Main: StoryObj<HvCheckBoxProps> = {
   args: { label: "Checkbox 0" },
   argTypes: {
     classes: { control: { disable: true } },
-    action: { control: { disable: true } },
+    statusMessage: { control: { disable: true } },
+    status: { control: { disable: true } },
     labelProps: { control: { disable: true } },
   },
   render: (args) => {

--- a/packages/core/src/components/CheckBoxGroup/CheckBoxGroup.stories.tsx
+++ b/packages/core/src/components/CheckBoxGroup/CheckBoxGroup.stories.tsx
@@ -26,6 +26,10 @@ export const Main: StoryObj<HvCheckBoxGroupProps> = {
   },
   argTypes: {
     classes: { control: { disable: true } },
+    value: { control: { disable: true } },
+    defaultValue: { control: { disable: true } },
+    status: { control: { disable: true } },
+    statusMessage: { control: { disable: true } },
   },
   render: (args) => {
     return (

--- a/packages/core/src/components/Container/Container.stories.tsx
+++ b/packages/core/src/components/Container/Container.stories.tsx
@@ -25,7 +25,6 @@ export const Main: StoryObj<HvContainerProps> = {
   argTypes: {
     classes: { control: { disable: true } },
     component: { control: { disable: true } },
-    sx: { control: { disable: true } },
   },
   render: (args) => {
     const styles: { [key: string]: CSSInterpolation } = {

--- a/packages/core/src/components/DatePicker/DatePicker.stories.tsx
+++ b/packages/core/src/components/DatePicker/DatePicker.stories.tsx
@@ -43,6 +43,8 @@ export default meta;
 
 export const Main: StoryObj<HvDatePickerProps> = {
   args: {
+    placeholder: "Select date",
+    label: "Date",
     disabled: false,
     required: false,
     status: "standBy",
@@ -55,9 +57,18 @@ export const Main: StoryObj<HvDatePickerProps> = {
   },
   argTypes: {
     classes: { control: { disable: true } },
+    statusMessage: { control: { disable: true } },
+    description: { control: { disable: true } },
+    labels: { control: { disable: true } },
+    value: { control: { disable: true } },
+    startValue: { control: { disable: true } },
+    endValue: { control: { disable: true } },
+    startAdornment: { control: { disable: true } },
+    calendarProps: { control: { disable: true } },
+    dropdownProps: { control: { disable: true } },
   },
   render: (args) => {
-    return <HvDatePicker placeholder="Select date" label="Date" {...args} />;
+    return <HvDatePicker {...args} />;
   },
 };
 

--- a/packages/core/src/components/DatePicker/DatePicker.tsx
+++ b/packages/core/src/components/DatePicker/DatePicker.tsx
@@ -53,19 +53,6 @@ export type HvDatePickerStatus = HvFormStatus;
 export interface HvDatePickerProps
   extends HvBaseProps<HTMLDivElement, "onChange"> {
   /**
-   * Class names to be applied.
-   */
-  className?: string;
-  /**
-   * A Jss Object used to override or extend the component styles applied.
-   */
-  classes?: HvDatePickerClasses;
-  /**
-   * Id to be applied to the form element root node.
-   */
-  id?: string;
-
-  /**
    * The form element name.
    */
   name?: string;
@@ -77,26 +64,13 @@ export interface HvDatePickerProps
    */
   label?: React.ReactNode;
   /**
-   * @ignore
-   */
-  "aria-label"?: string;
-  /**
-   * @ignore
-   */
-  "aria-labelledby"?: string;
-  /**
    * Provide additional descriptive text for the form element.
    */
   description?: React.ReactNode;
   /**
-   * @ignore
-   */
-  "aria-describedby"?: string;
-  /**
    * The placeholder value when nothing is selected.
    */
   placeholder?: string;
-
   /**
    * Indicates that the form element is disabled.
    */
@@ -105,7 +79,6 @@ export interface HvDatePickerProps
    * Indicates that user input is required on the form element.
    */
   required?: boolean;
-
   /**
    * The status of the form element.
    *
@@ -127,7 +100,6 @@ export interface HvDatePickerProps
    * Will only be used when the validation status is invalid.
    */
   "aria-errormessage"?: string;
-
   /**
    * The callback fired when the value changes.
    */
@@ -161,7 +133,6 @@ export interface HvDatePickerProps
      */
     invalidDateLabel?: string;
   };
-
   /**
    * The initial value of the input when in single calendar mode.
    */
@@ -188,7 +159,6 @@ export interface HvDatePickerProps
    * The calendar locale. If undefined, it uses calendar default
    */
   locale?: string;
-
   /**
    * Controls if actions buttons are visible at the calendar.
    */
@@ -222,6 +192,10 @@ export interface HvDatePickerProps
    * Additional props passed to the HvCalendar component.
    */
   calendarProps?: Partial<HvCalendarProps>;
+  /**
+   * A Jss Object used to override or extend the component styles applied.
+   */
+  classes?: HvDatePickerClasses;
 }
 
 /**

--- a/packages/core/src/components/Dialog/Dialog.stories.tsx
+++ b/packages/core/src/components/Dialog/Dialog.stories.tsx
@@ -123,11 +123,6 @@ export const Main: StoryObj<HvDialogProps> = {
   argTypes: {
     maxWidth: { control: "select", options: ["xs", "sm", "md", "lg", "xl"] },
     classes: { control: { disable: true } },
-    BackdropComponent: { control: { disable: true } },
-    BackdropProps: { control: { disable: true } },
-    slotProps: { control: { disable: true } },
-    components: { control: { disable: true } },
-    componentsProps: { control: { disable: true } },
   },
   parameters: {
     eyes: {

--- a/packages/core/src/components/Dialog/Dialog.tsx
+++ b/packages/core/src/components/Dialog/Dialog.tsx
@@ -24,8 +24,6 @@ export type HvDialogClasses = ExtractNames<typeof useClasses>;
 export interface HvDialogProps
   extends Omit<MuiDialogProps, "fullScreen" | "classes" | "open">,
     HvBaseProps {
-  /** Id to be applied to the root node. */
-  id?: string;
   /** Current state of the Dialog. */
   open?: boolean;
   /** Function executed on close. */
@@ -53,6 +51,10 @@ export interface HvDialogProps
   classes?: HvDialogClasses;
   /** Variant of the dialog. Adds a status bar to the top of the dialog. If not provided, no status bar is added. */
   variant?: "success" | "error" | "warning";
+  /** @ignore */
+  ref?: MuiDialogProps["ref"];
+  /** @ignore */
+  component?: MuiDialogProps["component"];
 }
 
 export const HvDialog = (props: HvDialogProps) => {

--- a/packages/core/src/components/DotPagination/DotPagination.stories.tsx
+++ b/packages/core/src/components/DotPagination/DotPagination.stories.tsx
@@ -28,6 +28,8 @@ const styles = {
 export const Main: StoryObj<HvDotPaginationProps> = {
   argTypes: {
     classes: { control: { disable: true } },
+    unselectedIcon: { control: { disable: true } },
+    selectedIcon: { control: { disable: true } },
   },
   render: () => {
     const [page, setPage] = useState<number>(0);

--- a/packages/core/src/components/Drawer/Drawer.tsx
+++ b/packages/core/src/components/Drawer/Drawer.tsx
@@ -66,6 +66,10 @@ export interface HvDrawerProps
    * Title for the button close.
    */
   buttonTitle?: string;
+  /** @ignore */
+  ref?: MuiDrawerProps["ref"];
+  /** @ignore */
+  component?: MuiDrawerProps["component"];
 }
 
 const getBackgroundColor = (color: string) => {

--- a/packages/core/src/components/Dropdown/Dropdown.tsx
+++ b/packages/core/src/components/Dropdown/Dropdown.tsx
@@ -35,17 +35,9 @@ export type HvDropdownClasses = ExtractNames<typeof useClasses>;
 export interface HvDropdownProps
   extends HvBaseProps<HTMLDivElement, "onChange"> {
   /**
-   * Class names to be applied.
-   */
-  className?: string;
-  /**
    * A Jss Object used to override or extend the component styles applied.
    */
   classes?: HvDropdownClasses;
-  /**
-   * Id to be applied to the form element root node.
-   */
-  id?: string;
   /**
    * The form element name.
    */
@@ -58,26 +50,13 @@ export interface HvDropdownProps
    */
   label?: any;
   /**
-   * @ignore
-   */
-  "aria-label"?: string;
-  /**
-   * @ignore
-   */
-  "aria-labelledby"?: string;
-  /**
    * Provide additional descriptive text for the form element.
    */
   description?: any;
   /**
-   * @ignore
-   */
-  "aria-describedby"?: string;
-  /**
    * The placeholder value when nothing is selected.
    */
   placeholder?: string;
-
   /**
    * Indicates that the form element is disabled.
    */
@@ -111,12 +90,10 @@ export interface HvDropdownProps
    * Will only be used when the validation status is invalid.
    */
   "aria-errormessage"?: string;
-
   /**
    * The callback fired when the value changes.
    */
   onChange?: (selected: HvListValue | HvListValue[] | undefined) => void;
-
   /**
    * The list to be rendered by the dropdown.
    */
@@ -171,7 +148,6 @@ export interface HvDropdownProps
    * An object containing props to be wired to the popper component.
    */
   popperProps?: Partial<PopperProps>;
-
   /**
    * Callback called when the user cancels the changes.
    *

--- a/packages/core/src/components/EmptyState/EmptyState.stories.tsx
+++ b/packages/core/src/components/EmptyState/EmptyState.stories.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable jsx-a11y/anchor-is-valid */
 import { Meta, StoryObj } from "@storybook/react";
 import { BarChart, Ghost, Info } from "@hitachivantara/uikit-react-icons";
 import {
@@ -31,22 +30,13 @@ export const Main: StoryObj<HvEmptyStateProps> = {
 };
 
 export const WithAction: StoryObj<HvEmptyStateProps> = {
-  args: {
-    title: "No data routes",
-    message: "After you start adding Data Routes, they will appear here.",
-    icon: <BarChart />,
-  },
-  argTypes: {
-    icon: { control: { disable: true } },
-    classes: { control: { disable: true } },
-  },
-  render: ({ title, message, icon }) => {
+  render: () => {
     const CustomAction = <HvLink route="/">Create a new data route</HvLink>;
     return (
       <HvEmptyState
-        title={title}
-        message={message}
-        icon={icon}
+        title="No data routes"
+        message="After you start adding Data Routes, they will appear here."
+        icon={<BarChart />}
         action={CustomAction}
       />
     );
@@ -54,15 +44,7 @@ export const WithAction: StoryObj<HvEmptyStateProps> = {
 };
 
 export const CustomMessages: StoryObj<HvEmptyStateProps> = {
-  args: {
-    title: "This page can't be displayed",
-    icon: <Ghost />,
-  },
-  argTypes: {
-    icon: { control: { disable: true } },
-    classes: { control: { disable: true } },
-  },
-  render: ({ title, icon }) => {
+  render: () => {
     const CustomAction = (
       <>
         <HvTypography>Here are some helpful links instead:</HvTypography>
@@ -75,9 +57,9 @@ export const CustomMessages: StoryObj<HvEmptyStateProps> = {
     const CustomMessage = <HvTypography>404 Not Found</HvTypography>;
     return (
       <HvEmptyState
-        title={title}
+        title="This page can't be displayed"
         message={CustomMessage}
-        icon={icon}
+        icon={<Ghost />}
         action={CustomAction}
       />
     );
@@ -85,15 +67,7 @@ export const CustomMessages: StoryObj<HvEmptyStateProps> = {
 };
 
 export const Minimal: StoryObj<HvEmptyStateProps> = {
-  args: {
-    message: "No data to display",
-    icon: <Info />,
-  },
-  argTypes: {
-    icon: { control: { disable: true } },
-    classes: { control: { disable: true } },
-  },
-  render: ({ message, icon }) => {
-    return <HvEmptyState message={message} icon={icon} />;
+  render: () => {
+    return <HvEmptyState message="No data to display" icon={<Info />} />;
   },
 };

--- a/packages/core/src/components/Grid/Grid.stories.tsx
+++ b/packages/core/src/components/Grid/Grid.stories.tsx
@@ -18,6 +18,9 @@ const meta: Meta<typeof HvGrid> = {
 export default meta;
 
 export const Main: StoryObj<HvGridProps> = {
+  argTypes: {
+    classes: { control: { disable: true } },
+  },
   render: () => {
     const StyledItem = styled("div")({
       padding: theme.space.sm,

--- a/packages/core/src/components/ListContainer/ListContainer.tsx
+++ b/packages/core/src/components/ListContainer/ListContainer.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useContext, useMemo } from "react";
+import React, { useRef, useContext, useMemo, forwardRef } from "react";
 
 import { HvBaseProps } from "@core/types/generic";
 import { useForkRef } from "@core/hooks/useForkRef";
@@ -31,7 +31,7 @@ export interface HvListContainerProps extends HvBaseProps<HTMLUListElement> {
  * The simple list is for continuous <b>vertical indexes of text or icons+text</b>. The content of these lists must be simple: ideally simples fields.
  * This pattern is ideal for <b>selections</b>. It should be used inside a HvPanel.
  */
-export const HvListContainer = React.forwardRef(
+export const HvListContainer = forwardRef(
   (props: HvListContainerProps, externalRef) => {
     const {
       id,

--- a/packages/core/src/components/Loading/Loading.tsx
+++ b/packages/core/src/components/Loading/Loading.tsx
@@ -22,6 +22,7 @@ export interface HvLoadingProps extends HvBaseProps {
   hidden?: boolean;
   /** Color applied to the bars. */
   color?: HvColorAny;
+  /** A Jss Object used to override or extend the styles applied to the component. */
   classes?: HvLoadingClasses;
 }
 

--- a/packages/core/src/components/Panel/Panel.stories.tsx
+++ b/packages/core/src/components/Panel/Panel.stories.tsx
@@ -16,6 +16,9 @@ const meta: Meta<typeof HvPanel> = {
 export default meta;
 
 export const Main: StoryObj<HvPanelProps> = {
+  argTypes: {
+    classes: { control: { disable: true } },
+  },
   render: () => {
     return (
       <HvPanel>

--- a/packages/core/src/components/Radio/Radio.stories.tsx
+++ b/packages/core/src/components/Radio/Radio.stories.tsx
@@ -41,7 +41,11 @@ export const Main: StoryObj<HvRadioProps> = {
     status: "standBy",
     statusMessage: "This is Invalid",
   },
-  argTypes: {},
+  argTypes: {
+    classes: { control: { disable: true } },
+    labelProps: { control: { disable: true } },
+    inputProps: { control: { disable: true } },
+  },
   render: (args) => {
     return <HvRadio {...args} />;
   },

--- a/packages/core/src/components/Radio/Radio.tsx
+++ b/packages/core/src/components/Radio/Radio.tsx
@@ -29,17 +29,9 @@ export interface HvRadioProps
   extends Omit<MuiRadioProps, "onChange" | "classes">,
     HvBaseProps<HTMLButtonElement, "onChange" | "color"> {
   /**
-   * Class names to be applied.
-   */
-  className?: string;
-  /**
    * A Jss Object used to override or extend the styles applied to the radio button.
    */
   classes?: HvRadioClasses;
-  /**
-   * Id to be applied to the form element root node.
-   */
-  id?: string;
   /**
    * The form element name.
    */
@@ -57,18 +49,6 @@ export interface HvRadioProps
    * If not provided, an aria-label or aria-labelledby must be provided.
    */
   label?: React.ReactNode;
-  /**
-   * @ignore
-   */
-  "aria-label"?: string;
-  /**
-   * @ignore
-   */
-  "aria-labelledby"?: string;
-  /**
-   * @ignore
-   */
-  "aria-describedby"?: string;
   /**
    * Properties passed on to the label element.
    */
@@ -138,10 +118,10 @@ export interface HvRadioProps
    * We trigger a `onFocus` callback too.
    */
   onFocusVisible?: (event: React.FocusEvent<any>) => void;
-  /**
-   * @ignore
-   */
-  onBlur?: (event: React.FocusEvent<any>) => void;
+  /** @ignore */
+  ref?: MuiRadioProps["ref"];
+  /** @ignore */
+  component?: MuiRadioProps["component"];
 }
 
 /**

--- a/packages/core/src/components/RadioGroup/RadioGroup.stories.tsx
+++ b/packages/core/src/components/RadioGroup/RadioGroup.stories.tsx
@@ -23,6 +23,10 @@ export const Main: StoryObj<HvRadioGroupProps> = {
   },
   argTypes: {
     classes: { control: { disable: true } },
+    value: { control: { disable: true } },
+    defaultValue: { control: { disable: true } },
+    status: { control: { disable: true } },
+    statusMessage: { control: { disable: true } },
   },
   render: (args) => {
     return (

--- a/packages/core/src/components/ScrollTo/Horizontal/ScrollToHorizontal.stories.tsx
+++ b/packages/core/src/components/ScrollTo/Horizontal/ScrollToHorizontal.stories.tsx
@@ -17,6 +17,10 @@ export default meta;
 
 export const Main: StoryObj<HvScrollToHorizontalProps> = {
   args: { tooltipPosition: "top" },
+  argTypes: {
+    classes: { control: { disable: true } },
+    options: { control: { disable: true } },
+  },
   render: (args) => {
     const options = [
       { label: "Server status summary", value: "mainId1" },

--- a/packages/core/src/components/ScrollTo/Vertical/ScrollToVertical.stories.tsx
+++ b/packages/core/src/components/ScrollTo/Vertical/ScrollToVertical.stories.tsx
@@ -19,6 +19,10 @@ export const Main: StoryObj<HvScrollToVerticalProps> = {
   args: {
     tooltipPosition: "left",
   },
+  argTypes: {
+    classes: { control: { disable: true } },
+    options: { control: { disable: true } },
+  },
   render: (args) => {
     const options = [
       { label: "Server status summary", value: "mainId1" },

--- a/packages/core/src/components/Slider/Slider.stories.tsx
+++ b/packages/core/src/components/Slider/Slider.stories.tsx
@@ -31,6 +31,17 @@ export default meta;
 
 export const Main: StoryObj<HvSliderProps> = {
   args: { label: "Failure Rate", defaultValues: [10] },
+  argTypes: {
+    classes: { control: { disable: true } },
+    sliderProps: { control: { disable: true } },
+    status: { control: { disable: true } },
+    statusMessage: { control: { disable: true } },
+    values: { control: { disable: true } },
+    knobProperties: { control: { disable: true } },
+    markProperties: { control: { disable: true } },
+    inputProps: { control: { disable: true } },
+    knobProps: { control: { disable: true } },
+  },
   render: (args) => {
     return <HvSlider id="Main" {...args} />;
   },

--- a/packages/core/src/components/Snackbar/Snackbar.stories.tsx
+++ b/packages/core/src/components/Snackbar/Snackbar.stories.tsx
@@ -37,7 +37,6 @@ export const Main: StoryObj<HvSnackbarProps> = {
     action: { control: { disable: true } },
     actionCallback: { control: { disable: true } },
     snackbarContentProps: { control: { disable: true } },
-    ref: { control: { disable: true } },
   },
   render: (args) => {
     return <HvSnackbar {...args} />;

--- a/packages/core/src/components/Snackbar/Snackbar.tsx
+++ b/packages/core/src/components/Snackbar/Snackbar.tsx
@@ -65,6 +65,8 @@ export interface HvSnackbarProps
   snackbarContentProps?: HvSnackbarContentProps;
   /** A Jss Object used to override or extend the styles applied to the component. */
   classes?: HvSnackbarClasses;
+  /** @ignore */
+  ref?: MuiSnackbarProps["ref"];
 }
 
 const transLeft = (props) => <Slide {...props} direction="left" />;

--- a/packages/core/src/components/Stack/Stack.stories.tsx
+++ b/packages/core/src/components/Stack/Stack.stories.tsx
@@ -50,7 +50,6 @@ export const Main: StoryObj<HvStackProps> = {
   },
   argTypes: {
     classes: { control: { disable: true } },
-    children: { control: { disable: true } },
     dividerProps: { control: { disable: true } },
     direction: { control: { type: "radio" }, options: ["column", "row"] },
     spacing: {

--- a/packages/core/src/components/Switch/Switch.stories.tsx
+++ b/packages/core/src/components/Switch/Switch.stories.tsx
@@ -45,6 +45,8 @@ export const Main: StoryObj<HvSwitchProps> = {
   argTypes: {
     classes: { control: { disable: true } },
     labelProps: { control: { disable: true } },
+    status: { control: { disable: true } },
+    inputProps: { control: { disable: true } },
   },
   render: (args) => {
     return <HvSwitch {...args} />;

--- a/packages/core/src/components/Switch/Switch.tsx
+++ b/packages/core/src/components/Switch/Switch.tsx
@@ -28,17 +28,9 @@ export interface HvSwitchProps
   extends Omit<MuiSwitchProps, "onChange" | "classes">,
     HvBaseProps<HTMLButtonElement, "onChange" | "color"> {
   /**
-   * Class names to be applied.
-   */
-  className?: string;
-  /**
    * A Jss Object used to override or extend the styles applied to the switch.
    */
   classes?: HvSwitchClasses;
-  /**
-   * Id to be applied to the form element root node.
-   */
-  id?: string;
   /**
    * The form element name.
    */
@@ -59,18 +51,6 @@ export interface HvSwitchProps
    * If not provided, an aria-label or aria-labelledby must be inputted via inputProps.
    */
   label?: React.ReactNode;
-  /**
-   * @ignore
-   */
-  "aria-label"?: string;
-  /**
-   * @ignore
-   */
-  "aria-labelledby"?: string;
-  /**
-   * @ignore
-   */
-  "aria-describedby"?: string;
   /**
    * Properties passed on to the label element.
    */
@@ -126,6 +106,10 @@ export interface HvSwitchProps
    * Properties passed on to the input element.
    */
   inputProps?: React.InputHTMLAttributes<HTMLInputElement>;
+  /** @ignore */
+  ref?: MuiSwitchProps["ref"];
+  /** @ignore */
+  component?: MuiSwitchProps["component"];
 }
 
 /**

--- a/packages/core/src/components/Tabs/Tabs.tsx
+++ b/packages/core/src/components/Tabs/Tabs.tsx
@@ -21,6 +21,10 @@ export interface HvTabsProps extends Omit<MuiTabsProps, "onChange"> {
    * A Jss Object used to override or extend the component styles.
    */
   classes?: HvTabsClasses;
+  /** @ignore */
+  ref?: MuiTabsProps["ref"];
+  /** @ignore */
+  component?: MuiTabsProps["component"];
 }
 
 /**

--- a/packages/core/src/components/Tag/Tag.stories.tsx
+++ b/packages/core/src/components/Tag/Tag.stories.tsx
@@ -41,13 +41,9 @@ export const Main: StoryObj<HvTagProps> = {
     type: "semantic",
     color: "neutral_20",
     disabled: false,
-    clickable: false,
   },
   argTypes: {
     classes: { control: { disable: true } },
-    children: { control: { disable: true } },
-    sx: { control: { disable: true } },
-    icon: { control: { disable: true } },
     deleteIcon: { control: { disable: true } },
     deleteButtonProps: { control: { disable: true } },
     type: { control: { type: "radio" }, options: ["semantic", "categorical"] },

--- a/packages/core/src/components/Tag/Tag.tsx
+++ b/packages/core/src/components/Tag/Tag.tsx
@@ -1,4 +1,4 @@
-import { CSSProperties, useState } from "react";
+import { useState } from "react";
 import { HvColorAny, theme } from "@hitachivantara/uikit-styles";
 import Chip, { ChipProps as MuiChipProps } from "@mui/material/Chip";
 import { HvBaseProps } from "@core/types/generic";
@@ -18,8 +18,6 @@ export type HvTagClasses = ExtractNames<typeof useClasses>;
 export interface HvTagProps
   extends Omit<MuiChipProps, "color" | "classes">,
     HvBaseProps<HTMLDivElement, "children"> {
-  /** Inline styles to be applied to the root element. */
-  style?: CSSProperties;
   /** The label of the tag element. */
   label?: React.ReactNode;
   /** Indicates that the form element is disabled. */
@@ -45,6 +43,10 @@ export interface HvTagProps
   deleteButtonProps?: HvButtonProps;
   /** A Jss Object used to override or extend the styles applied to the component. */
   classes?: HvTagClasses;
+  /** @ignore */
+  ref?: MuiChipProps["ref"];
+  /** @ignore */
+  component?: MuiChipProps["component"];
 }
 
 const getColor = (customColor, type, colors) => {

--- a/packages/core/src/components/TextArea/TextArea.stories.tsx
+++ b/packages/core/src/components/TextArea/TextArea.stories.tsx
@@ -20,7 +20,6 @@ export const Main: StoryObj<HvTextAreaProps> = {
     label: "Label",
     placeholder: "Enter value",
     rows: 5,
-    invalid: false,
     resizable: false,
     description: "Textarea description",
     hideCounter: false,
@@ -32,8 +31,159 @@ export const Main: StoryObj<HvTextAreaProps> = {
     statusMessage: "Oops, something's gone wrong!",
   },
   argTypes: {
-    countCharProps: { control: { disable: true } },
-    classes: { control: { disable: true } },
+    label: {
+      description:
+        "The label of the form element. The form element must be labeled for accessibility reasons. If not provided, an aria-label or aria-labelledby must be provided instead.",
+      table: {
+        type: { summary: "React.ReactNode" },
+      },
+    },
+    placeholder: {
+      description: "The placeholder value of the text area.",
+      table: {
+        type: { summary: "string" },
+      },
+    },
+    description: {
+      description: "Provide additional descriptive text for the form element.",
+      table: {
+        type: { summary: "React.ReactNode" },
+      },
+    },
+    status: {
+      description:
+        "The status of the form element. Valid is correct, invalid is incorrect and standBy means no validations have run. When uncontrolled and unspecified it will default to `standBy` and change to either `valid` or `invalid` after any change to the state.",
+      table: {
+        type: { summary: "HvFormStatus" },
+      },
+    },
+    statusMessage: {
+      description: "The error message to show when `status` is `invalid`.",
+      table: {
+        type: { summary: "React.ReactNode" },
+      },
+    },
+    middleCountLabel: {
+      description: "Text between the current char counter and max value.",
+      table: {
+        defaultValue: { summary: "/" },
+        type: { summary: "string" },
+      },
+    },
+    validationMessages: {
+      description:
+        "An Object containing the various texts associated with the input.",
+      table: {
+        type: { summary: "HvValidationMessages" },
+      },
+    },
+    validation: {
+      description:
+        "The custom validation function, it receives the value and must return either `true` for valid or `false` for invalid, default validations would only occur if this function is null or undefined.",
+      table: {
+        type: { summary: "(value: string) => boolean" },
+      },
+    },
+    maxCharQuantity: {
+      description:
+        "The maximum allowed length of the characters, if this value is null no check will be performed.",
+      table: {
+        type: { summary: "number" },
+      },
+    },
+    minCharQuantity: {
+      description:
+        "The minimum allowed length of the characters, if this value is null no check will be performed.",
+      table: {
+        type: { summary: "number" },
+      },
+    },
+    autoFocus: {
+      description: "If `true` it should autofocus.",
+      table: {
+        defaultValue: { summary: "false" },
+        type: { summary: "boolean" },
+      },
+    },
+    rows: {
+      description: "The number of rows of the text area.",
+      table: {
+        type: { summary: "number" },
+      },
+    },
+    resizable: {
+      description: "If `true` the component is resizable.",
+      table: {
+        defaultValue: { summary: "false" },
+        type: { summary: "boolean" },
+      },
+    },
+    autoScroll: {
+      description:
+        "Auto-scroll: automatically scroll to the end on value changes. Will stop if the user scrolls up and resume if scrolled to the bottom.",
+      table: {
+        defaultValue: { summary: "false" },
+        type: { summary: "boolean" },
+      },
+    },
+    blockMax: {
+      description: "If `true` it isn't possible to pass the `maxCharQuantity`.",
+      table: {
+        defaultValue: { summary: "false" },
+        type: { summary: "boolean" },
+      },
+    },
+    hideCounter: {
+      description:
+        "If `true` the character counter isn't shown even if `maxCharQuantity` is set.",
+      table: {
+        defaultValue: { summary: "false" },
+        type: { summary: "boolean" },
+      },
+    },
+    countCharProps: {
+      description: "Props passed to the char count.",
+      control: { disable: true },
+      table: {
+        type: { summary: "Partial<HvCharCounterProps>" },
+      },
+    },
+    onChange: {
+      description: "Called back when the value is changed.",
+      table: {
+        type: {
+          summary:
+            "(event: React.ChangeEvent<HTMLTextAreaElement>, value: string) => void",
+        },
+      },
+    },
+    onBlur: {
+      description: "Called back when the value is changed.",
+      table: {
+        type: {
+          summary:
+            "(event: React.FocusEvent<HTMLTextAreaElement>, value: string, validationState: HvInputValidity) => void",
+        },
+      },
+    },
+    onFocus: {
+      description:
+        "The function that will be executed onBlur, allows checking the value state, it receives the value.",
+      table: {
+        type: {
+          summary:
+            "(event: React.FocusEvent<HTMLTextAreaElement>, value: string) => void",
+        },
+      },
+    },
+    classes: {
+      description:
+        "A Jss Object used to override or extend the styles applied to the component.",
+      table: {
+        type: { summary: "HvTextAreaClasses" },
+      },
+      control: { disable: true },
+    },
   },
   render: (args) => {
     return <HvTextArea id="main" {...args} />;

--- a/packages/core/src/components/TextArea/TextArea.tsx
+++ b/packages/core/src/components/TextArea/TextArea.tsx
@@ -160,356 +160,358 @@ export interface HvTextAreaProps
 /**
  * A text area is a multiline text input box, with an optional character counter when there is a length limit.
  */
-export const HvTextArea = forwardRef<any, HvTextAreaProps>((props, ref) => {
-  const {
-    id,
-    className,
-    classes: classesProp,
-    name,
-    label,
-    description,
-    placeholder,
-    status,
-    statusMessage,
-    validationMessages,
-    maxCharQuantity,
-    minCharQuantity,
-    value: valueProp,
-    inputRef: inputRefProp,
-    rows = 1,
-    defaultValue = "",
-    middleCountLabel = "/",
-    countCharProps = {},
-    inputProps = {},
-    required = false,
-    readOnly = false,
-    disabled = false,
-    autoFocus = false,
-    resizable = false,
-    autoScroll = false,
-    hideCounter = false,
-    blockMax = false,
-    "aria-label": ariaLabel,
-    "aria-labelledby": ariaLabelledBy,
-    "aria-describedby": ariaDescribedBy,
-    "aria-errormessage": ariaErrorMessage,
-    validation,
-    onChange,
-    onBlur,
-    onFocus,
-    ...others
-  } = useDefaultProps("HvTextArea", props);
-
-  const { classes, cx } = useClasses(classesProp);
-
-  const elementId = useUniqueId(id, "hvtextarea");
-
-  // Signals that the user has manually edited the input value
-  const isDirty = useRef<boolean>(false);
-
-  const inputRef = useRef<HTMLTextAreaElement>(null);
-  const forkedRef = useForkRef(ref, inputRefProp, inputRef);
-
-  const [focused, setFocused] = useState<boolean>(false);
-
-  const [autoScrolling, setAutoScrolling] = useState(autoScroll);
-
-  const [validationState, setValidationState] = useControlled(
-    status,
-    validationStates.standBy
-  );
-
-  const [validationMessage, setValidationMessage] = useControlled(
-    statusMessage,
-    ""
-  );
-
-  const [value, setValue] = useControlled(valueProp, defaultValue);
-
-  const isStateInvalid = isInvalid(validationState);
-
-  const isEmptyValue = value == null || value === "";
-
-  const hasLabel = label != null;
-
-  const hasDescription = description != null;
-
-  const hasCounter = maxCharQuantity != null && !hideCounter;
-
-  // ValidationMessages reference tends to change, as users will not memorize/useState for it;
-  // Dependencies must be more explicit so we set
-  const errorMessages = useMemo(
-    () => ({ ...DEFAULT_ERROR_MESSAGES, ...validationMessages }),
-    [validationMessages]
-  );
-
-  // Validates the input, sets the status and the statusMessage accordingly (if uncontrolled)
-  // and returns the validity state of the input.
-  const performValidation = useCallback(() => {
-    const inputValidity = validateInput(
-      inputRef.current,
-      value,
-      required,
-      minCharQuantity,
+export const HvTextArea = forwardRef<any, HvTextAreaProps>(
+  (props: HvTextAreaProps, ref) => {
+    const {
+      id,
+      className,
+      classes: classesProp,
+      name,
+      label,
+      description,
+      placeholder,
+      status,
+      statusMessage,
+      validationMessages,
       maxCharQuantity,
-      validationTypes.none,
-      validation
+      minCharQuantity,
+      value: valueProp,
+      inputRef: inputRefProp,
+      rows = 1,
+      defaultValue = "",
+      middleCountLabel = "/",
+      countCharProps = {},
+      inputProps = {},
+      required = false,
+      readOnly = false,
+      disabled = false,
+      autoFocus = false,
+      resizable = false,
+      autoScroll = false,
+      hideCounter = false,
+      blockMax = false,
+      "aria-label": ariaLabel,
+      "aria-labelledby": ariaLabelledBy,
+      "aria-describedby": ariaDescribedBy,
+      "aria-errormessage": ariaErrorMessage,
+      validation,
+      onChange,
+      onBlur,
+      onFocus,
+      ...others
+    } = useDefaultProps("HvTextArea", props);
+
+    const { classes, cx } = useClasses(classesProp);
+
+    const elementId = useUniqueId(id, "hvtextarea");
+
+    // Signals that the user has manually edited the input value
+    const isDirty = useRef<boolean>(false);
+
+    const inputRef = useRef<HTMLTextAreaElement>(null);
+    const forkedRef = useForkRef(ref, inputRefProp, inputRef);
+
+    const [focused, setFocused] = useState<boolean>(false);
+
+    const [autoScrolling, setAutoScrolling] = useState(autoScroll);
+
+    const [validationState, setValidationState] = useControlled(
+      status,
+      validationStates.standBy
     );
 
-    // This will only run if status is uncontrolled
-    setValidationState(computeValidationState(inputValidity, isEmptyValue));
-
-    // This will only run if statusMessage is uncontrolled
-    setValidationMessage(
-      computeValidationMessage(inputValidity, errorMessages)
+    const [validationMessage, setValidationMessage] = useControlled(
+      statusMessage,
+      ""
     );
 
-    return inputValidity;
-  }, [
-    errorMessages,
-    inputRef,
-    isEmptyValue,
-    maxCharQuantity,
-    minCharQuantity,
-    required,
-    setValidationMessage,
-    setValidationState,
-    validation,
-    value,
-  ]);
+    const [value, setValue] = useControlled(valueProp, defaultValue);
 
-  const isOverflow = (currentValue) =>
-    isNil(maxCharQuantity) ? false : currentValue.length > maxCharQuantity;
+    const isStateInvalid = isInvalid(validationState);
 
-  /**
-   * Limit the string to the maxCharQuantity length.
-   *
-   * @param value - string to evaluate
-   * @returns {string|*} - string according the limit
-   */
-  const limitValue = (currentValue) => {
-    if (currentValue === undefined || !blockMax) return currentValue;
-    return !isOverflow(currentValue)
-      ? currentValue
-      : currentValue.substring(0, maxCharQuantity);
-  };
+    const isEmptyValue = value == null || value === "";
 
-  /**
-   * Validates the text area updating the state and modifying the warning text, also executes
-   * the user provided onBlur passing the current validation status and value.
-   *
-   * @returns {undefined}
-   */
-  const onContainerBlurHandler = (event) => {
-    setFocused(false);
+    const hasLabel = label != null;
 
-    const inputValidity = performValidation();
+    const hasDescription = description != null;
 
-    onBlur?.(event, value, inputValidity);
-  };
+    const hasCounter = maxCharQuantity != null && !hideCounter;
 
-  /**
-   * Updates the length of the string while is being inputted, also executes the user onChange
-   * allowing the customization of the input if required.
-   *
-   * @param {String} value - The value provided by the HvInput
-   */
-  const onChangeHandler = (event, currentValue) => {
-    isDirty.current = true;
+    // ValidationMessages reference tends to change, as users will not memorize/useState for it;
+    // Dependencies must be more explicit so we set
+    const errorMessages = useMemo(
+      () => ({ ...DEFAULT_ERROR_MESSAGES, ...validationMessages }),
+      [validationMessages]
+    );
 
-    const limitedValue = blockMax ? limitValue(currentValue) : currentValue;
+    // Validates the input, sets the status and the statusMessage accordingly (if uncontrolled)
+    // and returns the validity state of the input.
+    const performValidation = useCallback(() => {
+      const inputValidity = validateInput(
+        inputRef.current,
+        value,
+        required,
+        minCharQuantity,
+        maxCharQuantity,
+        validationTypes.none,
+        validation
+      );
 
-    // Set the input value (only when value is uncontrolled)
-    setValue(limitedValue);
+      // This will only run if status is uncontrolled
+      setValidationState(computeValidationState(inputValidity, isEmptyValue));
 
-    onChange?.(event, limitedValue);
-  };
+      // This will only run if statusMessage is uncontrolled
+      setValidationMessage(
+        computeValidationMessage(inputValidity, errorMessages)
+      );
 
-  /**
-   * Updates the state putting again the value from the state because the input value is
-   * not automatically manage, it also executes the onFocus function from the user passing the value
-   */
-  const onFocusHandler = (event) => {
-    setFocused(true);
+      return inputValidity;
+    }, [
+      errorMessages,
+      inputRef,
+      isEmptyValue,
+      maxCharQuantity,
+      minCharQuantity,
+      required,
+      setValidationMessage,
+      setValidationState,
+      validation,
+      value,
+    ]);
 
-    // Reset validation status to standBy (only when status is uncontrolled)
-    setValidationState(validationStates.standBy);
+    const isOverflow = (currentValue) =>
+      isNil(maxCharQuantity) ? false : currentValue.length > maxCharQuantity;
 
-    onFocus?.(event, value);
-  };
-
-  const isScrolledDown = useCallback(() => {
-    const el = inputRef.current;
-    return el == null || el.offsetHeight + el.scrollTop >= el.scrollHeight;
-  }, [inputRef]);
-
-  const scrollDown = useCallback(() => {
-    const el = inputRef.current;
-    if (el != null) {
-      el.scrollTop = el.scrollHeight - el.clientHeight;
-    }
-  }, [inputRef]);
-
-  const addScrollListener = useCallback(() => {
-    const scrollHandler = {
-      handleEvent: () => {
-        setAutoScrolling(isScrolledDown());
-      },
+    /**
+     * Limit the string to the maxCharQuantity length.
+     *
+     * @param value - string to evaluate
+     * @returns {string|*} - string according the limit
+     */
+    const limitValue = (currentValue) => {
+      if (currentValue === undefined || !blockMax) return currentValue;
+      return !isOverflow(currentValue)
+        ? currentValue
+        : currentValue.substring(0, maxCharQuantity);
     };
-    inputRef.current?.addEventListener("scroll", scrollHandler);
-  }, [inputRef, isScrolledDown]);
 
-  useEffect(() => {
-    if (autoScroll) {
-      addScrollListener();
-    }
-  }, [autoScroll, addScrollListener]);
+    /**
+     * Validates the text area updating the state and modifying the warning text, also executes
+     * the user provided onBlur passing the current validation status and value.
+     *
+     * @returns {undefined}
+     */
+    const onContainerBlurHandler = (event) => {
+      setFocused(false);
 
-  useEffect(() => {
-    if (autoScrolling) {
-      scrollDown();
-    }
-  }, [valueProp, autoScrolling, scrollDown]);
+      const inputValidity = performValidation();
 
-  // Run initial validation after first render
-  // and also when any validation condition changes
-  useEffect(() => {
-    if (focused || (!isDirty.current && isEmptyValue)) {
-      // Skip validation if currently focused or if empty and
-      // the user never manually edited the input value
-      return;
-    }
+      onBlur?.(event, value, inputValidity);
+    };
 
-    performValidation();
-  }, [focused, isEmptyValue, performValidation]);
+    /**
+     * Updates the length of the string while is being inputted, also executes the user onChange
+     * allowing the customization of the input if required.
+     *
+     * @param {String} value - The value provided by the HvInput
+     */
+    const onChangeHandler = (event, currentValue) => {
+      isDirty.current = true;
 
-  // The error message area will only be created if:
-  //   - an external element that provides an error message isn't identified via aria-errormessage AND
-  //   - both status and statusMessage properties are being controlled OR
-  //   - status is uncontrolled and any of the built-in validations are active
-  const canShowError =
-    ariaErrorMessage == null &&
-    ((status !== undefined && statusMessage !== undefined) ||
-      (status === undefined &&
-        hasBuiltInValidations(
-          required,
-          validationTypes.none,
-          minCharQuantity,
-          // If blockMax is true maxCharQuantity will never produce an error
-          // unless the value is controlled, so we can't prevent it to overflow maxCharQuantity
-          maxCharQuantity != null && (blockMax !== true || value != null)
-            ? maxCharQuantity
-            : null,
-          validation,
-          inputProps
-        )));
+      const limitedValue = blockMax ? limitValue(currentValue) : currentValue;
 
-  let errorMessageId;
-  if (isStateInvalid) {
-    errorMessageId = canShowError
-      ? setId(elementId, "error")
-      : ariaErrorMessage;
-  }
+      // Set the input value (only when value is uncontrolled)
+      setValue(limitedValue);
 
-  return (
-    <HvFormElement
-      id={id}
-      name={name}
-      status={validationState}
-      disabled={disabled}
-      required={required}
-      readOnly={readOnly}
-      className={cx(
-        classes.root,
-        {
-          [classes.resizable]: resizable,
-          [classes.disabled]: disabled,
-          [classes.invalid]: isStateInvalid,
+      onChange?.(event, limitedValue);
+    };
+
+    /**
+     * Updates the state putting again the value from the state because the input value is
+     * not automatically manage, it also executes the onFocus function from the user passing the value
+     */
+    const onFocusHandler = (event) => {
+      setFocused(true);
+
+      // Reset validation status to standBy (only when status is uncontrolled)
+      setValidationState(validationStates.standBy);
+
+      onFocus?.(event, value);
+    };
+
+    const isScrolledDown = useCallback(() => {
+      const el = inputRef.current;
+      return el == null || el.offsetHeight + el.scrollTop >= el.scrollHeight;
+    }, [inputRef]);
+
+    const scrollDown = useCallback(() => {
+      const el = inputRef.current;
+      if (el != null) {
+        el.scrollTop = el.scrollHeight - el.clientHeight;
+      }
+    }, [inputRef]);
+
+    const addScrollListener = useCallback(() => {
+      const scrollHandler = {
+        handleEvent: () => {
+          setAutoScrolling(isScrolledDown());
         },
-        className
-      )}
-      onBlur={onContainerBlurHandler}
-    >
-      {(hasLabel || hasDescription) && (
-        <div className={classes.labelContainer}>
-          {hasLabel && (
-            <HvLabel
-              className={classes.label}
-              id={setId(id, "label")}
-              htmlFor={setId(elementId, "input")}
-              label={label}
-            />
-          )}
+      };
+      inputRef.current?.addEventListener("scroll", scrollHandler);
+    }, [inputRef, isScrolledDown]);
 
-          {hasDescription && (
-            <HvInfoMessage
-              className={classes.description}
-              id={setId(elementId, "description")}
-            >
-              {description}
-            </HvInfoMessage>
-          )}
-        </div>
-      )}
+    useEffect(() => {
+      if (autoScroll) {
+        addScrollListener();
+      }
+    }, [autoScroll, addScrollListener]);
 
-      {hasCounter && (
-        <HvCharCounter
-          id={setId(elementId, "charCounter")}
-          className={classes.characterCounter}
-          separator={middleCountLabel}
-          currentCharQuantity={value.length}
-          maxCharQuantity={maxCharQuantity}
-          {...countCharProps}
-        />
-      )}
+    useEffect(() => {
+      if (autoScrolling) {
+        scrollDown();
+      }
+    }, [valueProp, autoScrolling, scrollDown]);
 
-      <HvBaseInput
-        classes={{
-          root: classes.baseInput,
-          input: classes.input,
-          inputResizable: classes.inputResizable,
-        }}
-        id={hasLabel ? setId(elementId, "input") : setId(id, "input")}
+    // Run initial validation after first render
+    // and also when any validation condition changes
+    useEffect(() => {
+      if (focused || (!isDirty.current && isEmptyValue)) {
+        // Skip validation if currently focused or if empty and
+        // the user never manually edited the input value
+        return;
+      }
+
+      performValidation();
+    }, [focused, isEmptyValue, performValidation]);
+
+    // The error message area will only be created if:
+    //   - an external element that provides an error message isn't identified via aria-errormessage AND
+    //   - both status and statusMessage properties are being controlled OR
+    //   - status is uncontrolled and any of the built-in validations are active
+    const canShowError =
+      ariaErrorMessage == null &&
+      ((status !== undefined && statusMessage !== undefined) ||
+        (status === undefined &&
+          hasBuiltInValidations(
+            required,
+            validationTypes.none,
+            minCharQuantity,
+            // If blockMax is true maxCharQuantity will never produce an error
+            // unless the value is controlled, so we can't prevent it to overflow maxCharQuantity
+            maxCharQuantity != null && (blockMax !== true || value != null)
+              ? maxCharQuantity
+              : null,
+            validation,
+            inputProps
+          )));
+
+    let errorMessageId;
+    if (isStateInvalid) {
+      errorMessageId = canShowError
+        ? setId(elementId, "error")
+        : ariaErrorMessage;
+    }
+
+    return (
+      <HvFormElement
+        id={id}
         name={name}
-        value={value}
+        status={validationState}
+        disabled={disabled}
         required={required}
         readOnly={readOnly}
-        disabled={disabled}
-        onChange={onChangeHandler}
-        autoFocus={autoFocus}
-        onFocus={onFocusHandler}
-        placeholder={placeholder}
-        invalid={isStateInvalid}
-        resizable={resizable}
-        multiline
-        rows={rows}
-        inputProps={{
-          "aria-label": ariaLabel,
-          "aria-labelledby": ariaLabelledBy,
-          "aria-invalid": isStateInvalid ? true : undefined,
-          "aria-errormessage": errorMessageId,
-          "aria-describedby":
-            ariaDescribedBy != null
-              ? ariaDescribedBy
-              : (description && setId(elementId, "description")) || undefined,
-          "aria-controls": maxCharQuantity
-            ? setId(elementId, "charCounter")
-            : undefined,
-          ...inputProps,
-        }}
-        inputRef={forkedRef}
-        {...others}
-      />
+        className={cx(
+          classes.root,
+          {
+            [classes.resizable]: resizable,
+            [classes.disabled]: disabled,
+            [classes.invalid]: isStateInvalid,
+          },
+          className
+        )}
+        onBlur={onContainerBlurHandler}
+      >
+        {(hasLabel || hasDescription) && (
+          <div className={classes.labelContainer}>
+            {hasLabel && (
+              <HvLabel
+                className={classes.label}
+                id={setId(id, "label")}
+                htmlFor={setId(elementId, "input")}
+                label={label}
+              />
+            )}
 
-      {canShowError && (
-        <HvWarningText
-          id={setId(elementId, "error")}
-          className={classes.error}
-          disableBorder
-        >
-          {validationMessage}
-        </HvWarningText>
-      )}
-    </HvFormElement>
-  );
-});
+            {hasDescription && (
+              <HvInfoMessage
+                className={classes.description}
+                id={setId(elementId, "description")}
+              >
+                {description}
+              </HvInfoMessage>
+            )}
+          </div>
+        )}
+
+        {hasCounter && (
+          <HvCharCounter
+            id={setId(elementId, "charCounter")}
+            className={classes.characterCounter}
+            separator={middleCountLabel}
+            currentCharQuantity={value.length}
+            maxCharQuantity={maxCharQuantity}
+            {...countCharProps}
+          />
+        )}
+
+        <HvBaseInput
+          classes={{
+            root: classes.baseInput,
+            input: classes.input,
+            inputResizable: classes.inputResizable,
+          }}
+          id={hasLabel ? setId(elementId, "input") : setId(id, "input")}
+          name={name}
+          value={value}
+          required={required}
+          readOnly={readOnly}
+          disabled={disabled}
+          onChange={onChangeHandler}
+          autoFocus={autoFocus}
+          onFocus={onFocusHandler}
+          placeholder={placeholder}
+          invalid={isStateInvalid}
+          resizable={resizable}
+          multiline
+          rows={rows}
+          inputProps={{
+            "aria-label": ariaLabel,
+            "aria-labelledby": ariaLabelledBy,
+            "aria-invalid": isStateInvalid ? true : undefined,
+            "aria-errormessage": errorMessageId,
+            "aria-describedby":
+              ariaDescribedBy != null
+                ? ariaDescribedBy
+                : (description && setId(elementId, "description")) || undefined,
+            "aria-controls": maxCharQuantity
+              ? setId(elementId, "charCounter")
+              : undefined,
+            ...inputProps,
+          }}
+          inputRef={forkedRef}
+          {...others}
+        />
+
+        {canShowError && (
+          <HvWarningText
+            id={setId(elementId, "error")}
+            className={classes.error}
+            disableBorder
+          >
+            {validationMessage}
+          </HvWarningText>
+        )}
+      </HvFormElement>
+    );
+  }
+);

--- a/packages/core/src/components/TextArea/TextArea.tsx
+++ b/packages/core/src/components/TextArea/TextArea.tsx
@@ -49,8 +49,10 @@ export type HvTextAreaClasses = ExtractNames<typeof useClasses>;
 export interface HvTextAreaProps
   extends Omit<
     HvBaseInputProps,
-    "onChange" | "onBlur" | "rows" | "classes" | "onFocus"
+    "onChange" | "onBlur" | "rows" | "classes" | "onFocus" | "placeholder"
   > {
+  /** The placeholder value of the text area. */
+  placeholder?: string;
   /**
    * The label of the form element.
    *
@@ -160,358 +162,356 @@ export interface HvTextAreaProps
 /**
  * A text area is a multiline text input box, with an optional character counter when there is a length limit.
  */
-export const HvTextArea = forwardRef<any, HvTextAreaProps>(
-  (props: HvTextAreaProps, ref) => {
-    const {
-      id,
-      className,
-      classes: classesProp,
-      name,
-      label,
-      description,
-      placeholder,
-      status,
-      statusMessage,
-      validationMessages,
-      maxCharQuantity,
-      minCharQuantity,
-      value: valueProp,
-      inputRef: inputRefProp,
-      rows = 1,
-      defaultValue = "",
-      middleCountLabel = "/",
-      countCharProps = {},
-      inputProps = {},
-      required = false,
-      readOnly = false,
-      disabled = false,
-      autoFocus = false,
-      resizable = false,
-      autoScroll = false,
-      hideCounter = false,
-      blockMax = false,
-      "aria-label": ariaLabel,
-      "aria-labelledby": ariaLabelledBy,
-      "aria-describedby": ariaDescribedBy,
-      "aria-errormessage": ariaErrorMessage,
-      validation,
-      onChange,
-      onBlur,
-      onFocus,
-      ...others
-    } = useDefaultProps("HvTextArea", props);
+export const HvTextArea = forwardRef<any, HvTextAreaProps>((props, ref) => {
+  const {
+    id,
+    className,
+    classes: classesProp,
+    name,
+    label,
+    description,
+    placeholder,
+    status,
+    statusMessage,
+    validationMessages,
+    maxCharQuantity,
+    minCharQuantity,
+    value: valueProp,
+    inputRef: inputRefProp,
+    rows = 1,
+    defaultValue = "",
+    middleCountLabel = "/",
+    countCharProps = {},
+    inputProps = {},
+    required = false,
+    readOnly = false,
+    disabled = false,
+    autoFocus = false,
+    resizable = false,
+    autoScroll = false,
+    hideCounter = false,
+    blockMax = false,
+    "aria-label": ariaLabel,
+    "aria-labelledby": ariaLabelledBy,
+    "aria-describedby": ariaDescribedBy,
+    "aria-errormessage": ariaErrorMessage,
+    validation,
+    onChange,
+    onBlur,
+    onFocus,
+    ...others
+  } = useDefaultProps("HvTextArea", props);
 
-    const { classes, cx } = useClasses(classesProp);
+  const { classes, cx } = useClasses(classesProp);
 
-    const elementId = useUniqueId(id, "hvtextarea");
+  const elementId = useUniqueId(id, "hvtextarea");
 
-    // Signals that the user has manually edited the input value
-    const isDirty = useRef<boolean>(false);
+  // Signals that the user has manually edited the input value
+  const isDirty = useRef<boolean>(false);
 
-    const inputRef = useRef<HTMLTextAreaElement>(null);
-    const forkedRef = useForkRef(ref, inputRefProp, inputRef);
+  const inputRef = useRef<HTMLTextAreaElement>(null);
+  const forkedRef = useForkRef(ref, inputRefProp, inputRef);
 
-    const [focused, setFocused] = useState<boolean>(false);
+  const [focused, setFocused] = useState<boolean>(false);
 
-    const [autoScrolling, setAutoScrolling] = useState(autoScroll);
+  const [autoScrolling, setAutoScrolling] = useState(autoScroll);
 
-    const [validationState, setValidationState] = useControlled(
-      status,
-      validationStates.standBy
-    );
+  const [validationState, setValidationState] = useControlled(
+    status,
+    validationStates.standBy
+  );
 
-    const [validationMessage, setValidationMessage] = useControlled(
-      statusMessage,
-      ""
-    );
+  const [validationMessage, setValidationMessage] = useControlled(
+    statusMessage,
+    ""
+  );
 
-    const [value, setValue] = useControlled(valueProp, defaultValue);
+  const [value, setValue] = useControlled(valueProp, defaultValue);
 
-    const isStateInvalid = isInvalid(validationState);
+  const isStateInvalid = isInvalid(validationState);
 
-    const isEmptyValue = value == null || value === "";
+  const isEmptyValue = value == null || value === "";
 
-    const hasLabel = label != null;
+  const hasLabel = label != null;
 
-    const hasDescription = description != null;
+  const hasDescription = description != null;
 
-    const hasCounter = maxCharQuantity != null && !hideCounter;
+  const hasCounter = maxCharQuantity != null && !hideCounter;
 
-    // ValidationMessages reference tends to change, as users will not memorize/useState for it;
-    // Dependencies must be more explicit so we set
-    const errorMessages = useMemo(
-      () => ({ ...DEFAULT_ERROR_MESSAGES, ...validationMessages }),
-      [validationMessages]
-    );
+  // ValidationMessages reference tends to change, as users will not memorize/useState for it;
+  // Dependencies must be more explicit so we set
+  const errorMessages = useMemo(
+    () => ({ ...DEFAULT_ERROR_MESSAGES, ...validationMessages }),
+    [validationMessages]
+  );
 
-    // Validates the input, sets the status and the statusMessage accordingly (if uncontrolled)
-    // and returns the validity state of the input.
-    const performValidation = useCallback(() => {
-      const inputValidity = validateInput(
-        inputRef.current,
-        value,
-        required,
-        minCharQuantity,
-        maxCharQuantity,
-        validationTypes.none,
-        validation
-      );
-
-      // This will only run if status is uncontrolled
-      setValidationState(computeValidationState(inputValidity, isEmptyValue));
-
-      // This will only run if statusMessage is uncontrolled
-      setValidationMessage(
-        computeValidationMessage(inputValidity, errorMessages)
-      );
-
-      return inputValidity;
-    }, [
-      errorMessages,
-      inputRef,
-      isEmptyValue,
-      maxCharQuantity,
-      minCharQuantity,
-      required,
-      setValidationMessage,
-      setValidationState,
-      validation,
+  // Validates the input, sets the status and the statusMessage accordingly (if uncontrolled)
+  // and returns the validity state of the input.
+  const performValidation = useCallback(() => {
+    const inputValidity = validateInput(
+      inputRef.current,
       value,
-    ]);
+      required,
+      minCharQuantity,
+      maxCharQuantity,
+      validationTypes.none,
+      validation
+    );
 
-    const isOverflow = (currentValue) =>
-      isNil(maxCharQuantity) ? false : currentValue.length > maxCharQuantity;
+    // This will only run if status is uncontrolled
+    setValidationState(computeValidationState(inputValidity, isEmptyValue));
 
-    /**
-     * Limit the string to the maxCharQuantity length.
-     *
-     * @param value - string to evaluate
-     * @returns {string|*} - string according the limit
-     */
-    const limitValue = (currentValue) => {
-      if (currentValue === undefined || !blockMax) return currentValue;
-      return !isOverflow(currentValue)
-        ? currentValue
-        : currentValue.substring(0, maxCharQuantity);
+    // This will only run if statusMessage is uncontrolled
+    setValidationMessage(
+      computeValidationMessage(inputValidity, errorMessages)
+    );
+
+    return inputValidity;
+  }, [
+    errorMessages,
+    inputRef,
+    isEmptyValue,
+    maxCharQuantity,
+    minCharQuantity,
+    required,
+    setValidationMessage,
+    setValidationState,
+    validation,
+    value,
+  ]);
+
+  const isOverflow = (currentValue) =>
+    isNil(maxCharQuantity) ? false : currentValue.length > maxCharQuantity;
+
+  /**
+   * Limit the string to the maxCharQuantity length.
+   *
+   * @param value - string to evaluate
+   * @returns {string|*} - string according the limit
+   */
+  const limitValue = (currentValue) => {
+    if (currentValue === undefined || !blockMax) return currentValue;
+    return !isOverflow(currentValue)
+      ? currentValue
+      : currentValue.substring(0, maxCharQuantity);
+  };
+
+  /**
+   * Validates the text area updating the state and modifying the warning text, also executes
+   * the user provided onBlur passing the current validation status and value.
+   *
+   * @returns {undefined}
+   */
+  const onContainerBlurHandler = (event) => {
+    setFocused(false);
+
+    const inputValidity = performValidation();
+
+    onBlur?.(event, value, inputValidity);
+  };
+
+  /**
+   * Updates the length of the string while is being inputted, also executes the user onChange
+   * allowing the customization of the input if required.
+   *
+   * @param {String} value - The value provided by the HvInput
+   */
+  const onChangeHandler = (event, currentValue) => {
+    isDirty.current = true;
+
+    const limitedValue = blockMax ? limitValue(currentValue) : currentValue;
+
+    // Set the input value (only when value is uncontrolled)
+    setValue(limitedValue);
+
+    onChange?.(event, limitedValue);
+  };
+
+  /**
+   * Updates the state putting again the value from the state because the input value is
+   * not automatically manage, it also executes the onFocus function from the user passing the value
+   */
+  const onFocusHandler = (event) => {
+    setFocused(true);
+
+    // Reset validation status to standBy (only when status is uncontrolled)
+    setValidationState(validationStates.standBy);
+
+    onFocus?.(event, value);
+  };
+
+  const isScrolledDown = useCallback(() => {
+    const el = inputRef.current;
+    return el == null || el.offsetHeight + el.scrollTop >= el.scrollHeight;
+  }, [inputRef]);
+
+  const scrollDown = useCallback(() => {
+    const el = inputRef.current;
+    if (el != null) {
+      el.scrollTop = el.scrollHeight - el.clientHeight;
+    }
+  }, [inputRef]);
+
+  const addScrollListener = useCallback(() => {
+    const scrollHandler = {
+      handleEvent: () => {
+        setAutoScrolling(isScrolledDown());
+      },
     };
+    inputRef.current?.addEventListener("scroll", scrollHandler);
+  }, [inputRef, isScrolledDown]);
 
-    /**
-     * Validates the text area updating the state and modifying the warning text, also executes
-     * the user provided onBlur passing the current validation status and value.
-     *
-     * @returns {undefined}
-     */
-    const onContainerBlurHandler = (event) => {
-      setFocused(false);
+  useEffect(() => {
+    if (autoScroll) {
+      addScrollListener();
+    }
+  }, [autoScroll, addScrollListener]);
 
-      const inputValidity = performValidation();
+  useEffect(() => {
+    if (autoScrolling) {
+      scrollDown();
+    }
+  }, [valueProp, autoScrolling, scrollDown]);
 
-      onBlur?.(event, value, inputValidity);
-    };
-
-    /**
-     * Updates the length of the string while is being inputted, also executes the user onChange
-     * allowing the customization of the input if required.
-     *
-     * @param {String} value - The value provided by the HvInput
-     */
-    const onChangeHandler = (event, currentValue) => {
-      isDirty.current = true;
-
-      const limitedValue = blockMax ? limitValue(currentValue) : currentValue;
-
-      // Set the input value (only when value is uncontrolled)
-      setValue(limitedValue);
-
-      onChange?.(event, limitedValue);
-    };
-
-    /**
-     * Updates the state putting again the value from the state because the input value is
-     * not automatically manage, it also executes the onFocus function from the user passing the value
-     */
-    const onFocusHandler = (event) => {
-      setFocused(true);
-
-      // Reset validation status to standBy (only when status is uncontrolled)
-      setValidationState(validationStates.standBy);
-
-      onFocus?.(event, value);
-    };
-
-    const isScrolledDown = useCallback(() => {
-      const el = inputRef.current;
-      return el == null || el.offsetHeight + el.scrollTop >= el.scrollHeight;
-    }, [inputRef]);
-
-    const scrollDown = useCallback(() => {
-      const el = inputRef.current;
-      if (el != null) {
-        el.scrollTop = el.scrollHeight - el.clientHeight;
-      }
-    }, [inputRef]);
-
-    const addScrollListener = useCallback(() => {
-      const scrollHandler = {
-        handleEvent: () => {
-          setAutoScrolling(isScrolledDown());
-        },
-      };
-      inputRef.current?.addEventListener("scroll", scrollHandler);
-    }, [inputRef, isScrolledDown]);
-
-    useEffect(() => {
-      if (autoScroll) {
-        addScrollListener();
-      }
-    }, [autoScroll, addScrollListener]);
-
-    useEffect(() => {
-      if (autoScrolling) {
-        scrollDown();
-      }
-    }, [valueProp, autoScrolling, scrollDown]);
-
-    // Run initial validation after first render
-    // and also when any validation condition changes
-    useEffect(() => {
-      if (focused || (!isDirty.current && isEmptyValue)) {
-        // Skip validation if currently focused or if empty and
-        // the user never manually edited the input value
-        return;
-      }
-
-      performValidation();
-    }, [focused, isEmptyValue, performValidation]);
-
-    // The error message area will only be created if:
-    //   - an external element that provides an error message isn't identified via aria-errormessage AND
-    //   - both status and statusMessage properties are being controlled OR
-    //   - status is uncontrolled and any of the built-in validations are active
-    const canShowError =
-      ariaErrorMessage == null &&
-      ((status !== undefined && statusMessage !== undefined) ||
-        (status === undefined &&
-          hasBuiltInValidations(
-            required,
-            validationTypes.none,
-            minCharQuantity,
-            // If blockMax is true maxCharQuantity will never produce an error
-            // unless the value is controlled, so we can't prevent it to overflow maxCharQuantity
-            maxCharQuantity != null && (blockMax !== true || value != null)
-              ? maxCharQuantity
-              : null,
-            validation,
-            inputProps
-          )));
-
-    let errorMessageId;
-    if (isStateInvalid) {
-      errorMessageId = canShowError
-        ? setId(elementId, "error")
-        : ariaErrorMessage;
+  // Run initial validation after first render
+  // and also when any validation condition changes
+  useEffect(() => {
+    if (focused || (!isDirty.current && isEmptyValue)) {
+      // Skip validation if currently focused or if empty and
+      // the user never manually edited the input value
+      return;
     }
 
-    return (
-      <HvFormElement
-        id={id}
+    performValidation();
+  }, [focused, isEmptyValue, performValidation]);
+
+  // The error message area will only be created if:
+  //   - an external element that provides an error message isn't identified via aria-errormessage AND
+  //   - both status and statusMessage properties are being controlled OR
+  //   - status is uncontrolled and any of the built-in validations are active
+  const canShowError =
+    ariaErrorMessage == null &&
+    ((status !== undefined && statusMessage !== undefined) ||
+      (status === undefined &&
+        hasBuiltInValidations(
+          required,
+          validationTypes.none,
+          minCharQuantity,
+          // If blockMax is true maxCharQuantity will never produce an error
+          // unless the value is controlled, so we can't prevent it to overflow maxCharQuantity
+          maxCharQuantity != null && (blockMax !== true || value != null)
+            ? maxCharQuantity
+            : null,
+          validation,
+          inputProps
+        )));
+
+  let errorMessageId;
+  if (isStateInvalid) {
+    errorMessageId = canShowError
+      ? setId(elementId, "error")
+      : ariaErrorMessage;
+  }
+
+  return (
+    <HvFormElement
+      id={id}
+      name={name}
+      status={validationState}
+      disabled={disabled}
+      required={required}
+      readOnly={readOnly}
+      className={cx(
+        classes.root,
+        {
+          [classes.resizable]: resizable,
+          [classes.disabled]: disabled,
+          [classes.invalid]: isStateInvalid,
+        },
+        className
+      )}
+      onBlur={onContainerBlurHandler}
+    >
+      {(hasLabel || hasDescription) && (
+        <div className={classes.labelContainer}>
+          {hasLabel && (
+            <HvLabel
+              className={classes.label}
+              id={setId(id, "label")}
+              htmlFor={setId(elementId, "input")}
+              label={label}
+            />
+          )}
+
+          {hasDescription && (
+            <HvInfoMessage
+              className={classes.description}
+              id={setId(elementId, "description")}
+            >
+              {description}
+            </HvInfoMessage>
+          )}
+        </div>
+      )}
+
+      {hasCounter && (
+        <HvCharCounter
+          id={setId(elementId, "charCounter")}
+          className={classes.characterCounter}
+          separator={middleCountLabel}
+          currentCharQuantity={value.length}
+          maxCharQuantity={maxCharQuantity}
+          {...countCharProps}
+        />
+      )}
+
+      <HvBaseInput
+        classes={{
+          root: classes.baseInput,
+          input: classes.input,
+          inputResizable: classes.inputResizable,
+        }}
+        id={hasLabel ? setId(elementId, "input") : setId(id, "input")}
         name={name}
-        status={validationState}
-        disabled={disabled}
+        value={value}
         required={required}
         readOnly={readOnly}
-        className={cx(
-          classes.root,
-          {
-            [classes.resizable]: resizable,
-            [classes.disabled]: disabled,
-            [classes.invalid]: isStateInvalid,
-          },
-          className
-        )}
-        onBlur={onContainerBlurHandler}
-      >
-        {(hasLabel || hasDescription) && (
-          <div className={classes.labelContainer}>
-            {hasLabel && (
-              <HvLabel
-                className={classes.label}
-                id={setId(id, "label")}
-                htmlFor={setId(elementId, "input")}
-                label={label}
-              />
-            )}
+        disabled={disabled}
+        onChange={onChangeHandler}
+        autoFocus={autoFocus}
+        onFocus={onFocusHandler}
+        placeholder={placeholder}
+        invalid={isStateInvalid}
+        resizable={resizable}
+        multiline
+        rows={rows}
+        inputProps={{
+          "aria-label": ariaLabel,
+          "aria-labelledby": ariaLabelledBy,
+          "aria-invalid": isStateInvalid ? true : undefined,
+          "aria-errormessage": errorMessageId,
+          "aria-describedby":
+            ariaDescribedBy != null
+              ? ariaDescribedBy
+              : (description && setId(elementId, "description")) || undefined,
+          "aria-controls": maxCharQuantity
+            ? setId(elementId, "charCounter")
+            : undefined,
+          ...inputProps,
+        }}
+        inputRef={forkedRef}
+        {...others}
+      />
 
-            {hasDescription && (
-              <HvInfoMessage
-                className={classes.description}
-                id={setId(elementId, "description")}
-              >
-                {description}
-              </HvInfoMessage>
-            )}
-          </div>
-        )}
-
-        {hasCounter && (
-          <HvCharCounter
-            id={setId(elementId, "charCounter")}
-            className={classes.characterCounter}
-            separator={middleCountLabel}
-            currentCharQuantity={value.length}
-            maxCharQuantity={maxCharQuantity}
-            {...countCharProps}
-          />
-        )}
-
-        <HvBaseInput
-          classes={{
-            root: classes.baseInput,
-            input: classes.input,
-            inputResizable: classes.inputResizable,
-          }}
-          id={hasLabel ? setId(elementId, "input") : setId(id, "input")}
-          name={name}
-          value={value}
-          required={required}
-          readOnly={readOnly}
-          disabled={disabled}
-          onChange={onChangeHandler}
-          autoFocus={autoFocus}
-          onFocus={onFocusHandler}
-          placeholder={placeholder}
-          invalid={isStateInvalid}
-          resizable={resizable}
-          multiline
-          rows={rows}
-          inputProps={{
-            "aria-label": ariaLabel,
-            "aria-labelledby": ariaLabelledBy,
-            "aria-invalid": isStateInvalid ? true : undefined,
-            "aria-errormessage": errorMessageId,
-            "aria-describedby":
-              ariaDescribedBy != null
-                ? ariaDescribedBy
-                : (description && setId(elementId, "description")) || undefined,
-            "aria-controls": maxCharQuantity
-              ? setId(elementId, "charCounter")
-              : undefined,
-            ...inputProps,
-          }}
-          inputRef={forkedRef}
-          {...others}
-        />
-
-        {canShowError && (
-          <HvWarningText
-            id={setId(elementId, "error")}
-            className={classes.error}
-            disableBorder
-          >
-            {validationMessage}
-          </HvWarningText>
-        )}
-      </HvFormElement>
-    );
-  }
-);
+      {canShowError && (
+        <HvWarningText
+          id={setId(elementId, "error")}
+          className={classes.error}
+          disableBorder
+        >
+          {validationMessage}
+        </HvWarningText>
+      )}
+    </HvFormElement>
+  );
+});

--- a/packages/core/src/components/TimeAgo/TimeAgo.stories.tsx
+++ b/packages/core/src/components/TimeAgo/TimeAgo.stories.tsx
@@ -51,10 +51,71 @@ export const Main: StoryObj<HvTimeAgoProps> = {
     justText: false,
   },
   argTypes: {
-    classes: { control: { disable: true } },
-    component: { control: { disable: true } },
-    emptyElement: { control: { disable: true } },
-    locale: { control: "select", options: ["en", "fr", "de", "pt"] },
+    timestamp: {
+      description:
+        "The timestamp to format, in seconds or milliseconds. Defaults to `emptyElement` if value is null or 0.",
+      table: {
+        type: { summary: "number" },
+      },
+    },
+    locale: {
+      description:
+        "The locale to be used. Should be on of the dayjs supported locales and explicitly imported. See https://day.js.org/docs/en/i18n/i18n.",
+      control: "select",
+      options: ["en", "fr", "de", "pt"],
+      table: {
+        defaultValue: { summary: "en" },
+        type: { summary: "string" },
+      },
+    },
+    disableRefresh: {
+      description: "Disables periodic date refreshes.",
+      table: {
+        defaultValue: { summary: "false" },
+        type: { summary: "boolean" },
+      },
+    },
+    showSeconds: {
+      description: "Whether to show seconds in the rendered time.",
+      table: {
+        defaultValue: { summary: "false" },
+        type: { summary: "boolean" },
+      },
+    },
+    justText: {
+      description:
+        "Whether the component should render just the string. Consider using `useTimeAgo` instead.",
+      table: {
+        defaultValue: { summary: "false" },
+        type: { summary: "boolean" },
+      },
+    },
+    classes: {
+      description:
+        "A Jss Object used to override or extend the styles applied to the component.",
+      table: {
+        type: { summary: "HvTimeAgoClasses" },
+      },
+      control: { disable: true },
+    },
+    component: {
+      description:
+        "Element to use for the root node. Defaults to `HvTypography`.",
+      table: {
+        defaultValue: { summary: "HvTypography" },
+        type: { summary: "React.ElementType" },
+      },
+      control: { disable: true },
+    },
+    emptyElement: {
+      description:
+        "The element to render when the timestamp is null or 0. Defaults to `—` (Em Dash).",
+      control: { disable: true },
+      table: {
+        defaultValue: { summary: "-" },
+        type: { summary: "string" },
+      },
+    },
   },
   render: (args) => {
     return <HvTimeAgo {...args} />;

--- a/packages/core/src/components/TimePicker/TimePicker.stories.tsx
+++ b/packages/core/src/components/TimePicker/TimePicker.stories.tsx
@@ -32,7 +32,9 @@ export const Main: StoryObj<HvTimePickerProps> = {
   argTypes: {
     classes: { control: { disable: true } },
     timeFormat: { control: { disable: true } },
-    onChange: { control: { disable: true } },
+    value: { control: { disable: true } },
+    defaultValue: { control: { disable: true } },
+    dropdownProps: { control: { disable: true } },
   },
   parameters: {
     eyes: {

--- a/packages/core/src/components/TimePicker/TimePicker.tsx
+++ b/packages/core/src/components/TimePicker/TimePicker.tsx
@@ -77,8 +77,6 @@ export interface HvTimePickerProps
     HvFormElementProps,
     "classes" | "value" | "defaultValue" | "onChange" | "onFocus" | "onBlur"
   > {
-  /** Id to be applied to the form element root node. */
-  id?: string;
   /** A Jss Object used to override or extend the styles applied to the component. */
   classes?: HvTimePickerClasses;
   /** Current value of the element when _controlled_. Follows the 24-hour format. */
@@ -104,24 +102,30 @@ export interface HvTimePickerProps
   locale?: string;
   /** Whether the dropdown is expandable. */
   disableExpand?: boolean;
-
   /**
    * Callback function to be triggered when the input value is changed.
    * It is invoked with a `{hours, minutes, seconds}` object, always in the 24h format
    */
   onChange?: (value: HvTimePickerValue) => void;
-
   /** Callback called when dropdown changes the expanded state. */
   onToggle?: (event: Event, isOpen: boolean) => void;
-
   /** Disable the portal behavior. The children stay within it's parent DOM hierarchy. */
   disablePortal?: boolean;
-
   /** Sets if the calendar container should follow the date picker input out of the screen or stay visible. */
   escapeWithReference?: boolean;
-
   /** Extra properties to be passed to the TimePicker's dropdown. */
   dropdownProps?: Partial<HvBaseDropdownProps>;
+  /**
+   * The label of the form element.
+   *
+   * The form element must be labeled for accessibility reasons.
+   * If not provided, an aria-label or aria-labelledby must be provided instead.
+   */
+  label?: React.ReactNode;
+  /**
+   * Provide additional descriptive text for the form element.
+   */
+  description?: React.ReactNode;
 }
 
 /**

--- a/packages/core/src/components/Typography/Typography.stories.tsx
+++ b/packages/core/src/components/Typography/Typography.stories.tsx
@@ -18,9 +18,60 @@ export const Main: StoryObj<HvTypographyProps> = {
     paragraph: false,
   },
   argTypes: {
-    variant: { options: typographyVariants },
-    component: { control: { disable: true } },
-    classes: { control: { disable: true } },
+    variant: {
+      description:
+        "Use the variant prop to change the visual style of the Typography.",
+      table: {
+        defaultValue: { summary: "body" },
+        type: { summary: "HvTypographyVariants | HvTypographyLegacyVariants" },
+      },
+      options: typographyVariants,
+    },
+    link: {
+      description: "If `true` the typography will display the look of a link.",
+      table: {
+        defaultValue: { summary: "false" },
+        type: { summary: "boolean" },
+      },
+    },
+    disabled: {
+      description:
+        "If `true` the typography will display the look of a disabled state.",
+      table: {
+        defaultValue: { summary: "false" },
+        type: { summary: "boolean" },
+      },
+    },
+    paragraph: {
+      description: "If `true`, the text will have a bottom margin.",
+      table: {
+        defaultValue: { summary: "false" },
+        type: { summary: "boolean" },
+      },
+    },
+    noWrap: {
+      description:
+        "If `true`, the text will not wrap, but instead will truncate with a text overflow ellipsis. Note that text overflow can only happen with block or inline-block level elements (the element needs to have a width in order to overflow).",
+      table: {
+        defaultValue: { summary: "false" },
+        type: { summary: "boolean" },
+      },
+    },
+    component: {
+      description: "Element to use for the root node.",
+      table: {
+        type: { summary: "React.ElementType" },
+      },
+      control: { disable: true },
+    },
+    classes: {
+      description:
+        "A Jss Object used to override or extend the styles applied to the component.",
+      table: {
+        type: { summary: "HvTypographyClasses" },
+      },
+      control: { disable: true },
+    },
   },
   decorators: [(Story) => <div style={{ width: 400 }}>{Story()}</div>],
   render: (args) => (


### PR DESCRIPTION
We were having some problems with the args tables in some components:
- Missing descriptions added to args table:
   - The descriptions were manually added for the text area, time ago and typography components. I was not able to find another solution.
- Missing `classes` props fixed 
- Unnecessary props removed from args table