### PR TITLE
refactor(app): use `~/` prefix for package imports

### DIFF
--- a/app/.eslintrc
+++ b/app/.eslintrc
@@ -2,6 +2,7 @@
   "rules": {
     "no-alert": "off",
     "no-console": "off",
+    "import/extensions": "off",
     "import/order": [
       "error",
       {
@@ -18,27 +19,7 @@
             "position": "before"
           },
           {
-            "pattern": "assets/**",
-            "group": "internal"
-          },
-          {
-            "pattern": "components/**",
-            "group": "internal"
-          },
-          {
-            "pattern": "generator/**",
-            "group": "internal"
-          },
-          {
-            "pattern": "lib/**",
-            "group": "internal"
-          },
-          {
-            "pattern": "pages/**",
-            "group": "internal"
-          },
-          {
-            "pattern": "types/**",
+            "pattern": "~/**",
             "group": "internal"
           }
         ],

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -1,9 +1,9 @@
 import { ds3, ds5, HvProvider, theme } from "@hitachivantara/uikit-react-core";
 
-import "lib/i18n";
-import Content from "generator/Content";
-import Sidebar from "generator/Sidebar";
-import GeneratorProvider from "generator/GeneratorContext";
+import "~/lib/i18n";
+import Content from "~/generator/Content";
+import Sidebar from "~/generator/Sidebar";
+import GeneratorProvider from "~/generator/GeneratorContext";
 
 const App = () => {
   return (

--- a/app/src/components/assetInventory/CardView/CardView.tsx
+++ b/app/src/components/assetInventory/CardView/CardView.tsx
@@ -11,7 +11,7 @@ import {
   HvTableInstance,
 } from "@hitachivantara/uikit-react-core";
 
-import { getStatusIcon } from "lib/utils/assetInventory";
+import { getStatusIcon } from "~/lib/utils/assetInventory";
 
 interface CarViewProps {
   instance: HvTableInstance<AssetInventoryModel, string>;

--- a/app/src/components/assetInventory/ListView/ListView.tsx
+++ b/app/src/components/assetInventory/ListView/ListView.tsx
@@ -10,7 +10,7 @@ import {
   HvTableInstance,
 } from "@hitachivantara/uikit-react-core";
 
-import { getColumns, idsToControl } from "lib/utils/assetInventory";
+import { getColumns, idsToControl } from "~/lib/utils/assetInventory";
 
 interface ListViewProps {
   instance: HvTableInstance<AssetInventoryModel, string>;

--- a/app/src/components/common/Container/Container.tsx
+++ b/app/src/components/common/Container/Container.tsx
@@ -1,7 +1,7 @@
 import { Suspense } from "react";
 import { HvContainer } from "@hitachivantara/uikit-react-core";
 
-import { Loading, LoadingProps } from "components/common/Loading";
+import { Loading, LoadingProps } from "~/components/common/Loading";
 
 import classes from "./styles";
 

--- a/app/src/components/common/Header/Header.tsx
+++ b/app/src/components/common/Header/Header.tsx
@@ -12,10 +12,10 @@ import {
   HvTypography,
 } from "@hitachivantara/uikit-react-core";
 
-import logo from "assets/logo.png";
-import { NavigationContext } from "lib/context/NavigationContext";
-import navigation from "lib/navigation";
-import { useGeneratorContext } from "generator/GeneratorContext";
+import logo from "~/assets/logo.png";
+import { NavigationContext } from "~/lib/context/NavigationContext";
+import navigation from "~/lib/navigation";
+import { useGeneratorContext } from "~/generator/GeneratorContext";
 
 export const Header = () => {
   const navigate = useNavigate();

--- a/app/src/components/common/Tutorial/Step.tsx
+++ b/app/src/components/common/Tutorial/Step.tsx
@@ -1,4 +1,5 @@
 import { Dispatch, SetStateAction, useEffect } from "react";
+import { useNavigate } from "react-router-dom";
 import { clsx } from "clsx";
 import { css } from "@emotion/css";
 import {
@@ -10,9 +11,7 @@ import {
   HvTypography,
 } from "@hitachivantara/uikit-react-core";
 
-import { useNavigate } from "react-router-dom";
-
-import { useGeneratorContext } from "generator/GeneratorContext";
+import { useGeneratorContext } from "~/generator/GeneratorContext";
 
 import { tutorialData } from "./tutorialData";
 import classes from "./tutorialStyles";

--- a/app/src/components/common/index.ts
+++ b/app/src/components/common/index.ts
@@ -1,6 +1,0 @@
-export * from "./Container";
-export * from "./Header";
-export * from "./Loading";
-export * from "./ThemeSwitcher";
-export * from "./UnitSlider";
-export * from "./Tutorial";

--- a/app/src/components/detailsView/Table/Table.tsx
+++ b/app/src/components/detailsView/Table/Table.tsx
@@ -12,7 +12,7 @@ import {
   useHvPagination,
 } from "@hitachivantara/uikit-react-core";
 
-import { getColumns, makeData, NewEntry } from "lib/utils/details";
+import { getColumns, makeData, NewEntry } from "~/lib/utils/details";
 
 import classes from "./styles.js";
 

--- a/app/src/components/listView/Kpi/Kpi.tsx
+++ b/app/src/components/listView/Kpi/Kpi.tsx
@@ -7,8 +7,8 @@ import {
 } from "@hitachivantara/uikit-react-core";
 import { TopXS, BottomXS } from "@hitachivantara/uikit-react-icons";
 
-import { Indicator } from "components/listView";
-import { getStatusIcon } from "lib/utils/listView";
+import { Indicator } from "~/components/listView";
+import { getStatusIcon } from "~/lib/utils/listView";
 
 import classes from "./styles";
 

--- a/app/src/components/listView/Table/Table.tsx
+++ b/app/src/components/listView/Table/Table.tsx
@@ -11,7 +11,7 @@ import {
   HvTableInstance,
 } from "@hitachivantara/uikit-react-core";
 
-import { getColumns } from "lib/utils/listView";
+import { getColumns } from "~/lib/utils/listView";
 
 interface TableProps {
   instance: HvTableInstance<ListViewModel, string>;

--- a/app/src/generator/CodeEditor/CodeEditor.tsx
+++ b/app/src/generator/CodeEditor/CodeEditor.tsx
@@ -1,4 +1,6 @@
 import { Dispatch, SetStateAction, useEffect, useState } from "react";
+import debounce from "lodash/debounce";
+import JSON5 from "json5";
 import {
   HvBox,
   HvButton,
@@ -6,15 +8,12 @@ import {
   HvTypography,
   useTheme,
 } from "@hitachivantara/uikit-react-core";
-import debounce from "lodash/debounce";
-import JSON5 from "json5";
 import { Download, Reset, Duplicate } from "@hitachivantara/uikit-react-icons";
-
 import { HvCodeEditor } from "@hitachivantara/uikit-react-code-editor";
 
-import { useGeneratorContext } from "generator/GeneratorContext";
-import { getThemeCode } from "generator/utils";
-import { IconButton } from "components/common/IconButton";
+import { useGeneratorContext } from "~/generator/GeneratorContext";
+import { getThemeCode } from "~/generator/utils";
+import { IconButton } from "~/components/common/IconButton";
 
 import { styles } from "./CodeEditor.styles";
 

--- a/app/src/generator/Colors/Colors.tsx
+++ b/app/src/generator/Colors/Colors.tsx
@@ -5,11 +5,10 @@ import {
   useTheme,
   baseDropdownClasses,
 } from "@hitachivantara/uikit-react-core";
-
 import { HvThemeTokens } from "@hitachivantara/uikit-styles";
 import { css } from "@emotion/css";
 
-import { useGeneratorContext } from "generator/GeneratorContext";
+import { useGeneratorContext } from "~/generator/GeneratorContext";
 
 import { styles } from "./Colors.styles";
 import { getColorGroupName, getColors, groupsToShow } from "./utils";

--- a/app/src/generator/Content.tsx
+++ b/app/src/generator/Content.tsx
@@ -1,10 +1,11 @@
 import { BrowserRouter as Router } from "react-router-dom";
 import { HvProvider, useTheme } from "@hitachivantara/uikit-react-core";
 
-import { Container, Tutorial } from "components/common";
-import { NavigationProvider } from "lib/context/NavigationContext";
-import navigation from "lib/navigation";
-import Routes from "lib/routes";
+import { Container } from "~/components/common/Container";
+import { Tutorial } from "~/components/common/Tutorial";
+import { NavigationProvider } from "~/lib/context/NavigationContext";
+import navigation from "~/lib/navigation";
+import Routes from "~/lib/routes";
 
 import { useGeneratorContext } from "./GeneratorContext";
 

--- a/app/src/generator/FontFamily/FontFamily.tsx
+++ b/app/src/generator/FontFamily/FontFamily.tsx
@@ -1,4 +1,6 @@
 import { SyntheticEvent, useState } from "react";
+import { css } from "@emotion/css";
+import { SnackbarCloseReason } from "@mui/material";
 import {
   HvBox,
   HvButton,
@@ -7,13 +9,10 @@ import {
   HvListValue,
   HvSnackbar,
 } from "@hitachivantara/uikit-react-core";
-
 import { Add } from "@hitachivantara/uikit-react-icons";
-import { css } from "@emotion/css";
-import { SnackbarCloseReason } from "@mui/material";
 
-import { useGeneratorContext } from "generator/GeneratorContext";
-import { extractFontsNames } from "generator/utils";
+import { useGeneratorContext } from "~/generator/GeneratorContext";
+import { extractFontsNames } from "~/generator/utils";
 
 import { styles } from "./FontFamily.styles";
 

--- a/app/src/generator/FontSizes/FontSizes.tsx
+++ b/app/src/generator/FontSizes/FontSizes.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { css } from "@emotion/css";
 import {
   theme,
   useTheme,
@@ -7,11 +8,9 @@ import {
   HvListValue,
 } from "@hitachivantara/uikit-react-core";
 
-import { css } from "@emotion/css";
-
-import { useGeneratorContext } from "generator/GeneratorContext";
-import { ScaleProps, UnitSlider } from "components/common";
-import { extractFontSizeUnit } from "generator/utils";
+import { useGeneratorContext } from "~/generator/GeneratorContext";
+import { ScaleProps, UnitSlider } from "~/components/common/UnitSlider";
+import { extractFontSizeUnit } from "~/generator/utils";
 
 import { styles } from "./FontSizes.styles";
 

--- a/app/src/generator/Radii/Radii.tsx
+++ b/app/src/generator/Radii/Radii.tsx
@@ -6,9 +6,9 @@ import {
 } from "@hitachivantara/uikit-react-core";
 import { HvThemeTokens } from "@hitachivantara/uikit-styles";
 
-import { useGeneratorContext } from "generator/GeneratorContext";
-import { UnitSlider } from "components/common";
-import { extractFontSizeUnit } from "generator/utils";
+import { useGeneratorContext } from "~/generator/GeneratorContext";
+import { UnitSlider } from "~/components/common/UnitSlider";
+import { extractFontSizeUnit } from "~/generator/utils";
 
 import { styles } from "./Radii.styles";
 

--- a/app/src/generator/Sidebar/Sidebar.tsx
+++ b/app/src/generator/Sidebar/Sidebar.tsx
@@ -13,7 +13,6 @@ import {
   theme,
   useTheme,
 } from "@hitachivantara/uikit-react-core";
-
 import {
   Bold,
   FontSize,
@@ -23,19 +22,19 @@ import {
 
 import { css } from "@emotion/css";
 
-import { useGeneratorContext } from "generator/GeneratorContext";
-import CodeEditor from "generator/CodeEditor";
+import { useGeneratorContext } from "~/generator/GeneratorContext";
+import CodeEditor from "~/generator/CodeEditor";
 
 import { styles } from "./Sidebar.styles";
 
-const Colors = lazy(() => import("generator/Colors"));
-const FontSizes = lazy(() => import("generator/FontSizes"));
-const FontFamily = lazy(() => import("generator/FontFamily"));
-const Radii = lazy(() => import("generator/Radii"));
-const Spacing = lazy(() => import("generator/Spacing"));
-const Typography = lazy(() => import("generator/Typography"));
-const Zindices = lazy(() => import("generator/Zindices"));
-const Sizes = lazy(() => import("generator/Sizes"));
+const Colors = lazy(() => import("~/generator/Colors"));
+const FontSizes = lazy(() => import("~/generator/FontSizes"));
+const FontFamily = lazy(() => import("~/generator/FontFamily"));
+const Radii = lazy(() => import("~/generator/Radii"));
+const Spacing = lazy(() => import("~/generator/Spacing"));
+const Typography = lazy(() => import("~/generator/Typography"));
+const Zindices = lazy(() => import("~/generator/Zindices"));
+const Sizes = lazy(() => import("~/generator/Sizes"));
 
 const Sidebar = () => {
   const { selectedTheme, selectedMode, colorModes, changeTheme, themes } =

--- a/app/src/generator/Sizes/Sizes.tsx
+++ b/app/src/generator/Sizes/Sizes.tsx
@@ -2,8 +2,8 @@ import { useRef, useState } from "react";
 import { HvTypography, useTheme } from "@hitachivantara/uikit-react-core";
 import { HvThemeTokens } from "@hitachivantara/uikit-styles";
 
-import { useGeneratorContext } from "generator/GeneratorContext";
-import { UnitSlider } from "components/common";
+import { useGeneratorContext } from "~/generator/GeneratorContext";
+import { UnitSlider } from "~/components/common/UnitSlider";
 
 import { styles } from "./Sizes.styles";
 

--- a/app/src/generator/Spacing/Spacing.tsx
+++ b/app/src/generator/Spacing/Spacing.tsx
@@ -2,8 +2,8 @@ import { useRef, useState } from "react";
 import { HvTypography, useTheme } from "@hitachivantara/uikit-react-core";
 import { HvThemeTokens } from "@hitachivantara/uikit-styles";
 
-import { useGeneratorContext } from "generator/GeneratorContext";
-import { UnitSlider } from "components/common";
+import { useGeneratorContext } from "~/generator/GeneratorContext";
+import { UnitSlider } from "~/components/common/UnitSlider";
 
 import { styles } from "./Spacing.styles";
 

--- a/app/src/generator/Typography/Typography.tsx
+++ b/app/src/generator/Typography/Typography.tsx
@@ -15,10 +15,9 @@ import debounce from "lodash/debounce";
 
 import { css } from "@emotion/css";
 
-import { extractFontSizeUnit } from "generator/utils";
-import { useGeneratorContext } from "generator/GeneratorContext";
-
-import { ScaleProps, UnitSlider } from "components/common";
+import { extractFontSizeUnit } from "~/generator/utils";
+import { useGeneratorContext } from "~/generator/GeneratorContext";
+import { ScaleProps, UnitSlider } from "~/components/common/UnitSlider";
 
 import { styles } from "./Typography.styles";
 

--- a/app/src/generator/Zindices/Zindices.tsx
+++ b/app/src/generator/Zindices/Zindices.tsx
@@ -8,7 +8,7 @@ import {
 } from "@hitachivantara/uikit-react-core";
 import { HvThemeTokens } from "@hitachivantara/uikit-styles";
 
-import { useGeneratorContext } from "generator/GeneratorContext";
+import { useGeneratorContext } from "~/generator/GeneratorContext";
 
 import { styles } from "./Zindices.styles";
 

--- a/app/src/lib/context/NavigationContext.tsx
+++ b/app/src/lib/context/NavigationContext.tsx
@@ -1,7 +1,7 @@
 import { useMemo, createContext } from "react";
 
-import { Header } from "components/common";
-import useNavigation from "lib/hooks/useNavigation";
+import { Header } from "~/components/common/Header";
+import useNavigation from "~/lib/hooks/useNavigation";
 
 interface NavigationProviderProps {
   children: React.ReactNode;

--- a/app/src/lib/hooks/useNavigation.ts
+++ b/app/src/lib/hooks/useNavigation.ts
@@ -1,7 +1,7 @@
 import { useState, useEffect } from "react";
 import { useLocation } from "react-router-dom";
 
-import { getActivePath } from "lib/utils/navigation";
+import { getActivePath } from "~/lib/utils/navigation";
 
 const useNavigation = (
   navigationData: NavigationData[] = []

--- a/app/src/lib/routes.tsx
+++ b/app/src/lib/routes.tsx
@@ -1,9 +1,9 @@
 import { lazy } from "react";
 import { Routes, Route, Navigate } from "react-router-dom";
 
-const Components = lazy(() => import("pages/Components"));
-const Instructions = lazy(() => import("pages/Instructions"));
-const NotFound = lazy(() => import("pages/NotFound"));
+const Components = lazy(() => import("~/pages/Components"));
+const Instructions = lazy(() => import("~/pages/Instructions"));
+const NotFound = lazy(() => import("~/pages/NotFound"));
 
 // Templates
 /* eslint-disable import/no-relative-packages */

--- a/app/src/pages/Components/Components.tsx
+++ b/app/src/pages/Components/Components.tsx
@@ -38,7 +38,7 @@ import {
   Avatar,
   ProgressBar,
   Loading,
-} from "components/components";
+} from "~/components/components";
 
 import { styles } from "./Components.styles";
 

--- a/app/src/pages/Instructions/Instructions.tsx
+++ b/app/src/pages/Instructions/Instructions.tsx
@@ -24,7 +24,7 @@ import {
   FontSizeBigger,
 } from "@hitachivantara/uikit-react-icons";
 
-import { useGeneratorContext } from "generator/GeneratorContext";
+import { useGeneratorContext } from "~/generator/GeneratorContext";
 
 import classes from "./styles";
 

--- a/app/tsconfig.json
+++ b/app/tsconfig.json
@@ -15,7 +15,9 @@
     "isolatedModules": true,
     "noEmit": true,
     "jsx": "react-jsx",
-    "baseUrl": "./src"
+    "paths": {
+      "~/*": ["./src/*"]
+    }
   },
   "include": ["src"],
   "references": [


### PR DESCRIPTION
- helps organising imports
- makes it clearer it's an internal import and not an external import
- most UI frameworks use this