### PR TITLE
chore: increase applitools timeout

### DIFF
--- a/.config/applitools.config.js
+++ b/.config/applitools.config.js
@@ -15,6 +15,7 @@ module.exports = {
   puppeteerOptions: {
     args: ["--no-sandbox", "--disable-setuid-sandbox"],
     ignoreHTTPSErrors: true,
+    protocolTimeout: 300000,
   },
 
   appName: process.env.APPLITOOLS_APP_NAME,


### PR DESCRIPTION
The `protocolTimeout` was increased (defaults to 3min) to try to avoid these errors on Applitools:

`Error when reading stories: Runtime.callFunctionOn timed out. Increase the 'protocolTimeout' setting in launch/connect calls for a higher timeout if needed.` 