### PR TITLE
docs: overflown content in samples fixed

### DIFF
--- a/.storybook/theme/styles/docs.ts
+++ b/.storybook/theme/styles/docs.ts
@@ -1,4 +1,3 @@
-import { CSSObject } from "@emotion/css";
 import { theme } from "@hitachivantara/uikit-react-core";
 
 const { colors } = theme;
@@ -21,11 +20,6 @@ export const getDocsStyles = () => {
       },
 
       ".sbdocs-preview": {
-        overflow: "visible",
-        "& > div, & > div > div": {
-          overflow: "visible",
-        },
-
         borderColor: colors.atmo3,
 
         "& .os-content>pre": {

--- a/packages/core/src/components/DatePicker/DatePicker.stories.tsx
+++ b/packages/core/src/components/DatePicker/DatePicker.stories.tsx
@@ -21,7 +21,12 @@ import {
 } from "@hitachivantara/uikit-react-core";
 
 const containerDecorator: DecoratorFn = (Story) => (
-  <div className={cx("decorator", css({ width: 340, padding: 10 }))}>
+  <div
+    className={cx(
+      "decorator",
+      css({ width: 340, minHeight: 550, padding: 10 })
+    )}
+  >
     {Story()}
   </div>
 );

--- a/packages/core/src/components/Dropdown/Dropdown.stories.tsx
+++ b/packages/core/src/components/Dropdown/Dropdown.stories.tsx
@@ -18,8 +18,12 @@ import {
   theme,
 } from "@hitachivantara/uikit-react-core";
 
+const heightDecorator: DecoratorFn = (Story) => (
+  <div style={{ minHeight: 400 }}>{Story()}</div>
+);
+
 const widthDecorator: DecoratorFn = (Story) => (
-  <div style={{ minHeight: 120, width: 310 }}>{Story()}</div>
+  <div style={{ width: 310 }}>{Story()}</div>
 );
 
 export default {
@@ -60,10 +64,7 @@ export const Main: StoryObj<HvDropdownProps> = {
       runBefore() {},
     },
   },
-  decorators: [
-    widthDecorator,
-    (Story) => <div style={{ minHeight: 400 }}>{Story()}</div>,
-  ],
+  decorators: [widthDecorator, heightDecorator],
   render: (args) => (
     <HvDropdown
       label="Select values"
@@ -142,7 +143,7 @@ export const WithIcons: StoryObj<HvDropdownProps> = {
       },
     },
   },
-  decorators: [widthDecorator],
+  decorators: [widthDecorator, heightDecorator],
   render: (args) => {
     const [values, setValues] = useState<HvListValue[]>([]);
 
@@ -177,7 +178,7 @@ export const Empty: StoryObj<HvDropdownProps> = {
 };
 
 export const MultiSelection: StoryObj<HvDropdownProps> = {
-  decorators: [widthDecorator],
+  decorators: [widthDecorator, heightDecorator],
   render: () => {
     return (
       <HvDropdown
@@ -196,6 +197,7 @@ export const MultiSelection: StoryObj<HvDropdownProps> = {
 };
 
 export const SingleSelectionWithSearch: StoryObj<HvDropdownProps> = {
+  decorators: [widthDecorator, heightDecorator],
   parameters: {
     docs: {
       description: {
@@ -204,7 +206,6 @@ export const SingleSelectionWithSearch: StoryObj<HvDropdownProps> = {
       },
     },
   },
-  decorators: [widthDecorator],
   render: () => (
     <HvDropdown
       aria-label="With search"
@@ -220,6 +221,7 @@ export const SingleSelectionWithSearch: StoryObj<HvDropdownProps> = {
 };
 
 export const ExternalErrorMessage: StoryObj<HvDropdownProps> = {
+  decorators: [heightDecorator],
   parameters: {
     docs: {
       description: {
@@ -345,7 +347,7 @@ export const WithDefinedHeight: StoryObj<HvDropdownProps> = {
     },
     eyes: { include: false },
   },
-  decorators: [widthDecorator],
+  decorators: [widthDecorator, heightDecorator],
   render: () => {
     const values = [...Array(100)].map((_, i) => ({
       id: `${i}`,
@@ -374,7 +376,7 @@ export const Virtualized: StoryObj<HvDropdownProps> = {
     },
     eyes: { include: false },
   },
-  decorators: [widthDecorator],
+  decorators: [widthDecorator, heightDecorator],
   render: () => {
     const values = [...Array(1500)].map((_, i) => ({
       id: `${i}`,

--- a/packages/core/src/components/TimePicker/TimePicker.stories.tsx
+++ b/packages/core/src/components/TimePicker/TimePicker.stories.tsx
@@ -1,6 +1,6 @@
-import { CSSProperties, useRef, useState } from "react";
+import { useRef, useState } from "react";
 
-import { Meta, StoryObj } from "@storybook/react";
+import { DecoratorFn, Meta, StoryObj } from "@storybook/react";
 import { waitFor, screen, fireEvent } from "@storybook/testing-library";
 
 import { Time as TimeIcon } from "@hitachivantara/uikit-react-icons";
@@ -13,15 +13,27 @@ import {
   HvTimePickerValue,
 } from "@hitachivantara/uikit-react-core";
 
-import { CSSInterpolation, css } from "@emotion/css";
+import { CSSInterpolation, css, cx } from "@emotion/css";
+import { Global } from "@emotion/react";
+
+const containerDecorator: DecoratorFn = (Story) => (
+  <div className={cx("decorator", css({ width: 250, minHeight: 250 }))}>
+    {Story()}
+  </div>
+);
+
+const unsetDecorator: DecoratorFn = (Story) => (
+  <>
+    <Global styles={{ ".decorator:has(.unset)": { width: "unset" } }} />
+    <div className="unset">{Story()}</div>
+  </>
+);
 
 export default {
   title: "Components/Time Picker",
   component: HvTimePicker,
+  decorators: [containerDecorator],
 } as Meta<typeof HvTimePicker>;
-
-const makeDecorator = (styles: CSSProperties) => (Story) =>
-  <div style={styles}>{Story()}</div>;
 
 export const Main: StoryObj<HvTimePickerProps> = {
   args: {
@@ -45,7 +57,6 @@ export const Main: StoryObj<HvTimePickerProps> = {
       },
     },
   },
-  decorators: [makeDecorator({ minHeight: 200, width: 200 })],
   render: (args) => {
     return <HvTimePicker {...args} />;
   },
@@ -61,7 +72,6 @@ export const Form: StoryObj<HvTimePickerProps> = {
       },
     },
   },
-  decorators: [makeDecorator({ minHeight: 200, width: 200 })],
   render: () => {
     return (
       <form
@@ -94,6 +104,7 @@ export const Variants: StoryObj<HvTimePickerProps> = {
       },
     },
   },
+  decorators: [unsetDecorator],
   render: () => {
     const value: HvTimePickerValue = { hours: 5, minutes: 30, seconds: 14 };
 
@@ -134,7 +145,6 @@ export const Controlled: StoryObj<HvTimePickerProps> = {
     },
     eyes: { include: false },
   },
-  decorators: [makeDecorator({ minHeight: 200, width: 200 })],
   render: () => {
     const [value, setValue] = useState<HvTimePickerValue>({
       hours: 19,
@@ -174,7 +184,6 @@ export const Format12Hours: StoryObj<HvTimePickerProps> = {
       },
     },
   },
-  decorators: [makeDecorator({ minHeight: 200, width: 220 })],
   render: () => {
     return (
       <HvTimePicker
@@ -197,7 +206,6 @@ export const Native: StoryObj<HvTimePickerProps> = {
     },
     eyes: { include: false },
   },
-  decorators: [makeDecorator({ minHeight: 200 })],
   render: () => {
     const ref = useRef<HTMLInputElement>(null);
     const [disabled, setDisabled] = useState(false);

--- a/packages/viz/src/components/BaseChart/stories/utils.tsx
+++ b/packages/viz/src/components/BaseChart/stories/utils.tsx
@@ -1,14 +1,28 @@
 import { DecoratorFn } from "@storybook/react";
 import { css } from "@emotion/css";
 import { theme } from "@hitachivantara/uikit-react-core";
+import { Global } from "@emotion/react";
 
 export const vizDecorator: DecoratorFn = (Story) => (
-  <div
-    className={css({
-      backgroundColor: theme.colors.atmo1,
-      padding: 20,
-    })}
-  >
-    {Story()}
-  </div>
+  <>
+    <Global
+      styles={{
+        // This is necessary for the chart tooltips to not be hidden
+        ".sbdocs.sbdocs-preview": {
+          overflow: "visible",
+          "& > div, & > div > div": {
+            overflow: "visible",
+          },
+        },
+      }}
+    />
+    <div
+      className={css({
+        backgroundColor: theme.colors.atmo1,
+        padding: 20,
+      })}
+    >
+      {Story()}
+    </div>
+  </>
 );


### PR DESCRIPTION
The following components had samples overflowing their container. This was fixed.
- Global actions
- Stack
- Step navigation