### PR TITLE
docs: document title fixed

### DIFF
--- a/.storybook/manager-head.html
+++ b/.storybook/manager-head.html
@@ -1,7 +1,4 @@
 <!-- Storybook override -->
-<script>
-  document.title = "NEXT UI Kit";
-</script>
 <link rel="preconnect" href="https://fonts.googleapis.com" />
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
 <link

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "dev": "npm run dev -w app",
     "doc": "storybook dev -p 6006",
     "build": "lerna run build",
-    "build:doc": "storybook build --docs -o dist --quiet",
+    "build:doc": "storybook build --docs -o dist --quiet && node scripts/storybook-title",
     "build:app": "vite build app",
     "test": "lerna run test",
     "test:pa11y": "pa11y-ci -c .config/pa11yci.config.js",

--- a/scripts/storybook-title/index.js
+++ b/scripts/storybook-title/index.js
@@ -1,0 +1,34 @@
+/* eslint-disable no-console */
+const fs = require("fs");
+const path = require("path");
+
+const fixTitle = (filePath, title) => {
+  const data = fs.readFileSync(filePath, "utf-8");
+  const updatedData = data.replace(
+    /<title>.*<\/title>/,
+    `<title>${title}</title>`
+  );
+
+  fs.writeFileSync(filePath, updatedData);
+};
+
+const fixStorybookTitle = () => {
+  try {
+    console.log("⏳ Fixing Storybook title.");
+
+    const title = "NEXT UI Kit";
+    const storybookDist = path.resolve(__dirname, "../../dist");
+    const htmlFile = `${storybookDist}/index.html`;
+    const iframeFile = `${storybookDist}/iframe.html`;
+
+    fixTitle(htmlFile, title);
+    fixTitle(iframeFile, title);
+
+    console.log("🚀 Storybook title fixed.");
+  } catch (error) {
+    console.error("❌ Error fixing Storybook title:", error);
+    process.exit(1);
+  }
+};
+
+fixStorybookTitle();


### PR DESCRIPTION
- This [PR](https://github.com/lumada-design/hv-uikit-react/pull/3702) was not able to fix the following problem:

<img width="430" alt="Screenshot 2023-09-22 at 14 42 45" src="https://github.com/lumada-design/hv-uikit-react/assets/43220251/a448d44e-4abe-4847-8f8e-41a48b4458cf">


- In this PR the title is changed directly on the `dist` folder by running a script after building the docs. I saw Fluent UI using this method to update their title. Unfortunately, from what I've seen, Storybook doesn't have a better way of doing this.