### PR TITLE
fix(theme): spacing

### DIFF
--- a/packages/styles/src/theme.ts
+++ b/packages/styles/src/theme.ts
@@ -105,7 +105,7 @@ const themeVars: HvThemeVars = mapCSSVars({
 
 const spacing: HvThemeUtils["spacing"] = (...args) => {
   if (hasMultipleArgs(args)) {
-    return args.map(spacingUtil).join(" ");
+    return args.map((arg) => spacingUtil(arg, themeVars)).join(" ");
   }
 
   const [value] = args;
@@ -113,11 +113,11 @@ const spacing: HvThemeUtils["spacing"] = (...args) => {
   switch (typeof value) {
     case "number":
     case "string":
-      return spacingUtil(value);
+      return spacingUtil(value, themeVars);
     // TODO: remove in v6
     case "object":
       return value && value.length > 0
-        ? value.map(spacingUtilOld).join(" ")
+        ? value.map((val) => spacingUtilOld(val, themeVars)).join(" ")
         : "0px";
     default:
       return "0px";

--- a/packages/styles/src/utils.ts
+++ b/packages/styles/src/utils.ts
@@ -1,24 +1,31 @@
-import type { DeepString, HvThemeStructure, SpacingValue } from "./types";
-import { space } from "./tokens/space";
+import type {
+  DeepString,
+  HvThemeStructure,
+  HvThemeVars,
+  SpacingValue,
+} from "./types";
 
-export const spacingUtil = (value: SpacingValue): string => {
+export const spacingUtil = (value: SpacingValue, vars: HvThemeVars): string => {
   switch (typeof value) {
     case "number":
-      return `calc(${space.base} * ${value}px)`;
+      return `calc(${vars.space.base} * ${value}px)`;
     case "string":
-      return space[value] || value;
+      return vars.space[value] || value;
     default:
       return value;
   }
 };
 
 // TODO: remove in favour or `spacingUtil` in v6
-export const spacingUtilOld = (value: SpacingValue): string => {
+export const spacingUtilOld = (
+  value: SpacingValue,
+  vars: HvThemeVars
+): string => {
   switch (typeof value) {
     case "number":
       return `${value}px`;
     case "string":
-      return space[value] || value;
+      return vars.space[value] || value;
     default:
       return "0px";
   }


### PR DESCRIPTION
The `spacing` util was using the `space` token. This means that in DS3 this util was always using the DS5 values. Also, if someone was providing custom `space` values to the theme, the `spacing` util  was not using them. This was fixed by using the CSS vars instead.