### PR TITLE
feat(Flow): multiple select param

### DIFF
--- a/packages/lab/src/components/Flow/Node/Parameters/Text.tsx
+++ b/packages/lab/src/components/Flow/Node/Parameters/Text.tsx
@@ -1,19 +1,32 @@
 import { useState } from "react";
-import { HvInput } from "@hitachivantara/uikit-react-core";
+import { HvInput, HvInputProps } from "@hitachivantara/uikit-react-core";
 import { useReactFlow } from "reactflow";
 
-const Text = ({ nodeId, param, data }) => {
-  const reactFlowInstance = useReactFlow();
-  const [text, setText] = useState(data[param.id]);
+import { HvFlowNodeTextParam } from "../../types";
 
-  const onTextChange = (val) => {
+interface TextProps {
+  nodeId: string;
+  param: Omit<HvFlowNodeTextParam, "type">;
+  data: any;
+}
+
+const Text = ({ nodeId, param, data }: TextProps) => {
+  const { id, label } = param;
+
+  const reactFlowInstance = useReactFlow();
+
+  const [text, setText] = useState(data[id]);
+
+  const onTextChange: HvInputProps["onChange"] = (event, val) => {
     const nodes = reactFlowInstance.getNodes();
+
     const newNodes = nodes.map((node) => {
       if (node.id === nodeId) {
-        node.data = { ...node.data, [param.id]: val };
+        node.data = { ...node.data, [id]: val };
       }
       return node;
     });
+
     reactFlowInstance.setNodes(newNodes);
     setText(val);
   };
@@ -21,9 +34,9 @@ const Text = ({ nodeId, param, data }) => {
   return (
     <HvInput
       className="nodrag" // Prevents dragging within the input field
-      label={param.label}
+      label={label}
       value={text}
-      onChange={(evt, val) => onTextChange(val)}
+      onChange={onTextChange}
     />
   );
 };

--- a/packages/lab/src/components/Flow/stories/Base/Dashboard.tsx
+++ b/packages/lab/src/components/Flow/stories/Base/Dashboard.tsx
@@ -1,6 +1,7 @@
 import { HvFlowNode } from "@hitachivantara/uikit-react-lab";
+import { NodeProps } from "reactflow";
 
-export const Dashboard = (props) => {
+export const Dashboard = (props: NodeProps) => {
   return (
     <HvFlowNode
       description="Dashboard description"

--- a/packages/lab/src/components/Flow/stories/Base/KPI.tsx
+++ b/packages/lab/src/components/Flow/stories/Base/KPI.tsx
@@ -1,6 +1,7 @@
 import { HvFlowNode } from "@hitachivantara/uikit-react-lab";
+import { NodeProps } from "reactflow";
 
-export const KPI = (props) => {
+export const KPI = (props: NodeProps) => {
   return <HvFlowNode description="KPI description" {...props} />;
 };
 

--- a/packages/lab/src/components/Flow/stories/Base/LineChart.tsx
+++ b/packages/lab/src/components/Flow/stories/Base/LineChart.tsx
@@ -1,6 +1,7 @@
 import { HvFlowNode } from "@hitachivantara/uikit-react-lab";
+import { NodeProps } from "reactflow";
 
-export const LineChart = (props) => {
+export const LineChart = (props: NodeProps) => {
   return <HvFlowNode description="LineChart description" {...props} />;
 };
 

--- a/packages/lab/src/components/Flow/stories/Base/MLModelDetection.tsx
+++ b/packages/lab/src/components/Flow/stories/Base/MLModelDetection.tsx
@@ -1,6 +1,7 @@
 import { HvFlowNode } from "@hitachivantara/uikit-react-lab";
+import { NodeProps } from "reactflow";
 
-export const MLModelDetection = (props) => {
+export const MLModelDetection = (props: NodeProps) => {
   return <HvFlowNode description="Anomaly detection description" {...props} />;
 };
 

--- a/packages/lab/src/components/Flow/stories/Base/MLModelPrediction.tsx
+++ b/packages/lab/src/components/Flow/stories/Base/MLModelPrediction.tsx
@@ -1,6 +1,7 @@
 import { HvFlowNode } from "@hitachivantara/uikit-react-lab";
+import { NodeProps } from "reactflow";
 
-export const MLModelPrediction = (props) => {
+export const MLModelPrediction = (props: NodeProps) => {
   return <HvFlowNode description="Anomaly Prediction description" {...props} />;
 };
 

--- a/packages/lab/src/components/Flow/stories/Base/NoGroup/LineChart.tsx
+++ b/packages/lab/src/components/Flow/stories/Base/NoGroup/LineChart.tsx
@@ -1,6 +1,7 @@
 import { HvFlowNode } from "@hitachivantara/uikit-react-lab";
+import { NodeProps } from "reactflow";
 
-export const LineChart = (props) => {
+export const LineChart = (props: NodeProps) => {
   return (
     <HvFlowNode
       description="LineChart description"

--- a/packages/lab/src/components/Flow/stories/Base/NoGroup/MLModelPrediction.tsx
+++ b/packages/lab/src/components/Flow/stories/Base/NoGroup/MLModelPrediction.tsx
@@ -1,6 +1,7 @@
 import { HvFlowNode } from "@hitachivantara/uikit-react-lab";
+import { NodeProps } from "reactflow";
 
-export const MLModelPrediction = (props) => {
+export const MLModelPrediction = (props: NodeProps) => {
   return (
     <HvFlowNode
       description="Anomaly Prediction description"

--- a/packages/lab/src/components/Flow/stories/Base/NoGroup/Tron.tsx
+++ b/packages/lab/src/components/Flow/stories/Base/NoGroup/Tron.tsx
@@ -1,6 +1,7 @@
 import { HvFlowNode } from "@hitachivantara/uikit-react-lab";
+import { NodeProps } from "reactflow";
 
-export const Tron = (props) => {
+export const Tron = (props: NodeProps) => {
   return (
     <HvFlowNode
       description="Tron asset description"

--- a/packages/lab/src/components/Flow/stories/Base/Table.tsx
+++ b/packages/lab/src/components/Flow/stories/Base/Table.tsx
@@ -1,6 +1,7 @@
 import { HvFlowNode } from "@hitachivantara/uikit-react-lab";
+import { NodeProps } from "reactflow";
 
-export const Table = (props) => {
+export const Table = (props: NodeProps) => {
   return <HvFlowNode description="Table description" {...props} />;
 };
 

--- a/packages/lab/src/components/Flow/stories/Base/Tron.tsx
+++ b/packages/lab/src/components/Flow/stories/Base/Tron.tsx
@@ -10,9 +10,9 @@ import {
 } from "@hitachivantara/uikit-react-core";
 import { Favorite, Flag, Search } from "@hitachivantara/uikit-react-icons";
 import { HvFlowNode, useFlowNode } from "@hitachivantara/uikit-react-lab";
-import { Node } from "reactflow";
+import { Node, NodeProps } from "reactflow";
 
-export const Tron = (props) => {
+export const Tron = (props: NodeProps) => {
   const { id } = props;
   const [showDialog, setShowDialog] = useState(false);
   const [details, setDetails] = useState<Node | undefined>();

--- a/packages/lab/src/components/Flow/stories/CustomDrop/BarChart.tsx
+++ b/packages/lab/src/components/Flow/stories/CustomDrop/BarChart.tsx
@@ -1,11 +1,11 @@
 import { css } from "@emotion/css";
 import { HvFlowNode } from "@hitachivantara/uikit-react-lab";
 import { HvBarChart } from "@hitachivantara/uikit-react-viz";
-import { useStore } from "reactflow";
+import { NodeProps, useStore } from "reactflow";
 
 import { data } from "./data";
 
-export const BarChart = (props) => {
+export const BarChart = (props: NodeProps) => {
   const { id } = props;
   const nodes = useStore((state) => state.getNodes());
   const edges = useStore((state) => state.edges);

--- a/packages/lab/src/components/Flow/stories/CustomDrop/BarChart.tsx
+++ b/packages/lab/src/components/Flow/stories/CustomDrop/BarChart.tsx
@@ -20,12 +20,19 @@ export const BarChart = (props: NodeProps) => {
       {...props}
     >
       {dataNode && dataNode.data && dataNode.data.country && (
-        <div>
+        <div
+          className={css({
+            height: 300,
+          })}
+        >
           <HvBarChart
             data={data[dataNode.data.country]}
             groupBy="Month"
             measures="Precipitation"
-            grid={{ top: 10, bottom: 40, right: 10, left: 40 }}
+            yAxis={{
+              name: "mm",
+            }}
+            grid={{ bottom: 40, top: 40 }}
           />
         </div>
       )}

--- a/packages/lab/src/components/Flow/stories/CustomDrop/LineChart.tsx
+++ b/packages/lab/src/components/Flow/stories/CustomDrop/LineChart.tsx
@@ -1,11 +1,11 @@
 import { css } from "@emotion/css";
 import { HvFlowNode } from "@hitachivantara/uikit-react-lab";
 import { HvLineChart } from "@hitachivantara/uikit-react-viz";
-import { useStore } from "reactflow";
+import { NodeProps, useStore } from "reactflow";
 
 import { data } from "./data";
 
-export const LineChart = (props) => {
+export const LineChart = (props: NodeProps) => {
   const { id } = props;
   const nodes = useStore((state) => state.getNodes());
   const edges = useStore((state) => state.edges);

--- a/packages/lab/src/components/Flow/stories/CustomDrop/LineChart.tsx
+++ b/packages/lab/src/components/Flow/stories/CustomDrop/LineChart.tsx
@@ -20,12 +20,19 @@ export const LineChart = (props: NodeProps) => {
       {...props}
     >
       {dataNode && dataNode.data && dataNode.data.country && (
-        <div>
+        <div
+          className={css({
+            height: 300,
+          })}
+        >
           <HvLineChart
             data={data[dataNode.data.country]}
             groupBy="Month"
             measures="Precipitation"
-            grid={{ top: 10, bottom: 40, right: 10, left: 40 }}
+            yAxis={{
+              name: "mm",
+            }}
+            grid={{ bottom: 40, top: 40 }}
           />
         </div>
       )}

--- a/packages/lab/src/components/Flow/stories/CustomDrop/Precipitation.tsx
+++ b/packages/lab/src/components/Flow/stories/CustomDrop/Precipitation.tsx
@@ -1,8 +1,9 @@
 import { HvFlowNode } from "@hitachivantara/uikit-react-lab";
+import { NodeProps } from "reactflow";
 
 import { data } from "./data";
 
-export const Precipitation = (props) => {
+export const Precipitation = (props: NodeProps) => {
   return (
     <HvFlowNode
       description="Precipitation data"

--- a/packages/lab/src/components/Flow/stories/Dynamic/utils.tsx
+++ b/packages/lab/src/components/Flow/stories/Dynamic/utils.tsx
@@ -1,7 +1,8 @@
 import { HvFlowNode } from "@hitachivantara/uikit-react-lab";
+import { NodeProps } from "reactflow";
 
 export const createAsset = ({ label, description, params, data }) => {
-  const Asset = (props) => {
+  const Asset = (props: NodeProps) => {
     return (
       <HvFlowNode
         description={description}

--- a/packages/lab/src/components/Flow/stories/Visualizations/BarChart.tsx
+++ b/packages/lab/src/components/Flow/stories/Visualizations/BarChart.tsx
@@ -1,5 +1,4 @@
 import { css } from "@emotion/css";
-import { theme } from "@hitachivantara/uikit-react-core";
 import { HvFlowNode } from "@hitachivantara/uikit-react-lab";
 import { HvBarChart } from "@hitachivantara/uikit-react-viz";
 import { NodeProps, useStore } from "reactflow";
@@ -24,15 +23,20 @@ export const BarChart = (props: NodeProps) => {
         dataNode.data.jsonData &&
         dataNode.data.jsonData.length > 0 && (
           <div
-            style={{
-              padding: theme.spacing("xs", "xs", "xs", "sm"),
-            }}
+            className={css({
+              height: 300,
+            })}
           >
             <HvBarChart
               data={dataNode.data.jsonData}
               splitBy="country"
               groupBy="year"
               measures="population"
+              yAxis={{
+                name: "Millions",
+                labelFormatter: (value) => `${Number(value) / 1000000}`,
+              }}
+              grid={{ bottom: 40 }}
             />
           </div>
         )}

--- a/packages/lab/src/components/Flow/stories/Visualizations/BarChart.tsx
+++ b/packages/lab/src/components/Flow/stories/Visualizations/BarChart.tsx
@@ -2,9 +2,9 @@ import { css } from "@emotion/css";
 import { theme } from "@hitachivantara/uikit-react-core";
 import { HvFlowNode } from "@hitachivantara/uikit-react-lab";
 import { HvBarChart } from "@hitachivantara/uikit-react-viz";
-import { useStore } from "reactflow";
+import { NodeProps, useStore } from "reactflow";
 
-export const BarChart = (props) => {
+export const BarChart = (props: NodeProps) => {
   const { id } = props;
   const nodes = useStore((state) => state.getNodes());
   const edges = useStore((state) => state.edges);

--- a/packages/lab/src/components/Flow/stories/Visualizations/Filter.tsx
+++ b/packages/lab/src/components/Flow/stories/Visualizations/Filter.tsx
@@ -6,13 +6,13 @@ import {
   theme,
 } from "@hitachivantara/uikit-react-core";
 import { useFlowNode, HvFlowNode } from "@hitachivantara/uikit-react-lab";
-import { useReactFlow, useStore } from "reactflow";
+import { NodeProps, useReactFlow, useStore } from "reactflow";
 
 function filterDataByCountries(data, countriesToFilter: string[]) {
   return data.filter((item) => countriesToFilter.includes(item.country));
 }
 
-export const Filter = (props) => {
+export const Filter = (props: NodeProps) => {
   const { id } = props;
 
   const [checked, setChecked] = useState<string[]>([]);

--- a/packages/lab/src/components/Flow/stories/Visualizations/JsonInput.tsx
+++ b/packages/lab/src/components/Flow/stories/Visualizations/JsonInput.tsx
@@ -1,6 +1,7 @@
 import { HvFlowNode } from "@hitachivantara/uikit-react-lab";
+import { NodeProps } from "reactflow";
 
-export const JsonInput = (props) => {
+export const JsonInput = (props: NodeProps) => {
   return <HvFlowNode description="Population Datakky7" {...props} />;
 };
 

--- a/packages/lab/src/components/Flow/stories/Visualizations/LineChart.tsx
+++ b/packages/lab/src/components/Flow/stories/Visualizations/LineChart.tsx
@@ -1,5 +1,4 @@
 import { css } from "@emotion/css";
-import { theme } from "@hitachivantara/uikit-react-core";
 import { HvFlowNode } from "@hitachivantara/uikit-react-lab";
 import { HvLineChart } from "@hitachivantara/uikit-react-viz";
 import { NodeProps, useStore } from "reactflow";
@@ -24,15 +23,20 @@ export const LineChart = (props: NodeProps) => {
         dataNode.data.jsonData &&
         dataNode.data.jsonData.length > 0 && (
           <div
-            style={{
-              padding: theme.spacing("xs", "xs", "xs", "sm"),
-            }}
+            className={css({
+              height: 300,
+            })}
           >
             <HvLineChart
               data={dataNode.data.jsonData}
               splitBy="country"
               groupBy="year"
               measures="population"
+              yAxis={{
+                name: "Millions",
+                labelFormatter: (value) => `${Number(value) / 1000000}`,
+              }}
+              grid={{ bottom: 40 }}
             />
           </div>
         )}

--- a/packages/lab/src/components/Flow/stories/Visualizations/LineChart.tsx
+++ b/packages/lab/src/components/Flow/stories/Visualizations/LineChart.tsx
@@ -2,9 +2,9 @@ import { css } from "@emotion/css";
 import { theme } from "@hitachivantara/uikit-react-core";
 import { HvFlowNode } from "@hitachivantara/uikit-react-lab";
 import { HvLineChart } from "@hitachivantara/uikit-react-viz";
-import { useStore } from "reactflow";
+import { NodeProps, useStore } from "reactflow";
 
-export const LineChart = (props) => {
+export const LineChart = (props: NodeProps) => {
   const { id } = props;
   const nodes = useStore((state) => state.getNodes());
   const edges = useStore((state) => state.edges);

--- a/packages/lab/src/components/Flow/types/flow.ts
+++ b/packages/lab/src/components/Flow/types/flow.ts
@@ -77,13 +77,22 @@ export type HvFlowNodeOutput = {
   maxConnections?: number;
 };
 
-export type HvFlowNodeParam = {
+export interface HvFlowNodeSharedParam {
   id: string;
-  type: "text" | "select";
   label: string;
+}
+
+export interface HvFlowNodeTextParam extends HvFlowNodeSharedParam {
+  type: "text";
+}
+
+export interface HvFlowNodeSelectParam extends HvFlowNodeSharedParam {
+  type: "select";
+  multiple?: boolean;
   options?: string[];
-  value?: string;
-};
+}
+
+export type HvFlowNodeParam = HvFlowNodeSelectParam | HvFlowNodeTextParam;
 
 export interface HvFlowNodeAction extends HvActionGeneric {
   callback?: (node: Node) => void;


### PR DESCRIPTION
- Multiple select param added by using the `multiple` prop:
   - Prop `value` removed from `HvFlowNodeParam` since it wasn't used anywhere
- Visualisations styling Improved in the flow samples
- Missing `NodeProps` type added to nodes in samples