### PR TITLE
ci: bump to node@18

### DIFF
--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -10,7 +10,7 @@ runs:
     - name: Install Node.js
       uses: actions/setup-node@v3
       with:
-        node-version: 16
+        node-version: 18
 
     - name: Install dependencies
       env:

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@
 <div align="center">
 
 ![License](https://img.shields.io/badge/license-Apache%202-blue.svg)
-![React](https://img.shields.io/badge/react->=17-blue.svg)
-![Node](https://img.shields.io/badge/node-16-brightgreen.svg)
+![React](https://img.shields.io/badge/react-17|18-blue.svg)
+![Node](https://img.shields.io/badge/node-16|18-brightgreen.svg)
 ![Master Nightly](https://github.com/lumada-design/hv-uikit-react/workflows/Master%20Nightly/badge.svg)
 
 </div>


### PR DESCRIPTION
- bump internal CI usage to `node@18`
- updated README with support version
- everything seems to be working fine 👌 