### PR TITLE
chore: a11y workflow and script fixed

### DIFF
--- a/.github/workflows/tests-a11y.yml
+++ b/.github/workflows/tests-a11y.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Run Tests
         run: |
           npx concurrently -k -s first -n "SB,TEST" -c "magenta,blue" \
-          "npx http-server dist --port 6006 --silent" \
+          "npx serve dist -l 6006 -L" \
           "npx wait-on tcp:6006 && npm run test:a11y" || true
 
       - name: Archive a11y report

--- a/scripts/a11y-report/index.js
+++ b/scripts/a11y-report/index.js
@@ -29,7 +29,7 @@ const buildReport = () => {
 
     // Create report
     execSync(
-      `npx storybook-a11y-report --storybookUrl ${storybookUrl} --outputFormat html --outDir ${outputDir} -o ${excludeStories}`
+      `npx storybook-a11y-report --storybookUrl ${storybookUrl} --outputFormat html --outDir ${outputDir} ${excludeStories}`
     );
 
     console.log("⏳ Adding custom CSS to report...");
@@ -39,7 +39,8 @@ const buildReport = () => {
     const cssFile = path.resolve(__dirname, "styles.css");
 
     // Add CSS file to report directory
-    fs.copyFileSync(cssFile, [reportDir, "/styles.css"].join(""));
+    fs.mkdirSync([reportDir, "/styles"].join(""));
+    fs.copyFileSync(cssFile, [reportDir, "/styles/styles.css"].join(""));
 
     // Customize report
     const htmlData = fs.readFileSync(reportFile, "utf8");
@@ -47,7 +48,7 @@ const buildReport = () => {
       .replace(
         "<title>Accessibility report</title>",
         `<title>NEXT UI Kit Accessibility Report</title>
-        <link rel="stylesheet" type="text/css" href="styles.css" />
+        <link rel="stylesheet" type="text/css" href="styles/styles.css" />
         <link href="https://fonts.googleapis.com/css?family=Open+Sans:400,600" rel="stylesheet"/>`
       )
       .replace(


### PR DESCRIPTION
- `http-server` replaced by `serve` because the workflow would get stuck on this step
- `a11y` script updated to copy CSS file inside a sub-folder

With these changes, the report is deployed as expected: https://lumada-design.github.io/uikit-a11y/