### PR TITLE
fix: layout page and links fixed in docs

### DIFF
--- a/.storybook/blocks/DocsContainer.tsx
+++ b/.storybook/blocks/DocsContainer.tsx
@@ -7,6 +7,7 @@ import { addons } from "@storybook/addons";
 import {
   HvProvider,
   HvTypography,
+  HvTypographyProps,
   theme,
 } from "@hitachivantara/uikit-react-core";
 
@@ -16,11 +17,12 @@ import { ADDON_EVENT } from "../addons/mode-selector/constants";
 import { themes } from ".storybook/theme";
 
 const components: Record<string, ComponentType> = {
-  a: (props) => (
+  a: (props: HvTypographyProps<"a">) => (
     <HvTypography
       link
       component="a"
       style={{ color: theme.colors.primary }}
+      target={props.href?.includes("./?path=/docs/") ? undefined : "_self"}
       {...props}
     />
   ),

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ Use GitHub issues for bug reports and feature requests or one of our available c
 
 New components should be contributed to the `lab` package in `packages/lab/src/components/<COMPONENT_NAME>`.
 
-Check out our [Component Guidelines](/docs/overview-community-component-guidelines--page) for a guide on how to structure components, and the [submitting a pull request](#submitting-a-pull-request) on how to contribute it.
+Check out our [Component Guidelines](./?path=/docs/overview-community-component-guidelines--docs) for a guide on how to structure components, and the [submitting a pull request](#submitting-a-pull-request) on how to contribute it.
 
 <h2 id="submitting-an-issue">Submitting an issue</h2>
 

--- a/docs/foundation/colors/Colors.stories.mdx
+++ b/docs/foundation/colors/Colors.stories.mdx
@@ -15,7 +15,7 @@ Example of a color variable:
 theme.colors.atmo5;
 ```
 
-**Note:** Colors names have changed in UI Kit v5.x. Please be sure to check the [colors mapping table](/docs/overview-migration-from-v4-x--page#colors) on the migration guide.
+**Note:** Colors names have changed in UI Kit v5.x. Please be sure to check the [colors mapping table](./?path=/docs/overview-migration-from-v4-x--docs#colors) on the migration guide.
 
 <Story name="Main">
   <Colors />

--- a/docs/guides/layout/Layout.stories.mdx
+++ b/docs/guides/layout/Layout.stories.mdx
@@ -54,7 +54,7 @@ Whenever the screen resolution goes above or below a breakpoint, the layout shou
 
 ## Container <a id="container" />
 
-The [Container](/docs/components-container--main) is one of the most basic layout components we provide to our community, and it enables you to center content horizontally on the page.
+The [Container](./?path=/docs/components-container--docs) is one of the most basic layout components we provide to our community, and it enables you to center content horizontally on the page.
 
 This component is very useful when your content can't grow beyond a specific breakpoint. In this case, you can use `maxWidth` to specify the breakpoint
 to which the content is bounded. The content will automatically grow or shrink according with the size of the screen and breakpoint used ensuring that
@@ -66,11 +66,11 @@ If necessary, multiple nested containers can be used as shown in the example bel
   <ContainerSample />
 </Story>
 
-For more information, please go to the [container's API](/docs/components-container--main).
+For more information, please go to the [container's API](./?path=/docs/components-container--docs).
 
 ## Grid <a id="grid" />
 
-The [Grid](/docs/components-grid-grid--main) component enables you to create responsive grid layouts with a variable amount of columns. The grid items will also adapt themselves
+The [Grid](./?path=/docs/components-grid-grid--docs) component enables you to create responsive grid layouts with a variable amount of columns. The grid items will also adapt themselves
 to suit the screen sizes.
 
 By default this component is based on a 12-column grid layout. This can be easily changed through the `columns` property. If this property is set to
@@ -85,11 +85,11 @@ Below is an example on how to use the grid component where the Design System dir
   <GridSample />
 </Story>
 
-Learn more about this component [here](/docs/components-grid-grid--main).
+Learn more about this component [here](./?path=/docs/components-grid-grid--docs).
 
 ## Simple Grid <a id="simple-grid" />
 
-The [Simple Grid](/docs/components-grid-simple-grid--main) component is an alternative to the grid component mentioned above and it provides an easy way of creating responsive grids where each item takes an equal amount
+The [Simple Grid](./?path=/docs/components-grid-simple-grid--docs) component is an alternative to the grid component mentioned above and it provides an easy way of creating responsive grids where each item takes an equal amount
 of space. The items will grow or shrink whenever the screen size changes.
 
 This component should be used whenever you need to create grids where items should be distributed across a specific number of columns with the same width.
@@ -105,4 +105,4 @@ In the example below a grid with three columns was created to distribute the car
   <SimpleGridSample />
 </Story>
 
-More information about can be found [here](/docs/components-grid-simple-grid--main).
+More information about can be found [here](./?path=/docs/components-grid-simple-grid--docs).

--- a/docs/guides/layout/Layout.stories.mdx
+++ b/docs/guides/layout/Layout.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Canvas } from "@storybook/addon-docs";
+import { Meta, Story } from "@storybook/addon-docs";
 import {
   ContainerSample,
   SimpleGridSample,
@@ -62,9 +62,9 @@ it doesn't grow beyond the specified width.
 
 If necessary, multiple nested containers can be used as shown in the example below.
 
-<Canvas>
-  <Story name="Container" story={ContainerSample} />
-</Canvas>
+<Story name="Container">
+  <ContainerSample />
+</Story>
 
 For more information, please go to the [container's API](/docs/components-container--main).
 
@@ -81,9 +81,9 @@ on your needs.
 
 Below is an example on how to use the grid component where the Design System directives were used and some grid items were spanned across multiple columns.
 
-<Canvas>
-  <Story name="Grid" story={GridSample} />
-</Canvas>
+<Story name="Grid">
+  <GridSample />
+</Story>
 
 Learn more about this component [here](/docs/components-grid-grid--main).
 
@@ -101,8 +101,8 @@ enabling you to create much simpler grids than the grid component.
 In the example below a grid with three columns was created to distribute the cards across them, and when the screen width goes under the Design System
 `sm` (600px) breakpoint the grid only has two columns.
 
-<Canvas>
-  <Story name="SimpleGrid" story={SimpleGridSample} />
-</Canvas>
+<Story name="SimpleGrid">
+  <SimpleGridSample />
+</Story>
 
 More information about can be found [here](/docs/components-grid-simple-grid--main).

--- a/docs/guides/provider/Provider.stories.mdx
+++ b/docs/guides/provider/Provider.stories.mdx
@@ -24,7 +24,7 @@ const MyApp = ({ children }) => {
 <ArgsTable of={HvProvider} />
 
 The `HvProvider` enables you to define your themes through the `themes` property which accepts a list of themes. Then, the `theme` and `colorMode` properties
-are used to specify the active theme and color mode. For more information, please read the [**theming**](/docs/guides-theming--main#theming) documentation.
+are used to specify the active theme and color mode. For more information, please read the [**theming**](./?path=/docs/guides-theming--docs#theming) documentation.
 
 If several `HvProvider`'s are used, you'll need to create different root elements, set the `rootElementId` property for each one of the providers, and scope the
 theme styles to the root element with the `cssTheme` property.

--- a/docs/guides/styling/Customization.stories.mdx
+++ b/docs/guides/styling/Customization.stories.mdx
@@ -288,7 +288,7 @@ to change specific parts of a component at a global scale in your application ap
 
 Only very specific properties of a component can be customized using the `createTheme` utility varying from component to component.
 Overtime time we will work toward providing more customizable properties for components. However, at the moment, only some components can be customized
-through the theme. For more information, please read the [theming](/docs/guides-theming-theming--main#theme-structure) documentation where a structure of the theme with
+through the theme. For more information, please read the [theming](./?path=/docs/guides-theming--docs#theme-structure) documentation where a structure of the theme with
 the components that are customizable is provided.
 
 In the example below, the border radius and background color of the `HvCard` component was customized.
@@ -379,4 +379,4 @@ const MyApp = () => {
   <GlobalOverride />
 </Story>
 
-Please report to the [theming](/docs/guides-theming-theming--main#theming) documentation for more information.
+Please report to the [theming](./?path=/docs/guides-theming--docs#theming) documentation for more information.

--- a/docs/guides/theming/WhiteLabeling.stories.mdx
+++ b/docs/guides/theming/WhiteLabeling.stories.mdx
@@ -17,7 +17,7 @@ The white labeling customizations can be implemented at the theme level with the
 one of the default Design System themes (DS3 or DS5) by customizing its global properties, such as font family, colors, shadows, among others, and specific properties
 of the components.
 
-The [theming](/docs/guides-theming-theming--main#theming) documentation offers more detailed information on the default themes' structures and
+The [theming](./?path=/docs/guides-theming--docs#theming) documentation offers more detailed information on the default themes' structures and
 the properties that are customizable as well as the `createTheme` utility.
 
 The example below clearly shows how a theme from the NEXT Design System can be customized to meet different UI guidelines.
@@ -72,4 +72,4 @@ components were able change their default styling.
 </Unstyled>
 
 Implementing deeper customizations to an element than the ones presented above requires you to use others types of customization.
-For more information on how you can customize components, report to the [customization](/docs/guides-styling-customization--inline-styles#customization) documentation.
+For more information on how you can customize components, report to the [customization](./?path=/docs/guides-styling--docs#customization) documentation.

--- a/docs/guides/visualizations/Visualizations.stories.mdx
+++ b/docs/guides/visualizations/Visualizations.stories.mdx
@@ -9,12 +9,12 @@ import { HvProvider } from "@hitachivantara/uikit-react-core";
 The NEXT UI Kit offers a set of visualizations that enables you to visual display information through graphical representations.
 At the moment, the following visualizations are available and we are continuously working on expanding the selection we offer:
 
-- [KPI](/docs/visualizations-kpi--main)
-- [Table](/docs/visualizations-table--main)
-- [Line chart](/docs/visualizations-line-chart--main)
-- [Bar chart](/docs/visualizations-bar-chart--main)
-- [Donut chart](/docs/visualizations-donut-chart--main)
-- [Confusion matrix](/docs/visualizations-confusion-matrix--main)
+- [KPI](./?path=/docs/visualizations-kpi--docs)
+- [Table](./?path=/docs/visualizations-table--docs)
+- [Line chart](./?path=/docs/visualizations-line-chart--docs)
+- [Bar chart](./?path=/docs/visualizations-bar-chart--docs)
+- [Donut chart](./?path=/docs/visualizations-donut-chart--docs)
+- [Confusion matrix](./?path=/docs/visualizations-confusion-matrix--docs)
 
 The KPI and Table components are available on the `uikit-react-core` package while all the other visualizations are in the `uikit-react-viz` package.
 
@@ -24,7 +24,7 @@ All the information below is only applicable to the visualizations from the `uik
 
 Before using any of the UI Kit visualizations, it's necessary to add the `HvVizProvider` component to your application.
 This component is responsible for enabling theming capabilities for the visualizations. Without this provider the visualizations will not comply to Design System
-and consequently to the UI Kit themes defined by the [`HvProvider` component](/docs/guides-provider--main) from the core package.
+and consequently to the UI Kit themes defined by the [`HvProvider` component](./?path=/docs/guides-provider--docs) from the core package.
 
 The `HvVizProvider` component should preferably be used at the root of your component tree and should always be wrapped by the `HvProvider` component
 since the former uses the themes provided by the latter to configure the visualizations themes.

--- a/docs/overview/GetStarted.stories.mdx
+++ b/docs/overview/GetStarted.stories.mdx
@@ -51,8 +51,8 @@ const MyApp = ({ children }) => {
 
 This will initialize the UI Kit with the `Design System 5`theme and the `dawn` color mode by default. Depending on your design requirements, you may need to customize or use other themes.
 
-For more information, please report to the [**provider**](/docs/guides-provider--main#provider)
-and [**theming**](/docs/guides-theming--main#theming) documentation.
+For more information, please report to the [**provider**](./?path=/docs/guides-provider--docs#provider)
+and [**theming**](./?path=/docs/guides-theming--docs#theming) documentation.
 
 #### 2. Load the default font
 
@@ -68,7 +68,7 @@ This can be achieved through the **Google Web Fonts CDN** by using the following
 />
 ```
 
-Please, report to the [**typography**](/docs/foundation-typography--main) documentation for more information.
+Please, report to the [**typography**](./?path=/docs/foundation-typography--docs) documentation for more information.
 
 #### 3. Use the components
 

--- a/docs/overview/migration/MigrationV3.stories.mdx
+++ b/docs/overview/migration/MigrationV3.stories.mdx
@@ -258,7 +258,7 @@ Some components have been been adapted to work as a form element to ensure consi
 Components that follows this API will possess the following props:
 
 - `label` renders an HvLabel to identify the element
-- `name` Name of the form element for accesibility
+- `name` Name of the form element for accessibility
 - `status` the current status of the element used to trigger validation messages
 - `statusMessage` the message show when the `status` prop is invalid
 - `value` the current value of the element if declared the element starts behaving as a controlled component.
@@ -327,7 +327,7 @@ The `selectDefault` prop was removed
 ### Loading
 
 Loading is now visible by default. To hide it, use `hidden` prop.
-Removed option to pass `children` and use component as a wrapper "HOC". We still provide a [sample](http://lumada-design.github.io/uikit/master/?path=/docs/components-loading--main#with-children) of an `HvLoading` wrapping a component.
+Removed option to pass `children` and use component as a wrapper "HOC". We still provide a [sample](https://lumada-design.github.io/uikit/v3.x/?path=/docs/feedback-loading--main#with-children) of an `HvLoading` wrapping a component.
 
 - `text` renamed to `label`
 - `isActive` renamed to `hidden`, and is not visible by default (`hidden=false`)
@@ -412,7 +412,7 @@ The `HvSearchbox` was removed to construct a searchbox use the `HvInput`.
 + />
 ```
 
-for more information check the searchbox [sample](https://lumada-design.github.io/uikit/master/?path=/docs/forms-search-box--main)
+for more information check the searchbox [sample](https://lumada-design.github.io/uikit/v3.x/?path=/docs/inputs-search-box--main)
 
 ### Switch
 
@@ -440,8 +440,8 @@ The Switch is now a form element. Check [Form Element](#formelement) for more in
 - `disabled` class removed.
 - `icon` class removed.
 
-- `animated` removed animated icons should be implemented externally check [sample](https://lumada-design.github.io/uikit/master/?path=/docs/components-toggle-button--main#animated)
-- `labels` removed, apply the accessibility labels directly, check the toggleButton [sample](https://lumada-design.github.io/uikit/master/?path=/docs/components-toggle-button--main)
+- `animated` removed animated icons should be implemented externally check [sample](https://lumada-design.github.io/uikit/v3.x/?path=/docs/inputs-toggle-button--main#animated)
+- `labels` removed, apply the accessibility labels directly, check the toggleButton [sample](https://lumada-design.github.io/uikit/v3.x/?path=/docs/inputs-toggle-button--main)
 
 ### TextArea
 

--- a/docs/overview/migration/MigrationV4.stories.mdx
+++ b/docs/overview/migration/MigrationV4.stories.mdx
@@ -138,7 +138,7 @@ If you need to scope the CSS to avoid styling conflicts, you can set this prop t
 
 If you are providing the baseline styles, you can set this prop to `false`.
 
-Check [CSS Baseline](http://localhost:9001/?path=/docs/theme-css-baseline--page) for more information.
+Check [CSS Baseline](https://lumada-design.github.io/uikit/v4.x/?path=/docs/guides-styling-css-baseline--page) for more information.
 
 ### Promoted components (lab > core):
 

--- a/docs/overview/migration/MigrationV5.stories.mdx
+++ b/docs/overview/migration/MigrationV5.stories.mdx
@@ -74,7 +74,7 @@ The following packages were **deprecated** in v5.x and are no longer needed:
 - `@hitachivantara/uikit-react-compat`
 - `@hitachivantara/uikit-common-themes`
 
-For more information about the project status access this [page](/story/overview-project-status--page).
+For more information about the project status access this [page](./?path=/docs/overview-project-status--docs).
 
 If you are able to upgrade your application despite the limitations discussed above, upgrade the UI Kit packages to the latest v5.x versions
 using the command below.
@@ -112,7 +112,7 @@ rely on MUI to access the `theme` object where all the theme's properties are st
 Thus, to access these properties, you now need to import the `theme` object from the `uikit-react-core` package. You can also access them through the `useTheme`
 hook also imported from the `core` package. While the values of the former are CSS variables and will be enough in most cases, the later are exact values that you
 can use in cases where the usage of CSS variables is not possible. Find more information about the `theme` object and the `useTheme` hook on the
-[theming](/docs/guides-theming-theming--theme-context#theming) documentation.
+[theming](./?path=/docs/guides-theming--docs#theming) documentation.
 
 **Note that there is currently an exception and you'll need to continue using the theme object from MUI for [CSS media queries](https://mui.com/material-ui/customization/breakpoints/#css-media-queries).**
 In future versions we expect these media queries to be added to our own theme but until then use the ones from MUI.
@@ -154,7 +154,7 @@ Since the theme has a different structure from the one provided on v4.x, find be
 #### Typography
 
 New variants where added to the typography and, when possible, the DS3 variants where mapped to the new DS5 variants as shown above. However, DS3 variants are
-still available in cases where mapping was not possible. Learn more about the new variants on the [typography page](/docs/foundation-typography-usage--usage).
+still available in cases where mapping was not possible. Learn more about the new variants on the [typography page](./?path=/docs/foundation-typography-usage--docs).
 
 #### zIndices
 
@@ -168,7 +168,7 @@ We expected to add these media queries to our own theme in future versions.
 #### Colors
 
 Changes were introduced to the colors in Design System v5.x. To have a better understanding of the changes between DS3 and DS5 report to the
-[colors page](/docs/foundation-colors--main) where you can switch between the design systems and to this [table](#colors) where the breaking changes are
+[colors page](./?path=/docs/foundation-colors--docs) where you can switch between the design systems and to this [table](#colors) where the breaking changes are
 highlighted.
 
 Regarding the shadows, you have to explicitly use the value `none` where you were previously using `theme.hv.shadows[0]`. Only the value for `theme.hv.shadows[1]` was
@@ -178,7 +178,7 @@ added to theme and you can access it through `theme.colors.shadow` as shown in t
 
 Regarding the spacing methods, we only have one in v5.x when there were previously two in v4.x, `theme.spacing()` and `theme.hvSpacing()`. We decided to combine
 both methods and create a `theme.spacing()` method in the new theme object. Note that while the previously base used for the `theme.spacing()` function was 7.5px,
-we now use different ones for the DS5 and DS3 themes. Read more about this on this [page](/docs/guides-theming-theming--main#spacing).
+we now use different ones for the DS5 and DS3 themes. Read more about this on this [page](./?path=/docs/guides-theming--docs#spacing).
 
 ### Update styling and theme utilities <a id="update-utilities" />
 
@@ -534,14 +534,14 @@ Furthermore, we also use [Arquero](https://uwdata.github.io/arquero/api/), which
 to manipulate and transform data points. Thus, in v5.x, the visualizations are able to manipulate your data if necessary by splitting, grouping, sorting,
 and aggregating data points.
 
-For more information about how to get started with the visualizations, please take a look at the [visualizations guide](/docs/guides-visualizations--page).
+For more information about how to get started with the visualizations, please take a look at the [visualizations guide](./?path=/docs/guides-visualizations--docs).
 
 ## Breaking changes and deprecated values in components <a id="breaking-changes-deprecated-components" />
 
 ### Provider <a id="provider" />
 
-Since we implemented our new theming system, the `HvProvider` API changed significantly. Because of this we recommend that you read the [provider](/docs/guides-provider--main)
-and [theming](/docs/guides-theming-theming--main) documentation where the new API is thoroughly explained.
+Since we implemented our new theming system, the `HvProvider` API changed significantly. Because of this we recommend that you read the [provider](./?path=/docs/guides-provider--docs)
+and [theming](./?path=/docs/guides-theming--docs) documentation where the new API is thoroughly explained.
 
 Briefly, the following properties where removed and/or updated:
 
@@ -556,7 +556,7 @@ Briefly, the following properties where removed and/or updated:
 ### Button <a id="button" />
 
 The `HvButton` API suffered various changes since we stopped using MUI's button under the hood. In this sense, it is expected you'll no longer be able to use
-MUI's specific properties since they were dropped. We recommend you take a look at the button's API available on this [page](/docs/components-button-button--main)
+MUI's specific properties since they were dropped. We recommend you take a look at the button's API available on this [page](./?path=/docs/components-button--docs)
 to have a better overview of the changes and properties you can use.
 
 In this sense, the `category` property was renamed to `variant`, and the variants `secondary` and `ghost` are now deprecated and should be updated
@@ -587,7 +587,7 @@ advise to update them to appropriate DS5 variants.
 
 The `link` and `disabled` properties were also added to the component.
 
-Learn more about the typography variants on this [page](/docs/foundation-typography-usage--usage).
+Learn more about the typography variants on this [page](./?path=/docs/foundation-typography-usage--docs).
 
 ### Card <a id="card" />
 
@@ -607,7 +607,7 @@ The `onToggleOpen` property was removed from the `HvDropdownMenu` and `onToggle`
 The `HvDotPagination` component has different specifications for DS3 and DS5. However, due to limitations, it was only possible to implement the component with
 the DS5 specifications. Thus, if you are using the DS3 theme on your application, the `HvDotPagination` component will be the one from DS5. However, the new properties
 `unselectedIcon` and `selectedIcon` were added to the component in order to easily customize it and meet the DS3 guidelines.
-Learn how to do this on this [page](/docs/components-pagination-dot-pagination--customized-dot-pagination).
+Learn how to do this on this [page](./?path=/docs/components-pagination-dot-pagination--docs).
 
 ### Avatar <a id="avatar" />
 
@@ -713,7 +713,7 @@ The locale must be passed as a prop as the component no longer reads the locale 
 ### Color picker <a id="color-picker" />
 
 The properties listed below were added to the color picker component to support the various use cases defined in the DS5 specifications. If you need to
-use the DS3 version, the component can easily be customized to meet the guidelines as shown in the example provided in this [story](/docs/lab-color-picker--main#customized-color-picker).
+use the DS3 version, the component can easily be customized to meet the guidelines as shown in the example provided in this [story](./?path=/docs/widgets-color-picker--docs#customized-color-picker).
 
 - `placeholder`
 - `recommendedColors`

--- a/docs/overview/status/ProjectStatus.stories.mdx
+++ b/docs/overview/status/ProjectStatus.stories.mdx
@@ -9,7 +9,6 @@ Stay up-to-date on the status of the project and its development. This can help 
 
 - [Versions](#versions)
 - [Supported browsers](#supported-browsers)
-- [Packages](#packages)
 - [DS alignment](#ds-alignment)
 
 ## Versions <a id="versions" />
@@ -23,7 +22,7 @@ The most recent version is recommended for use in production.
 | September 2022 | [UI Kit v4.x](https://lumada-design.github.io/uikit/v4.x)   | [Design System 3.x](https://hitachivantara.sharepoint.com/sites/DesignSystem/Pattern%20Library/Home.aspx) | 16, 17        | [5.x](https://mui.com/)    | 11.x            |
 | October 2020   | [UI Kit v3.x](https://lumada-design.github.io/uikit/v3.x)   | [Design System 3.x](https://hitachivantara.sharepoint.com/sites/DesignSystem/Pattern%20Library/Home.aspx) | 16, 17        | [4.x](https://v4.mui.com/) | -               |
 
-To know more about the practices that are followed for release and versioning, please read our [release and versioning](/docs/overview-community-releases--page) documentation.
+To know more about the practices that are followed for release and versioning, please read our [release and versioning](./?path=/docs/overview-community-releases--docs) documentation.
 
 ## Supported browsers <a id="supported-browsers" />
 
@@ -58,7 +57,7 @@ The following table shows the components alignment with **NEXT DS 5.6.0** and th
   </li>
 </ul>
 
-If you need a component or feature that is not supported, please reach out to us or check our [contribution guide](/docs/overview-community-contributing--page).
+If you need a component or feature that is not supported, please reach out to us or check our [contribution guide](./?path=/docs/overview-community-contributing--docs).
 
 <div>
   {Object.entries(data).map(([key, value]) => (

--- a/packages/core/src/components/Table/stories/TableHooks/TableHooks.stories.mdx
+++ b/packages/core/src/components/Table/stories/TableHooks/TableHooks.stories.mdx
@@ -27,14 +27,14 @@ The following plugin hooks are available:
 - `useHvTableStyles`: Ensures the correct styling of the table by injecting the column's `variant` and `align` options into the `HvTableHeader` and
   `HvTableCell` components (via `getHeaderProps` and `getCellProps`, respectively). Also adds support for injecting the `styles`, `className` and
   `classes` into the `HvTable`, `HvTableHeader`, and `HvTableCell` components.
-- `useHvPagination`: Eases the wiring of the `HvPagination` component when using pagination. [See pagination](/docs/guides-table-table-hooks-hooks-usehvpagination--use-hv-pagination-story).
-- `useHvRowSelection`: Creates and manages the UI for selecting rows. [See selection](/docs/guides-table-table-hooks-hooks-usehvrowselection--use-hv-selection-story).
-- `useHvBulkActions`: Eases the wiring of the `HvBulkActions` component. [See bulk selection and actions](/docs/guides-table-table-hooks-hooks-usehvbulkactions--use-hv-bulk-actions-story).
-- `useHvSortBy`: Manages the table's header sorting functionality. [See sorting](/docs/guides-table-table-hooks-hooks-usehvsortby--use-hv-sort-by-story).
-- `useHvRowExpand`: Manages the row expanding functionality. [See row expanding](/docs/guides-table-table-hooks-hooks-usehvrowexpand--use-hv-row-expand-story).
-- `useHvGroupBy`: Allows defining header groups. [See selection](/docs/guides-table-table-hooks-hooks-usehvgroupby--use-hv-group-by-story).
-- `useHvTableSticky`: Allows defining sticky headers and columns. [See sticky headers and columns](/docs/guides-table-table-hooks-hooks-usehvtablesticky--use-hv-table-sticky-story).
-- `useHvHeaderGroups`: Allows defining grouped headers. [See grouped headers](/docs/guides-table-table-hooks-hooks-usehvheadergroups--use-hv-header-groups-story).
+- `useHvPagination`: Eases the wiring of the `HvPagination` component when using pagination. [See pagination](./?path=/docs/visualizations-table-table-hooks-usehvpagination--docs).
+- `useHvRowSelection`: Creates and manages the UI for selecting rows. [See selection](./?path=/docs/visualizations-table-table-hooks-usehvrowselection--docs).
+- `useHvBulkActions`: Eases the wiring of the `HvBulkActions` component. [See bulk selection and actions](./?path=/docs/visualizations-table-table-hooks-usehvbulkactions--docs).
+- `useHvSortBy`: Manages the table's header sorting functionality. [See sorting](./?path=/docs/visualizations-table-table-hooks-usehvsortby--docs).
+- `useHvRowExpand`: Manages the row expanding functionality. [See row expanding](./?path=/docs/visualizations-table-table-hooks-usehvrowexpand--docs).
+- `useHvGroupBy`: Allows defining header groups. [See selection](./?path=/docs/visualizations-table-table-hooks-usehvgroupby--docs).
+- `useHvTableSticky`: Allows defining sticky headers and columns. [See sticky headers and columns](./?path=/docs/visualizations-table-table-hooks-usehvtablesticky--docs).
+- `useHvHeaderGroups`: Allows defining grouped headers. [See grouped headers](./?path=/docs/visualizations-table-table-hooks-usehvheadergroups--docs).
 
 <Canvas>
   <Story name="Table Hooks" story={UseHvHooksStory} />

--- a/packages/core/src/components/Table/stories/TableRenderers/TableRenderers.stories.mdx
+++ b/packages/core/src/components/Table/stories/TableRenderers/TableRenderers.stories.mdx
@@ -5,7 +5,7 @@ import { AllColumnRenderersStory } from "./TableRenderers";
 
 # Table Renderers
 
-The UI Kit library provides a collection of utility functions that, together with the [Table Hooks](/docs/guides-table-table-hooks--use-hv-hooks-story),
+The UI Kit library provides a collection of utility functions that, together with the [Table Hooks](./?path=/docs/visualizations-table-table-hooks--docs),
 ease the setup of common column configurations, including the render function, alignment, missing data fallbacks and cell overflow.
 
 They add a set of out of the box features, not meant to be 100% feature complete, but instead, ease the majority of use-cases we have been encountering.
@@ -13,14 +13,14 @@ If you need any customization or extension to these renderers, please feel free 
 
 The following renderers are available:
 
-- `hvTextColumn`: Renders a string and includes an overflow tooltip. [More details here](/docs/guides-table-table-renderers-renderers-text-column-renderer--text-column-renderer-story).
-- `hvNumberColumn`: Renders a number aligning it correctly and includes an overflow tooltip. [More details here](/docs/guides-table-table-renderers-renderers-number-column-renderer--number-column-renderer-story).
-- `hvDateColumn`: Renders a date and formats it. [More details here](/docs/guides-table-table-renderers-renderers-date-column-renderer--date-column-renderer-story).
-- `hvExpandColumn`: Renders a column that includes an expand button. [More details here](/docs/guides-table-table-renderers-renderers-expand-column-renderer--expand-column-renderer-story).
-- `hvTagColumn`: Renders a column with a tag component inside the cell. [More details here](/docs/guides-table-table-renderers-renderers-tag-column-renderer--tag-column-renderer-story).
-- `hvSwitchColumn`: Renders a column that includes a switch to toggle between two values. [More details here](/docs/guides-table-table-renderers-renderers-switch-column-renderer--switch-column-renderer-story).
-- `hvDropdownColumn`: Renders a column that include a dropdown select between various values. [More details here](/docs/guides-table-table-renderers-renderers-dropdown-column-renderer--dropdown-column-renderer-story).
-- `hvProgressColumn`: Renders a progress bar to compare between a current value and max value. [More details here](/docs/guides-table-table-renderers-renderers-progress-column-renderer--progress-column-renderer-story).
+- `hvTextColumn`: Renders a string and includes an overflow tooltip. [More details here](./?path=/docs/visualizations-table-table-renderers-text-column-renderer--docs).
+- `hvNumberColumn`: Renders a number aligning it correctly and includes an overflow tooltip. [More details here](./?path=/docs/visualizations-table-table-renderers-number-column-renderer--docs).
+- `hvDateColumn`: Renders a date and formats it. [More details here](./?path=/docs/visualizations-table-table-renderers-date-column-renderer--docs).
+- `hvExpandColumn`: Renders a column that includes an expand button. [More details here](./?path=/docs/visualizations-table-table-renderers-expand-column-renderer--docs).
+- `hvTagColumn`: Renders a column with a tag component inside the cell. [More details here](./?path=/docs/visualizations-table-table-renderers-tag-column-renderer--docs).
+- `hvSwitchColumn`: Renders a column that includes a switch to toggle between two values. [More details here](./?path=/docs/visualizations-table-table-renderers-switch-column-renderer--docs).
+- `hvDropdownColumn`: Renders a column that include a dropdown select between various values. [More details here](./?path=/docs/visualizations-table-table-renderers-dropdown-column-renderer--docs).
+- `hvProgressColumn`: Renders a progress bar to compare between a current value and max value. [More details here](./?path=/docs/visualizations-table-table-renderers-progress-column-renderer--docs).
 
 ## All Renderers Table
 


### PR DESCRIPTION
- "Simple Grid" sample in the layout page fixed: breakpoints were undefined
- "Packages" removed from the "Project Status" table of contents since this section doesn't exist
- Wrong URLs fixed
- Links fixed in the docs:
   - Anchor links to navigate to a page section were opening a new iframe
   - Links linking to other storybook pages were broken and leading to "Not found" pages