### PR TITLE
docs: overflown content in samples fixed

### DIFF
--- a/.storybook/theme/styles/docs.ts
+++ b/.storybook/theme/styles/docs.ts
@@ -6,11 +6,7 @@ export const getDocsStyles = () => {
       lineHeight: "24px",
 
       ".sbdocs-preview": {
-        overflow: "visible",
         zIndex: 1,
-        "& > div, & > div > div": {
-          overflow: "visible",
-        },
       },
     },
   };

--- a/packages/viz/src/components/BaseChart/stories/utils.tsx
+++ b/packages/viz/src/components/BaseChart/stories/utils.tsx
@@ -1,14 +1,28 @@
 import { DecoratorFn } from "@storybook/react";
 import { css } from "@emotion/css";
 import { theme } from "@hitachivantara/uikit-react-core";
+import { Global } from "@emotion/react";
 
 export const vizDecorator: DecoratorFn = (Story) => (
-  <div
-    className={css({
-      backgroundColor: theme.colors.atmo1,
-      padding: 20,
-    })}
-  >
-    {Story()}
-  </div>
+  <>
+    <Global
+      styles={{
+        // This is necessary for the chart tooltips to not be hidden
+        ".sbdocs.sbdocs-preview": {
+          overflow: "visible",
+          "& > div, & > div > div": {
+            overflow: "visible",
+          },
+        },
+      }}
+    />
+    <div
+      className={css({
+        backgroundColor: theme.colors.atmo1,
+        padding: 20,
+      })}
+    >
+      {Story()}
+    </div>
+  </>
 );


### PR DESCRIPTION
The following components had samples overflowing their container. This was fixed.
- Global actions
- Stack
- Step navigation

Reopens https://github.com/lumada-design/hv-uikit-react/pull/3698.