### PR TITLE
fix(Flow): several fixes 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -68,7 +68,7 @@
         "react-dom": "^18.2.0",
         "react-google-charts": "^4.0.0",
         "react-leaflet": "^4.2.1",
-        "reactflow": "^11.8.3",
+        "reactflow": "^11.9.4",
         "remark-gfm": "^3.0.1",
         "storybook": "^7.4.1",
         "storybook-a11y-report": "^0.0.20",
@@ -7198,11 +7198,11 @@
       }
     },
     "node_modules/@reactflow/background": {
-      "version": "11.2.8",
-      "resolved": "https://registry.npmjs.org/@reactflow/background/-/background-11.2.8.tgz",
-      "integrity": "sha512-5o41N2LygiNC2/Pk8Ak2rIJjXbKHfQ23/Y9LFsnAlufqwdzFqKA8txExpsMoPVHHlbAdA/xpQaMuoChGPqmyDw==",
+      "version": "11.3.4",
+      "resolved": "https://registry.npmjs.org/@reactflow/background/-/background-11.3.4.tgz",
+      "integrity": "sha512-bgwvqWxF09chwmdkyClpYEMaewBspdwjgLbbFlLf4SpWPFMYyuvCBQrcISsvy/EDEWO9i3Uj9ktgGAhvtSQsmA==",
       "dependencies": {
-        "@reactflow/core": "11.8.3",
+        "@reactflow/core": "11.9.4",
         "classcat": "^5.0.3",
         "zustand": "^4.4.1"
       },
@@ -7212,11 +7212,11 @@
       }
     },
     "node_modules/@reactflow/controls": {
-      "version": "11.1.19",
-      "resolved": "https://registry.npmjs.org/@reactflow/controls/-/controls-11.1.19.tgz",
-      "integrity": "sha512-Vo0LFfAYjiSRMLEII/aeBo+1MT2a0Yc7iLVnkuRTLzChC0EX+A2Fa+JlzeOEYKxXlN4qcDxckRNGR7092v1HOQ==",
+      "version": "11.2.4",
+      "resolved": "https://registry.npmjs.org/@reactflow/controls/-/controls-11.2.4.tgz",
+      "integrity": "sha512-x6e5p9iHjC6gd+4SoZ3DOOp0F1MefGKQ8hT6yPVdqxfo1+rV2WhrWvrX/MCoEu12Dp7457LdLfa0giy3aho8tQ==",
       "dependencies": {
-        "@reactflow/core": "11.8.3",
+        "@reactflow/core": "11.9.4",
         "classcat": "^5.0.3",
         "zustand": "^4.4.1"
       },
@@ -7226,9 +7226,9 @@
       }
     },
     "node_modules/@reactflow/core": {
-      "version": "11.8.3",
-      "resolved": "https://registry.npmjs.org/@reactflow/core/-/core-11.8.3.tgz",
-      "integrity": "sha512-y6DN8Wy4V4KQBGHFqlj9zWRjLJU6CgdnVwWaEA/PdDg/YUkFBMpZnXqTs60czinoA2rAcvsz50syLTPsj5e+Wg==",
+      "version": "11.9.4",
+      "resolved": "https://registry.npmjs.org/@reactflow/core/-/core-11.9.4.tgz",
+      "integrity": "sha512-Ko7nKPOYalwDTTbRHi2+QXDiidSAcpUzGN3G+0B+QysLZkcaPCkpkMjjHiDC4c/Z1BJBzs1FRJg/T6BXaBnYkg==",
       "dependencies": {
         "@types/d3": "^7.4.0",
         "@types/d3-drag": "^3.0.1",
@@ -7246,11 +7246,11 @@
       }
     },
     "node_modules/@reactflow/minimap": {
-      "version": "11.6.3",
-      "resolved": "https://registry.npmjs.org/@reactflow/minimap/-/minimap-11.6.3.tgz",
-      "integrity": "sha512-PSA28dk09RnBHOA1zb45fjQXz3UozSJZmsIpgq49O3trfVFlSgRapxNdGsughWLs7/emg2M5jmi6Vc+ejcfjvQ==",
+      "version": "11.7.4",
+      "resolved": "https://registry.npmjs.org/@reactflow/minimap/-/minimap-11.7.4.tgz",
+      "integrity": "sha512-Jo1R+uDey9IV7O2s3m0gK2+cZpg9M8hq2EZJb3NGfOSzMAPhj3mby0fNJIgTzycreuht0TpA51c2YfjGI3YIOw==",
       "dependencies": {
-        "@reactflow/core": "11.8.3",
+        "@reactflow/core": "11.9.4",
         "@types/d3-selection": "^3.0.3",
         "@types/d3-zoom": "^3.0.1",
         "classcat": "^5.0.3",
@@ -7264,11 +7264,11 @@
       }
     },
     "node_modules/@reactflow/node-resizer": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/@reactflow/node-resizer/-/node-resizer-2.1.5.tgz",
-      "integrity": "sha512-z/hJlsptd2vTx13wKouqvN/Kln08qbkA+YTJLohc2aJ6rx3oGn9yX4E4IqNxhA7zNqYEdrnc1JTEA//ifh9z3w==",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/@reactflow/node-resizer/-/node-resizer-2.2.4.tgz",
+      "integrity": "sha512-+p271/hAsM5M1+RQTWW/02pbNkCHeGXwxGimIlL1tMIagyuko0NX2vOz2B8jxJnPKlF09Wj18BcXBNUm3nDcSg==",
       "dependencies": {
-        "@reactflow/core": "11.8.3",
+        "@reactflow/core": "11.9.4",
         "classcat": "^5.0.4",
         "d3-drag": "^3.0.0",
         "d3-selection": "^3.0.0",
@@ -7280,11 +7280,11 @@
       }
     },
     "node_modules/@reactflow/node-toolbar": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/@reactflow/node-toolbar/-/node-toolbar-1.2.7.tgz",
