### PR TITLE
fix(EmptyState): node component

### DIFF
--- a/packages/core/src/components/EmptyState/EmptyState.tsx
+++ b/packages/core/src/components/EmptyState/EmptyState.tsx
@@ -21,11 +21,11 @@ export interface HvEmptyStateProps
   /** Icon to be presented. */
   icon: React.ReactNode;
   /** The title to be shown. */
-  title?: string | React.ReactNode;
+  title?: React.ReactNode;
   /** The message to be shown. */
-  message?: string | React.ReactNode;
+  message?: React.ReactNode;
   /** The action message to be shown. */
-  action?: string | React.ReactNode;
+  action?: React.ReactNode;
   /** A Jss Object used to override or extend the styles applied to the empty state component. */
   classes?: HvEmptyStateClasses;
 }
@@ -59,7 +59,7 @@ export const HvEmptyState = (props: HvEmptyStateProps) => {
     style?: string
   ) =>
     node && (
-      <HvTypography variant={variant} className={style}>
+      <HvTypography component="div" variant={variant} className={style}>
         {node}
       </HvTypography>
     );

--- a/packages/lab/src/components/Flow/stories/Visualizations/Filter.tsx
+++ b/packages/lab/src/components/Flow/stories/Visualizations/Filter.tsx
@@ -62,6 +62,7 @@ export const Filter = (props) => {
         {options.map((o) => {
           return (
             <HvCheckBox
+              key={o}
               label={o}
               value={o}
               checked={self?.data?.checked?.includes(o)}


### PR DESCRIPTION
- Flow: missing key error fixed in the visualisations sample.
- Empty State: 
   - We had a [regression in the empty state component in v5.x](https://github.com/lumada-design/hv-uikit-react/blob/v4.x/packages/core/src/EmptyState/EmptyState.js#L10C45-L10C45) and we are rendering the nodes as `p` instead of `div`. This leads to the following error: `Warning: validateDOMNesting(...): <p> cannot appear as a descendant of <p>.`. This PR fixes this problem.
