### PR TITLE
fix(QueryBuilder): export types and default values

### DIFF
--- a/docs/overview/migration/MigrationV5.stories.mdx
+++ b/docs/overview/migration/MigrationV5.stories.mdx
@@ -461,31 +461,44 @@ In order to use them, you'll need to update the necessary imports. Please find a
 
 In v5.x some components and types were renamed as detailed in the table below.
 
-| Type or component | v4.x                   | v5.x                       |
-| ----------------- | ---------------------- | -------------------------- |
-| Component         | HvBreadcrumb           | HvBreadCrumb               |
-| Component         | HvImageCarousel        | HvCarousel                 |
-| Type              | NavigationItemProp     | HvHeaderNavigationItemProp |
-| Type              | ListValueProp          | HvListValue                |
-| Type              | ListLabelsProp         | HvListLabels               |
-| Type              | BreadCrumbPathElement  | HvBreadCrumbPathElement    |
-| Type              | HvActionContainerProps | HvActionBarProps           |
-| Type              | ActionGeneric          | HvActionGeneric            |
-| Type              | FileUploaderProps      | HvFileUploaderProps        |
-| Type              | FileUploaderLabelsProp | HvFileUploaderLabels       |
-| Type              | FilesAddedEvent        | HvFilesAddedEvent          |
-| Type              | FilesRemovedEvent      | HvFilesRemovedEvent        |
-| Type              | File                   | HvFileData                 |
-| Type              | FileProps              | HvFileProps                |
-| Type              | PaginationLabelsProp   | HvPaginationLabels         |
-| Type              | SimpleGridProps        | HvSimpleGridProps          |
-| Type              | StackDirection         | HvStackDirection           |
-| Type              | InputSuggestion        | HvInputSuggestion          |
-| Type              | TagSuggestion          | HvTagSuggestion            |
-| Type              | HvUiKitThemeNames      | HvThemeColorMode           |
-| Type              | KnobProperty           | HvKnobProperty             |
-| Type              | MarkProperty           | HvMarkProperty             |
-| Type              | FilterValue            | HvFilterGroupValue         |
+| Type or component | v4.x                   | v5.x                             |
+| ----------------- | ---------------------- | -------------------------------- |
+| Component         | HvBreadcrumb           | HvBreadCrumb                     |
+| Component         | HvImageCarousel        | HvCarousel                       |
+| Type              | NavigationItemProp     | HvHeaderNavigationItemProp       |
+| Type              | ListValueProp          | HvListValue                      |
+| Type              | ListLabelsProp         | HvListLabels                     |
+| Type              | BreadCrumbPathElement  | HvBreadCrumbPathElement          |
+| Type              | HvActionContainerProps | HvActionBarProps                 |
+| Type              | ActionGeneric          | HvActionGeneric                  |
+| Type              | FileUploaderProps      | HvFileUploaderProps              |
+| Type              | FileUploaderLabelsProp | HvFileUploaderLabels             |
+| Type              | FilesAddedEvent        | HvFilesAddedEvent                |
+| Type              | File                   | HvFileData                       |
+| Type              | FilesRemovedEvent      | HvFilesRemovedEvent              |
+| Type              | FileProps              | HvFileProps                      |
+| Type              | PaginationLabelsProp   | HvPaginationLabels               |
+| Type              | SimpleGridProps        | HvSimpleGridProps                |
+| Type              | StackDirection         | HvStackDirection                 |
+| Type              | InputSuggestion        | HvInputSuggestion                |
+| Type              | TagSuggestion          | HvTagSuggestion                  |
+| Type              | HvUiKitThemeNames      | HvThemeColorMode                 |
+| Type              | KnobProperty           | HvKnobProperty                   |
+| Type              | MarkProperty           | HvMarkProperty                   |
+| Type              | FilterValue            | HvFilterGroupValue               |
+| Default values    | defaultCombinators     | hvQueryBuilderDefaultCombinators |
+| Default values    | defaultLabels          | hvQueryBuilderDefaultLabels      |
+| Default values    | defaultOperators       | hvQueryBuilderDefaultOperators   |
+| Type              | BuilderAttribute       | HvQueryBuilderAttribute          |
+| Type              | NumericRange           | HvQueryBuilderNumericRange       |
+| Type              | DateTimeStrings        | HvQueryBuilderDateTimeStrings    |
+| Type              | DateTimeRange          | HvQueryBuilderDateTimeRange      |
+| Type              | QueryRuleValue         | HvQueryBuilderQueryRuleValue     |
+| Type              | Query                  | HvQueryBuilderQuery              |
+| Type              | QueryRule              | HvQueryBuilderQueryRule          |
+| Type              | QueryCombinator        | HvQueryBuilderQueryCombinator    |
+| Type              | QueryOperator          | HvQueryBuilderQueryOperator      |
+| Type              | Labels                 | HvQueryBuilderLabels             |
 
 ## Colors <a id="colors" />
 