-      "integrity": "sha512-vs+Wg1tjy3SuD7eoeTqEtscBfE9RY+APqC28urVvftkrtsN7KlnoQjqDG6aE45jWP4z+8bvFizRWjAhxysNLkg==",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/@reactflow/node-toolbar/-/node-toolbar-1.3.4.tgz",
+      "integrity": "sha512-TfcmpXHRBb2mUfzKGjburiU6FWqRME9pPFs1OwIC1z5e9BjupQhNDEKEk8XHi7PKL/mAiDfwuGXaM1BVVFuPqw==",
       "dependencies": {
-        "@reactflow/core": "11.8.3",
+        "@reactflow/core": "11.9.4",
         "classcat": "^5.0.3",
         "zustand": "^4.4.1"
       },
@@ -9431,9 +9431,9 @@
       }
     },
     "node_modules/@types/d3": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/@types/d3/-/d3-7.4.0.tgz",
-      "integrity": "sha512-jIfNVK0ZlxcuRDKtRS/SypEyOQ6UHaFQBKv032X45VvxSJ6Yi5G9behy9h6tNTHTDGh5Vq+KbmBjUWLgY4meCA==",
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/@types/d3/-/d3-7.4.1.tgz",
+      "integrity": "sha512-lBpYmbHTCtFKO1DB1R7E9dXp9/g1F3JXSGOF7iKPZ+wRmYg/Q6tCRHODGOc5Qk25fJRe2PI60EDRf2HLPUncMA==",
       "dependencies": {
         "@types/d3-array": "*",
         "@types/d3-axis": "*",
@@ -9468,67 +9468,67 @@
       }
     },
     "node_modules/@types/d3-array": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.0.7.tgz",
-      "integrity": "sha512-4/Q0FckQ8TBjsB0VdGFemJOG8BLXUB2KKlL0VmZ+eOYeOnTb/wDRQqYWpBmQ6IlvWkXwkYiot+n9Px2aTJ7zGQ=="
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.0.8.tgz",
+      "integrity": "sha512-2xAVyAUgaXHX9fubjcCbGAUOqYfRJN1em1EKR2HfzWBpObZhwfnZKvofTN4TplMqJdFQao61I+NVSai/vnBvDQ=="
     },
     "node_modules/@types/d3-axis": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@types/d3-axis/-/d3-axis-3.0.3.tgz",
-      "integrity": "sha512-SE3x/pLO/+GIHH17mvs1uUVPkZ3bHquGzvZpPAh4yadRy71J93MJBpgK/xY8l9gT28yTN1g9v3HfGSFeBMmwZw==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-axis/-/d3-axis-3.0.4.tgz",
+      "integrity": "sha512-ySnjI/7qm+J602VjcejXcqs1hEuu5UBbGaJGp+Cn/yKVc1iS3JueLVpToGdQsS2sqta7tqA/kG4ore/+LH90UA==",
       "dependencies": {
         "@types/d3-selection": "*"
       }
     },
     "node_modules/@types/d3-brush": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@types/d3-brush/-/d3-brush-3.0.3.tgz",
-      "integrity": "sha512-MQ1/M/B5ifTScHSe5koNkhxn2mhUPqXjGuKjjVYckplAPjP9t2I2sZafb/YVHDwhoXWZoSav+Q726eIbN3qprA==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-brush/-/d3-brush-3.0.4.tgz",
+      "integrity": "sha512-Kg5uIsdJNMCs5lTqeZFsTKqj9lBvpiFRDkYN3j2CDlPhonNDg9/gXVpv1E/MKh3tEqArryIj9o6RBGE/MQe+6Q==",
       "dependencies": {
         "@types/d3-selection": "*"
       }
     },
     "node_modules/@types/d3-chord": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@types/d3-chord/-/d3-chord-3.0.3.tgz",
-      "integrity": "sha512-keuSRwO02c7PBV3JMWuctIfdeJrVFI7RpzouehvBWL4/GGUB3PBNg/9ZKPZAgJphzmS2v2+7vr7BGDQw1CAulw=="
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-chord/-/d3-chord-3.0.4.tgz",
+      "integrity": "sha512-p4PvN1N+7GL3Y/NI9Ug1TKwowUV6h664kmxL79ctp1HRYCk1mhP0+SXhjRsoWXCdnJfbLLLmpV99rt8dMrHrzg=="
     },
     "node_modules/@types/d3-color": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.0.tgz",
-      "integrity": "sha512-HKuicPHJuvPgCD+np6Se9MQvS6OCbJmOjGvylzMJRlDwUXjKTTXs6Pwgk79O09Vj/ho3u1ofXnhFOaEWWPrlwA=="
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.1.tgz",
+      "integrity": "sha512-CSAVrHAtM9wfuLJ2tpvvwCU/F22sm7rMHNN+yh9D6O6hyAms3+O0cgMpC1pm6UEUMOntuZC8bMt74PteiDUdCg=="
     },
     "node_modules/@types/d3-contour": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@types/d3-contour/-/d3-contour-3.0.3.tgz",
-      "integrity": "sha512-x7G/tdDZt4m09XZnG2SutbIuQqmkNYqR9uhDMdPlpJbcwepkEjEWG29euFcgVA1k6cn92CHdDL9Z+fOnxnbVQw==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-contour/-/d3-contour-3.0.4.tgz",
+      "integrity": "sha512-B0aeX8Xg3MNUglULxqDvlgY1SVXuN2xtEleYSAY0iMhl/SMVT7snzgAveejjwM3KaWuNXIoXEJ7dmXE8oPq/jA==",
       "dependencies": {
         "@types/d3-array": "*",
         "@types/geojson": "*"
       }
     },
     "node_modules/@types/d3-delaunay": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@types/d3-delaunay/-/d3-delaunay-6.0.1.tgz",
-      "integrity": "sha512-tLxQ2sfT0p6sxdG75c6f/ekqxjyYR0+LwPrsO1mbC9YDBzPJhs2HbJJRrn8Ez1DBoHRo2yx7YEATI+8V1nGMnQ=="
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-delaunay/-/d3-delaunay-6.0.2.tgz",
+      "integrity": "sha512-WplUJ/OHU7eITneDqNnzK+2pgR+WDzUHG6XAUVo+oWHPQq74VcgUdw8a4ODweaZzF56OVYK+x9GxCyuq6hSu1A=="
     },
     "node_modules/@types/d3-dispatch": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@types/d3-dispatch/-/d3-dispatch-3.0.3.tgz",
