### PR TITLE
feat(FlowSidebar): drag overlay customisation and fix drag overlay position in docs

### DIFF
--- a/packages/lab/src/components/Flow/Sidebar/Sidebar.tsx
+++ b/packages/lab/src/components/Flow/Sidebar/Sidebar.tsx
@@ -1,15 +1,13 @@
 import { useEffect, useMemo, useState } from "react";
-
 import debounce from "lodash/debounce";
-
 import {
   DndContextProps,
   DragOverlay,
+  DragOverlayProps,
   useDndMonitor,
   useDroppable,
 } from "@dnd-kit/core";
 import { restrictToWindowEdges } from "@dnd-kit/modifiers";
-
 import {
   ExtractNames,
   HvDrawer,
@@ -47,6 +45,12 @@ export interface HvFlowSidebarProps
     searchPlaceholder?: string;
     searchAriaLabel?: string;
   };
+  /**
+   * Dnd Kit drag overlay props for customization.
+   *
+   * More information can be found in the [Dnd Kit documentation](https://docs.dndkit.com/api-documentation/draggable/drag-overlay).
+   */
+  dragOverlayProps?: DragOverlayProps;
 }
 
 const DEFAULT_LABELS: HvFlowSidebarProps["labels"] = {
@@ -64,6 +68,7 @@ export const HvFlowSidebar = ({
   buttonTitle = "Close",
   classes: classesProp,
   labels: labelsProps,
+  dragOverlayProps,
   ...others
 }: HvFlowSidebarProps) => {
   const { classes } = useClasses(classesProp);
@@ -186,7 +191,7 @@ export const HvFlowSidebar = ({
           </div>
         </div>
       </HvDrawer>
-      <DragOverlay modifiers={[restrictToWindowEdges]}>
+      <DragOverlay modifiers={[restrictToWindowEdges]} {...dragOverlayProps}>
         {draggingLabel ? (
           <HvFlowSidebarGroupItem label={draggingLabel} isDragging />
         ) : null}

--- a/packages/lab/src/components/Flow/stories/Base/index.tsx
+++ b/packages/lab/src/components/Flow/stories/Base/index.tsx
@@ -10,6 +10,7 @@ import {
   HvFlowProps,
   HvFlowDefaultActions,
 } from "@hitachivantara/uikit-react-lab";
+import { Modifier } from "@dnd-kit/core";
 
 // The code for these components are available here: https://github.com/lumada-design/hv-uikit-react/tree/master/packages/lab/src/components/Flow/stories/Base
 import { Dashboard } from "./Dashboard";
@@ -68,3 +69,23 @@ export const nodeTypes = {
 } satisfies HvFlowProps["nodeTypes"];
 
 export type NodeType = keyof typeof nodeTypes;
+
+// Fixes a problem we have while dragging node types from the sidebar to the flow in storybook docs mode
+type RestrictToSampleModifier = Modifier extends (...args: infer A) => infer R
+  ? (rootId: string, ...args: A) => R
+  : unknown;
+
+export const restrictToSample: RestrictToSampleModifier = (
+  rootId,
+  { transform }
+) => {
+  const rect = document.getElementById(rootId)?.getBoundingClientRect();
+
+  const docsMode = window.location.search.includes("?viewMode=docs");
+
+  return {
+    ...transform,
+    x: docsMode && rect?.x ? -rect.x + transform.x : transform.x,
+    y: docsMode && rect?.y ? -rect.y + transform.y : transform.y,
+  };
+};

--- a/packages/lab/src/components/Flow/stories/CustomDrop/index.tsx
+++ b/packages/lab/src/components/Flow/stories/CustomDrop/index.tsx
@@ -10,6 +10,7 @@ import {
   HvDropdownProps,
   HvGlobalActions,
   theme,
+  useTheme,
 } from "@hitachivantara/uikit-react-core";
 import {
   Add,
@@ -24,12 +25,15 @@ import {
   HvFlowControls,
 } from "@hitachivantara/uikit-react-lab";
 import { Node, ReactFlowInstance } from "reactflow";
+import { restrictToWindowEdges } from "@dnd-kit/modifiers";
 
 // The code for these components and values are available here: https://github.com/lumada-design/hv-uikit-react/tree/master/packages/lab/src/components/Flow/stories/CustomDrop
 import { Precipitation } from "./Precipitation";
 import { data } from "./data";
 import { LineChart } from "./LineChart";
 import { BarChart } from "./BarChart";
+// The code for these utils are available here: https://github.com/lumada-design/hv-uikit-react/tree/master/packages/lab/src/components/Flow/stories/Base
+import { restrictToSample } from "../Base";
 
 // Node groups
 export type NodeGroups = "sources" | "visualizations";
@@ -72,6 +76,8 @@ const classes = {
 };
 
 export const CustomDrop = () => {
+  const { rootId } = useTheme();
+
   const [reactFlowInstance, setReactFlowInstance] =
     useState<ReactFlowInstance>();
 
@@ -150,6 +156,13 @@ export const CustomDrop = () => {
               description="Please choose within the options below"
               open={open}
               onClose={() => setOpen(false)}
+              // Needed to fix storybook
+              dragOverlayProps={{
+                modifiers: [
+                  restrictToWindowEdges,
+                  (args) => restrictToSample(rootId || "", args),
+                ],
+              }}
             />
           }
           onInit={setReactFlowInstance}

--- a/packages/lab/src/components/Flow/stories/Dynamic/index.tsx
+++ b/packages/lab/src/components/Flow/stories/Dynamic/index.tsx
@@ -4,6 +4,7 @@ import {
   HvButton,
   HvGlobalActions,
   theme,
+  useTheme,
 } from "@hitachivantara/uikit-react-core";
 import { Add, Backwards, DataSource } from "@hitachivantara/uikit-react-icons";
 import {
@@ -12,9 +13,12 @@ import {
   HvFlowProps,
   HvFlowControls,
 } from "@hitachivantara/uikit-react-lab";
+import { restrictToWindowEdges } from "@dnd-kit/modifiers";
 
 // The code for these utils are available here: https://github.com/lumada-design/hv-uikit-react/tree/master/packages/lab/src/components/Flow/stories/Dynamic
 import { createAsset } from "./utils";
+// The code for these utils are available here: https://github.com/lumada-design/hv-uikit-react/tree/master/packages/lab/src/components/Flow/stories/Base
+import { restrictToSample } from "../Base";
 
 // Node groups
 type NodeGroups = "assets";
@@ -52,6 +56,8 @@ const getRandomOption = () => {
 };
 
 export const Dynamic = () => {
+  const { rootId } = useTheme();
+
   const [open, setOpen] = useState(false);
 
   const nodeTypes = useMemo(() => {
@@ -112,6 +118,13 @@ export const Dynamic = () => {
               description="Please choose within the options below"
               open={open}
               onClose={() => setOpen(false)}
+              // Needed to fix storybook
+              dragOverlayProps={{
+                modifiers: [
+                  restrictToWindowEdges,
+                  (args) => restrictToSample(rootId || "", args),
+                ],
+              }}
             />
           }
         >

--- a/packages/lab/src/components/Flow/stories/InitialState/index.tsx
+++ b/packages/lab/src/components/Flow/stories/InitialState/index.tsx
@@ -1,10 +1,10 @@
 import { useState } from "react";
-
 import { css } from "@emotion/css";
 import {
   HvButton,
   HvGlobalActions,
   theme,
+  useTheme,
 } from "@hitachivantara/uikit-react-core";
 import { Add, Backwards } from "@hitachivantara/uikit-react-icons";
 import {
@@ -12,9 +12,10 @@ import {
   HvFlow,
   HvFlowControls,
 } from "@hitachivantara/uikit-react-lab";
+import { restrictToWindowEdges } from "@dnd-kit/modifiers";
 
 // The code for these values are available here: https://github.com/lumada-design/hv-uikit-react/tree/master/packages/lab/src/components/Flow/stories/Base/index.tsx
-import { nodeGroups, nodeTypes } from "../Base";
+import { nodeGroups, nodeTypes, restrictToSample } from "../Base";
 
 const initialState = {
   nodes: [
@@ -172,6 +173,8 @@ export const classes = {
 };
 
 export const InitialState = () => {
+  const { rootId } = useTheme();
+
   const [open, setOpen] = useState(false);
 
   return (
@@ -207,6 +210,13 @@ export const InitialState = () => {
               description="Please choose within the options below"
               open={open}
               onClose={() => setOpen(false)}
+              // Needed to fix storybook
+              dragOverlayProps={{
+                modifiers: [
+                  restrictToWindowEdges,
+                  (args) => restrictToSample(rootId || "", args),
+                ],
+              }}
             />
           }
         >

--- a/packages/lab/src/components/Flow/stories/Main/index.tsx
+++ b/packages/lab/src/components/Flow/stories/Main/index.tsx
@@ -1,11 +1,11 @@
 import { useState } from "react";
-
 import { css } from "@emotion/css";
 import {
   HvButton,
   HvGlobalActions,
   HvTypography,
   theme,
+  useTheme,
 } from "@hitachivantara/uikit-react-core";
 import { Add, Backwards, Fail } from "@hitachivantara/uikit-react-icons";
 import {
@@ -15,6 +15,7 @@ import {
   HvFlow,
   HvFlowProps,
 } from "@hitachivantara/uikit-react-lab";
+import { restrictToWindowEdges } from "@dnd-kit/modifiers";
 
 // The code for these values are available here: https://github.com/lumada-design/hv-uikit-react/tree/master/packages/lab/src/components/Flow/stories/Base/index.tsx
 import {
@@ -23,6 +24,7 @@ import {
   defaultActions,
   nodeGroups,
   nodeTypes,
+  restrictToSample,
 } from "../Base";
 
 // Flow
@@ -39,6 +41,8 @@ export const classes = {
 };
 
 export const Main = () => {
+  const { rootId } = useTheme();
+
   const [open, setOpen] = useState(false);
 
   const CustomAction = (
@@ -91,6 +95,13 @@ export const Main = () => {
               description="Please choose within the options below"
               open={open}
               onClose={() => setOpen(false)}
+              // Needed to fix storybook
+              dragOverlayProps={{
+                modifiers: [
+                  restrictToWindowEdges,
+                  (args) => restrictToSample(rootId || "", args),
+                ],
+              }}
             />
           }
           // Keeping track of flow updates

--- a/packages/lab/src/components/Flow/stories/Visualizations/index.tsx
+++ b/packages/lab/src/components/Flow/stories/Visualizations/index.tsx
@@ -1,10 +1,10 @@
 import { useState } from "react";
-
 import { css } from "@emotion/css";
 import {
   HvButton,
   HvGlobalActions,
   theme,
+  useTheme,
 } from "@hitachivantara/uikit-react-core";
 import {
   Add,
@@ -19,6 +19,7 @@ import {
   HvFlowProps,
   HvFlowControls,
 } from "@hitachivantara/uikit-react-lab";
+import { restrictToWindowEdges } from "@dnd-kit/modifiers";
 
 // The code for these components are available here: https://github.com/lumada-design/hv-uikit-react/tree/master/packages/lab/src/components/Flow/stories/Visualizations
 import { BarChart } from "./BarChart";
@@ -26,7 +27,7 @@ import { Filter } from "./Filter";
 import { JsonInput } from "./JsonInput";
 import { LineChart } from "./LineChart";
 // The code for these values are available here: https://github.com/lumada-design/hv-uikit-react/tree/master/packages/lab/src/components/Flow/stories/Base/index.tsx
-import { defaultActions } from "../Base";
+import { defaultActions, restrictToSample } from "../Base";
 
 // Note types
 const nodeTypes = {
@@ -157,6 +158,8 @@ export const classes = {
 };
 
 export const Visualizations = () => {
+  const { rootId } = useTheme();
+
   const [open, setOpen] = useState(false);
 
   return (
@@ -198,6 +201,13 @@ export const Visualizations = () => {
               description="Please choose within the options below"
               open={open}
               onClose={() => setOpen(false)}
+              // Needed to fix storybook
+              dragOverlayProps={{
+                modifiers: [
+                  restrictToWindowEdges,
+                  (args) => restrictToSample(rootId || "", args),
+                ],
+              }}
             />
           }
         >


### PR DESCRIPTION
The drag overlay position was fixed on storybook docs mode:
- For this, a new `dragOverlayProps` prop was added to the `HvFlowSidebar`