### PR TITLE
fix(useHvPagination): add missing pluginOrder restrictions

### DIFF
--- a/packages/core/src/components/Table/hooks/usePagination.ts
+++ b/packages/core/src/components/Table/hooks/usePagination.ts
@@ -42,7 +42,18 @@ export type UsePaginationProps = (<D extends object = Record<string, unknown>>(
 // #endregion ##### TYPES #####
 
 const useInstanceHook = (instance) => {
-  ensurePluginOrder(instance.plugins, ["usePagination"], "useHvPagination");
+  ensurePluginOrder(
+    instance.plugins,
+    [
+      "usePagination",
+      "useHvGlobalFilter",
+      "useHvFilters",
+      "useGroupBy",
+      "useHvSortBy",
+      "useHvRowExpand",
+    ],
+    "useHvPagination"
+  );
 
   const getInstance = useGetLatest(instance);
   const getHvPaginationProps = makePropGetter(


### PR DESCRIPTION
Add missing `useHvPagination` plugin order, which can lead to wrong filtering/sorting state