### PR TITLE
docs(Flow): refactor samples

### DIFF
--- a/packages/lab/src/components/Flow/stories/Base/Dashboard.tsx
+++ b/packages/lab/src/components/Flow/stories/Base/Dashboard.tsx
@@ -1,4 +1,4 @@
-import { HvFlowNode } from "../Node/Node";
+import { HvFlowNode } from "@hitachivantara/uikit-react-lab";
 
 export const Dashboard = (props) => {
   return (

--- a/packages/lab/src/components/Flow/stories/Base/KPI.tsx
+++ b/packages/lab/src/components/Flow/stories/Base/KPI.tsx
@@ -1,11 +1,11 @@
-import { HvFlowNode } from "../Node/Node";
+import { HvFlowNode } from "@hitachivantara/uikit-react-lab";
 
-export const LineChart = (props) => {
-  return <HvFlowNode description="LineChart description" {...props} />;
+export const KPI = (props) => {
+  return <HvFlowNode description="KPI description" {...props} />;
 };
 
-LineChart.meta = {
-  label: "LineChart",
+KPI.meta = {
+  label: "KPI",
   groupId: "insights",
   inputs: [
     {

--- a/packages/lab/src/components/Flow/stories/Base/LineChart.tsx
+++ b/packages/lab/src/components/Flow/stories/Base/LineChart.tsx
@@ -1,11 +1,11 @@
-import { HvFlowNode } from "../Node/Node";
+import { HvFlowNode } from "@hitachivantara/uikit-react-lab";
 
-export const KPI = (props) => {
-  return <HvFlowNode description="KPI description" {...props} />;
+export const LineChart = (props) => {
+  return <HvFlowNode description="LineChart description" {...props} />;
 };
 
-KPI.meta = {
-  label: "KPI",
+LineChart.meta = {
+  label: "LineChart",
   groupId: "insights",
   inputs: [
     {

--- a/packages/lab/src/components/Flow/stories/Base/MLModelDetection.tsx
+++ b/packages/lab/src/components/Flow/stories/Base/MLModelDetection.tsx
@@ -1,4 +1,4 @@
-import { HvFlowNode } from "../Node/Node";
+import { HvFlowNode } from "@hitachivantara/uikit-react-lab";
 
 export const MLModelDetection = (props) => {
   return <HvFlowNode description="Anomaly detection description" {...props} />;

--- a/packages/lab/src/components/Flow/stories/Base/MLModelPrediction.tsx
+++ b/packages/lab/src/components/Flow/stories/Base/MLModelPrediction.tsx
@@ -1,4 +1,4 @@
-import { HvFlowNode } from "../Node/Node";
+import { HvFlowNode } from "@hitachivantara/uikit-react-lab";
 
 export const MLModelPrediction = (props) => {
   return <HvFlowNode description="Anomaly Prediction description" {...props} />;

--- a/packages/lab/src/components/Flow/stories/Base/Table.tsx
+++ b/packages/lab/src/components/Flow/stories/Base/Table.tsx
@@ -1,4 +1,4 @@
-import { HvFlowNode } from "../Node/Node";
+import { HvFlowNode } from "@hitachivantara/uikit-react-lab";
 
 export const Table = (props) => {
   return <HvFlowNode description="Table description" {...props} />;

--- a/packages/lab/src/components/Flow/stories/Base/Tron.tsx
+++ b/packages/lab/src/components/Flow/stories/Base/Tron.tsx
@@ -1,3 +1,5 @@
+import { useState } from "react";
+
 import { css } from "@emotion/css";
 import {
   HvButton,
@@ -7,10 +9,8 @@ import {
   HvDialogTitle,
 } from "@hitachivantara/uikit-react-core";
 import { Favorite, Flag, Search } from "@hitachivantara/uikit-react-icons";
-import { useState } from "react";
+import { HvFlowNode, useFlowNode } from "@hitachivantara/uikit-react-lab";
 import { Node } from "reactflow";
-import { useFlowNode } from "../hooks/useFlowNode";
-import { HvFlowNode } from "../Node/Node";
 
 export const Tron = (props) => {
   const { id } = props;

--- a/packages/lab/src/components/Flow/stories/Base/index.tsx
+++ b/packages/lab/src/components/Flow/stories/Base/index.tsx
@@ -1,0 +1,70 @@
+import {
+  Cards,
+  Cluster,
+  Delete,
+  Duplicate,
+  MachineLearning,
+  LineChartAlt,
+} from "@hitachivantara/uikit-react-icons";
+import {
+  HvFlowProps,
+  HvFlowDefaultActions,
+} from "@hitachivantara/uikit-react-lab";
+
+// The code for these components are available here: https://github.com/lumada-design/hv-uikit-react/tree/master/packages/lab/src/components/Flow/stories/Base
+import { Dashboard } from "./Dashboard";
+import { KPI } from "./KPI";
+import { LineChart } from "./LineChart";
+import { MLModelDetection } from "./MLModelDetection";
+import { MLModelPrediction } from "./MLModelPrediction";
+import { Table } from "./Table";
+import { Tron } from "./Tron";
+
+// Default actions
+export const defaultActions: HvFlowDefaultActions[] = [
+  { id: "delete", label: "Delete", icon: <Delete /> },
+  { id: "duplicate", label: "Duplicate", icon: <Duplicate /> },
+];
+
+// Node groups
+export type NodeGroups = "assets" | "models" | "insights" | "dashboard";
+
+export const nodeGroups = {
+  assets: {
+    label: "Asset",
+    color: "cat3_80",
+    description: "Find here all the available assets.",
+    icon: <Cluster />,
+  },
+  models: {
+    label: "ML Model",
+    color: "cat1_80",
+    description: "Find here all the available ML models.",
+    icon: <MachineLearning />,
+  },
+  insights: {
+    label: "Insight",
+    color: "cat6_80",
+    description: "Find here all the available insights.",
+    icon: <LineChartAlt />,
+  },
+  dashboard: {
+    label: "Dashboard",
+    color: "cat2_80",
+    description: "Find here all the available dashboards.",
+    icon: <Cards />,
+  },
+} satisfies HvFlowProps<NodeGroups>["nodeGroups"];
+
+// Node types
+export const nodeTypes = {
+  tron: Tron,
+  mlModelPrediction: MLModelPrediction,
+  mlModelDetection: MLModelDetection,
+  kpi: KPI,
+  lineChart: LineChart,
+  table: Table,
+  dashboard: Dashboard,
+} satisfies HvFlowProps["nodeTypes"];
+
+export type NodeType = keyof typeof nodeTypes;

--- a/packages/lab/src/components/Flow/stories/Flow.stories.tsx
+++ b/packages/lab/src/components/Flow/stories/Flow.stories.tsx
@@ -1,45 +1,20 @@
-import { useState } from "react";
-
 import {
-  HvButton,
-  HvGlobalActions,
-  HvTypography,
-  theme,
-} from "@hitachivantara/uikit-react-core";
-import {
-  Add,
-  Backwards,
-  Delete,
-  Duplicate,
-  Fail,
-  Favorite,
-  Group,
-  Heart,
-  LineChartAlt,
-} from "@hitachivantara/uikit-react-icons";
-
+  HvFlowBackground,
+  HvFlowControls,
+  HvFlowMinimap,
+  HvFlowSidebar,
+  HvFlow,
+  HvFlowProps,
+} from "@hitachivantara/uikit-react-lab";
 import { Meta, StoryObj } from "@storybook/react";
-
-import { css } from "@emotion/css";
-
 import { waitFor, screen, fireEvent } from "@storybook/testing-library";
 
-import { MarkerType } from "reactflow";
-import { HvFlow, HvFlowProps } from "../Flow";
-import { HvFlowBackground } from "../Background";
-import { HvFlowControls } from "../Controls";
-import { HvFlowMinimap } from "../Minimap";
-import { HvFlowSidebar } from "../Sidebar";
-import { HvFlowEmpty } from "../Empty";
-import { Tron } from "./Tron";
-import { MLModelPrediction } from "./MLModelPrediction";
-import { MLModelDetection } from "./MLModelDetection";
-import { KPI } from "./KPI";
-import { LineChart } from "./LineChart";
-import { Table } from "./Table";
-import { Dashboard } from "./Dashboard";
-import { HvFlowDefaultActions } from "../types";
-import { Visualizations as VisualizationsStory } from "./Visualizations/Visualizations";
+import { InitialState as InitialStateStory } from "./InitialState";
+import InitialStateRaw from "./InitialState?raw";
+import { Main as MainStory } from "./Main";
+import MainRaw from "./Main?raw";
+import { Visualizations as VisualizationsStory } from "./Visualizations";
+import VisualizationsRaw from "./Visualizations?raw";
 
 const meta: Meta<typeof HvFlow> = {
   title: "Lab/Flow",
@@ -67,341 +42,15 @@ const meta: Meta<typeof HvFlow> = {
 };
 export default meta;
 
-const defaultActions: HvFlowDefaultActions[] = [
-  { id: "delete", label: "Delete", icon: <Delete /> },
-  { id: "duplicate", label: "Duplicate", icon: <Duplicate /> },
-];
-
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-const initialState = {
-  nodes: [
-    {
-      width: 250,
-      height: 287,
-      id: "b1831327e65",
-      position: { x: 230.5967160116935, y: -97.14041347943862 },
-      data: {},
-      type: "tron",
-      positionAbsolute: { x: 230.5967160116935, y: -97.14041347943862 },
-      selected: false,
-      dragging: false,
-    },
-    {
-      width: 250,
-      height: 344,
-      id: "1831327e654",
-      position: { x: 1790.932393945947, y: -76.26621521352459 },
-      data: { dashboardType: "Time Series" },
-      type: "dashboard",
-      selected: true,
-      positionAbsolute: { x: 1790.932393945947, y: -76.26621521352459 },
-      dragging: false,
-    },
-    {
-      width: 250,
-      height: 279,
-      id: "831327e6549",
-      position: { x: 1157.0707002906995, y: -568.6650660564602 },
-      data: {},
-      type: "kpi",
-      selected: false,
-      positionAbsolute: { x: 1157.0707002906995, y: -568.6650660564602 },
-      dragging: false,
-    },
-    {
-      width: 250,
-      height: 279,
-      id: "31327e65496",
-      position: { x: 1162.4773542051269, y: 39.698031531068864 },
-      data: {},
-      type: "kpi",
-      selected: false,
-      positionAbsolute: { x: 1162.4773542051269, y: 39.698031531068864 },
-      dragging: false,
-    },
-    {
-      width: 250,
-      height: 279,
-      id: "1327e654964",
-      position: { x: 1165.3409624998887, y: -263.00419193314747 },
-      data: {},
-      type: "kpi",
-      selected: false,
-      positionAbsolute: { x: 1165.3409624998887, y: -263.00419193314747 },
-      dragging: false,
-    },
-    {
-      width: 250,
-      height: 279,
-      id: "327e654964e",
-      position: { x: 1166.4303617693265, y: 336.30245348985204 },
-      data: {},
-      type: "lineChart",
-      selected: false,
-      positionAbsolute: { x: 1166.4303617693265, y: 336.30245348985204 },
-      dragging: false,
-    },
-    {
-      width: 250,
-      height: 279,
-      id: "27e654964ea",
-      position: { x: 1171.7932914949638, y: 634.845421781169 },
-      data: {},
-      type: "table",
-      selected: false,
-      positionAbsolute: { x: 1171.7932914949638, y: 634.845421781169 },
-      dragging: false,
-    },
-    {
-      width: 250,
-      height: 279,
-      id: "7e654964ea3",
-      position: { x: 699.1400753100402, y: -276.0663081100252 },
-      data: {},
-      type: "mlModelPrediction",
-      selected: false,
-      positionAbsolute: { x: 699.1400753100402, y: -276.0663081100252 },
-      dragging: false,
-    },
-    {
-      width: 250,
-      height: 279,
-      id: "e654964ea39",
-      position: { x: 712.277606829035, y: 88.64323412853832 },
-      data: {},
-      type: "mlModelDetection",
-      selected: false,
-      positionAbsolute: { x: 712.277606829035, y: 88.64323412853832 },
-      dragging: false,
-    },
-  ],
-  edges: [
-    {
-      markerEnd: { type: MarkerType.ArrowClosed, height: 20, width: 20 },
-      source: "831327e6549",
-      sourceHandle: "0",
-      target: "1831327e654",
-      targetHandle: "0",
-      id: "reactflow__edge-831327e65490-1831327e6540",
-    },
-    {
-      markerEnd: { type: MarkerType.ArrowClosed, height: 20, width: 20 },
-      source: "31327e65496",
-      sourceHandle: "0",
-      target: "1831327e654",
-      targetHandle: "0",
-      id: "reactflow__edge-31327e654960-1831327e6540",
-    },
-    {
-      markerEnd: { type: MarkerType.ArrowClosed, height: 20, width: 20 },
-      source: "1327e654964",
-      sourceHandle: "0",
-      target: "1831327e654",
-      targetHandle: "0",
-      id: "reactflow__edge-1327e6549640-1831327e6540",
-    },
-    {
-      markerEnd: { type: MarkerType.ArrowClosed, height: 20, width: 20 },
-      source: "327e654964e",
-      sourceHandle: "0",
-      target: "1831327e654",
-      targetHandle: "0",
-      id: "reactflow__edge-327e654964e0-1831327e6540",
-    },
-    {
-      markerEnd: { type: MarkerType.ArrowClosed, height: 20, width: 20 },
-      source: "27e654964ea",
-      sourceHandle: "0",
-      target: "1831327e654",
-      targetHandle: "0",
-      id: "reactflow__edge-27e654964ea0-1831327e6540",
-    },
-    {
-      markerEnd: { type: MarkerType.ArrowClosed, height: 20, width: 20 },
-      source: "7e654964ea3",
-      sourceHandle: "0",
-      target: "831327e6549",
-      targetHandle: "0",
-      id: "reactflow__edge-7e654964ea30-831327e65490",
-    },
-    {
-      markerEnd: { type: MarkerType.ArrowClosed, height: 20, width: 20 },
-      source: "e654964ea39",
-      sourceHandle: "0",
-      target: "27e654964ea",
-      targetHandle: "0",
-      id: "reactflow__edge-e654964ea390-27e654964ea0",
-    },
-    {
-      markerEnd: { type: MarkerType.ArrowClosed, height: 20, width: 20 },
-      source: "e654964ea39",
-      sourceHandle: "0",
-      target: "327e654964e",
-      targetHandle: "0",
-      id: "reactflow__edge-e654964ea390-327e654964e0",
-    },
-    {
-      markerEnd: { type: MarkerType.ArrowClosed, height: 20, width: 20 },
-      source: "e654964ea39",
-      sourceHandle: "0",
-      target: "31327e65496",
-      targetHandle: "0",
-      id: "reactflow__edge-e654964ea390-31327e654960",
-    },
-    {
-      markerEnd: { type: MarkerType.ArrowClosed, height: 20, width: 20 },
-      source: "e654964ea39",
-      sourceHandle: "0",
-      target: "1327e654964",
-      targetHandle: "0",
-      id: "reactflow__edge-e654964ea390-1327e6549640",
-    },
-    {
-      markerEnd: { type: MarkerType.ArrowClosed, height: 20, width: 20 },
-      source: "b1831327e65",
-      sourceHandle: "0",
-      target: "7e654964ea3",
-      targetHandle: "0",
-      id: "reactflow__edge-b1831327e650-7e654964ea30",
-    },
-    {
-      markerEnd: { type: MarkerType.ArrowClosed, height: 20, width: 20 },
-      source: "b1831327e65",
-      sourceHandle: "1",
-      target: "e654964ea39",
-      targetHandle: "0",
-      id: "reactflow__edge-b1831327e651-e654964ea390",
-    },
-  ],
-  viewport: { x: 50, y: 300, zoom: 0.53 },
-};
-
-// Node groups
-type NodeGroups = "assets" | "models" | "insights" | "dashboard";
-const nodeGroups = {
-  assets: {
-    label: "Assets",
-    color: "cat3_80",
-    description: "This is my description for assets.",
-    icon: <Heart />,
-  },
-  models: {
-    label: "ML Model",
-    color: "cat1_80",
-    description: "This is my description for digital twin.",
-    icon: <Favorite />,
-  },
-  insights: {
-    label: "Insights",
-    color: "cat6_80",
-    description: "This is my description for insights.",
-    icon: <Group />,
-  },
-  dashboard: {
-    label: "Dashboard",
-    color: "cat2_80",
-    description: "This is my description for dashboard.",
-    icon: <LineChartAlt />,
-  },
-} satisfies HvFlowProps<NodeGroups>["nodeGroups"];
-
-// Node types
-const nodeTypes = {
-  tron: Tron,
-  mlModelPrediction: MLModelPrediction,
-  mlModelDetection: MLModelDetection,
-  kpi: KPI,
-  lineChart: LineChart,
-  table: Table,
-  dashboard: Dashboard,
-} satisfies HvFlowProps["nodeTypes"];
-type NodeType = keyof typeof nodeTypes;
-
-// Flow
-const nodes = [] satisfies HvFlowProps<NodeGroups, NodeType>["nodes"];
-const edges = [] satisfies HvFlowProps<NodeGroups, NodeType>["edges"];
-
-// Styles
-const styles = {
-  root: css({ height: "100vh" }),
-  globalActions: css({ paddingBottom: theme.space.md }),
-  flow: css({
-    height: "calc(100% - 90px)",
-  }),
-};
-
 export const Main: StoryObj<HvFlowProps> = {
-  render: () => {
-    const [open, setOpen] = useState(false);
-
-    const CustomAction = (
-      <div className={css({ display: "flex", flexDirection: "row" })}>
-        <HvTypography
-          link
-          component="a"
-          href="#"
-          onClick={(e) => {
-            e.preventDefault();
-            setOpen(true);
-          }}
-        >
-          Add nodes
-        </HvTypography>
-        <HvTypography>&nbsp;to start building your flow.</HvTypography>
-      </div>
-    );
-
-    return (
-      <div className={styles.root}>
-        <HvGlobalActions
-          className={styles.globalActions}
-          position="relative"
-          backButton={
-            <HvButton aria-label="Back" icon>
-              <Backwards role="none" />
-            </HvButton>
-          }
-          title="New Flow"
-        >
-          <HvButton
-            variant="primary"
-            startIcon={<Add role="none" />}
-            onClick={() => setOpen(true)}
-          >
-            Add Node
-          </HvButton>
-        </HvGlobalActions>
-        <div className={styles.flow}>
-          <HvFlow
-            nodes={nodes}
-            edges={edges}
-            nodeTypes={nodeTypes}
-            nodeGroups={nodeGroups}
-            defaultActions={defaultActions}
-            sidebar={
-              <HvFlowSidebar
-                title="Add Node"
-                description="Please choose within the options below"
-                open={open}
-                onClose={() => setOpen(false)}
-              />
-            }
-            // Keeping track of flow updates
-            onFlowChange={(nds, eds) =>
-              console.log("Flow updated: ", { nodes: nds, edges: eds })
-            }
-          >
-            <HvFlowControls />
-            <HvFlowEmpty
-              title="Empty Flow"
-              action={CustomAction}
-              icon={<Fail />}
-            />
-          </HvFlow>
-        </div>
-      </div>
-    );
+  parameters: {
+    docs: {
+      source: {
+        code: MainRaw,
+      },
+    },
   },
+  render: () => <MainStory />,
 };
 
 export const InitialState: StoryObj<HvFlowProps> = {
@@ -410,72 +59,27 @@ export const InitialState: StoryObj<HvFlowProps> = {
       description: {
         story: "A Flow with an initial state",
       },
+      source: {
+        code: InitialStateRaw,
+      },
     },
     eyes: { include: false },
   },
-
-  render: () => {
-    const [open, setOpen] = useState(false);
-
-    return (
-      <div className={styles.root}>
-        <HvGlobalActions
-          className={styles.globalActions}
-          position="relative"
-          backButton={
-            <HvButton aria-label="Back" icon>
-              <Backwards role="none" />
-            </HvButton>
-          }
-          title="New Flow"
-        >
-          <HvButton
-            variant="primary"
-            startIcon={<Add role="none" />}
-            onClick={() => setOpen(true)}
-          >
-            Add Node
-          </HvButton>
-        </HvGlobalActions>
-        <div className={styles.flow}>
-          <HvFlow
-            nodes={initialState.nodes}
-            edges={initialState.edges}
-            nodeTypes={nodeTypes}
-            nodeGroups={nodeGroups}
-            defaultViewport={initialState.viewport}
-            sidebar={
-              <HvFlowSidebar
-                title="Add Node"
-                description="Please choose within the options below"
-                open={open}
-                onClose={() => setOpen(false)}
-              />
-            }
-            // Keeping track of flow updates
-            onFlowChange={(nds, eds) =>
-              console.log("Flow updated: ", { nodes: nds, edges: eds })
-            }
-          >
-            <HvFlowControls />
-          </HvFlow>
-        </div>
-      </div>
-    );
-  },
+  render: () => <InitialStateStory />,
 };
 
 export const Visualizations: StoryObj<HvFlowProps> = {
   parameters: {
     docs: {
       description: {
-        story: `The HvFlowNode component can take any content as children. In this sample we create visualizations based on the JSON output of the first node.
-        <br /><br />Please refer to the code samples in our repository for more details: <br />
-          https://github.com/lumada-design/hv-uikit-react/blob/master/packages/lab/src/components/Flow/stories/Visualizations/Visualizations.tsx`,
+        story: `The HvFlowNode component can take any content as children. In this sample, we created visualizations based on the JSON output of the first node.
+        <br /><br />Please refer to the <b><a target="_blank" href="https://github.com/lumada-design/hv-uikit-react/blob/master/packages/lab/src/components/Flow/stories/Visualizations/Visualizations.tsx">code samples</a> </b> in our repository for more details.`,
+      },
+      source: {
+        code: VisualizationsRaw,
       },
     },
     eyes: { include: false },
   },
-
   render: () => <VisualizationsStory />,
 };

--- a/packages/lab/src/components/Flow/stories/InitialState/index.tsx
+++ b/packages/lab/src/components/Flow/stories/InitialState/index.tsx
@@ -1,0 +1,218 @@
+import { useState } from "react";
+
+import { css } from "@emotion/css";
+import {
+  HvButton,
+  HvGlobalActions,
+  theme,
+} from "@hitachivantara/uikit-react-core";
+import { Add, Backwards } from "@hitachivantara/uikit-react-icons";
+import {
+  HvFlowSidebar,
+  HvFlow,
+  HvFlowControls,
+} from "@hitachivantara/uikit-react-lab";
+
+// The code for these values are available here: https://github.com/lumada-design/hv-uikit-react/tree/master/packages/lab/src/components/Flow/stories/Base/index.tsx
+import { nodeGroups, nodeTypes } from "../Base";
+
+const initialState = {
+  nodes: [
+    {
+      id: "b1831327e65",
+      position: { x: 230.5967160116935, y: -97.14041347943862 },
+      data: {},
+      type: "tron",
+    },
+    {
+      id: "1831327e654",
+      position: { x: 1790.932393945947, y: -76.26621521352459 },
+      data: { dashboardType: "Time Series" },
+      type: "dashboard",
+    },
+    {
+      id: "831327e6549",
+      position: { x: 1157.0707002906995, y: -568.6650660564602 },
+      data: {},
+      type: "kpi",
+    },
+    {
+      id: "31327e65496",
+      position: { x: 1162.4773542051269, y: 39.698031531068864 },
+      data: {},
+      type: "kpi",
+    },
+    {
+      id: "1327e654964",
+      position: { x: 1165.3409624998887, y: -263.00419193314747 },
+      data: {},
+      type: "kpi",
+    },
+    {
+      id: "327e654964e",
+      position: { x: 1166.4303617693265, y: 336.30245348985204 },
+      data: {},
+      type: "lineChart",
+    },
+    {
+      id: "27e654964ea",
+      position: { x: 1171.7932914949638, y: 634.845421781169 },
+      data: {},
+      type: "table",
+    },
+    {
+      id: "7e654964ea3",
+      position: { x: 699.1400753100402, y: -276.0663081100252 },
+      data: {},
+      type: "mlModelPrediction",
+    },
+    {
+      id: "e654964ea39",
+      position: { x: 712.277606829035, y: 88.64323412853832 },
+      data: {},
+      type: "mlModelDetection",
+    },
+  ],
+  edges: [
+    {
+      source: "831327e6549",
+      sourceHandle: "0",
+      target: "1831327e654",
+      targetHandle: "0",
+      id: "reactflow__edge-831327e65490-1831327e6540",
+    },
+    {
+      source: "31327e65496",
+      sourceHandle: "0",
+      target: "1831327e654",
+      targetHandle: "0",
+      id: "reactflow__edge-31327e654960-1831327e6540",
+    },
+    {
+      source: "1327e654964",
+      sourceHandle: "0",
+      target: "1831327e654",
+      targetHandle: "0",
+      id: "reactflow__edge-1327e6549640-1831327e6540",
+    },
+    {
+      source: "327e654964e",
+      sourceHandle: "0",
+      target: "1831327e654",
+      targetHandle: "0",
+      id: "reactflow__edge-327e654964e0-1831327e6540",
+    },
+    {
+      source: "27e654964ea",
+      sourceHandle: "0",
+      target: "1831327e654",
+      targetHandle: "0",
+      id: "reactflow__edge-27e654964ea0-1831327e6540",
+    },
+    {
+      source: "7e654964ea3",
+      sourceHandle: "0",
+      target: "831327e6549",
+      targetHandle: "0",
+      id: "reactflow__edge-7e654964ea30-831327e65490",
+    },
+    {
+      source: "e654964ea39",
+      sourceHandle: "0",
+      target: "27e654964ea",
+      targetHandle: "0",
+      id: "reactflow__edge-e654964ea390-27e654964ea0",
+    },
+    {
+      source: "e654964ea39",
+      sourceHandle: "0",
+      target: "327e654964e",
+      targetHandle: "0",
+      id: "reactflow__edge-e654964ea390-327e654964e0",
+    },
+    {
+      source: "e654964ea39",
+      sourceHandle: "0",
+      target: "31327e65496",
+      targetHandle: "0",
+      id: "reactflow__edge-e654964ea390-31327e654960",
+    },
+    {
+      source: "e654964ea39",
+      sourceHandle: "0",
+      target: "1327e654964",
+      targetHandle: "0",
+      id: "reactflow__edge-e654964ea390-1327e6549640",
+    },
+    {
+      source: "b1831327e65",
+      sourceHandle: "0",
+      target: "7e654964ea3",
+      targetHandle: "0",
+      id: "reactflow__edge-b1831327e650-7e654964ea30",
+    },
+    {
+      source: "b1831327e65",
+      sourceHandle: "1",
+      target: "e654964ea39",
+      targetHandle: "0",
+      id: "reactflow__edge-b1831327e651-e654964ea390",
+    },
+  ],
+  viewport: { x: 50, y: 300, zoom: 0.53 },
+};
+
+// Classes
+export const classes = {
+  root: css({ height: "100vh" }),
+  globalActions: css({ paddingBottom: theme.space.md }),
+  flow: css({
+    height: "calc(100% - 90px)",
+  }),
+};
+
+export const InitialState = () => {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <div className={classes.root}>
+      <HvGlobalActions
+        className={classes.globalActions}
+        position="relative"
+        backButton={
+          <HvButton aria-label="Back" icon>
+            <Backwards role="none" />
+          </HvButton>
+        }
+        title="New Flow"
+      >
+        <HvButton
+          variant="primary"
+          startIcon={<Add role="none" />}
+          onClick={() => setOpen(true)}
+        >
+          Add Node
+        </HvButton>
+      </HvGlobalActions>
+      <div className={classes.flow}>
+        <HvFlow
+          nodes={initialState.nodes}
+          edges={initialState.edges}
+          nodeTypes={nodeTypes}
+          nodeGroups={nodeGroups}
+          defaultViewport={initialState.viewport}
+          sidebar={
+            <HvFlowSidebar
+              title="Add Node"
+              description="Please choose within the options below"
+              open={open}
+              onClose={() => setOpen(false)}
+            />
+          }
+        >
+          <HvFlowControls />
+        </HvFlow>
+      </div>
+    </div>
+  );
+};

--- a/packages/lab/src/components/Flow/stories/Main/index.tsx
+++ b/packages/lab/src/components/Flow/stories/Main/index.tsx
@@ -1,0 +1,111 @@
+import { useState } from "react";
+
+import { css } from "@emotion/css";
+import {
+  HvButton,
+  HvGlobalActions,
+  HvTypography,
+  theme,
+} from "@hitachivantara/uikit-react-core";
+import { Add, Backwards, Fail } from "@hitachivantara/uikit-react-icons";
+import {
+  HvFlowControls,
+  HvFlowSidebar,
+  HvFlowEmpty,
+  HvFlow,
+  HvFlowProps,
+} from "@hitachivantara/uikit-react-lab";
+
+// The code for these values are available here: https://github.com/lumada-design/hv-uikit-react/tree/master/packages/lab/src/components/Flow/stories/Base/index.tsx
+import {
+  NodeGroups,
+  NodeType,
+  defaultActions,
+  nodeGroups,
+  nodeTypes,
+} from "../Base";
+
+// Flow
+const nodes = [] satisfies HvFlowProps<NodeGroups, NodeType>["nodes"];
+const edges = [] satisfies HvFlowProps<NodeGroups, NodeType>["edges"];
+
+// Classes
+export const classes = {
+  root: css({ height: "100vh" }),
+  globalActions: css({ paddingBottom: theme.space.md }),
+  flow: css({
+    height: "calc(100% - 90px)",
+  }),
+};
+
+export const Main = () => {
+  const [open, setOpen] = useState(false);
+
+  const CustomAction = (
+    <div className={css({ display: "flex", flexDirection: "row" })}>
+      <HvTypography
+        link
+        component="a"
+        href="#"
+        onClick={(e) => {
+          e.preventDefault();
+          setOpen(true);
+        }}
+      >
+        Add nodes
+      </HvTypography>
+      <HvTypography>&nbsp;to start building your flow.</HvTypography>
+    </div>
+  );
+
+  return (
+    <div className={classes.root}>
+      <HvGlobalActions
+        className={classes.globalActions}
+        position="relative"
+        backButton={
+          <HvButton aria-label="Back" icon>
+            <Backwards role="none" />
+          </HvButton>
+        }
+        title="New Flow"
+      >
+        <HvButton
+          variant="primary"
+          startIcon={<Add role="none" />}
+          onClick={() => setOpen(true)}
+        >
+          Add Node
+        </HvButton>
+      </HvGlobalActions>
+      <div className={classes.flow}>
+        <HvFlow
+          nodes={nodes}
+          edges={edges}
+          nodeTypes={nodeTypes}
+          nodeGroups={nodeGroups}
+          defaultActions={defaultActions}
+          sidebar={
+            <HvFlowSidebar
+              title="Add Node"
+              description="Please choose within the options below"
+              open={open}
+              onClose={() => setOpen(false)}
+            />
+          }
+          // Keeping track of flow updates
+          onFlowChange={(nds, eds) =>
+            console.log("Flow updated: ", { nodes: nds, edges: eds })
+          }
+        >
+          <HvFlowControls />
+          <HvFlowEmpty
+            title="Empty Flow"
+            action={CustomAction}
+            icon={<Fail />}
+          />
+        </HvFlow>
+      </div>
+    </div>
+  );
+};

--- a/packages/lab/src/components/Flow/stories/Visualizations/BarChart.tsx
+++ b/packages/lab/src/components/Flow/stories/Visualizations/BarChart.tsx
@@ -1,7 +1,7 @@
 import { css } from "@emotion/css";
+import { HvFlowNode } from "@hitachivantara/uikit-react-lab";
 import { HvBarChart } from "@hitachivantara/uikit-react-viz";
 import { useStore } from "reactflow";
-import { HvFlowNode } from "../../Node/Node";
 
 export const BarChart = (props) => {
   const { id } = props;

--- a/packages/lab/src/components/Flow/stories/Visualizations/Filter.tsx
+++ b/packages/lab/src/components/Flow/stories/Visualizations/Filter.tsx
@@ -1,8 +1,8 @@
-import { HvCheckBox, HvCheckBoxGroup } from "@hitachivantara/uikit-react-core";
 import { useEffect, useState } from "react";
+
+import { HvCheckBox, HvCheckBoxGroup } from "@hitachivantara/uikit-react-core";
+import { useFlowNode, HvFlowNode } from "@hitachivantara/uikit-react-lab";
 import { useReactFlow, useStore } from "reactflow";
-import { useFlowNode } from "../../hooks/useFlowNode";
-import { HvFlowNode } from "../../Node/Node";
 
 function filterDataByCountries(data, countriesToFilter: string[]) {
   return data.filter((item) => countriesToFilter.includes(item.country));
@@ -12,12 +12,14 @@ export const Filter = (props) => {
   const { id } = props;
 
   const [checked, setChecked] = useState<string[]>([]);
+
   const reactFlowInstance = useReactFlow();
+
   const nodes = useStore((state) => state.getNodes());
   const edges = useStore((state) => state.edges);
-  // const filter = useStore((state) => state.getNodes().find((n) => n.id === id))
-  //   ?.data.filter;
+
   let options: string[] = [];
+
   const { node: self } = useFlowNode(id);
 
   useEffect(() => {

--- a/packages/lab/src/components/Flow/stories/Visualizations/JsonInput.tsx
+++ b/packages/lab/src/components/Flow/stories/Visualizations/JsonInput.tsx
@@ -1,4 +1,4 @@
-import { HvFlowNode } from "../../Node/Node";
+import { HvFlowNode } from "@hitachivantara/uikit-react-lab";
 
 export const JsonInput = (props) => {
   return <HvFlowNode description="Population Datakky7" {...props} />;

--- a/packages/lab/src/components/Flow/stories/Visualizations/LineChart.tsx
+++ b/packages/lab/src/components/Flow/stories/Visualizations/LineChart.tsx
@@ -1,7 +1,7 @@
 import { css } from "@emotion/css";
+import { HvFlowNode } from "@hitachivantara/uikit-react-lab";
 import { HvLineChart } from "@hitachivantara/uikit-react-viz";
 import { useStore } from "reactflow";
-import { HvFlowNode } from "../../Node/Node";
 
 export const LineChart = (props) => {
   const { id } = props;

--- a/packages/lab/src/components/Flow/stories/Visualizations/index.tsx
+++ b/packages/lab/src/components/Flow/stories/Visualizations/index.tsx
@@ -1,30 +1,34 @@
+import { useState } from "react";
+
 import { css } from "@emotion/css";
-import { HvButton, HvGlobalActions } from "@hitachivantara/uikit-react-core";
+import {
+  HvButton,
+  HvGlobalActions,
+  theme,
+} from "@hitachivantara/uikit-react-core";
 import {
   Add,
   Backwards,
-  LineChart as LineChartIcon,
-  Heart,
-  Transformation,
-  Delete,
-  Duplicate,
+  LineChartAlt,
+  Operation,
+  DataSource,
 } from "@hitachivantara/uikit-react-icons";
-import { theme } from "@hitachivantara/uikit-styles";
-import { useState } from "react";
-import { HvFlowSidebar } from "../../Sidebar";
-import { HvFlow, HvFlowProps } from "../../Flow";
-import { HvFlowControls } from "../../Controls";
-import { JsonInput } from "./JsonInput";
-import { LineChart } from "./LineChart";
+import {
+  HvFlowSidebar,
+  HvFlow,
+  HvFlowProps,
+  HvFlowControls,
+} from "@hitachivantara/uikit-react-lab";
+
+// The code for these components are available here: https://github.com/lumada-design/hv-uikit-react/tree/master/packages/lab/src/components/Flow/stories/Visualizations
 import { BarChart } from "./BarChart";
 import { Filter } from "./Filter";
-import { HvFlowDefaultActions } from "../../types";
+import { JsonInput } from "./JsonInput";
+import { LineChart } from "./LineChart";
+// The code for these values are available here: https://github.com/lumada-design/hv-uikit-react/tree/master/packages/lab/src/components/Flow/stories/Base/index.tsx
+import { defaultActions } from "../Base";
 
-const defaultActions: HvFlowDefaultActions[] = [
-  { id: "delete", label: "Delete", icon: <Delete /> },
-  { id: "duplicate", label: "Duplicate", icon: <Duplicate /> },
-];
-
+// Note types
 const nodeTypes = {
   jsonInput: JsonInput,
   filter: Filter,
@@ -39,22 +43,22 @@ type NodeGroups = "inputs" | "transformations" | "visualizations";
 
 const nodeGroups = {
   inputs: {
-    label: "Inputs",
+    label: "Input",
     color: "cat3_80",
-    description: "This is my description for inputs.",
-    icon: <Heart />,
+    description: "Find here all the available inputs.",
+    icon: <DataSource />,
   },
   transformations: {
-    label: "Transformations",
+    label: "Transformation",
     color: "cat5_80",
-    description: "This is my description for transformations.",
-    icon: <Transformation />,
+    description: "Find here all the available transformations.",
+    icon: <Operation />,
   },
   visualizations: {
-    label: "Visualizations",
+    label: "Visualization",
     color: "cat1_80",
-    description: "This is my description for visualizations.",
-    icon: <LineChartIcon />,
+    description: "Find here all the available visualizations.",
+    icon: <LineChartAlt />,
   },
 } satisfies HvFlowProps<NodeGroups>["nodeGroups"];
 
@@ -143,7 +147,8 @@ const edges = [
   },
 ] satisfies HvFlowProps<NodeGroups, NodeType>["edges"];
 
-const classes = {
+// Classes
+export const classes = {
   root: css({ height: "100vh" }),
   globalActions: css({ paddingBottom: theme.space.md }),
   flow: css({
@@ -194,10 +199,6 @@ export const Visualizations = () => {
               open={open}
               onClose={() => setOpen(false)}
             />
-          }
-          // Keeping track of flow updates
-          onFlowChange={(nds, eds) =>
-            console.log("Flow updated: ", { nodes: nds, edges: eds })
           }
         >
           <HvFlowControls />

--- a/packages/lab/src/components/types/global.d.ts
+++ b/packages/lab/src/components/types/global.d.ts
@@ -1,0 +1,3 @@
+declare module "*?raw" {
+  export default "" as string;
+}


### PR DESCRIPTION
The Flow samples were refactored because they were confusing for users and the available code was useless sometimes:
- Each sample has its own folder to reduce confusion
- The imports were updated to import from the `lab` package instead of an absolute path (when possible)
- The samples show the code in a `raw` format: the code samples are now more legible and useful
- Comments were added with a link to find the code for the values and components that can only be imported from absolute paths