### PR TITLE
feat(AppSwitcher): applications title now displays in two lines before ellipsis

### DIFF
--- a/packages/core/src/components/AppSwitcher/Action/Action.styles.tsx
+++ b/packages/core/src/components/AppSwitcher/Action/Action.styles.tsx
@@ -46,8 +46,11 @@ export const { staticClasses, useClasses } = createClasses(
       textAlign: "left",
 
       overflow: "hidden",
-      whiteSpace: "nowrap",
+      whiteSpace: "normal",
       textOverflow: "ellipsis",
+      display: "-webkit-box",
+      "-webkit-line-clamp": "2",
+      "-webkit-box-orient": "vertical",
 
       color: "inherit",
     },


### PR DESCRIPTION
The App Switcher panel falls short in space for the applications title, especially when it has an icon and a description, hence this PR to allow for at least two lines before cropping the remaining text.