### PR TITLE
feat(Flow): customise drop event

### DIFF
--- a/packages/lab/src/components/Flow/DroppableFlow.tsx
+++ b/packages/lab/src/components/Flow/DroppableFlow.tsx
@@ -43,8 +43,20 @@ export interface HvDroppableFlowProps<
   edges?: Edge[];
   /** A Jss Object used to override or extend the styles applied to the component. */
   classes?: HvFlowClasses;
-  /** Function called when the flow changes. Returns the updated nodes and edges. */
+  /** Callback called when the flow changes. Returns the updated nodes and edges. */
   onFlowChange?: (nodes: Node<NodeData, NodeType>[], edges: Edge[]) => void;
+  /**
+   * Callback called when a node is dropped in the flow.
+   *
+   * This callback should be used to override the custom UI Kit drop event.
+   * Thus, when defined, the user is responsible for adding nodes to the flow.
+   *
+   * This callback is called when `HvFlowSidebar` is used or a custom sidebar was created using Dnd Kit.
+   * When a custom sidebar was created using the native HTML drag and drop API, refer to the `onDrop` callback.
+   *
+   * Returns the event and the node to be added to the flow.
+   */
+  onDndDrop?: (event: DragEndEvent, node: Node) => void;
 }
 
 export const getNode = (nodes: Node[], nodeId: string) => {
@@ -103,6 +115,7 @@ export const HvDroppableFlow = ({
   className,
   children,
   onFlowChange,
+  onDndDrop,
   classes: classesProp,
   nodes: initialNodes = [],
   edges: initialEdges = [],
@@ -146,12 +159,19 @@ export const HvDroppableFlow = ({
           // Node data
           const data = event.active.data.current?.hvFlow?.data || {};
 
+          // Node to add
           const newNode: Node = {
             id: uid(),
             position,
             data,
             type,
           };
+
+          // Drop override
+          if (onDndDrop) {
+            onDndDrop(event, newNode);
+            return;
+          }
 
           setNodes((nds) => nds.concat(newNode));
         } else {
@@ -162,7 +182,7 @@ export const HvDroppableFlow = ({
         }
       }
     },
-    [elementId, nodeTypes, reactFlowInstance]
+    [elementId, nodeTypes, onDndDrop, reactFlowInstance]
   );
 
   useDndMonitor({

--- a/packages/lab/src/components/Flow/Node/Node.styles.tsx
+++ b/packages/lab/src/components/Flow/Node/Node.styles.tsx
@@ -13,6 +13,8 @@ export const { staticClasses, useClasses } = createClasses("HvFlowNode", {
     flexDirection: "row",
     justifyContent: "space-between",
     alignItems: "center",
+    borderTopLeftRadius: theme.radii.round,
+    borderTopRightRadius: theme.radii.round,
   },
   groupContainer: {
     display: "flex",

--- a/packages/lab/src/components/Flow/stories/CustomDrop/BarChart.tsx
+++ b/packages/lab/src/components/Flow/stories/CustomDrop/BarChart.tsx
@@ -3,34 +3,32 @@ import { HvFlowNode } from "@hitachivantara/uikit-react-lab";
 import { HvBarChart } from "@hitachivantara/uikit-react-viz";
 import { useStore } from "reactflow";
 
+import { data } from "./data";
+
 export const BarChart = (props) => {
   const { id } = props;
   const nodes = useStore((state) => state.getNodes());
   const edges = useStore((state) => state.edges);
   const dataNodeId = edges.find((e) => e.target === id)?.source;
-
   const dataNode = nodes.find((n) => n.id === dataNodeId);
 
   return (
     <HvFlowNode
-      description="Bar Chart description"
+      description="Bar Chart"
       expanded
       classes={{ root: css({ width: 500 }) }}
       {...props}
     >
-      {dataNode &&
-        dataNode.data &&
-        dataNode.data.jsonData &&
-        dataNode.data.jsonData.length > 0 && (
-          <div>
-            <HvBarChart
-              data={dataNode.data.jsonData}
-              splitBy="country"
-              groupBy="year"
-              measures="population"
-            />
-          </div>
-        )}
+      {dataNode && dataNode.data && dataNode.data.country && (
+        <div>
+          <HvBarChart
+            data={data[dataNode.data.country]}
+            groupBy="Month"
+            measures="Precipitation"
+            grid={{ top: 10, bottom: 40, right: 10, left: 40 }}
+          />
+        </div>
+      )}
     </HvFlowNode>
   );
 };
@@ -42,8 +40,7 @@ BarChart.meta = {
     {
       label: "Data",
       isMandatory: true,
-      accepts: ["jsonData"],
+      accepts: ["data"],
     },
   ],
-  outputs: [],
 };

--- a/packages/lab/src/components/Flow/stories/CustomDrop/LineChart.tsx
+++ b/packages/lab/src/components/Flow/stories/CustomDrop/LineChart.tsx
@@ -1,49 +1,46 @@
 import { css } from "@emotion/css";
 import { HvFlowNode } from "@hitachivantara/uikit-react-lab";
-import { HvBarChart } from "@hitachivantara/uikit-react-viz";
+import { HvLineChart } from "@hitachivantara/uikit-react-viz";
 import { useStore } from "reactflow";
 
-export const BarChart = (props) => {
+import { data } from "./data";
+
+export const LineChart = (props) => {
   const { id } = props;
   const nodes = useStore((state) => state.getNodes());
   const edges = useStore((state) => state.edges);
   const dataNodeId = edges.find((e) => e.target === id)?.source;
-
   const dataNode = nodes.find((n) => n.id === dataNodeId);
 
   return (
     <HvFlowNode
-      description="Bar Chart description"
+      description="Line Chart"
       expanded
       classes={{ root: css({ width: 500 }) }}
       {...props}
     >
-      {dataNode &&
-        dataNode.data &&
-        dataNode.data.jsonData &&
-        dataNode.data.jsonData.length > 0 && (
-          <div>
-            <HvBarChart
-              data={dataNode.data.jsonData}
-              splitBy="country"
-              groupBy="year"
-              measures="population"
-            />
-          </div>
-        )}
+      {dataNode && dataNode.data && dataNode.data.country && (
+        <div>
+          <HvLineChart
+            data={data[dataNode.data.country]}
+            groupBy="Month"
+            measures="Precipitation"
+            grid={{ top: 10, bottom: 40, right: 10, left: 40 }}
+          />
+        </div>
+      )}
     </HvFlowNode>
   );
 };
 
-BarChart.meta = {
-  label: "Bar Chart",
+LineChart.meta = {
+  label: "Line Chart",
   groupId: "visualizations",
   inputs: [
     {
       label: "Data",
       isMandatory: true,
-      accepts: ["jsonData"],
+      accepts: ["data"],
     },
   ],
-  outputs: [],
 };

--- a/packages/lab/src/components/Flow/stories/CustomDrop/Precipitation.tsx
+++ b/packages/lab/src/components/Flow/stories/CustomDrop/Precipitation.tsx
@@ -1,0 +1,33 @@
+import { HvFlowNode } from "@hitachivantara/uikit-react-lab";
+
+import { data } from "./data";
+
+export const Precipitation = (props) => {
+  return (
+    <HvFlowNode
+      description="Precipitation data"
+      expanded
+      params={[
+        {
+          id: "country",
+          label: "Country",
+          type: "select",
+          options: Object.keys(data),
+        },
+      ]}
+      {...props}
+    />
+  );
+};
+
+Precipitation.meta = {
+  label: "Precipitation",
+  groupId: "sources",
+  outputs: [
+    {
+      label: "Data",
+      isMandatory: true,
+      provides: "data",
+    },
+  ],
+};

--- a/packages/lab/src/components/Flow/stories/CustomDrop/data.ts
+++ b/packages/lab/src/components/Flow/stories/CustomDrop/data.ts
@@ -1,0 +1,35 @@
+const months = [
+  "January",
+  "February",
+  "March",
+  "April",
+  "May",
+  "June",
+  "July",
+  "August",
+  "September",
+  "October",
+  "November",
+  "December",
+];
+
+export const data = {
+  portugal: {
+    Month: months,
+    Precipitation: [
+      12.6, 15.9, 19.0, 26.0, 28.2, 70.7, 145.6, 132.2, 78.7, 22.8, 4.0, 2.9,
+    ],
+  },
+  usa: {
+    Month: months,
+    Precipitation: [
+      32.2, 17.2, 12.9, 22.0, 11.2, 99.7, 92.6, 11.2, 23.7, 19.8, 2.0, 7.9,
+    ],
+  },
+  japan: {
+    Month: months,
+    Precipitation: [
+      12.4, 34.9, 18.0, 45.2, 33.2, 67.7, 187.6, 245.2, 22.7, 12.8, 1.0, 6.9,
+    ],
+  },
+};

--- a/packages/lab/src/components/Flow/stories/CustomDrop/index.tsx
+++ b/packages/lab/src/components/Flow/stories/CustomDrop/index.tsx
@@ -1,0 +1,185 @@
+import { useMemo, useState } from "react";
+import { css } from "@emotion/css";
+import {
+  HvButton,
+  HvDialog,
+  HvDialogActions,
+  HvDialogContent,
+  HvDialogTitle,
+  HvDropdown,
+  HvDropdownProps,
+  HvGlobalActions,
+  theme,
+} from "@hitachivantara/uikit-react-core";
+import {
+  Add,
+  Backwards,
+  DataSource,
+  LineChartAlt,
+} from "@hitachivantara/uikit-react-icons";
+import {
+  HvFlowSidebar,
+  HvFlow,
+  HvFlowProps,
+  HvFlowControls,
+} from "@hitachivantara/uikit-react-lab";
+import { Node, ReactFlowInstance } from "reactflow";
+
+// The code for these components and values are available here: https://github.com/lumada-design/hv-uikit-react/tree/master/packages/lab/src/components/Flow/stories/CustomDrop
+import { Precipitation } from "./Precipitation";
+import { data } from "./data";
+import { LineChart } from "./LineChart";
+import { BarChart } from "./BarChart";
+
+// Node groups
+export type NodeGroups = "sources" | "visualizations";
+
+export const nodeGroups = {
+  sources: {
+    label: "Data Source",
+    color: "cat3_80",
+    description: "Find here all the available data sources.",
+    icon: <DataSource />,
+  },
+  visualizations: {
+    label: "Visualization",
+    color: "cat1_80",
+    description: "Find here all the available visualizations.",
+    icon: <LineChartAlt />,
+  },
+} satisfies HvFlowProps<NodeGroups>["nodeGroups"];
+
+// Node types
+export const nodeTypes = {
+  precipitation: Precipitation,
+  lineChart: LineChart,
+  barChart: BarChart,
+} satisfies HvFlowProps["nodeTypes"];
+
+export type NodeType = keyof typeof nodeTypes;
+
+// Flow
+const nodes = [] satisfies HvFlowProps<NodeGroups, NodeType>["nodes"];
+const edges = [] satisfies HvFlowProps<NodeGroups, NodeType>["edges"];
+
+// Classes
+const classes = {
+  root: css({ height: "100vh" }),
+  globalActions: css({ paddingBottom: theme.space.md }),
+  flow: css({
+    height: "calc(100% - 90px)",
+  }),
+};
+
+export const CustomDrop = () => {
+  const [reactFlowInstance, setReactFlowInstance] =
+    useState<ReactFlowInstance>();
+
+  const [open, setOpen] = useState(false);
+  const [precipitationConfig, setPrecipitationConfig] = useState<Node>();
+
+  const options = useMemo(
+    () =>
+      Object.keys(data).map((key) => {
+        return { label: key };
+      }),
+    []
+  );
+
+  const handleCloseConfig = () => {
+    setPrecipitationConfig(undefined);
+  };
+
+  const handleChangeConfig: HvDropdownProps["onChange"] = (value) => {
+    if (value && !Array.isArray(value) && precipitationConfig) {
+      setPrecipitationConfig({
+        ...precipitationConfig,
+        data: {
+          ...precipitationConfig.data,
+          country: value.label,
+        },
+      });
+    }
+  };
+
+  const handleApplyConfig = () => {
+    if (precipitationConfig) {
+      reactFlowInstance?.setNodes((nds) => nds.concat(precipitationConfig));
+
+      setPrecipitationConfig(undefined);
+    }
+  };
+
+  const handleDrop: HvFlowProps["onDndDrop"] = (event, node) => {
+    if (node.type === "precipitation") {
+      setPrecipitationConfig(node);
+    } else {
+      reactFlowInstance?.setNodes((nds) => nds.concat(node));
+    }
+  };
+
+  return (
+    <div className={classes.root}>
+      <HvGlobalActions
+        className={classes.globalActions}
+        position="relative"
+        backButton={
+          <HvButton aria-label="Back" icon>
+            <Backwards role="none" />
+          </HvButton>
+        }
+        title="New Flow"
+      >
+        <HvButton
+          variant="primary"
+          startIcon={<Add role="none" />}
+          onClick={() => setOpen(true)}
+        >
+          Add Node
+        </HvButton>
+      </HvGlobalActions>
+      <div className={classes.flow}>
+        <HvFlow
+          nodes={nodes}
+          edges={edges}
+          nodeTypes={nodeTypes}
+          nodeGroups={nodeGroups}
+          sidebar={
+            <HvFlowSidebar
+              title="Add Node"
+              description="Please choose within the options below"
+              open={open}
+              onClose={() => setOpen(false)}
+            />
+          }
+          onInit={setReactFlowInstance}
+          onDndDrop={handleDrop}
+        >
+          <HvFlowControls />
+        </HvFlow>
+      </div>
+      <HvDialog open={!!precipitationConfig} onClose={handleCloseConfig}>
+        <HvDialogTitle variant="info">Configure the node</HvDialogTitle>
+        <HvDialogContent>
+          <HvDropdown
+            label="Select the country"
+            values={options}
+            onChange={handleChangeConfig}
+          />
+        </HvDialogContent>
+        <HvDialogActions>
+          <HvButton
+            disabled={!precipitationConfig?.data.country}
+            variant="primary"
+            onClick={handleApplyConfig}
+          >
+            Apply
+          </HvButton>
+          <HvButton variant="secondarySubtle" onClick={handleCloseConfig}>
+            Cancel
+          </HvButton>
+        </HvDialogActions>
+      </HvDialog>
+    </div>
+  );
+};

--- a/packages/lab/src/components/Flow/stories/Dynamic/index.tsx
+++ b/packages/lab/src/components/Flow/stories/Dynamic/index.tsx
@@ -1,15 +1,11 @@
 import { useMemo, useState } from "react";
-
 import { css } from "@emotion/css";
-
 import {
   HvButton,
   HvGlobalActions,
   theme,
 } from "@hitachivantara/uikit-react-core";
-
 import { Add, Backwards, DataSource } from "@hitachivantara/uikit-react-icons";
-
 import {
   HvFlowSidebar,
   HvFlow,
@@ -17,6 +13,7 @@ import {
   HvFlowControls,
 } from "@hitachivantara/uikit-react-lab";
 
+// The code for these utils are available here: https://github.com/lumada-design/hv-uikit-react/tree/master/packages/lab/src/components/Flow/stories/Dynamic
 import { createAsset } from "./utils";
 
 // Node groups

--- a/packages/lab/src/components/Flow/stories/Flow.stories.tsx
+++ b/packages/lab/src/components/Flow/stories/Flow.stories.tsx
@@ -17,6 +17,8 @@ import { Visualizations as VisualizationsStory } from "./Visualizations";
 import VisualizationsRaw from "./Visualizations?raw";
 import { Dynamic as DynamicStory } from "./Dynamic";
 import DynamicRaw from "./Dynamic?raw";
+import { CustomDrop as CustomDropStory } from "./CustomDrop";
+import CustomDropRaw from "./CustomDrop?raw";
 
 const meta: Meta<typeof HvFlow> = {
   title: "Lab/Flow",
@@ -75,7 +77,7 @@ export const Visualizations: StoryObj<HvFlowProps> = {
     docs: {
       description: {
         story: `The HvFlowNode component can take any content as children. In this sample, we created visualizations based on the JSON output of the first node.
-        <br /><br />Please refer to the <b><a target="_blank" href="https://github.com/lumada-design/hv-uikit-react/blob/master/packages/lab/src/components/Flow/stories/Visualizations/Visualizations.tsx">code samples</a> </b> in our repository for more details.`,
+        <br /><br />Please refer to the [code samples](https://github.com/lumada-design/hv-uikit-react/blob/master/packages/lab/src/components/Flow/stories/Visualizations/Visualizations.tsx) in our repository for more details.`,
       },
       source: {
         code: VisualizationsRaw,
@@ -89,9 +91,6 @@ export const Visualizations: StoryObj<HvFlowProps> = {
 export const DynamicNodes: StoryObj<HvFlowProps> = {
   parameters: {
     docs: {
-      description: {
-        story: ``,
-      },
       source: {
         code: DynamicRaw,
       },
@@ -99,4 +98,20 @@ export const DynamicNodes: StoryObj<HvFlowProps> = {
     eyes: { include: false },
   },
   render: () => <DynamicStory />,
+};
+
+export const CustomDrop: StoryObj<HvFlowProps> = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "If necessary, the drop event can be customized through the `onDndDrop` property. This callback is used to override the custom UI Kit drop event. Thus, when defined, you are responsible for adding nodes to the flow. In this sample, the drop event was overridden to show a dialog to configure the node.",
+      },
+      source: {
+        code: CustomDropRaw,
+      },
+    },
+    eyes: { include: false },
+  },
+  render: () => <CustomDropStory />,
 };


### PR DESCRIPTION
In this PR, a new callback called `onDndDrop` was created to override our custom drop event:
- This callback is called when a node is dropped in the flow.
- When defined, the user is responsible for adding nodes to the flow.
- This callback is called when `HvFlowSidebar` is used or a custom sidebar was created using Dnd Kit. When a custom sidebar is created using the native HTML drag and drop API, the user should use the native `onDrop` callback.
   - This is why I called it  `onDndDrop`. If you think this should be changed, let me know.  
- This callback returns the event and the node to be added to the flow.