### PR TITLE
feat(Flow): decouple flow from node groups

### DIFF
--- a/packages/lab/src/components/Flow/Node/Node.tsx
+++ b/packages/lab/src/components/Flow/Node/Node.tsx
@@ -1,4 +1,4 @@
-import { SyntheticEvent, isValidElement, useState } from "react";
+import React, { SyntheticEvent, isValidElement, useState } from "react";
 
 import {
   ExtractNames,
@@ -22,6 +22,13 @@ export { staticClasses as flowNodeClasses };
 // TODO How to include here the types from the parent component?
 export type HvFlowNodeClasses = ExtractNames<typeof useClasses>;
 
+export type HvFlowNodeDefaults = {
+  title?: string;
+  subTitle?: string;
+  color?: string;
+  icon?: React.ReactNode;
+};
+
 export interface HvFlowNodeProps<T = any>
   extends Omit<HvFlowBaseNodeProps<T>, "classes"> {
   /** Node description */
@@ -36,6 +43,8 @@ export interface HvFlowNodeProps<T = any>
   expanded?: boolean;
   /** Node parameters */
   params?: HvFlowNodeParam[];
+  /** A set of node default values for when there are no groups to fetch this data from. */
+  nodeDefaults?: HvFlowNodeDefaults;
   /** A Jss Object used to override or extend the styles applied to the component. */
   classes?: HvFlowNodeClasses | HvFlowBaseNodeProps<T>["classes"];
 }
@@ -53,6 +62,7 @@ export const HvFlowNode = ({
   maxVisibleActions = 1,
   expanded = false,
   params,
+  nodeDefaults,
   classes: classesProp,
   children,
   ...props
@@ -63,13 +73,16 @@ export const HvFlowNode = ({
 
   const { nodeGroups, nodeTypes, defaultActions } = useFlowContext();
   const groupId = nodeTypes?.[type].meta?.groupId;
-  const subtitle = nodeTypes?.[type].meta?.label;
-  const groupLabel = groupId && nodeGroups && nodeGroups[groupId].label;
+  const subtitle = nodeTypes?.[type].meta?.label || nodeDefaults?.subTitle;
+  const groupLabel =
+    (groupId && nodeGroups && nodeGroups[groupId].label) || nodeDefaults?.title;
 
   const inputs = nodeTypes?.[type]?.meta?.inputs;
   const outputs = nodeTypes?.[type]?.meta?.outputs;
-  const icon = groupId && nodeGroups && nodeGroups[groupId].icon;
-  const colorProp = groupId && nodeGroups && nodeGroups[groupId].color;
+  const icon =
+    (groupId && nodeGroups && nodeGroups[groupId].icon) || nodeDefaults?.icon;
+  const colorProp =
+    (groupId && nodeGroups && nodeGroups[groupId].color) || nodeDefaults?.color;
   const color = getColor(colorProp);
 
   const actsVisible = actions?.slice(0, maxVisibleActions);

--- a/packages/lab/src/components/Flow/Sidebar/Sidebar.styles.tsx
+++ b/packages/lab/src/components/Flow/Sidebar/Sidebar.styles.tsx
@@ -18,4 +18,7 @@ export const { staticClasses, useClasses } = createClasses("HvFlowSidebar", {
     gap: theme.space.sm,
     listStyleType: "none",
   },
+  nodeType: {
+    marginBottom: theme.space.xs,
+  },
 });

--- a/packages/lab/src/components/Flow/Sidebar/SidebarGroup/SidebarGroup.tsx
+++ b/packages/lab/src/components/Flow/Sidebar/SidebarGroup/SidebarGroup.tsx
@@ -21,11 +21,13 @@ export { staticClasses as flowSidebarGroupClasses };
 
 export type HvFlowSidebarGroupClasses = ExtractNames<typeof useClasses>;
 
-export type HvFlowSidebarGroupNodes = {
+export type HvFlowSidebarGroupNode = {
   type: string;
   label: string;
   data?: unknown;
-}[];
+};
+
+export type HvFlowSidebarGroupNodes = HvFlowSidebarGroupNode[];
 
 export interface HvFlowSidebarGroupProps extends HvFlowNodeGroup {
   /** Group id. */

--- a/packages/lab/src/components/Flow/stories/Base/NoGroup/LineChart.tsx
+++ b/packages/lab/src/components/Flow/stories/Base/NoGroup/LineChart.tsx
@@ -1,0 +1,26 @@
+import { HvFlowNode } from "@hitachivantara/uikit-react-lab";
+
+export const LineChart = (props) => {
+  return (
+    <HvFlowNode
+      description="LineChart description"
+      nodeDefaults={{
+        title: "Line Chart",
+        subTitle: "Visualization",
+        color: "cat12_80",
+      }}
+      {...props}
+    />
+  );
+};
+
+LineChart.meta = {
+  label: "LineChart",
+  inputs: [
+    {
+      label: "Data",
+      isMandatory: true,
+      accepts: ["prediction", "detection"],
+    },
+  ],
+};

--- a/packages/lab/src/components/Flow/stories/Base/NoGroup/MLModelPrediction.tsx
+++ b/packages/lab/src/components/Flow/stories/Base/NoGroup/MLModelPrediction.tsx
@@ -1,0 +1,33 @@
+import { HvFlowNode } from "@hitachivantara/uikit-react-lab";
+
+export const MLModelPrediction = (props) => {
+  return (
+    <HvFlowNode
+      description="Anomaly Prediction description"
+      nodeDefaults={{
+        title: "ML Model Prediction",
+        subTitle: "ML Model Prediction",
+        color: "cat10_80",
+      }}
+      {...props}
+    />
+  );
+};
+
+MLModelPrediction.meta = {
+  label: "ML Model Prediction",
+  inputs: [
+    {
+      label: "Sensor Data",
+      isMandatory: true,
+      accepts: ["sensorData"],
+    },
+  ],
+  outputs: [
+    {
+      label: "Prediction",
+      isMandatory: true,
+      provides: "prediction",
+    },
+  ],
+};

--- a/packages/lab/src/components/Flow/stories/Base/NoGroup/Tron.tsx
+++ b/packages/lab/src/components/Flow/stories/Base/NoGroup/Tron.tsx
@@ -1,0 +1,41 @@
+import { HvFlowNode } from "@hitachivantara/uikit-react-lab";
+
+export const Tron = (props) => {
+  return (
+    <HvFlowNode
+      description="Tron asset description"
+      expanded
+      maxVisibleActions={1}
+      params={[
+        {
+          id: "asset",
+          label: "Asset",
+          type: "select",
+          options: ["Way Side", "Cars"],
+        },
+      ]}
+      nodeDefaults={{
+        title: "Tron",
+        subTitle: "Asset",
+        color: "cat11_80",
+      }}
+      {...props}
+    />
+  );
+};
+
+Tron.meta = {
+  label: "Tron",
+  outputs: [
+    {
+      label: "Sensor Group 1",
+      isMandatory: true,
+      provides: "sensorData",
+    },
+    {
+      label: "Sensor Group 2",
+      isMandatory: true,
+      provides: "sensorData",
+    },
+  ],
+};

--- a/packages/lab/src/components/Flow/stories/Flow.stories.tsx
+++ b/packages/lab/src/components/Flow/stories/Flow.stories.tsx
@@ -19,6 +19,8 @@ import { Dynamic as DynamicStory } from "./Dynamic";
 import DynamicRaw from "./Dynamic?raw";
 import { CustomDrop as CustomDropStory } from "./CustomDrop";
 import CustomDropRaw from "./CustomDrop?raw";
+import { NoGroups as NoGroupStory } from "./NoGroups";
+import NoGroupsRaw from "./NoGroups?raw";
 
 const meta: Meta<typeof HvFlow> = {
   title: "Lab/Flow",
@@ -114,4 +116,20 @@ export const CustomDrop: StoryObj<HvFlowProps> = {
     eyes: { include: false },
   },
   render: () => <CustomDropStory />,
+};
+
+export const NoGroups: StoryObj<HvFlowProps> = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "You don't need to use groups. If you don't use them, the sidebar will show a list of nodes.",
+      },
+      source: {
+        code: NoGroupsRaw,
+      },
+    },
+    eyes: { include: false },
+  },
+  render: () => <NoGroupStory />,
 };

--- a/packages/lab/src/components/Flow/stories/NoGroups/index.tsx
+++ b/packages/lab/src/components/Flow/stories/NoGroups/index.tsx
@@ -3,63 +3,50 @@ import { css } from "@emotion/css";
 import {
   HvButton,
   HvGlobalActions,
-  HvTypography,
   theme,
   useTheme,
 } from "@hitachivantara/uikit-react-core";
-import { Add, Backwards, Fail } from "@hitachivantara/uikit-react-icons";
+import { Add, Backwards } from "@hitachivantara/uikit-react-icons";
 import {
-  HvFlowControls,
   HvFlowSidebar,
-  HvFlowEmpty,
   HvFlow,
+  HvFlowControls,
   HvFlowProps,
 } from "@hitachivantara/uikit-react-lab";
 import { restrictToWindowEdges } from "@dnd-kit/modifiers";
 
-// The code for these values are available here: https://github.com/lumada-design/hv-uikit-react/tree/master/packages/lab/src/components/Flow/stories/Base/index.tsx
-import {
-  NodeGroups,
-  NodeType,
-  nodeGroups,
-  nodeTypes,
-  restrictToSample,
-} from "../Base";
-
-// Flow
-const nodes = [] satisfies HvFlowProps<NodeGroups, NodeType>["nodes"];
-const edges = [] satisfies HvFlowProps<NodeGroups, NodeType>["edges"];
+// The code for these utils are available here: https://github.com/lumada-design/hv-uikit-react/tree/master/packages/lab/src/components/Flow/stories/Base
+import { restrictToSample } from "../Base";
+import { Tron } from "../Base/NoGroup/Tron";
+import { LineChart } from "../Base/NoGroup/LineChart";
+import { MLModelPrediction } from "../Base/NoGroup/MLModelPrediction";
 
 // Classes
 export const classes = {
-  root: css({ height: "100vh" }),
+  root: css({
+    height: "100vh",
+    [`& .HvFlowSidebarGroup-itemsContainer`]: {
+      maxHeight: 300,
+      overflow: "scroll",
+    },
+  }),
   globalActions: css({ paddingBottom: theme.space.md }),
   flow: css({
     height: "calc(100% - 90px)",
   }),
 };
 
-export const Main = () => {
+// Node types
+export const nodeTypes = {
+  tron: Tron,
+  mlModelPrediction: MLModelPrediction,
+  lineChart: LineChart,
+} satisfies HvFlowProps["nodeTypes"];
+
+export const NoGroups = () => {
   const { rootId } = useTheme();
 
   const [open, setOpen] = useState(false);
-
-  const CustomAction = (
-    <div className={css({ display: "flex", flexDirection: "row" })}>
-      <HvTypography
-        link
-        component="a"
-        href="#"
-        onClick={(e) => {
-          e.preventDefault();
-          setOpen(true);
-        }}
-      >
-        Add nodes
-      </HvTypography>
-      <HvTypography>&nbsp;to start building your flow.</HvTypography>
-    </div>
-  );
 
   return (
     <div className={classes.root}>
@@ -83,10 +70,14 @@ export const Main = () => {
       </HvGlobalActions>
       <div className={classes.flow}>
         <HvFlow
-          nodes={nodes}
-          edges={edges}
+          nodes={[]}
+          edges={[]}
           nodeTypes={nodeTypes}
-          nodeGroups={nodeGroups}
+          defaultViewport={{
+            zoom: 0.7,
+            x: 0,
+            y: 0,
+          }}
           sidebar={
             <HvFlowSidebar
               title="Add Node"
@@ -100,25 +91,10 @@ export const Main = () => {
                   (args) => restrictToSample(rootId || "", args),
                 ],
               }}
-              defaultGroupProps={{
-                label: "All",
-                color: "cat11_80",
-                description:
-                  "This is for all the nodes that don't have groupId",
-              }}
             />
-          }
-          // Keeping track of flow updates
-          onFlowChange={(nds, eds) =>
-            console.log("Flow updated: ", { nodes: nds, edges: eds })
           }
         >
           <HvFlowControls />
-          <HvFlowEmpty
-            title="Empty Flow"
-            action={CustomAction}
-            icon={<Fail />}
-          />
         </HvFlow>
       </div>
     </div>

--- a/packages/lab/src/components/Flow/stories/Usage.stories.mdx
+++ b/packages/lab/src/components/Flow/stories/Usage.stories.mdx
@@ -1,6 +1,6 @@
 import { Meta, Canvas, Story } from "@storybook/addon-docs";
 
-<Meta title="Lab/Flow/Usage" />
+<Meta title="Guides/Flow" />
 
 # Creating flows <a id="creating-flows" />
 
@@ -34,11 +34,11 @@ Summary:
 
 To use the `HvFlow` component you'll need to define:
 
-- Node groups
 - Node types
 
 Optionally you can also define:
 
+- Node groups
 - Initial nodes
 - Initial edges
 - Default actions that all nodes will have
@@ -98,6 +98,9 @@ You can then create the sidebar by using the `HvFlowSidebar` component as a prop
 </HvFlow>
 ```
 
+But node groups are not mandatory. If you don't pass a `nodeGroups` prop to the `HvFlow` component, then all node types will be listed
+in the sidebar in a simple list of nodes.
+
 ## Layout <a id="layout" />
 
 There a few controls that you can add to your flow to control its layout and some functionality. All of these are components that you
@@ -126,7 +129,7 @@ component and shares the same interface.
 ## Custom nodes and node types <a id="custom-nodes-and-node-types" />
 
 The `HvFlowNode` component allows you to create your own nodes. It provides a base for your own custom nodes and is not to be used directly as a node on the flow.
-There are a few properties that should be set on your node `meta` property: the label, the list of inputs and outputs and the id of the group it belongs to.
+There are a few properties that should be set on your node `meta` property: the label, the list of inputs and outputs and, optionally, the id of the group it belongs to.
 The parameters are passed as a property of the `HvFlowNode` component.
 
 Example custom node:
@@ -172,6 +175,28 @@ CustomNode.meta = {
     },
   ],
 };
+```
+
+If you don't set a group id for any given node, then it will be added to a `Default` group that will serve as a repository to all nodes
+that are not in a group. The `Default` group is customizable via the `defaultGroupProps` on the `HvFlowSidebar` component. Example:
+
+```tsx
+<HvFlow
+  (...)
+  sidebar={
+    <HvFlowSidebar
+      (...)
+      defaultGroupProps={{
+        label: "All",
+        color: "cat11_80",
+        description:
+          "This is for all the nodes that don't have groupId",
+      }}
+    />
+  }
+>
+  (...)
+</HvFlow>
 ```
 
 ### Inputs and Outputs <a id="inputs-and-outputs" />

--- a/packages/lab/src/components/Flow/types/flow.ts
+++ b/packages/lab/src/components/Flow/types/flow.ts
@@ -51,7 +51,7 @@ export type HvFlowNodeTypeMeta<
   NodeData = any
 > = {
   label: string;
-  groupId: GroupId;
+  groupId?: GroupId;
   inputs?: HvFlowNodeInput[];
   outputs?: HvFlowNodeOutput[];
   data?: NodeData;


### PR DESCRIPTION
- Make groups optional in the Flow component
- If `nodeGroups` is provided any node that doesn't have a `groupId` will be placed on a "Default" group
  - the "Default" group is customizable via the new `defaultGroupProps` on the `Sidebar` component
- If `nodeGroups`is not provided then all the nodes are listed ungrouped on the sidebar
  - Since there are no groups to fetch data from (like the group name, group color, etc), a new `nodeDefaults` prop was added to the `Node` component that allows for passing this values
- Updated the Flow docs:
  - Added relevant samples
  - Moved the Flow `Usage` documentation to the `Guides` section