### PR TITLE
feat(Flow): add Node actions

### DIFF
--- a/packages/lab/src/components/Flow/Flow.tsx
+++ b/packages/lab/src/components/Flow/Flow.tsx
@@ -13,6 +13,7 @@ import { restrictToWindowEdges } from "@dnd-kit/modifiers";
 
 import { ReactFlowProvider } from "reactflow";
 
+import { HvActionGeneric } from "@hitachivantara/uikit-react-core";
 import { HvFlowNodeGroups, HvFlowNodeTypes } from "./types";
 import { HvFlowProvider } from "./FlowContext";
 import { HvDroppableFlow, HvDroppableFlowProps } from "./DroppableFlow";
@@ -29,6 +30,8 @@ export interface HvFlowProps<
   nodeTypes?: HvFlowNodeTypes<NodeGroups>;
   /** Flow sidebar. */
   sidebar?: React.ReactNode;
+  /** Flow default actions. */
+  defaultActions?: HvActionGeneric[];
   /**
    * Dnd Kit context props. This should be used for accessibility purposes.
    *
@@ -49,6 +52,7 @@ export const HvFlow = ({
   nodeTypes,
   nodeGroups,
   sidebar,
+  defaultActions,
   dndContextProps,
   ...others
 }: HvFlowProps) => {
@@ -73,7 +77,11 @@ export const HvFlow = ({
   // HvFlowContext is our custom internal context.
   return (
     <ReactFlowProvider>
-      <HvFlowProvider nodeGroups={nodeGroups} nodeTypes={nodeTypes}>
+      <HvFlowProvider
+        nodeGroups={nodeGroups}
+        nodeTypes={nodeTypes}
+        defaultActions={defaultActions}
+      >
         <DndContext
           onDragStart={handleDragStart}
           onDragEnd={handleDragEnd}

--- a/packages/lab/src/components/Flow/FlowContext/FlowContext.tsx
+++ b/packages/lab/src/components/Flow/FlowContext/FlowContext.tsx
@@ -1,3 +1,4 @@
+import { HvActionGeneric } from "@hitachivantara/uikit-react-core";
 import {
   Dispatch,
   SetStateAction,
@@ -16,6 +17,8 @@ export interface HvFlowContextValue<NodeGroups extends keyof any = string> {
   nodeGroups?: HvFlowNodeGroups<NodeGroups>;
   /** Flow nodes groups expanded on sidebar. */
   expandedNodeGroups?: string[];
+  /** Flow default actions. */
+  defaultActions?: HvActionGeneric[];
   /** Function to set `expandedNodeGroups`. */
   setExpandedNodeGroups?: Dispatch<SetStateAction<string[]>>;
 }
@@ -27,6 +30,8 @@ export interface HvFlowProviderProps<NodeGroups extends keyof any = string> {
   nodeTypes?: HvFlowContextValue<NodeGroups>["nodeTypes"];
   /** Flow nodes groups. */
   nodeGroups?: HvFlowContextValue<NodeGroups>["nodeGroups"];
+  /** Flow default actions. */
+  defaultActions?: HvActionGeneric[];
   /** Children. */
   children?: React.ReactNode;
 }
