### PR TITLE
refactor(Dialog): slots, tooltip usage, context

### DIFF
--- a/packages/core/src/components/Dialog/Actions/Actions.tsx
+++ b/packages/core/src/components/Dialog/Actions/Actions.tsx
@@ -7,6 +7,7 @@ import { HvBaseProps } from "@core/types/generic";
 import { ExtractNames } from "@core/utils/classes";
 
 import { staticClasses, useClasses } from "./Actions.styles";
+import { useDialogContext } from "../context";
 
 export { staticClasses as dialogActionClasses };
 
@@ -15,7 +16,7 @@ export type HvDialogActionClasses = ExtractNames<typeof useClasses>;
 export interface HvDialogActionsProps
   extends Omit<MuiDialogActionsProps, "classes">,
     HvBaseProps {
-  /** Set the dialog to fullscreen mode. */
+  /** Set the dialog to fullscreen mode. @deprecated set `fullscreen` in `HvDialog` */
   fullscreen?: boolean;
   /** A Jss Object used to override or extend the styles applied to the component. */
   classes?: HvDialogActionClasses;
@@ -26,9 +27,11 @@ export const HvDialogActions = (props: HvDialogActionsProps) => {
     classes: classesProp,
     className,
     children,
-    fullscreen = false,
+    fullscreen: fullScreenProp,
     ...others
   } = useDefaultProps("HvDialogActions", props);
+  const context = useDialogContext();
+  const fullscreen = fullScreenProp ?? context.fullscreen;
 
   const { classes, cx } = useClasses(classesProp);
 

--- a/packages/core/src/components/Dialog/Dialog.tsx
+++ b/packages/core/src/components/Dialog/Dialog.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from "react";
+import { useCallback, useMemo } from "react";
 import { useDefaultProps } from "@core/hooks/useDefaultProps";
 
 import MuiDialog, { DialogProps as MuiDialogProps } from "@mui/material/Dialog";
@@ -15,6 +15,7 @@ import { useTheme } from "@core/hooks/useTheme";
 import { hexToRgbA } from "@core/utils/hexToRgbA";
 
 import { staticClasses, useClasses } from "./Dialog.styles";
+import { DialogContext } from "./context";
 
 export { staticClasses as dialogClasses };
 
@@ -79,6 +80,8 @@ export const HvDialog = (props: HvDialogProps) => {
     element?.focus();
   }, [firstFocusable]);
 
