### PR TITLE
fix(Drawer): close icon role updated to none to fix a11y issue

### DIFF
--- a/packages/core/src/components/Drawer/Drawer.tsx
+++ b/packages/core/src/components/Drawer/Drawer.tsx
@@ -97,7 +97,7 @@ export const HvDrawer = (props: HvDrawerProps) => {
     getVarValue(theme.drawer.backDropBackgroundColor, rootId) || ""
   );
 
-  const closeButtonDisplay = () => <Close role="presentation" />;
+  const closeButtonDisplay = () => <Close role="none" />;
 
   const CloseButtonTooltipWrapper = buttonTitle
     ? withTooltip(closeButtonDisplay, buttonTitle, "top")


### PR DESCRIPTION
The close icon role was updated to `none` to fix a11y issue on the flow component.