### PR TITLE
fix(Flow): prevent drag and zoom on nodes

### DIFF
--- a/packages/lab/src/components/Flow/Node/BaseNode.tsx
+++ b/packages/lab/src/components/Flow/Node/BaseNode.tsx
@@ -153,6 +153,7 @@ export const HvFlowBaseNode = ({
   return (
     <div
       className={cx(
+        "nowheel", // Disables the default canvas pan behaviour when scrolling inside the node
         css({ border: `1px solid ${color}` }),
         classes.root,
         className

--- a/packages/lab/src/components/Flow/Node/Parameters/Select.tsx
+++ b/packages/lab/src/components/Flow/Node/Parameters/Select.tsx
@@ -20,6 +20,7 @@ const Select = ({ nodeId, param, data }) => {
 
   return (
     <HvDropdown
+      className="nodrag" // Prevents dragging within the select field
       disablePortal
       label={param.label}
       values={param.options?.map((o) => {

--- a/packages/lab/src/components/Flow/Node/Parameters/Select.tsx
+++ b/packages/lab/src/components/Flow/Node/Parameters/Select.tsx
@@ -27,6 +27,7 @@ const Select = ({ nodeId, param, data }) => {
         return { id: o, label: o, selected: o === option };
       })}
       onChange={(item) => onSelectChange(item)}
+      maxHeight={100}
     />
   );
 };

--- a/packages/lab/src/components/Flow/Node/Parameters/Text.tsx
+++ b/packages/lab/src/components/Flow/Node/Parameters/Text.tsx
@@ -20,6 +20,7 @@ const Text = ({ nodeId, param, data }) => {
 
   return (
     <HvInput
+      className="nodrag" // Prevents dragging within the input field
       label={param.label}
       value={text}
       onChange={(evt, val) => onTextChange(val)}

--- a/packages/lab/src/components/Flow/stories/Base/Tron.tsx
+++ b/packages/lab/src/components/Flow/stories/Base/Tron.tsx
@@ -87,7 +87,7 @@ export const Tron = (props) => {
             id: "asset",
             label: "Asset",
             type: "select",
-            options: ["Way Side", "Cars"],
+            options: ["Way Side", "Cars", "Helix", "Launch Track"],
           },
         ]}
         {...props}


### PR DESCRIPTION
The following fixes were implemented:
- [`nodrag`](https://reactflow.dev/api-reference/types/node-props#notes) class added to the text and select params to prevent dragging the node within the fields: because of this it wasn't possible to select the text inside the input for example.
- [`nowheel`](https://reactflow.dev/api-reference/types/node-props#notes) class added to the base node to disable the default canvas pan behaviour when scrolling inside the node: without this the canvas was zooming in or out when scrolling inside the node.
- `maxHeight` added to the select param to avoid having huge list.

This can be tested with the "Tron" node inside the "Main" sample.