+  const contextValue = useMemo(() => ({ fullscreen }), [fullscreen]);
+
   return (
     <MuiDialog
       container={
@@ -138,13 +141,9 @@ export const HvDialog = (props: HvDialogProps) => {
           <Close role="none" />
         </HvButton>
       </HvTooltip>
-      {children && typeof children === "object"
-        ? React.Children.map(
-            children,
-            (c: React.ReactNode) =>
-              c && React.cloneElement(c as React.ReactElement, { fullscreen })
-          )
-        : children}
+      <DialogContext.Provider value={contextValue}>
+        {children}
+      </DialogContext.Provider>
     </MuiDialog>
   );
 };

--- a/packages/core/src/components/Dialog/Dialog.tsx
+++ b/packages/core/src/components/Dialog/Dialog.tsx
@@ -1,17 +1,16 @@
-import React, { useCallback, useMemo } from "react";
+import React, { useCallback } from "react";
 import { useDefaultProps } from "@core/hooks/useDefaultProps";
 
 import MuiDialog, { DialogProps as MuiDialogProps } from "@mui/material/Dialog";
-import MuiBackdrop from "@mui/material/Backdrop";
 
 import { Close } from "@hitachivantara/uikit-react-icons";
 import { theme } from "@hitachivantara/uikit-styles";
 
 import { HvButton } from "@core/components/Button";
+import { HvTooltip } from "@core/components/Tooltip";
 import { HvBaseProps } from "@core/types/generic";
 import { ExtractNames } from "@core/utils/classes";
 import { setId } from "@core/utils/setId";
-import { withTooltip } from "@core/hocs/withTooltip";
 import { useTheme } from "@core/hooks/useTheme";
 import { hexToRgbA } from "@core/utils/hexToRgbA";
 
@@ -26,11 +25,8 @@ export interface HvDialogProps
     HvBaseProps {
   /** Current state of the Dialog. */
   open?: boolean;
-  /** Function executed on close. */
-  onClose?: (
-    event: React.SyntheticEvent,
-    reason?: "escapeKeyDown" | "backdropClick"
-  ) => void;
+  /** Callback fired when the component requests to be closed. */
+  onClose?: (event: any, reason?: "escapeKeyDown" | "backdropClick") => void;
   /** @inheritdoc */
   maxWidth?: MuiDialogProps["maxWidth"];
   /** @inheritdoc */
@@ -74,25 +70,7 @@ export const HvDialog = (props: HvDialogProps) => {
   } = useDefaultProps("HvDialog", props);
 
   const { classes, css, cx } = useClasses(classesProp);
-  delete (others as any).fullScreen;
-
   const { rootId, colors } = useTheme();
-
-  // Because the `disableBackdropClick` property was deprecated in MUI5
-  // and we want to maintain that functionality to the user we're wrapping
-  // the onClose call here to make that check.
-  const wrappedClose = useCallback(
-    (
-      event: any,
-      bypassValidation: boolean = false,
-      reason?: "escapeKeyDown" | "backdropClick"
-    ) => {
-      if (bypassValidation || !disableBackdropClick) {
-        onClose?.(event, reason);
-      }
-    },
-    [onClose, disableBackdropClick]
-  );
 
   const measuredRef = useCallback(() => {
     if (!firstFocusable) return;
@@ -100,21 +78,6 @@ export const HvDialog = (props: HvDialogProps) => {
     const element = document.getElementById(firstFocusable);
     element?.focus();
   }, [firstFocusable]);
-
-  const closeButtonDisplay = () => <Close role="presentation" />;
-
-  const CloseButtonTooltipWrapper = buttonTitle
-    ? withTooltip(closeButtonDisplay, buttonTitle, "top")
-    : closeButtonDisplay;
-
-  const slots = useMemo<MuiDialogProps["slots"]>(
-    () => ({
-      backdrop: (backdropProps) => (
-        <MuiBackdrop open={open} onClick={wrappedClose} {...backdropProps} />
-      ),
-    }),
-    [open, wrappedClose]
-  );
 
   return (
     <MuiDialog
@@ -131,8 +94,13 @@ export const HvDialog = (props: HvDialogProps) => {
       ref={measuredRef}
       open={open}
       fullScreen={fullscreen}
-      onClose={(event, reason) => wrappedClose(event, undefined, reason)}
-      slots={slots}
+      onClose={(event, reason) => {
+        // `disableBackdropClick` property was removed in MUI5
+        // and we want to maintain that functionality
+        if (disableBackdropClick) return;
+
+        onClose?.(event, reason);
+      }}
       slotProps={{
         backdrop: {
           classes: {
@@ -160,15 +128,16 @@ export const HvDialog = (props: HvDialogProps) => {
       aria-modal
       {...others}
     >
-      <HvButton
-        id={setId(id, "close")}
-        className={classes.closeButton}
-        variant="secondaryGhost"
-        onClick={(event) => wrappedClose(event, true, undefined)}
-        aria-label={buttonTitle}
-      >
-        <CloseButtonTooltipWrapper />
-      </HvButton>
+      <HvTooltip placement="top" title={buttonTitle}>
+        <HvButton
+          id={setId(id, "close")}
+          className={classes.closeButton}
+          variant="secondaryGhost"
+          onClick={(event) => onClose?.(event, undefined)}
+        >
+          <Close role="none" />
+        </HvButton>
+      </HvTooltip>
       {children && typeof children === "object"
         ? React.Children.map(
             children,

--- a/packages/core/src/components/Dialog/Title/Title.tsx
+++ b/packages/core/src/components/Dialog/Title/Title.tsx
@@ -4,11 +4,11 @@ import MuiDialogTitle, {
 import { useDefaultProps } from "@core/hooks/useDefaultProps";
 
 import { HvTypography } from "@core/components/Typography";
-import { HvBaseProps } from "@core/types/generic";
 import { ExtractNames } from "@core/utils/classes";
 import { iconVariant } from "@core/utils/iconVariant";
 
 import { staticClasses, useClasses } from "./Title.styles";
+import { useDialogContext } from "../context";
 
 export { staticClasses as dialogTitleClasses };
 
@@ -22,8 +22,7 @@ export type HvDialogTitleVariant =
   | "default";
 
 export interface HvDialogTitleProps
-  extends Omit<MuiDialogTitleProps, "variant" | "classes">,
-    HvBaseProps<HTMLSpanElement, "color"> {
+  extends Omit<MuiDialogTitleProps, "variant" | "classes"> {
   /** Variant of the dialog title. */
   variant?: HvDialogTitleVariant;
   /** Controls if the associated icon to the variant should be shown. */
@@ -46,11 +45,9 @@ export const HvDialogTitle = (props: HvDialogTitleProps) => {
   } = useDefaultProps("HvDialogTitle", props);
 
   const { classes, css, cx } = useClasses(classesProp);
+  const { fullscreen } = useDialogContext();
 
   const isString = typeof children === "string";
-
-  const { fullscreen } = others as any;
-  delete (others as any).fullscreen;
 
   const icon = customIcon || (showIcon && iconVariant(variant));
 
@@ -69,8 +66,9 @@ export const HvDialogTitle = (props: HvDialogTitleProps) => {
       <div className={classes.messageContainer}>
         {icon}
         <div className={cx({ [classes.textWithIcon]: !!icon })}>
-          {!isString && children}
-          {isString && (
+          {!isString ? (
+            children
+          ) : (
             <HvTypography variant="title4" className={classes.titleText}>
               {children}
             </HvTypography>

--- a/packages/core/src/components/Dialog/context.ts
+++ b/packages/core/src/components/Dialog/context.ts
@@ -1,0 +1,5 @@
+import { createContext, useContext } from "react";
+
+export const DialogContext = createContext({ fullscreen: false });
+
+export const useDialogContext = () => useContext(DialogContext);


### PR DESCRIPTION
Simplifies Dialog internals:

- Remove `slots` overrides with seems to be adding nothing 🤷 and introduces a flicker when `onClose` isn't memoized
  - the backdrop color override is done with `slotProps`
- Replace `withTooltip` with `HvTooltip`. `HvTooltip` already handles conditionally showing the tooltip
- Remove `wrappedClose` in favour of inline calls. There's fewer calls to `onClose`, and we weren't respecting the `onClose` API in `wrappedClose`
- Refactor `fullscreen` calls and passing it to children.
  - We're injecting props into components that don't accept that prop (except for `HvDialogActions`) and then deleting it - refactored into a context. 
  - Deprecated `fullscreen` in `HvDialogActions`