### PR TITLE
fix(Flow): duplicate node id

### DIFF
--- a/packages/lab/src/components/Flow/Node/BaseNode.tsx
+++ b/packages/lab/src/components/Flow/Node/BaseNode.tsx
@@ -1,5 +1,4 @@
 import { isValidElement, useCallback, useEffect, useState } from "react";
-
 import {
   Edge,
   Handle,
@@ -9,7 +8,7 @@ import {
   useReactFlow,
   useStore,
 } from "reactflow";
-
+import { uid } from "uid";
 import {
   ExtractNames,
   HvActionGeneric,
@@ -25,7 +24,7 @@ import {
   HvFlowBuiltInActions,
   HvFlowNodeInput,
   HvFlowNodeOutput,
-} from "../types/index";
+} from "../types";
 import { useNodeMetaRegistry } from "../FlowContext/NodeMetaContext";
 import { staticClasses, useClasses } from "./BaseNode.styles";
 
@@ -129,7 +128,7 @@ export const HvFlowBaseNode = ({
           reactFlowInstance.addNodes([
             {
               ...node,
-              id: `${reactFlowInstance.getNodes().length + 1}`,
+              id: uid(),
               position: {
                 x: node.position.x,
                 y: node.position.y + (node.height || 0) + 20,


### PR DESCRIPTION
`uid` is used when creating a new node using the duplicate action to avoid having duplicated node ids:

https://github.com/lumada-design/hv-uikit-react/assets/43220251/26357301-da11-4bab-888a-8b92913fec71

