### PR TITLE
feat(DropdownMenu): align with DS 5.7

### DIFF
--- a/packages/core/src/components/DropDownMenu/DropDownMenu.stories.tsx
+++ b/packages/core/src/components/DropDownMenu/DropDownMenu.stories.tsx
@@ -73,10 +73,8 @@ export const WithIconsAndActions: StoryObj<HvDropDownMenuProps> = {
     return (
       <HvDropDownMenu
         expanded
-        id="dropdownmenu-with-icons-and-actions"
         placement="right"
         onClick={(e, item) => console.log(item.label)}
-        aria-label="dropdownMenu-3"
         dataList={[
           { label: "Label 1", icon: iconSelectedColor(User) },
           { label: "Label 2", icon: iconSelectedColor(Calendar) },
@@ -98,9 +96,7 @@ export const DisabledItems: StoryObj<HvDropDownMenuProps> = {
   render: () => {
     return (
       <HvDropDownMenu
-        id="dpmDisabledItems"
         expanded
-        aria-label="dropdownMenu-DisabledItems"
         dataList={[
           { label: "Label 1" },
           { label: "Label 2", disabled: true },
@@ -118,6 +114,7 @@ export const Controlled: StoryObj<HvDropDownMenuProps> = {
         story: "DropDownMenu toggle opening controlled by an external button.",
       },
     },
+    eyes: { include: false },
   },
   render: () => {
     const [open, setOpen] = useState(true);
@@ -135,11 +132,9 @@ export const Controlled: StoryObj<HvDropDownMenuProps> = {
           {!open ? "Open" : "Close"}
         </HvButton>
         <HvDropDownMenu
-          id="dropMenu"
           expanded={open}
           onClick={(e, item) => console.log(item.label)}
           disablePortal={false}
-          aria-label="dropdownMenu-1"
           keepOpened={false}
           dataList={[
             { label: "Label 1" },
@@ -153,8 +148,4 @@ export const Controlled: StoryObj<HvDropDownMenuProps> = {
       </>
     );
   },
-};
-
-Controlled.parameters = {
-  eyes: { include: false },
 };

--- a/packages/core/src/components/DropDownMenu/DropDownMenu.styles.tsx
+++ b/packages/core/src/components/DropDownMenu/DropDownMenu.styles.tsx
@@ -42,7 +42,7 @@ export const { staticClasses, useClasses } = createClasses("HvDropDownMenu", {
     },
 
     borderRadius: `${theme.radii.base} ${theme.radii.base} 0px 0px`,
-    border: `1px solid ${theme.colors.secondary_80}`,
+    border: `1px solid ${theme.colors.secondary}`,
   },
   /** Styles applied to the list root. */
   menuListRoot: {},

--- a/packages/core/src/components/DropDownMenu/DropDownMenu.tsx
+++ b/packages/core/src/components/DropDownMenu/DropDownMenu.tsx
@@ -4,7 +4,6 @@ import { theme } from "@hitachivantara/uikit-styles";
 import { MoreOptionsVertical } from "@hitachivantara/uikit-react-icons";
 
 import { useDefaultProps } from "@core/hooks/useDefaultProps";
-
 import { useUniqueId } from "@core/hooks/useUniqueId";
 import { useControlled } from "@core/hooks/useControlled";
 import { HvBaseProps } from "@core/types/generic";


### PR DESCRIPTION
DS 5.7 alignement for the `DropdownMenu`:
- Border color changed to `secondary`
- The rest was already updated in this [PR](https://github.com/lumada-design/hv-uikit-react/pull/3755)