### PR TITLE
feat(Flow): data added to flow node metadata

### DIFF
--- a/packages/lab/src/components/Flow/DroppableFlow.tsx
+++ b/packages/lab/src/components/Flow/DroppableFlow.tsx
@@ -143,10 +143,13 @@ export const HvDroppableFlow = ({
               (event.active.data.current?.hvFlow?.y || 0) - event.over.rect.top,
           });
 
+          // Node data
+          const data = event.active.data.current?.hvFlow?.data || {};
+
           const newNode: Node = {
             id: uid(),
             position,
-            data: {},
+            data,
             type,
           };
 

--- a/packages/lab/src/components/Flow/Flow.tsx
+++ b/packages/lab/src/components/Flow/Flow.tsx
@@ -26,7 +26,7 @@ export interface HvFlowProps<
   /** Flow nodes groups. */
   nodeGroups?: HvFlowNodeGroups<NodeGroups>;
   /** Flow nodes types. */
-  nodeTypes?: HvFlowNodeTypes<NodeGroups>;
+  nodeTypes?: HvFlowNodeTypes<NodeGroups, NodeData>;
   /** Flow sidebar. */
   sidebar?: React.ReactNode;
   /** Flow default actions. */

--- a/packages/lab/src/components/Flow/Sidebar/SidebarGroup/SidebarGroup.tsx
+++ b/packages/lab/src/components/Flow/Sidebar/SidebarGroup/SidebarGroup.tsx
@@ -24,6 +24,7 @@ export type HvFlowSidebarGroupClasses = ExtractNames<typeof useClasses>;
 export type HvFlowSidebarGroupNodes = {
   type: string;
   label: string;
+  data?: unknown;
 }[];
 
 export interface HvFlowSidebarGroupProps extends HvFlowNodeGroup {

--- a/packages/lab/src/components/Flow/Sidebar/SidebarGroup/SidebarGroupItem/DraggableSidebarGroupItem.tsx
+++ b/packages/lab/src/components/Flow/Sidebar/SidebarGroup/SidebarGroupItem/DraggableSidebarGroupItem.tsx
@@ -15,12 +15,15 @@ export interface HvFlowDraggableSidebarGroupItemProps
   extends HvFlowSidebarGroupItemProps {
   /** Item type. */
   type: string;
+  /** Item data. */
+  data?: unknown;
 }
 
 export const HvFlowDraggableSidebarGroupItem = ({
   id,
   label,
   type,
+  data,
   ...others
 }: HvFlowDraggableSidebarGroupItemProps) => {
   const itemRef = useRef<HTMLElement>(null);
@@ -39,6 +42,8 @@ export const HvFlowDraggableSidebarGroupItem = ({
           // Item position: used to position the item when dropped
           x: itemRef.current?.getBoundingClientRect().x,
           y: itemRef.current?.getBoundingClientRect().y,
+          // Data
+          data,
         },
       },
     });

--- a/packages/lab/src/components/Flow/Sidebar/utils.ts
+++ b/packages/lab/src/components/Flow/Sidebar/utils.ts
@@ -17,6 +17,7 @@ export const buildGroups = (
                 accN.push({
                   type: currN[0],
                   label: currN[1].meta?.label,
+                  data: currN[1].meta?.data,
                 });
               }
               return accN;

--- a/packages/lab/src/components/Flow/types/flow.ts
+++ b/packages/lab/src/components/Flow/types/flow.ts
@@ -4,22 +4,32 @@ import { ComponentClass, FunctionComponent } from "react";
 import { NodeProps } from "reactflow";
 
 /** Node types */
-export interface HvFlowNodeFunctionComponent<GroupId extends keyof any = string>
-  extends FunctionComponent<NodeProps> {
+export interface HvFlowNodeFunctionComponent<
+  GroupId extends keyof any = string,
+  NodeData = any
+> extends FunctionComponent<NodeProps> {
   /** Metadata used on the HvFlowSidebar component to group the node */
-  meta?: HvFlowNodeMeta<GroupId>;
+  meta?: HvFlowNodeMeta<GroupId, NodeData>;
 }
-export interface HvFlowNodeComponentClass<GroupId extends keyof any = string>
-  extends ComponentClass<NodeProps> {
+export interface HvFlowNodeComponentClass<
+  GroupId extends keyof any = string,
+  NodeData = any
+> extends ComponentClass<NodeProps> {
   /** Metadata used on the HvFlowSidebar component to group the node */
-  meta?: HvFlowNodeMeta<GroupId>;
+  meta?: HvFlowNodeMeta<GroupId, NodeData>;
 }
-export type HvFlowNodeComponentType<GroupId extends keyof any = string> =
-  | HvFlowNodeComponentClass<GroupId>
-  | HvFlowNodeFunctionComponent<GroupId>;
+export type HvFlowNodeComponentType<
+  GroupId extends keyof any = string,
+  NodeData = any
+> =
+  | HvFlowNodeComponentClass<GroupId, NodeData>
+  | HvFlowNodeFunctionComponent<GroupId, NodeData>;
 
-export type HvFlowNodeTypes<GroupId extends keyof any = string> = {
-  [key: string]: HvFlowNodeComponentType<GroupId>;
+export type HvFlowNodeTypes<
+  GroupId extends keyof any = string,
+  NodeData = any
+> = {
+  [key: string]: HvFlowNodeComponentType<GroupId, NodeData>;
 };
 
 /** Node groups */
@@ -34,11 +44,15 @@ export type HvFlowNodeGroups<GroupId extends keyof any = string> = Record<
   HvFlowNodeGroup
 >;
 
-export type HvFlowNodeMeta<GroupId extends keyof any = string> = {
+export type HvFlowNodeMeta<
+  GroupId extends keyof any = string,
+  NodeData = any
+> = {
   label: string;
   groupId: GroupId;
   inputs?: HvFlowNodeInput[];
   outputs?: HvFlowNodeOutput[];
+  data?: NodeData;
 };
 
 export type HvFlowNodeInput = {


### PR DESCRIPTION
In this PR, the `data` prop was added to the `HvFlowNode` metadata. This prop is then used to set the initial node `data` when the node is added to the flow. 