@@ -790,4 +803,4 @@ this prop was deprecated by the underlining component from material ui and you s
 ### Query Builder <a id="query-builder" />
 
 - All of the types exported from this component now have the `HvQueryBuilder` prefix. (e.g. the type: `Attribute` is now `HvQueryBuilderAttribute`).
-- The default values from this component have also change to have a `hvQueryBuilder` prefix. (e.g. `defaultLabels` is now `hvQuerybuilderDefaultLabels`)
+- The default values from this component have also changed to have a `hvQueryBuilder` prefix. (e.g. `defaultLabels` is now `hvQuerybuilderDefaultLabels`)

--- a/docs/overview/migration/MigrationV5.stories.mdx
+++ b/docs/overview/migration/MigrationV5.stories.mdx
@@ -47,6 +47,7 @@ Here's what there is to know about this migration:
   - [Time Picker](#time-picker)
   - [Table Renderer - Expand Column](#table-renderer-expand-column)
   - [Drawer](#drawer)
+  - [Query Builder](#query-builder)
 
 ## React packages <a id="react-packages" />
 
@@ -785,3 +786,8 @@ this prop was deprecated by the underlining component from material ui and you s
 - The deprecated props `hours`, `minutes`, and `seconds` were removed.
   - Users should now use either `defaultValue` or `value` to set the time, in an uncontrolled or controlled way respectively (which follows the `HvTimePickerValue` type).
 - The `HvTimePickerValue` no longer has the `period` property, as it uses the 24-hour format for consistency
+
+### Query Builder <a id="query-builder" />
+
+- All of the types exported from this component now have the `HvQueryBuilder` prefix. (e.g. the type: `Attribute` is now `HvQueryBuilderAttribute`).
+- The default values from this component have also change to have a `hvQueryBuilder` prefix. (e.g. `defaultLabels` is now `hvQuerybuilderDefaultLabels`)

--- a/packages/core/src/components/QueryBuilder/Context.tsx
+++ b/packages/core/src/components/QueryBuilder/Context.tsx
@@ -3,7 +3,7 @@ import {
   HvQueryBuilderAskAction,
   HvQueryBuilderAttribute,
   HvQueryBuilderQueryAction,
-  QueryBuilderLabels,
+  HvQueryBuilderLabels,
   HvQueryBuilderQueryCombinator,
   HvQueryBuilderQueryOperator,
 } from "./types";
@@ -320,7 +320,7 @@ interface QueryBuilderContextValue {
   operators: Record<string, HvQueryBuilderQueryOperator[]>;
   combinators: HvQueryBuilderQueryCombinator[];
   maxDepth: number;
-  labels: QueryBuilderLabels;
+  labels: HvQueryBuilderLabels;
   initialTouched: boolean;
   readOnly: boolean;
 }

--- a/packages/core/src/components/QueryBuilder/Context.tsx
+++ b/packages/core/src/components/QueryBuilder/Context.tsx
@@ -1,11 +1,11 @@
 import { createContext } from "react";
 import {
-  AskAction,
-  Attribute,
-  QueryAction,
+  HvQueryBuilderAskAction,
+  HvQueryBuilderAttribute,
+  HvQueryBuilderQueryAction,
   QueryBuilderLabels,
-  QueryCombinator,
-  QueryOperator,
+  HvQueryBuilderQueryCombinator,
+  HvQueryBuilderQueryOperator,
 } from "./types";
 
 export const defaultOperators = {
@@ -311,12 +311,14 @@ export const defaultLabels = {
 };
 
 interface QueryBuilderContextValue {
-  dispatchAction: React.Dispatch<QueryAction>;
-  askAction: React.Dispatch<React.SetStateAction<AskAction | undefined>>;
+  dispatchAction: React.Dispatch<HvQueryBuilderQueryAction>;
+  askAction: React.Dispatch<
+    React.SetStateAction<HvQueryBuilderAskAction | undefined>
+  >;
   selectLocation?: React.Dispatch<unknown>;
-  attributes?: Record<string, Attribute>;
-  operators: Record<string, QueryOperator[]>;
-  combinators: QueryCombinator[];
+  attributes?: Record<string, HvQueryBuilderAttribute>;
+  operators: Record<string, HvQueryBuilderQueryOperator[]>;
+  combinators: HvQueryBuilderQueryCombinator[];
   maxDepth: number;
   labels: QueryBuilderLabels;
   initialTouched: boolean;

--- a/packages/core/src/components/QueryBuilder/Context.tsx
+++ b/packages/core/src/components/QueryBuilder/Context.tsx
@@ -1,8 +1,8 @@
 import { createContext } from "react";
 import {
-  HvQueryBuilderAskAction,
+  AskAction,
   HvQueryBuilderAttribute,
-  HvQueryBuilderQueryAction,
+  QueryAction,
   HvQueryBuilderLabels,
   HvQueryBuilderQueryCombinator,
   HvQueryBuilderQueryOperator,
@@ -311,10 +311,8 @@ export const defaultLabels = {
 };
 
 interface QueryBuilderContextValue {
-  dispatchAction: React.Dispatch<HvQueryBuilderQueryAction>;
-  askAction: React.Dispatch<
-    React.SetStateAction<HvQueryBuilderAskAction | undefined>
-  >;
+  dispatchAction: React.Dispatch<QueryAction>;
+  askAction: React.Dispatch<React.SetStateAction<AskAction | undefined>>;
   selectLocation?: React.Dispatch<unknown>;
   attributes?: Record<string, HvQueryBuilderAttribute>;
   operators: Record<string, HvQueryBuilderQueryOperator[]>;

--- a/packages/core/src/components/QueryBuilder/QueryBuilder.stories.tsx
+++ b/packages/core/src/components/QueryBuilder/QueryBuilder.stories.tsx
@@ -1,10 +1,10 @@
 import {
   HvQueryBuilder,
   HvQueryBuilderProps,
+  hvQueryBuilderDefaultOperators,
 } from "@hitachivantara/uikit-react-core";
 import { Meta, StoryObj } from "@storybook/react";
 import { useMemo, useState } from "react";
-import { defaultOperators } from "./Context";
 
 import queryToMongo from "./queryToMongo";
 
@@ -43,8 +43,8 @@ export const Main: StoryObj<HvQueryBuilderProps> = {
       },
     },
     operators: {
-      ...defaultOperators,
-      customType: [...defaultOperators.text],
+      ...hvQueryBuilderDefaultOperators,
+      customType: [...hvQueryBuilderDefaultOperators.text],
     },
     readOnly: false,
   },

--- a/packages/core/src/components/QueryBuilder/QueryBuilder.tsx
+++ b/packages/core/src/components/QueryBuilder/QueryBuilder.tsx
@@ -17,7 +17,7 @@ import { ConfirmationDialog } from "./ConfirmationDialog";
 import { QueryBuilderContext } from "./Context";
 import { RuleGroup } from "./RuleGroup";
 import {
-  HvQueryBuilderAskAction,
+  AskAction,
   HvQueryBuilderAttribute,
   HvQueryBuilderQuery,
   HvQueryBuilderLabels,
@@ -48,7 +48,7 @@ export interface HvQueryBuilderProps {
   query?: HvQueryBuilderQuery;
   /**
    * Callback fired when query changes.
-   * @param {HvQueryBuilderQuery} value - the query representation.
+   * @param  value - the query representation.
    */
   onChange?: (value: HvQueryBuilderQuery) => void;
   /**
@@ -88,7 +88,7 @@ export const HvQueryBuilder = (props: HvQueryBuilderProps) => {
   } = useDefaultProps("HvQueryBuilder", props);
   const { classes } = useClasses(classesProp);
 
-  const [pendingAction, askAction] = useState<HvQueryBuilderAskAction>();
+  const [pendingAction, askAction] = useState<AskAction>();
   const currentAttributes = useRef<
     Record<string, HvQueryBuilderAttribute> | undefined | null
   >(null);

--- a/packages/core/src/components/QueryBuilder/QueryBuilder.tsx
+++ b/packages/core/src/components/QueryBuilder/QueryBuilder.tsx
@@ -17,12 +17,12 @@ import { ConfirmationDialog } from "./ConfirmationDialog";
 import { QueryBuilderContext } from "./Context";
 import { RuleGroup } from "./RuleGroup";
 import {
-  AskAction,
-  Attribute,
-  Query,
-  QueryBuilderLabels,
-  QueryCombinator,
-  QueryOperator,
+  HvQueryBuilderAskAction,
+  HvQueryBuilderAttribute,
+  HvQueryBuilderQuery,
+  HvQueryBuilderLabels,
+  HvQueryBuilderQueryCombinator,
+  HvQueryBuilderQueryOperator,
 } from "./types";
 import { clearNodeIds, emptyGroup } from "./utils";
 import reducer from "./utils/reducer";
@@ -33,24 +33,24 @@ export { staticClasses as queryBuilderClasses };
 export type HvQueryBuilderClasses = ExtractNames<typeof useClasses>;
 
 export interface HvQueryBuilderProps {
-  attributes?: Record<string, Attribute>;
+  attributes?: Record<string, HvQueryBuilderAttribute>;
   /**
    * The query rules operators by attribute type and combinator.
    */
-  operators?: Record<string, QueryOperator[]>;
+  operators?: Record<string, HvQueryBuilderQueryOperator[]>;
   /**
    * The query combinators operands.
    */
-  combinators?: QueryCombinator[];
+  combinators?: HvQueryBuilderQueryCombinator[];
   /**
    * The initial query representation.
    */
-  query?: Query;
+  query?: HvQueryBuilderQuery;
   /**
    * Callback fired when query changes.
-   * @param {Query} value - the query representation.
+   * @param {HvQueryBuilderQuery} value - the query representation.
    */
-  onChange?: (value: Query) => void;
+  onChange?: (value: HvQueryBuilderQuery) => void;
   /**
    * Max depth of nested query groups.
    */
@@ -58,7 +58,7 @@ export interface HvQueryBuilderProps {
   /**
    * An object containing all the labels.
    */
-  labels?: QueryBuilderLabels;
+  labels?: HvQueryBuilderLabels;
   /**
    * A flag indicating if the Query Builder is in read only mode.
    */
@@ -88,9 +88,9 @@ export const HvQueryBuilder = (props: HvQueryBuilderProps) => {
   } = useDefaultProps("HvQueryBuilder", props);
   const { classes } = useClasses(classesProp);
 
-  const [pendingAction, askAction] = useState<AskAction>();
+  const [pendingAction, askAction] = useState<HvQueryBuilderAskAction>();
   const currentAttributes = useRef<
-    Record<string, Attribute> | undefined | null
+    Record<string, HvQueryBuilderAttribute> | undefined | null
   >(null);
   const [state, dispatchAction] = useReducer(
     reducer,

--- a/packages/core/src/components/QueryBuilder/index.ts
+++ b/packages/core/src/components/QueryBuilder/index.ts
@@ -1,1 +1,4 @@
 export * from "./QueryBuilder";
+export * from "./ConfirmationDialog";
+export * from "./Rule";
+export * from "./RuleGroup";

--- a/packages/core/src/components/QueryBuilder/index.ts
+++ b/packages/core/src/components/QueryBuilder/index.ts
@@ -1,7 +1,7 @@
 export * from "./QueryBuilder";
 export {
-  defaultCombinators as hvQuerybuilderDefaultCombinators,
-  defaultLabels as hvQuerybuilderDefaultLabels,
-  defaultOperators as hvQuerybuilderDefaultOperators,
+  defaultCombinators as hvQueryBuilderDefaultCombinators,
+  defaultLabels as hvQueryBuilderDefaultLabels,
+  defaultOperators as hvQueryBuilderDefaultOperators,
 } from "./Context";
 export * from "./types";

--- a/packages/core/src/components/QueryBuilder/index.ts
+++ b/packages/core/src/components/QueryBuilder/index.ts
@@ -4,4 +4,15 @@ export {
   defaultLabels as hvQueryBuilderDefaultLabels,
   defaultOperators as hvQueryBuilderDefaultOperators,
 } from "./Context";
-export * from "./types";
+export type {
+  HvQueryBuilderAttribute,
+  HvQueryBuilderNumericRange,
+  HvQueryBuilderDateTimeStrings,
+  HvQueryBuilderDateTimeRange,
+  HvQueryBuilderQueryRuleValue,
+  HvQueryBuilderQuery,
+  HvQueryBuilderQueryRule,
+  HvQueryBuilderQueryCombinator,
+  HvQueryBuilderQueryOperator,
+  HvQueryBuilderLabels,
+} from "./types";

--- a/packages/core/src/components/QueryBuilder/index.ts
+++ b/packages/core/src/components/QueryBuilder/index.ts
@@ -1,4 +1,7 @@
 export * from "./QueryBuilder";
-export * from "./ConfirmationDialog";
-export * from "./Rule";
-export * from "./RuleGroup";
+export {
+  defaultCombinators as hvQuerybuilderDefaultCombinators,
+  defaultLabels as hvQuerybuilderDefaultLabels,
+  defaultOperators as hvQuerybuilderDefaultOperators,
+} from "./Context";
+export * from "./types";

--- a/packages/core/src/components/QueryBuilder/types.ts
+++ b/packages/core/src/components/QueryBuilder/types.ts
@@ -53,7 +53,7 @@ export interface HvQueryBuilderQueryOperator {
   combinators: string[];
 }
 
-interface HvQueryBuilderDialogLabels {
+interface DialogLabels {
   dialogTitle: string;
   dialogMessage: string;
   dialogConfirm: string;
@@ -61,28 +61,28 @@ interface HvQueryBuilderDialogLabels {
   dialogCloseTooltip: string;
 }
 
-interface HvQueryBuilderResetQueryAction {
+interface ResetQueryAction {
   type: "reset-query";
 }
 
-interface HvQueryBuilderResetGroupAction {
+interface ResetGroupAction {
   type: "reset-group";
   id?: number;
 }
 
-interface HvQueryBuilderAddRemoveAction {
+interface AddRemoveAction {
   type: "add-rule" | "add-group" | "remove-node";
   id?: number;
 }
 
-interface HvQueryBuilderSetCombinatorAction {
+interface SetCombinatorAction {
   type: "set-combinator";
   id?: number;
 
   combinator: string;
 }
 
-interface HvQueryBuilderSetAttributeAction {
+interface SetAttributeAction {
   type: "set-attribute";
   id?: number;
 
@@ -91,7 +91,7 @@ interface HvQueryBuilderSetAttributeAction {
   value?: HvQueryBuilderQueryRuleValue | null;
 }
 
-interface HvQueryBuilderSetOperatorAction {
+interface SetOperatorAction {
   type: "set-operator";
   id?: number;
 
@@ -99,25 +99,25 @@ interface HvQueryBuilderSetOperatorAction {
   value?: HvQueryBuilderQueryRuleValue | null;
 }
 
-interface HvQueryBuilderSetValueAction {
+interface SetValueAction {
   type: "set-value";
   id?: number;
 
   value: HvQueryBuilderQueryRuleValue | null;
 }
 
-export type HvQueryBuilderQueryAction =
-  | HvQueryBuilderResetQueryAction
-  | HvQueryBuilderResetGroupAction
-  | HvQueryBuilderAddRemoveAction
-  | HvQueryBuilderSetCombinatorAction
-  | HvQueryBuilderSetAttributeAction
-  | HvQueryBuilderSetOperatorAction
-  | HvQueryBuilderSetValueAction;
+export type QueryAction =
+  | ResetQueryAction
+  | ResetGroupAction
+  | AddRemoveAction
+  | SetCombinatorAction
+  | SetAttributeAction
+  | SetOperatorAction
+  | SetValueAction;
 
-export interface HvQueryBuilderAskAction {
-  actions: HvQueryBuilderQueryAction[];
-  dialog: HvQueryBuilderDialogLabels;
+export interface AskAction {
+  actions: QueryAction[];
+  dialog: DialogLabels;
 }
 
 export interface ValueComponentProps {
@@ -131,7 +131,7 @@ export interface HvQueryBuilderLabels {
     delete?: {
       ariaLabel: string;
       tooltip?: string;
-    } & HvQueryBuilderDialogLabels;
+    } & DialogLabels;
     addRule?: {
       label: string;
     };
@@ -208,17 +208,17 @@ export interface HvQueryBuilderLabels {
     delete: {
       ariaLabel: string;
       tooltip?: string;
-    } & HvQueryBuilderDialogLabels;
+    } & DialogLabels;
   };
   group: {
     delete: {
       ariaLabel: string;
       tooltip?: string;
-    } & HvQueryBuilderDialogLabels;
+    } & DialogLabels;
     reset: {
       ariaLabel: string;
       tooltip?: string;
-    } & HvQueryBuilderDialogLabels;
+    } & DialogLabels;
     addRule: {
       label: string;
     };

--- a/packages/core/src/components/QueryBuilder/types.ts
+++ b/packages/core/src/components/QueryBuilder/types.ts
@@ -1,4 +1,4 @@
-export interface Attribute extends Record<string, unknown> {
+export interface HvQueryBuilderAttribute extends Record<string, unknown> {
   id?: string;
   label: string;
   type: string;
@@ -6,54 +6,54 @@ export interface Attribute extends Record<string, unknown> {
   order?: number;
 }
 
-export interface NumericRange {
+export interface HvQueryBuilderNumericRange {
   from: number | string;
   to: number | string;
 }
 
-export interface DateTimeStrings {
+export interface HvQueryBuilderDateTimeStrings {
   date?: string;
   time?: string;
 }
 
-export interface DateTimeRange {
-  start?: DateTimeStrings;
-  end?: DateTimeStrings;
+export interface HvQueryBuilderDateTimeRange {
+  start?: HvQueryBuilderDateTimeStrings;
+  end?: HvQueryBuilderDateTimeStrings;
 }
 
-export type QueryRuleValue =
+export type HvQueryBuilderQueryRuleValue =
   | string
   | number
   | boolean
-  | NumericRange
-  | DateTimeStrings
-  | DateTimeRange;
+  | HvQueryBuilderNumericRange
+  | HvQueryBuilderDateTimeStrings
+  | HvQueryBuilderDateTimeRange;
 
-export interface QueryRule {
+export interface HvQueryBuilderQueryRule {
   id?: number | string;
   attribute?: string;
   operator?: string;
-  value?: QueryRuleValue;
+  value?: HvQueryBuilderQueryRuleValue;
 }
 
-export interface Query {
+export interface HvQueryBuilderQuery {
   id?: number;
   combinator: string;
-  rules: Array<QueryRule>;
+  rules: Array<HvQueryBuilderQueryRule>;
 }
 
-export interface QueryCombinator {
+export interface HvQueryBuilderQueryCombinator {
   operand: string;
   label: string;
 }
 
-export interface QueryOperator {
+export interface HvQueryBuilderQueryOperator {
   operator: string;
   label: string;
   combinators: string[];
 }
 
-interface DialogLabels {
+interface HvQueryBuilderDialogLabels {
   dialogTitle: string;
   dialogMessage: string;
   dialogConfirm: string;
@@ -61,63 +61,63 @@ interface DialogLabels {
   dialogCloseTooltip: string;
 }
 
-interface ResetQueryAction {
+interface HvQueryBuilderResetQueryAction {
   type: "reset-query";
 }
 
-interface ResetGroupAction {
+interface HvQueryBuilderResetGroupAction {
   type: "reset-group";
   id?: number;
 }
 
-interface AddRemoveAction {
+interface HvQueryBuilderAddRemoveAction {
   type: "add-rule" | "add-group" | "remove-node";
   id?: number;
 }
 
-interface SetCombinatorAction {
+interface HvQueryBuilderSetCombinatorAction {
   type: "set-combinator";
   id?: number;
 
   combinator: string;
 }
 
-interface SetAttributeAction {
+interface HvQueryBuilderSetAttributeAction {
   type: "set-attribute";
   id?: number;
 
   attribute?: string | null;
   operator?: string | null;
-  value?: QueryRuleValue | null;
+  value?: HvQueryBuilderQueryRuleValue | null;
 }
 
-interface SetOperatorAction {
+interface HvQueryBuilderSetOperatorAction {
   type: "set-operator";
   id?: number;
 
   operator: string | null;
-  value?: QueryRuleValue | null;
+  value?: HvQueryBuilderQueryRuleValue | null;
 }
 
-interface SetValueAction {
+interface HvQueryBuilderSetValueAction {
   type: "set-value";
   id?: number;
 
-  value: QueryRuleValue | null;
+  value: HvQueryBuilderQueryRuleValue | null;
 }
 
-export type QueryAction =
-  | ResetQueryAction
-  | ResetGroupAction
-  | AddRemoveAction
-  | SetCombinatorAction
-  | SetAttributeAction
-  | SetOperatorAction
-  | SetValueAction;
+export type HvQueryBuilderQueryAction =
+  | HvQueryBuilderResetQueryAction
+  | HvQueryBuilderResetGroupAction
+  | HvQueryBuilderAddRemoveAction
+  | HvQueryBuilderSetCombinatorAction
+  | HvQueryBuilderSetAttributeAction
+  | HvQueryBuilderSetOperatorAction
+  | HvQueryBuilderSetValueAction;
 
-export interface AskAction {
-  actions: QueryAction[];
-  dialog: DialogLabels;
+export interface HvQueryBuilderAskAction {
+  actions: HvQueryBuilderQueryAction[];
+  dialog: HvQueryBuilderDialogLabels;
 }
 
 export interface ValueComponentProps {
@@ -126,12 +126,12 @@ export interface ValueComponentProps {
   value?: unknown;
 }
 
-export interface QueryBuilderLabels {
+export interface HvQueryBuilderLabels {
   query?: {
     delete?: {
       ariaLabel: string;
       tooltip?: string;
-    } & DialogLabels;
+    } & HvQueryBuilderDialogLabels;
     addRule?: {
       label: string;
     };
@@ -208,17 +208,17 @@ export interface QueryBuilderLabels {
     delete: {
       ariaLabel: string;
       tooltip?: string;
-    } & DialogLabels;
+    } & HvQueryBuilderDialogLabels;
   };
   group: {
     delete: {
       ariaLabel: string;
       tooltip?: string;
-    } & DialogLabels;
+    } & HvQueryBuilderDialogLabels;
     reset: {
       ariaLabel: string;
       tooltip?: string;
-    } & DialogLabels;
+    } & HvQueryBuilderDialogLabels;
     addRule: {
       label: string;
     };


### PR DESCRIPTION
Should we add the HV or HVQuerybuilder prefix to there subcomponents?