-      "integrity": "sha512-Df7KW3Re7G6cIpIhQtqHin8yUxUHYAqiE41ffopbmU5+FifYUNV7RVyTg8rQdkEagg83m14QtS8InvNb95Zqug=="
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-dispatch/-/d3-dispatch-3.0.4.tgz",
+      "integrity": "sha512-NApHpGHRNxUy7e2Lfzl/cwOucmn4Xdx6FdmXzAoomo8T81LyGmlBjjko/vP0TVzawlvEFLDq8OCRLulW6DDzKw=="
     },
     "node_modules/@types/d3-drag": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-3.0.3.tgz",
-      "integrity": "sha512-82AuQMpBQjuXeIX4tjCYfWjpm3g7aGCfx6dFlxX2JlRaiME/QWcHzBsINl7gbHCODA2anPYlL31/Trj/UnjK9A==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-3.0.4.tgz",
+      "integrity": "sha512-/t53K1erTuUbP7WIX9SE0hlmytpTYRbIthlhbGkBHzCV5vPO++7yrk8OlisWPyIJO5TGowTmqCtGH2tokY5T/g==",
       "dependencies": {
         "@types/d3-selection": "*"
       }
     },
     "node_modules/@types/d3-dsv": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@types/d3-dsv/-/d3-dsv-3.0.2.tgz",
-      "integrity": "sha512-DooW5AOkj4AGmseVvbwHvwM/Ltu0Ks0WrhG6r5FG9riHT5oUUTHz6xHsHqJSVU8ZmPkOqlUEY2obS5C9oCIi2g=="
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-dsv/-/d3-dsv-3.0.4.tgz",
+      "integrity": "sha512-YxfUVJ55HxR8oq88136w09mBMPNhgH7PZjteq72onWXWOohGif/cLQnQv8V4A5lEGjXF04LhwSTpmzpY9wyVyA=="
     },
     "node_modules/@types/d3-ease": {
       "version": "3.0.0",
@@ -9536,40 +9536,40 @@
       "integrity": "sha512-aMo4eaAOijJjA6uU+GIeW018dvy9+oH5Y2VPPzjjfxevvGQ/oRDs+tfYC9b50Q4BygRR8yE2QCLsrT0WtAVseA=="
     },
     "node_modules/@types/d3-fetch": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@types/d3-fetch/-/d3-fetch-3.0.3.tgz",
-      "integrity": "sha512-/EsDKRiQkby3Z/8/AiZq8bsuLDo/tYHnNIZkUpSeEHWV7fHUl6QFBjvMPbhkKGk9jZutzfOkGygCV7eR/MkcXA==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-fetch/-/d3-fetch-3.0.4.tgz",
+      "integrity": "sha512-RleYajubALkGjrvatxWhlygfvB1KNF0Uzz9guRUeeA+M/2B7l8rxObYdktaX9zU1st04lMCHjZWe4vbl+msH2Q==",
       "dependencies": {
         "@types/d3-dsv": "*"
       }
     },
     "node_modules/@types/d3-force": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@types/d3-force/-/d3-force-3.0.5.tgz",
-      "integrity": "sha512-EGG+IWx93ESSXBwfh/5uPuR9Hp8M6o6qEGU7bBQslxCvrdUBQZha/EFpu/VMdLU4B0y4Oe4h175nSm7p9uqFug=="
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-force/-/d3-force-3.0.6.tgz",
+      "integrity": "sha512-G9wbOvCxkNlLrppoHLZ6oFpbm3z7ibfkXwLD8g5/4Aa7iTEV0Z7TQ0OL8UxAtvdOhCa2VZcSuqn1NQqyCEqmiw=="
     },
     "node_modules/@types/d3-format": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@types/d3-format/-/d3-format-3.0.1.tgz",
-      "integrity": "sha512-5KY70ifCCzorkLuIkDe0Z9YTf9RR2CjBX1iaJG+rgM/cPP+sO+q9YdQ9WdhQcgPj1EQiJ2/0+yUkkziTG6Lubg=="
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-format/-/d3-format-3.0.2.tgz",
+      "integrity": "sha512-9oQWvKk2qVBo49FQq8yD/et8Lx0W5Ac2FdGSOUecqOFKqh0wkpyHqf9Qc7A06ftTR+Lz13Pi3jHIQis0aCueOA=="
     },
     "node_modules/@types/d3-geo": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@types/d3-geo/-/d3-geo-3.0.4.tgz",
-      "integrity": "sha512-kmUK8rVVIBPKJ1/v36bk2aSgwRj2N/ZkjDT+FkMT5pgedZoPlyhaG62J+9EgNIgUXE6IIL0b7bkLxCzhE6U4VQ==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/d3-geo/-/d3-geo-3.0.5.tgz",
+      "integrity": "sha512-ysEEU93Wv9p2UZBxTK3kUP7veHgyhTA0qYtI7bxK5EMXb3JxGv0D4IH54PxprAF26n+uHci24McVmzwIdLgvgQ==",
       "dependencies": {
         "@types/geojson": "*"
       }
     },
     "node_modules/@types/d3-hierarchy": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/@types/d3-hierarchy/-/d3-hierarchy-3.1.3.tgz",
-      "integrity": "sha512-GpSK308Xj+HeLvogfEc7QsCOcIxkDwLhFYnOoohosEzOqv7/agxwvJER1v/kTC+CY1nfazR0F7gnHo7GE41/fw=="
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-hierarchy/-/d3-hierarchy-3.1.4.tgz",
+      "integrity": "sha512-wrvjpRFdmEu6yAqgjGy8MSud9ggxJj+I9XLuztLeSf/E0j0j6RQYtxH2J8U0Cfbgiw9ZDHyhpmaVuWhxscYaAQ=="
     },
     "node_modules/@types/d3-interpolate": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
-      "integrity": "sha512-jx5leotSeac3jr0RePOH1KdR9rISG91QIE4Q2PYTu4OymLTZfA3SrnURSLzKH48HmXVUru50b8nje4E79oQSQw==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.2.tgz",
+      "integrity": "sha512-zAbCj9lTqW9J9PlF4FwnvEjXZUy75NQqPm7DMHZXuxCFTpuTrdK2NMYGQekf4hlasL78fCYOLu4EE3/tXElwow==",
       "dependencies": {
         "@types/d3-color": "*"
       }
