### PR TITLE
feat(WarningText): align with DS 5.7

### DIFF
--- a/packages/core/src/components/Forms/WarningText/WarningText.styles.tsx
+++ b/packages/core/src/components/Forms/WarningText/WarningText.styles.tsx
@@ -4,16 +4,13 @@ import { createClasses } from "@core/utils/classes";
 
 export const { staticClasses, useClasses } = createClasses("HvWarningText", {
   root: { display: "none" },
-  defaultIcon: { minWidth: "32px" },
+  defaultIcon: { minWidth: "24px", width: "24px", height: "24px" },
   warningText: {
-    color: theme.colors.negative,
+    color: theme.colors.negative_120,
     paddingRight: theme.space.xs,
-    "&:first-of-type": {
-      paddingLeft: theme.space.xs,
-    },
   },
   show: { display: "flex" },
-  topGutter: { paddingTop: 6 },
+  topGutter: { paddingTop: "3px" },
   hideText: {
     // display none or visibility hidden prevents
     // browser to trigger the aria-alert

--- a/packages/core/src/components/Forms/WarningText/WarningText.tsx
+++ b/packages/core/src/components/Forms/WarningText/WarningText.tsx
@@ -67,7 +67,7 @@ export const HvWarningText = (props: HvWarningTextProps) => {
   const showWarning = localVisible && !localDisabled;
   const content = showWarning ? children : "";
   const localAdornment = adornment || (
-    <Fail className={classes.defaultIcon} color="negative" />
+    <Fail iconSize="XS" className={classes.defaultIcon} color="negative" />
   );
 
   return (
@@ -88,6 +88,7 @@ export const HvWarningText = (props: HvWarningTextProps) => {
           [classes.topGutter]: !disableGutter,
           [classes.hideText]: hideText,
         })}
+        variant="caption1"
         role="status"
         aria-live="polite"
         aria-relevant="additions text"

--- a/packages/styles/src/themes/ds3.ts
+++ b/packages/styles/src/themes/ds3.ts
@@ -421,6 +421,18 @@ const ds3 = makeTheme((theme) => ({
         },
       },
     },
+    HvBreadCrumbPage: {
+      classes: {
+        link: {
+          "&:hover": {
+            backgroundColor: theme.colors.atmo3,
+          },
+          "&:focus": {
+            backgroundColor: theme.colors.atmo3,
+          },
+        },
+      },
+    },
     HvBulkActions: {
       classes: {
         root: {
@@ -1312,22 +1324,28 @@ const ds3 = makeTheme((theme) => ({
         },
       },
     },
+    HvWarningText: {
+      classes: {
+        warningText: {
+          ...theme.typography.body,
+          color: theme.colors.negative,
+        },
+        topGutter: { paddingTop: "8px" },
+        defaultIcon: {
+          minWidth: "32px",
+          width: "32px",
+          height: "32px",
+          "& svg": {
+            height: "16px",
+            width: "16px",
+          },
+        },
+      },
+    },
     HvWizardContainer: {
       classes: {
         paper: {
           maxHeight: "calc(100% - (2 * 100px))",
-        },
-      },
-    },
-    HvBreadCrumbPage: {
-      classes: {
-        link: {
-          "&:hover": {
-            backgroundColor: theme.colors.atmo3,
-          },
-          "&:focus": {
-            backgroundColor: theme.colors.atmo3,
-          },
         },
       },
     },


### PR DESCRIPTION
The warning text was aligned with DS 5.7:
- The text color was updated to `negative120` and the variant to `caption1`
- The icon container's size was updated to `24px`:
   - Using Figma I concluded that I had to use the `XS` size for the icon but change the container's size to `24px` because [this icon size usually uses `32px` for the container according to DS](https://designsystem.hitachivantara.com/6c705d900/p/31e481-dawn-icons/t/28a0f9). I found this a bit strange since I had to override the default specs for the icons' sizes. 
- I did not update the border and icon color since they were already using `negative`. 

I also fixed the following:
- I removed the `paddingLeft` that was unnecessary for the `warningText`
- The `paddingTop` value for `topGutter` in DS3 was updated since the text was not aligned

Before:

https://github.com/lumada-design/hv-uikit-react/assets/43220251/5667c864-8bc8-428b-ac77-91d3aac05d6f

After:

https://github.com/lumada-design/hv-uikit-react/assets/43220251/04c2ef79-2b3c-4b6c-8c9a-09ab7e62efbc

