### PR TITLE
feat(Flow): max connections

### DIFF
--- a/packages/lab/src/components/Flow/DroppableFlow.tsx
+++ b/packages/lab/src/components/Flow/DroppableFlow.tsx
@@ -87,6 +87,7 @@ const validateEdge = (
 
   const sourceProvides = outputs[edge.sourceHandle]?.provides || "";
   const targetAccepts = inputs[edge.targetHandle]?.accepts || [];
+  const sourceMaxConnections = outputs[edge.sourceHandle]?.maxConnections;
   const targetMaxConnections = inputs[edge.targetHandle]?.maxConnections;
 
   let isValid = targetAccepts.includes(sourceProvides);
@@ -98,6 +99,15 @@ const validateEdge = (
     ).length;
 
     isValid = targetConnections < targetMaxConnections;
+  }
+
+  if (isValid && sourceMaxConnections != null) {
+    const sourceConnections = edges.filter(
+      (edg) =>
+        edg.source === edge.source && edg.sourceHandle === edge.sourceHandle
+    ).length;
+
+    isValid = sourceConnections < sourceMaxConnections;
   }
 
   return isValid;

--- a/packages/lab/src/components/Flow/DroppableFlow.tsx
+++ b/packages/lab/src/components/Flow/DroppableFlow.tsx
@@ -66,6 +66,7 @@ export const getNode = (nodes: Node[], nodeId: string) => {
 
 const validateEdge = (
   nodes: Node[],
+  edges: Edge[],
   edge: Edge,
   nodeMetaRegistry: HvFlowNodeMetaRegistry
 ) => {
@@ -86,8 +87,19 @@ const validateEdge = (
 
   const sourceProvides = outputs[edge.sourceHandle]?.provides || "";
   const targetAccepts = inputs[edge.targetHandle]?.accepts || [];
+  const targetMaxConnections = inputs[edge.targetHandle]?.maxConnections;
 
-  const isValid = targetAccepts.includes(sourceProvides);
+  let isValid = targetAccepts.includes(sourceProvides);
+
+  if (isValid && targetMaxConnections != null) {
+    const targetConnections = edges.filter(
+      (edg) =>
+        edg.target === edge.target && edg.targetHandle === edge.targetHandle
+    ).length;
+
+    isValid = targetConnections < targetMaxConnections;
+  }
+
   return isValid;
 };
 
@@ -220,7 +232,7 @@ export const HvDroppableFlow = ({
 
   const { registry } = useNodeMetaRegistry();
   const isValidConnection = (connection) =>
-    validateEdge(nodes, connection, registry);
+    validateEdge(nodes, edges, connection, registry);
 
   const defaultEdgeOptions = {
     markerEnd: {

--- a/packages/lab/src/components/Flow/Node/BaseNode.tsx
+++ b/packages/lab/src/components/Flow/Node/BaseNode.tsx
@@ -33,7 +33,7 @@ export { staticClasses as flowBaseNodeClasses };
 
 export type HvFlowBaseNodeClasses = ExtractNames<typeof useClasses>;
 
-export interface HvFlowBaseNodeProps<T>
+export interface HvFlowBaseNodeProps<T = any>
   extends Omit<HvBaseProps, "id">,
     NodeProps<T> {
   /** Header title */

--- a/packages/lab/src/components/Flow/Node/Node.tsx
+++ b/packages/lab/src/components/Flow/Node/Node.tsx
@@ -22,7 +22,7 @@ export { staticClasses as flowNodeClasses };
 // TODO How to include here the types from the parent component?
 export type HvFlowNodeClasses = ExtractNames<typeof useClasses>;
 
-export interface HvFlowNodeProps<T>
+export interface HvFlowNodeProps<T = any>
   extends Omit<HvFlowBaseNodeProps<T>, "classes"> {
   /** Node description */
   description?: string;

--- a/packages/lab/src/components/Flow/stories/Usage.stories.mdx
+++ b/packages/lab/src/components/Flow/stories/Usage.stories.mdx
@@ -176,27 +176,32 @@ CustomNode.meta = {
 
 ### Inputs and Outputs <a id="inputs-and-outputs" />
 
-Nodes need inputs and/or outputs to connect to other nodes. You define inputs and outputs on the `meta` property of the component and it
-follows a specific type:
+Nodes need inputs and/or outputs to connect to other nodes. Inputs and outputs can be defined on the `meta` property of the component and they
+follow specific types:
 
 ```typescript
 type HvFlowNodeInput = {
   label: string;
   isMandatory?: boolean;
   accepts?: string[];
+  maxConnections?: number;
 };
 
 type HvFlowNodeOutput = {
   label: string;
   isMandatory?: boolean;
-  provides?: string[];
+  provides?: string;
+  maxConnections?: number;
 };
 ```
 
-You'll notice that input nodes will have an `accepts` property and the output nodes have a `provides` property. These are used to limit
-how nodes connect to other nodes. These properties can have any array of strings in it and it's used just as a descriptor of what the
-node provides or accepts. So, for example, if a node provides `["data", "config"]` only nodes that accept any of these strings will
-allow a connection from that node.
+You'll notice that input nodes have an `accepts` property and the output nodes have a `provides` property. These are used to limit
+how nodes connect to other nodes and as a descriptor of what a node provides or accepts. Thus, for example, if a node
+provides `"config"`, only nodes that accept this string will allow a connection from that node. While inputs can accept an array of strings,
+an output only provides one.
+
+Furthermore, it's also possible to define the maximum number of connections allowed for a particular input and output. This enables you to limit
+the number of connections an input accepts as well as the number of connections an output can establish.
 
 ### Parameters <a id="parameters" />
 
@@ -218,7 +223,7 @@ It's saved in the form of:
 
 ```typescript
 data: {
-  [paramterId]: [parameterValue]
+  [parameterId]: [parameterValue]
 }
 ```
 

--- a/packages/lab/src/components/Flow/types/flow.ts
+++ b/packages/lab/src/components/Flow/types/flow.ts
@@ -67,6 +67,7 @@ export type HvFlowNodeInput = {
   label: string;
   isMandatory?: boolean;
   accepts?: string[];
+  maxConnections?: number;
 };
 
 export type HvFlowNodeOutput = {

--- a/packages/lab/src/components/Flow/types/flow.ts
+++ b/packages/lab/src/components/Flow/types/flow.ts
@@ -74,6 +74,7 @@ export type HvFlowNodeOutput = {
   label: string;
   isMandatory?: boolean;
   provides?: string;
+  maxConnections?: number;
 };
 
 export type HvFlowNodeParam = {


### PR DESCRIPTION
The property `maxConnections` was added to the node's outputs and inputs to define the maximum number of connections allowed.