### PR TITLE
docs: fix donut charts style

### DIFF
--- a/packages/core/src/components/Section/Section.stories.tsx
+++ b/packages/core/src/components/Section/Section.stories.tsx
@@ -70,7 +70,7 @@ export const WithActions: StoryObj<HvSectionProps> = {
         gridTemplateColumns: "repeat(2, 1fr)",
         gap: theme.space.sm,
       }),
-      root: css({ position: "relative" }),
+      root: css({ position: "relative", height: "100%" }),
       content: css({
         display: "flex",
         flexDirection: "column",

--- a/packages/core/src/components/Section/Section.tsx
+++ b/packages/core/src/components/Section/Section.tsx
@@ -25,7 +25,6 @@ export interface HvSectionProps
   /** When uncontrolled, defines the initial expanded state. */
   defaultExpanded?: boolean;
   /** Section actions */
-  // actions?: HvActionGeneric[];
   actions?: React.ReactNode;
   /** Section onExpand callback */
   onToggle?: (

--- a/templates/Dashboard/index.tsx
+++ b/templates/Dashboard/index.tsx
@@ -94,7 +94,7 @@ const Dashboard = () => {
         />
       </GridPanel>
       <GridPanel xs={12} md={4} isLoading={isLoading}>
-        <div className={css({ position: "relative" })}>
+        <div className={css({ position: "relative", height: "100%" })}>
           <HvDonutChart
             data={data.donutData}
             groupBy="Category"


### PR DESCRIPTION
This PR fixes:

<img width="1019" alt="Screenshot 2023-11-13 at 12 01 33" src="https://github.com/lumada-design/hv-uikit-react/assets/43220251/bb4fbeb0-f2e3-4021-ba74-ba7277759848">