@@ -9585,9 +9585,9 @@
       "integrity": "sha512-D49z4DyzTKXM0sGKVqiTDTYr+DHg/uxsiWDAkNrwXYuiZVd9o9wXZIo+YsHkifOiyBkmSWlEngHCQme54/hnHw=="
     },
     "node_modules/@types/d3-quadtree": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@types/d3-quadtree/-/d3-quadtree-3.0.2.tgz",
-      "integrity": "sha512-QNcK8Jguvc8lU+4OfeNx+qnVy7c0VrDJ+CCVFS9srBo2GL9Y18CnIxBdTF3v38flrGy5s1YggcoAiu6s4fLQIw=="
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-quadtree/-/d3-quadtree-3.0.3.tgz",
+      "integrity": "sha512-GDWaR+rGEk4ToLQSGugYnoh9AYYblsg/8kmdpa1KAJMwcdZ0v8rwgnldURxI5UrzxPlCPzF7by/Tjmv+Jn21Dg=="
     },
     "node_modules/@types/d3-random": {
       "version": "3.0.1",
@@ -9595,9 +9595,9 @@
       "integrity": "sha512-IIE6YTekGczpLYo/HehAy3JGF1ty7+usI97LqraNa8IiDur+L44d0VOjAvFQWJVdZOJHukUJw+ZdZBlgeUsHOQ=="
     },
     "node_modules/@types/d3-scale": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.4.tgz",
-      "integrity": "sha512-eq1ZeTj0yr72L8MQk6N6heP603ubnywSDRfNpi5enouR112HzGLS6RIvExCzZTraFF4HdzNpJMwA/zGiMoHUUw==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.5.tgz",
+      "integrity": "sha512-w/C++3W394MHzcLKO2kdsIn5KKNTOqeQVzyPSGPLzQbkPw/jpeaGtSRlakcKevGgGsjJxGsbqS0fPrVFDbHrDA==",
       "dependencies": {
         "@types/d3-time": "*"
       }
@@ -9608,27 +9608,27 @@
       "integrity": "sha512-dsoJGEIShosKVRBZB0Vo3C8nqSDqVGujJU6tPznsBJxNJNwMF8utmS83nvCBKQYPpjCzaaHcrf66iTRpZosLPw=="
     },
     "node_modules/@types/d3-selection": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.6.tgz",
-      "integrity": "sha512-2ACr96USZVjXR9KMD9IWi1Epo4rSDKnUtYn6q2SPhYxykvXTw9vR77lkFNruXVg4i1tzQtBxeDMx0oNvJWbF1w=="
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.7.tgz",
+      "integrity": "sha512-qoj2O7KjfqCobmtFOth8FMvjwMVPUAAmn6xiUbLl1ld7vQCPgffvyV5BBcEFfqWdilAUm+3zciU/3P3vZrUMlg=="
     },
     "node_modules/@types/d3-shape": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.2.tgz",
-      "integrity": "sha512-NN4CXr3qeOUNyK5WasVUV8NCSAx/CRVcwcb0BuuS1PiTqwIm6ABi1SyasLZ/vsVCFDArF+W4QiGzSry1eKYQ7w==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.3.tgz",
+      "integrity": "sha512-cHMdIq+rhF5IVwAV7t61pcEXfEHsEsrbBUPkFGBwTXuxtTAkBBrnrNA8++6OWm3jwVsXoZYQM8NEekg6CPJ3zw==",
       "dependencies": {
         "@types/d3-path": "*"
       }
     },
     "node_modules/@types/d3-time": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.0.tgz",
-      "integrity": "sha512-sZLCdHvBUcNby1cB6Fd3ZBrABbjz3v1Vm90nysCQ6Vt7vd6e/h9Lt7SiJUoEX0l4Dzc7P5llKyhqSi1ycSf1Hg=="
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.1.tgz",
+      "integrity": "sha512-5j/AnefKAhCw4HpITmLDTPlf4vhi8o/dES+zbegfPb7LaGfNyqkLxBR6E+4yvTAgnJLmhe80EXFMzUs38fw4oA=="
     },
     "node_modules/@types/d3-time-format": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-4.0.0.tgz",
-      "integrity": "sha512-yjfBUe6DJBsDin2BMIulhSHmr5qNR5Pxs17+oW4DoVPyVIXZ+m6bs7j1UVKP08Emv6jRmYrYqxYzO63mQxy1rw=="
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-4.0.1.tgz",
+      "integrity": "sha512-Br6EFeu9B1Zrem7KaYbr800xCmEDyq8uE60kEU8rWhC/XpFYX6ocGMZuRJDQfFCq6SyakQxNHFqIfJbFLf4x6Q=="
     },
     "node_modules/@types/d3-timer": {
       "version": "3.0.0",
@@ -9636,17 +9636,17 @@
       "integrity": "sha512-HNB/9GHqu7Fo8AQiugyJbv6ZxYz58wef0esl4Mv828w1ZKpAshw/uFWVDUcIB9KKFeFKoxS3cHY07FFgtTRZ1g=="
     },
     "node_modules/@types/d3-transition": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-3.0.4.tgz",
-      "integrity": "sha512-512a4uCOjUzsebydItSXsHrPeQblCVk8IKjqCUmrlvBWkkVh3donTTxmURDo1YPwIVDh5YVwCAO6gR4sgimCPQ==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-3.0.5.tgz",
+      "integrity": "sha512-dcfjP6prFxj3ziFOJrnt4W2P0oXNj/sGxsJXH8286sHtVZ4qWGbjuZj+RRCYx4YZ4C0izpeE8OqXVCtoWEtzYg==",
       "dependencies": {
         "@types/d3-selection": "*"
       }
     },
     "node_modules/@types/d3-zoom": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-3.0.4.tgz",