@@ -34,6 +39,7 @@ export interface HvFlowProviderProps<NodeGroups extends keyof any = string> {
 export const HvFlowProvider = ({
   nodeGroups,
   nodeTypes,
+  defaultActions,
   children,
 }: HvFlowProviderProps) => {
   const [expandedNodeGroups, setExpandedNodeGroups] = useState<string[]>([]);
@@ -42,10 +48,11 @@ export const HvFlowProvider = ({
     () => ({
       nodeTypes,
       nodeGroups,
+      defaultActions,
       expandedNodeGroups,
       setExpandedNodeGroups,
     }),
-    [nodeGroups, nodeTypes, expandedNodeGroups]
+    [nodeTypes, nodeGroups, defaultActions, expandedNodeGroups]
   );
 
   return (

--- a/packages/lab/src/components/Flow/Node/Node.styles.tsx
+++ b/packages/lab/src/components/Flow/Node/Node.styles.tsx
@@ -22,7 +22,22 @@ export const { staticClasses, useClasses } = createClasses("HvFlowNode", {
   group: {
     color: theme.colors.base_dark,
   },
-  titleContainer: { padding: theme.space.sm },
+  titleContainer: {
+    padding: theme.spacing(
+      theme.space.xs,
+      theme.space.xs,
+      theme.space.xs,
+      theme.space.sm
+    ),
+    display: "flex",
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+  },
+  actions: {
+    display: "flex",
+    alignItems: "center",
+  },
   inputsTitleContainer: {
     display: "flex",
     justifyContent: "center",

--- a/packages/lab/src/components/Flow/stories/Flow.stories.tsx
+++ b/packages/lab/src/components/Flow/stories/Flow.stories.tsx
@@ -8,9 +8,12 @@ import {
 import {
   Add,
   Backwards,
+  Delete,
+  Duplicate,
   Favorite,
+  Group,
   Heart,
-  Home,
+  LineChartAlt,
 } from "@hitachivantara/uikit-react-icons";
 
 import { Meta, StoryObj } from "@storybook/react";
@@ -32,6 +35,11 @@ import { KPI } from "./KPI";
 import { LineChart } from "./LineChart";
 import { Table } from "./Table";
 import { Dashboard } from "./Dashboard";
+
+const defaultActions = [
+  { id: "delete", label: "Delete", icon: <Delete /> },
+  { id: "duplicate", label: "Duplicate", icon: <Duplicate /> },
+];
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const initialState = {
@@ -283,13 +291,13 @@ const nodeGroups = {
     label: "Insights",
     color: "cat6_80",
     description: "This is my description for insights.",
-    icon: <Home />,
+    icon: <Group />,
   },
   dashboard: {
     label: "Dashboard",
     color: "cat2_80",
     description: "This is my description for dashboard.",
-    icon: <Home />,
+    icon: <LineChartAlt />,
   },
 } satisfies HvFlowProps<any, NodeType, NodeGroups>["nodeGroups"];
 
@@ -348,7 +356,7 @@ export const Main: StoryObj<HvFlowProps> = {
             edges={edges}
             nodeTypes={nodeTypes}
             nodeGroups={nodeGroups}
-            // defaultViewport={initialState.viewport}
+            defaultActions={defaultActions}
             sidebar={
               <HvFlowSidebar
                 title="Add Node"

--- a/packages/lab/src/components/Flow/stories/Tron.tsx
+++ b/packages/lab/src/components/Flow/stories/Tron.tsx
@@ -1,8 +1,98 @@
+import { css } from "@emotion/css";
+import {
+  HvButton,
+  HvDialog,
+  HvDialogActions,
+  HvDialogContent,
+  HvDialogTitle,
+} from "@hitachivantara/uikit-react-core";
+import { Favorite, Flag, Search } from "@hitachivantara/uikit-react-icons";
+import { useState } from "react";
+import { Node, useReactFlow } from "reactflow";
 import { HvFlowNode } from "../Node/Node";
 
 export const Tron = (props) => {
+  const [showDialog, setShowDialog] = useState(false);
+  const [details, setDetails] = useState<Node | undefined>();
+  const reactFlowInstance = useReactFlow();
+
+  const classes = {
+    container: css({
+      width: "40%",
+      minHeight: 200,
+    }),
+  };
+
+  const handleAction = (event: any, id: string, action: any) => {
+    const node: Node | undefined = reactFlowInstance.getNode(id);
+    if (!node) return;
+
+    switch (action.id) {
+      case "details": {
+        setDetails(node);
+        setShowDialog(true);
+        break;
+      }
+      default:
+        break;
+    }
+  };
+
   return (
-    <HvFlowNode title="Tron" description="Tron asset description" {...props} />
+    <>
+      <HvDialog
+        open={showDialog}
+        onClose={() => setShowDialog(false)}
+        classes={{ paper: classes.container }}
+      >
+        <HvDialogTitle>Tron</HvDialogTitle>
+        <HvDialogContent>{JSON.stringify(details?.data)}</HvDialogContent>
+        <HvDialogActions>
+          <HvButton
+            autoFocus
+            variant="secondaryGhost"
+            onClick={() => setShowDialog(false)}
+          >
+            Close
+          </HvButton>
+        </HvDialogActions>
+      </HvDialog>
+
+      <HvFlowNode
+        title="Tron"
+        description="Tron asset description"
+        expanded
+        maxVisibleActions={1}
+        actions={[
+          {
+            id: "details",
+            label: "View Details",
+            icon: <Search />,
+          },
+
+          {
+            id: "favorite",
+            label: "Add Favorite",
+            icon: <Favorite />,
+          },
+          {
+            id: "flag",
+            label: "Flag",
+            icon: <Flag />,
+          },
+        ]}
+        actionCallback={handleAction}
+        params={[
+          {
+            id: "asset",
+            label: "Asset",
+            type: "select",
+            options: ["Way Side", "Cars"],
+          },
+        ]}
+        {...props}
+      />
+    </>
   );
 };
 


### PR DESCRIPTION
Added node actions: 
- A flow can have default actions (set at the Flow level) that all nodes will have (delete, duplicate, ...)
  - The default actions will appear above the node when it's hovered
- A node type can have extra actions defined at the node level
- It's possible to set the `maxVisibleActions` on each node
