### PR TITLE
ci: test build on PR/Nightly

### DIFF
--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -1,4 +1,4 @@
-name: Static Checks
+name: Checks
 
 on:
   workflow_dispatch:
@@ -8,8 +8,8 @@ env:
   LICENSES_WHITELIST: Apache-2.0\;ISC\;BSD-2-Clause\;BSD-3-Clause\;MIT\;W3C\;Zlib\;CC-BY-4.0
 
 jobs:
-  run-checks:
-    name: Run Checks
+  checks:
+    name: Static Tests
     runs-on: ubuntu-latest
 
     steps:
@@ -29,5 +29,30 @@ jobs:
       - name: Run Typecheck
         run: npm run typecheck
 
+  test:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Install Dependencies
+        uses: ./.github/actions/install-dependencies
+
       - name: Run Test
         run: npm run test
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Install Dependencies
+        uses: ./.github/actions/install-dependencies
+
+      - name: Run Build
+        run: npm run build


### PR DESCRIPTION
- add `npm run build` to our checks
- parallelise Static tests, Unit tests, and Build
  - checks take half as long (~9m > ~5m) 🚀