-      "integrity": "sha512-cqkuY1ah9ZQre2POqjSLcM8g40UVya/qwEUrNYP2/rCVljbmqKCVcv+ebvwhlI5azIbSEL7m+os6n+WlYA43aA==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-3.0.5.tgz",
+      "integrity": "sha512-mIefdTLtxuWUWTbBupCUXPAXVPmi8/Uwrq41gQpRh0rD25GMU1ku+oTELqNY2NuuiI0F3wXC5e1liBQi7YS7XQ==",
       "dependencies": {
         "@types/d3-interpolate": "*",
         "@types/d3-selection": "*"
@@ -26433,16 +26433,16 @@
       }
     },
     "node_modules/reactflow": {
-      "version": "11.8.3",
-      "resolved": "https://registry.npmjs.org/reactflow/-/reactflow-11.8.3.tgz",
-      "integrity": "sha512-wuVxJOFqi1vhA4WAEJLK0JWx2TsTiWpxTXTRp/wvpqKInQgQcB49I2QNyNYsKJCQ6jjXektS7H+LXoaVK/pG4A==",
+      "version": "11.9.4",
+      "resolved": "https://registry.npmjs.org/reactflow/-/reactflow-11.9.4.tgz",
+      "integrity": "sha512-IHAKBkJngNvU9y1vZ5Nw9rvA3Z+zc9geTgQQIi9qq9Y9knGLlDDr9KfsjbFMew9AycAAgVg8TvBEakF4IT5lqg==",
       "dependencies": {
-        "@reactflow/background": "11.2.8",
-        "@reactflow/controls": "11.1.19",
-        "@reactflow/core": "11.8.3",
-        "@reactflow/minimap": "11.6.3",
-        "@reactflow/node-resizer": "2.1.5",
-        "@reactflow/node-toolbar": "1.2.7"
+        "@reactflow/background": "11.3.4",
+        "@reactflow/controls": "11.2.4",
+        "@reactflow/core": "11.9.4",
+        "@reactflow/minimap": "11.7.4",
+        "@reactflow/node-resizer": "2.2.4",
+        "@reactflow/node-toolbar": "1.3.4"
       },
       "peerDependencies": {
         "react": ">=17",
@@ -31662,7 +31662,7 @@
         "@hitachivantara/uikit-react-icons": "^5.6.8",
         "@hitachivantara/uikit-styles": "^5.13.0",
         "lodash": "^4.17.21",
-        "reactflow": "^11.8.3",
+        "reactflow": "^11.9.4",
         "uid": "^2.0.2",
         "usehooks-ts": "^2.9.1",
         "zustand": "^4.4.1"

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "react-dom": "^18.2.0",
     "react-google-charts": "^4.0.0",
     "react-leaflet": "^4.2.1",
-    "reactflow": "^11.8.3",
+    "reactflow": "^11.9.4",
     "remark-gfm": "^3.0.1",
     "storybook": "^7.4.1",
     "storybook-a11y-report": "^0.0.20",

--- a/packages/lab/package.json
+++ b/packages/lab/package.json
@@ -47,7 +47,7 @@
     "@hitachivantara/uikit-react-icons": "^5.6.8",
     "@hitachivantara/uikit-styles": "^5.13.0",
     "lodash": "^4.17.21",
-    "reactflow": "^11.8.3",
+    "reactflow": "^11.9.4",
     "uid": "^2.0.2",
     "usehooks-ts": "^2.9.1",
     "zustand": "^4.4.1"

--- a/packages/lab/src/components/Flow/DroppableFlow.tsx
+++ b/packages/lab/src/components/Flow/DroppableFlow.tsx
@@ -130,23 +130,34 @@ export const HvDroppableFlow = ({
       if (event.over && event.over.id === elementId) {
         const type = event.active.id.toString();
 
-        // Converts the coordinates to the react flow coordinate system
-        const position = reactFlowInstance.project({
-          x: (event.active.data.current?.hvFlow?.x || 0) - event.over.rect.left,
-          y: (event.active.data.current?.hvFlow?.y || 0) - event.over.rect.top,
-        });
+        // Only known node types can be dropped in the canvas
+        if (nodeTypes?.[type]) {
+          // Converts the coordinates to the react flow coordinate system
+          const position = reactFlowInstance.project({
+            x:
+              (event.active.data.current?.hvFlow?.x || 0) -
+              event.over.rect.left,
+            y:
+              (event.active.data.current?.hvFlow?.y || 0) - event.over.rect.top,
+          });
 
-        const newNode: Node = {
-          id: uid(),
-          position,
-          data: {},
-          type,
-        };
+          const newNode: Node = {
+            id: uid(),
+            position,
+            data: {},
+            type,
+          };
 
-        setNodes((nds) => nds.concat(newNode));
+          setNodes((nds) => nds.concat(newNode));
+        } else {
+          // eslint-disable-next-line no-console
+          console.error(
+            `Could not add node to the flow because of unknown type ${type}. Use nodeTypes to define all the node types.`
+          );
+        }
       }
     },
-    [elementId, reactFlowInstance, setNodes]
+    [elementId, nodeTypes, reactFlowInstance]
   );
 
   useDndMonitor({

--- a/packages/lab/src/components/Flow/DroppableFlow.tsx
+++ b/packages/lab/src/components/Flow/DroppableFlow.tsx
@@ -128,10 +128,10 @@ export const HvDroppableFlow = ({
   const handleDragEnd = useCallback(
     (event: DragEndEvent) => {
       if (event.over && event.over.id === elementId) {
-        const type = event.active.id.toString();
+        const type = event.active.data.current?.hvFlow?.type;
 
         // Only known node types can be dropped in the canvas
-        if (nodeTypes?.[type]) {
+        if (type && nodeTypes?.[type]) {
           // Converts the coordinates to the react flow coordinate system
           const position = reactFlowInstance.project({
             x:

--- a/packages/lab/src/components/Flow/DroppableFlow.tsx
+++ b/packages/lab/src/components/Flow/DroppableFlow.tsx
@@ -30,8 +30,8 @@ export { staticClasses as flowClasses };
 export type HvFlowClasses = ExtractNames<typeof useClasses>;
 
 export interface HvDroppableFlowProps<
-  NodeData = any,
-  NodeType extends string | undefined = string | undefined
+  NodeType extends string | undefined = string | undefined,
+  NodeData = any
 > extends Omit<ReactFlowProps, "nodes" | "edges" | "nodeTypes"> {
   /** Flow content: background, controls, and minimap. */
   children?: React.ReactNode;

--- a/packages/lab/src/components/Flow/Flow.tsx
+++ b/packages/lab/src/components/Flow/Flow.tsx
@@ -19,10 +19,10 @@ import { HvFlowProvider } from "./FlowContext";
 import { HvDroppableFlow, HvDroppableFlowProps } from "./DroppableFlow";
 
 export interface HvFlowProps<
-  NodeData = any,
+  NodeGroups extends keyof any = string,
   NodeType extends string | undefined = string | undefined,
-  NodeGroups extends keyof any = string
-> extends HvDroppableFlowProps<NodeData, NodeType> {
+  NodeData = any
+> extends HvDroppableFlowProps<NodeType, NodeData> {
   /** Flow nodes groups. */
   nodeGroups?: HvFlowNodeGroups<NodeGroups>;
   /** Flow nodes types. */

--- a/packages/lab/src/components/Flow/Flow.tsx
+++ b/packages/lab/src/components/Flow/Flow.tsx
@@ -1,9 +1,6 @@
-import { useState } from "react";
-
 import {
   DndContext,
   DndContextProps,
-  DragOverlay,
   KeyboardSensor,
   PointerSensor,
   useSensor,
@@ -20,7 +17,6 @@ import {
 } from "./types";
 import { HvFlowProvider } from "./FlowContext";
 import { HvDroppableFlow, HvDroppableFlowProps } from "./DroppableFlow";
-import { HvFlowSidebarGroupItem } from "./Sidebar/SidebarGroup/SidebarGroupItem";
 
 export interface HvFlowProps<
   NodeData = any,
@@ -59,22 +55,10 @@ export const HvFlow = ({
   dndContextProps,
   ...others
 }: HvFlowProps) => {
-  const [draggingLabel, setDraggingLabel] = useState(undefined);
-
   const sensors = useSensors(
     useSensor(PointerSensor),
     useSensor(KeyboardSensor)
   );
-
-  const handleDragStart: DndContextProps["onDragStart"] = (event) => {
-    if (event.active.data.current?.hvFlow) {
-      setDraggingLabel(event.active.data.current.hvFlow?.label);
-    }
-  };
-
-  const handleDragEnd: DndContextProps["onDragEnd"] = () => {
-    setDraggingLabel(undefined);
-  };
 
   // We're wrapping the main Flow component with the ReactFlowProvider to access the react flow instance.
   // HvFlowContext is our custom internal context.
@@ -86,19 +70,12 @@ export const HvFlow = ({
         defaultActions={defaultActions}
       >
         <DndContext
-          onDragStart={handleDragStart}
-          onDragEnd={handleDragEnd}
           sensors={sensors}
           modifiers={[restrictToWindowEdges]}
           {...dndContextProps}
         >
           <HvDroppableFlow {...others} />
           {sidebar}
-          <DragOverlay modifiers={[restrictToWindowEdges]}>
-            {draggingLabel ? (
-              <HvFlowSidebarGroupItem label={draggingLabel} isDragging />
-            ) : null}
-          </DragOverlay>
         </DndContext>
       </HvFlowProvider>
     </ReactFlowProvider>

--- a/packages/lab/src/components/Flow/Node/Node.tsx
+++ b/packages/lab/src/components/Flow/Node/Node.tsx
@@ -1,3 +1,14 @@
+import { isValidElement, useCallback, useEffect, useState } from "react";
+
+import {
+  Handle,
+  NodeProps,
+  NodeToolbar,
+  Position,
+  useReactFlow,
+  useStore,
+} from "reactflow";
+
 import {
   ExtractNames,
   HvActionGeneric,
@@ -10,23 +21,9 @@ import {
 } from "@hitachivantara/uikit-react-core";
 import { Down, Info, Up } from "@hitachivantara/uikit-react-icons";
 import { getColor, theme } from "@hitachivantara/uikit-styles";
-import { isValidElement, useCallback, useEffect, useState } from "react";
-import {
-  Handle,
-  NodeProps,
-  NodeToolbar,
-  Position,
-  useReactFlow,
-  useStore,
-} from "reactflow";
-import { useFlowContext } from "../FlowContext/FlowContext";
 
-import {
-  HvFlowDefaultAction,
-  HvFlowNodeInput,
-  HvFlowNodeOutput,
-  HvFlowNodeParam,
-} from "../types";
+import { useFlowContext } from "../FlowContext/FlowContext";
+import { HvFlowDefaultAction, HvFlowNodeParam } from "../types";
 import { staticClasses, useClasses } from "./Node.styles";
 import ParamRenderer from "./Parameters/ParamRenderer";
 
@@ -39,10 +36,6 @@ export interface HvFlowNodeProps extends Omit<HvBaseProps, "id">, NodeProps {
   description: string;
   /** Node expanded */
   expanded?: boolean;
-  /** Node inputs */
-  inputs?: HvFlowNodeInput[];
-  /** Node outputs */
-  outputs?: HvFlowNodeOutput[];
   /** Node parameters */
   params?: HvFlowNodeParam[];
   /** Node actions */

--- a/packages/lab/src/components/Flow/Sidebar/SidebarGroup/SidebarGroup.tsx
+++ b/packages/lab/src/components/Flow/Sidebar/SidebarGroup/SidebarGroup.tsx
@@ -22,7 +22,7 @@ export { staticClasses as flowSidebarGroupClasses };
 export type HvFlowSidebarGroupClasses = ExtractNames<typeof useClasses>;
 
 export type HvFlowSidebarGroupNodes = {
-  id: string;
+  type: string;
   label: string;
 }[];
 
@@ -94,7 +94,7 @@ export const HvFlowSidebarGroup = ({
         <div className={classes.itemsContainer}>
           {nodes.map((obj) => (
             <HvFlowDraggableSidebarGroupItem
-              key={obj.id}
+              key={obj.type}
               {...itemProps}
               {...obj}
             />

--- a/packages/lab/src/components/Flow/Sidebar/SidebarGroup/SidebarGroupItem/DraggableSidebarGroupItem.tsx
+++ b/packages/lab/src/components/Flow/Sidebar/SidebarGroup/SidebarGroupItem/DraggableSidebarGroupItem.tsx
@@ -4,6 +4,8 @@ import { useForkRef } from "@mui/material";
 
 import { useDraggable } from "@dnd-kit/core";
 
+import { useUniqueId } from "@hitachivantara/uikit-react-core";
+
 import {
   HvFlowSidebarGroupItem,
   HvFlowSidebarGroupItemProps,
@@ -11,22 +13,27 @@ import {
 
 export interface HvFlowDraggableSidebarGroupItemProps
   extends HvFlowSidebarGroupItemProps {
-  /** Item id: the item type. */
-  id: string;
+  /** Item type. */
+  type: string;
 }
 
 export const HvFlowDraggableSidebarGroupItem = ({
-  label,
   id,
+  label,
+  type,
   ...others
 }: HvFlowDraggableSidebarGroupItemProps) => {
   const itemRef = useRef<HTMLElement>(null);
 
+  const elementId = useUniqueId(id, `hvFlowDraggableItem-${type}`);
+
   const { attributes, listeners, setNodeRef, isDragging, transform } =
     useDraggable({
-      id,
+      id: elementId,
       data: {
         hvFlow: {
+          // Needed to know which item is being dragged and dropped
+          type,
           // Needed for the drag overlay: otherwise the item is cut by the drawer because of overflow
           label,
           // Item position: used to position the item when dropped

--- a/packages/lab/src/components/Flow/Sidebar/SidebarGroup/SidebarGroupItem/DraggableSidebarGroupItem.tsx
+++ b/packages/lab/src/components/Flow/Sidebar/SidebarGroup/SidebarGroupItem/DraggableSidebarGroupItem.tsx
@@ -1,6 +1,6 @@
-import { useForkRef } from "@mui/material";
-
 import { useRef } from "react";
+
+import { useForkRef } from "@mui/material";
 
 import { useDraggable } from "@dnd-kit/core";
 

--- a/packages/lab/src/components/Flow/Sidebar/utils.ts
+++ b/packages/lab/src/components/Flow/Sidebar/utils.ts
@@ -15,7 +15,7 @@ export const buildGroups = (
             (accN: HvFlowSidebarGroupNodes, currN) => {
               if (currN[1].meta?.groupId === curr[0]) {
                 accN.push({
-                  id: currN[0],
+                  type: currN[0],
                   label: currN[1].meta?.label,
                 });
               }

--- a/packages/lab/src/components/Flow/hooks/index.ts
+++ b/packages/lab/src/components/Flow/hooks/index.ts
@@ -1,0 +1,1 @@
+export * from "./useFlowNode";

--- a/packages/lab/src/components/Flow/index.ts
+++ b/packages/lab/src/components/Flow/index.ts
@@ -8,3 +8,4 @@ export * from "./Node";
 export type { HvFlowClasses } from "./DroppableFlow";
 export { flowClasses } from "./DroppableFlow";
 export * from "./types";
+export * from "./hooks";

--- a/packages/lab/src/components/Flow/stories/Flow.stories.tsx
+++ b/packages/lab/src/components/Flow/stories/Flow.stories.tsx
@@ -41,6 +41,32 @@ import { Dashboard } from "./Dashboard";
 import { HvFlowDefaultActions } from "../types";
 import { Visualizations as VisualizationsStory } from "./Visualizations/Visualizations";
 
+const meta: Meta<typeof HvFlow> = {
+  title: "Lab/Flow",
+  component: HvFlow,
+  // @ts-expect-error https://github.com/storybookjs/storybook/issues/20782
+  subcomponents: {
+    HvFlowBackground,
+    HvFlowControls,
+    HvFlowMinimap,
+    HvFlowSidebar,
+  } as unknown,
+  parameters: {
+    eyes: {
+      runBefore() {
+        fireEvent.click(
+          screen.getByRole("button", {
+            name: "Add Node",
+          })
+        );
+
+        return waitFor(() => screen.getByText("Search node..."));
+      },
+    },
+  },
+};
+export default meta;
+
 const defaultActions: HvFlowDefaultActions[] = [
   { id: "delete", label: "Delete", icon: <Delete /> },
   { id: "duplicate", label: "Duplicate", icon: <Duplicate /> },
@@ -250,35 +276,8 @@ const initialState = {
   viewport: { x: 50, y: 300, zoom: 0.53 },
 };
 
-const meta: Meta<typeof HvFlow> = {
-  title: "Lab/Flow",
-  component: HvFlow,
-  // @ts-expect-error https://github.com/storybookjs/storybook/issues/20782
-  subcomponents: {
-    HvFlowBackground,
-    HvFlowControls,
-    HvFlowMinimap,
-    HvFlowSidebar,
-  } as unknown,
-  parameters: {
-    eyes: {
-      runBefore() {
-        fireEvent.click(
-          screen.getByRole("button", {
-            name: "Add Node",
-          })
-        );
-
-        return waitFor(() => screen.getByText("Search node..."));
-      },
-    },
-  },
-};
-export default meta;
-
 // Node groups
 type NodeGroups = "assets" | "models" | "insights" | "dashboard";
-
 const nodeGroups = {
   assets: {
     label: "Assets",
@@ -306,6 +305,7 @@ const nodeGroups = {
   },
 } satisfies HvFlowProps<NodeGroups>["nodeGroups"];
 
+// Node types
 const nodeTypes = {
   tron: Tron,
   mlModelPrediction: MLModelPrediction,
@@ -315,25 +315,24 @@ const nodeTypes = {
   table: Table,
   dashboard: Dashboard,
 } satisfies HvFlowProps["nodeTypes"];
-
 type NodeType = keyof typeof nodeTypes;
 
 // Flow
 const nodes = [] satisfies HvFlowProps<NodeGroups, NodeType>["nodes"];
-
 const edges = [] satisfies HvFlowProps<NodeGroups, NodeType>["edges"];
+
+// Styles
+const styles = {
+  root: css({ height: "100vh" }),
+  globalActions: css({ paddingBottom: theme.space.md }),
+  flow: css({
+    height: "calc(100% - 90px)",
+  }),
+};
 
 export const Main: StoryObj<HvFlowProps> = {
   render: () => {
     const [open, setOpen] = useState(false);
-
-    const styles = {
-      root: { height: "100vh" },
-      globalActions: { paddingBottom: theme.space.md },
-      flow: {
-        height: "calc(100% - 90px)",
-      },
-    };
 
     const CustomAction = (
       <div className={css({ display: "flex", flexDirection: "row" })}>
@@ -353,9 +352,9 @@ export const Main: StoryObj<HvFlowProps> = {
     );
 
     return (
-      <div className={css(styles.root)}>
+      <div className={styles.root}>
         <HvGlobalActions
-          className={css(styles.globalActions)}
+          className={styles.globalActions}
           position="relative"
           backButton={
             <HvButton aria-label="Back" icon>
@@ -372,7 +371,7 @@ export const Main: StoryObj<HvFlowProps> = {
             Add Node
           </HvButton>
         </HvGlobalActions>
-        <div className={css(styles.flow)}>
+        <div className={styles.flow}>
           <HvFlow
             nodes={nodes}
             edges={edges}
@@ -418,18 +417,10 @@ export const InitialState: StoryObj<HvFlowProps> = {
   render: () => {
     const [open, setOpen] = useState(false);
 
-    const styles = {
-      root: { height: "100vh" },
-      globalActions: { paddingBottom: theme.space.md },
-      flow: {
-        height: "calc(100% - 90px)",
-      },
-    };
-
     return (
-      <div className={css(styles.root)}>
+      <div className={styles.root}>
         <HvGlobalActions
-          className={css(styles.globalActions)}
+          className={styles.globalActions}
           position="relative"
           backButton={
             <HvButton aria-label="Back" icon>
@@ -446,7 +437,7 @@ export const InitialState: StoryObj<HvFlowProps> = {
             Add Node
           </HvButton>
         </HvGlobalActions>
-        <div className={css(styles.flow)}>
+        <div className={styles.flow}>
           <HvFlow
             nodes={initialState.nodes}
             edges={initialState.edges}

--- a/packages/lab/src/components/Flow/stories/Flow.stories.tsx
+++ b/packages/lab/src/components/Flow/stories/Flow.stories.tsx
@@ -304,7 +304,7 @@ const nodeGroups = {
     description: "This is my description for dashboard.",
     icon: <LineChartAlt />,
   },
-} satisfies HvFlowProps<any, NodeType, NodeGroups>["nodeGroups"];
+} satisfies HvFlowProps<NodeGroups>["nodeGroups"];
 
 const nodeTypes = {
   tron: Tron,
@@ -319,9 +319,9 @@ const nodeTypes = {
 type NodeType = keyof typeof nodeTypes;
 
 // Flow
-const nodes = [] satisfies HvFlowProps<any, NodeType, NodeGroups>["nodes"];
+const nodes = [] satisfies HvFlowProps<NodeGroups, NodeType>["nodes"];
 
-const edges = [] satisfies HvFlowProps<any, NodeType, NodeGroups>["edges"];
+const edges = [] satisfies HvFlowProps<NodeGroups, NodeType>["edges"];
 
 export const Main: StoryObj<HvFlowProps> = {
   render: () => {
@@ -466,9 +466,7 @@ export const InitialState: StoryObj<HvFlowProps> = {
               console.log("Flow updated: ", { nodes: nds, edges: eds })
             }
           >
-            {/* <HvFlowBackground /> */}
             <HvFlowControls />
-            {/* <HvFlowMinimap /> */}
           </HvFlow>
         </div>
       </div>

--- a/packages/lab/src/components/Flow/stories/Usage.stories.mdx
+++ b/packages/lab/src/components/Flow/stories/Usage.stories.mdx
@@ -75,7 +75,7 @@ const nodeGroups = {
     description: "This is my description for models.",
     icon: <Favorite />,
   },
-} satisfies HvFlowProps<any, NodeType, NodeGroups>["nodeGroups"];
+} satisfies HvFlowProps<NodeGroups>["nodeGroups"];
 ```
 
 You can then create the sidebar by using the `HvFlowSidebar` component as a prop of the `HvFlow` component:

--- a/packages/lab/src/components/Flow/stories/Visualizations/Visualizations.tsx
+++ b/packages/lab/src/components/Flow/stories/Visualizations/Visualizations.tsx
@@ -33,6 +33,7 @@ const nodeTypes = {
 } satisfies HvFlowProps["nodeTypes"];
 
 type NodeType = keyof typeof nodeTypes;
+
 // Node groups
 type NodeGroups = "inputs" | "transformations" | "visualizations";
 
@@ -55,7 +56,7 @@ const nodeGroups = {
     description: "This is my description for visualizations.",
     icon: <LineChartIcon />,
   },
-} satisfies HvFlowProps<any, NodeType, NodeGroups>["nodeGroups"];
+} satisfies HvFlowProps<NodeGroups>["nodeGroups"];
 
 // Flow
 const nodes = [
@@ -109,7 +110,7 @@ const nodes = [
     position: { x: 980, y: 600 },
     data: {},
   },
-] satisfies HvFlowProps<any, NodeType, NodeGroups>["nodes"];
+] satisfies HvFlowProps<NodeGroups, NodeType>["nodes"];
 
 const edges = [
   {
@@ -140,7 +141,7 @@ const edges = [
     target: "barChartFiltered",
     targetHandle: "0",
   },
-] satisfies HvFlowProps<any, NodeType, NodeGroups>["edges"];
+] satisfies HvFlowProps<NodeGroups, NodeType>["edges"];
 
 const classes = {
   root: css({ height: "100vh" }),


### PR DESCRIPTION
This PR includes several fixes for the flow component:
- `useFlowNode` exported to be used externally by users
- the custom drag overlay for our sidebar was moved to the sidebar component in order to not appear when a custom sidebar is used
- unnecessary props (`outputs` and `inputs`) removed  from the `HvFlowNodeProps`
- when an unknown node type is dragged to the canvas, the node is not added to the flow and an error is thrown
- the node type is no longer set in the draggable item id and was moved to a specific property called `type`: this was leading to errors when different draggable items with the same node type were created

Other updates:
- `reactflow` package upgraded to the latest version
- docs styles deduped
- the order of the flow types was reversed: the most used types are listed first