### PR TITLE
chore: vite typings & use import.meta.env

### DIFF
--- a/packages/core/src/components/Button/Button.tsx
+++ b/packages/core/src/components/Button/Button.tsx
@@ -65,7 +65,7 @@ const mapVariant = (
 
   const mappedVariant = deprecatedVariantMap[variant];
 
-  if (mappedVariant) {
+  if (import.meta.env.DEV && mappedVariant) {
     // eslint-disable-next-line no-console
     console.warn(
       `Button variant '${variant}' is deprecated. Please use '${mappedVariant}'.`

--- a/packages/core/src/components/Calendar/CalendarUtils.test.tsx
+++ b/packages/core/src/components/Calendar/CalendarUtils.test.tsx
@@ -1,5 +1,3 @@
-import { vi } from "vitest";
-
 import {
   createDatesArray,
   getDateISO,
@@ -14,7 +12,6 @@ import {
   isDate,
   isSameDay,
   isSameMonth,
-  isValidLocale,
   zeroPad,
   makeUTCDate,
 } from "./utils";
@@ -229,21 +226,5 @@ describe("Calendar utils - createDatesArray", () => {
       currentMonthDates.length +
       nextMonthDates.length;
     expect(totalAmountOfDates).toBe(42);
-  });
-});
-
-describe("Calendar utils - isValidLocale", () => {
-  it("should return true for American locale `en-US`", () => {
-    expect(isValidLocale("en-US")).toBe(true);
-  });
-  it("should return false for a locale with the incorrect format `something wrong`", () => {
-    const originalError = console.error;
-
-    // Waiting error "Invalid locale: something wrong"
-    console.error = vi.fn();
-
-    expect(isValidLocale("something wrong")).toBe(false);
-
-    console.error = originalError;
   });
 });

--- a/packages/core/src/components/Calendar/utils.tsx
+++ b/packages/core/src/components/Calendar/utils.tsx
@@ -257,41 +257,6 @@ export const createDatesArray = (month: number, year: number) => {
   return [...prevMonthDates, ...currentMonthDates, ...nextMonthDates];
 };
 
-/**
- * Checks if the received locale is valid according to Intl.
- *
- * @param locale - The locale to be checked
- * @returns True if the locale is valid, false otherwise.
- */
-export const isValidLocale = (locale: string) => {
-  try {
-    if (Intl.DateTimeFormat.supportedLocalesOf(locale).length > 0) {
-      return true;
-    }
-    // eslint-disable-next-line no-console
-    console.warn(`${locale} is not supported. Falling back to a known locale.`);
-    return false;
-  } catch (error) {
-    if (
-      error != null &&
-      typeof error === "object" &&
-      "name" in error &&
-      error?.name === "RangeError"
-    ) {
-      // eslint-disable-next-line no-console
-      console.error(`Invalid locale: ${locale}`);
-      return false;
-    }
-    if (error != null && typeof error === "object" && "message" in error) {
-      // eslint-disable-next-line no-console
-      console.error(error?.message);
-      return false;
-    }
-
-    return false;
-  }
-};
-
 export const isRange = (date): date is DateRangeProp =>
   date != null && typeof date === "object" && "startDate" in date;
 

--- a/packages/core/src/components/Dropdown/Dropdown.tsx
+++ b/packages/core/src/components/Dropdown/Dropdown.tsx
@@ -296,7 +296,7 @@ export const HvDropdown = forwardRef<HTMLDivElement, HvDropdownProps>(
       );
     }, [labels, multiSelect, placeholder, values]);
 
-    if (virtualized && !height && process.env.NODE_ENV !== "production") {
+    if (import.meta.env.DEV && virtualized && !height) {
       // eslint-disable-next-line no-console
       console.error(
         "Dropdown/List in virtualized mode requires a height. Please define it."

--- a/packages/core/src/components/Table/stories/TableSamples/TableCompleteSample.tsx
+++ b/packages/core/src/components/Table/stories/TableSamples/TableCompleteSample.tsx
@@ -103,7 +103,6 @@ export const TableComplete = () => {
       onAction={handleAction}
       onBulkAction={handleBulkAction}
       onUpdate={({ pageIndex, pageSize, sortBy }) => {
-        console.log("update", { pageIndex, pageSize, sortBy });
         fetchData({ pageIndex, pageSize, sortBy });
       }}
       options={{

--- a/packages/core/src/components/TreeView/internals/DescendantProvider.tsx
+++ b/packages/core/src/components/TreeView/internals/DescendantProvider.tsx
@@ -58,10 +58,6 @@ interface DescendantContextValue {
 
 const DescendantContext = React.createContext<DescendantContextValue>({});
 
-if (process.env.NODE_ENV !== "production") {
-  DescendantContext.displayName = "DescendantContext";
-}
-
 function usePrevious<T>(value: T) {
   const ref = React.useRef<T | null>(null);
   React.useEffect(() => {

--- a/packages/core/src/components/TreeView/internals/TreeViewProvider.tsx
+++ b/packages/core/src/components/TreeView/internals/TreeViewProvider.tsx
@@ -38,10 +38,6 @@ export const TreeViewContext = createContext<TreeViewContextValue<any>>(
   DEFAULT_TREE_VIEW_CONTEXT_VALUE
 );
 
-if (process.env.NODE_ENV !== "production") {
-  TreeViewContext.displayName = "TreeViewContext";
-}
-
 export interface TreeViewProviderProps<
   TPlugins extends readonly TreeViewAnyPluginSignature[]
 > {

--- a/packages/core/src/components/Typography/utils.ts
+++ b/packages/core/src/components/Typography/utils.ts
@@ -73,21 +73,19 @@ const isLegacyVariant = (variant: string) => {
 };
 
 export const mapVariant = (variant: Variant, theme?: string) => {
+  if (theme === "ds3") return variant;
   const mappedVariant = mappableVariants.get(variant);
 
-  if (theme !== "ds3") {
+  if (import.meta.env.DEV) {
+    /* eslint-disable no-console */
+    const msg = `The typography variant ${variant} is deprecated.`;
     if (mappedVariant) {
-      // eslint-disable-next-line no-console
-      console.warn(
-        `The typography variant ${variant} is deprecated. You should use ${mappedVariant} instead.`
-      );
-      return mappedVariant;
+      console.warn(`${msg} Use ${mappedVariant} instead.`);
     }
     if (isLegacyVariant(variant)) {
-      // eslint-disable-next-line no-console
-      console.warn(`The typography variant ${variant} is deprecated.`);
+      console.warn(msg);
     }
   }
 
-  return variant;
+  return mappedVariant || variant;
 };

--- a/packages/core/src/components/VerticalNavigation/TreeView/descendants.tsx
+++ b/packages/core/src/components/VerticalNavigation/TreeView/descendants.tsx
@@ -61,10 +61,6 @@ interface DescendantContextValue {
   parentId?;
 }
 
-if (process.env.NODE_ENV !== "production") {
-  DescendantContext.displayName = "DescendantContext";
-}
-
 function usePrevious(value) {
   const ref = useRef(null);
   useEffect(() => {

--- a/packages/core/src/env.d.ts
+++ b/packages/core/src/env.d.ts
@@ -15,16 +15,3 @@ declare global {
     }
   }
 }
-
-// To import .png files on stories
-declare module "*.png" {
-  export default "" as string;
-}
-
-declare module "*.jpg" {
-  export default "" as string;
-}
-
-declare module "*?raw" {
-  export default "" as string;
-}

--- a/packages/core/src/hooks/useControlled.ts
+++ b/packages/core/src/hooks/useControlled.ts
@@ -13,10 +13,7 @@ export const useControlled = (controlledProp, initialState) => {
   const [valueState, setValue] = useState(initialState);
   const value = isControlled ? controlledProp : valueState;
 
-  if (
-    process.env.NODE_ENV !== "production" &&
-    isControlled !== (controlledProp !== undefined)
-  ) {
+  if (import.meta.env.DEV && isControlled !== (controlledProp !== undefined)) {
     // eslint-disable-next-line no-console
     console.error(
       [

--- a/packages/lab/src/components/Flow/DroppableFlow.tsx
+++ b/packages/lab/src/components/Flow/DroppableFlow.tsx
@@ -146,45 +146,46 @@ export const HvDroppableFlow = ({
 
   const handleDragEnd = useCallback(
     (event: DragEndEvent) => {
-      if (event.over && event.over.id === elementId) {
-        const type = event.active.data.current?.hvFlow?.type;
+      if (event.over?.id !== elementId) return;
 
-        // Only known node types can be dropped in the canvas
-        if (type && nodeTypes?.[type]) {
-          // Converts the coordinates to the react flow coordinate system
-          const position = reactFlowInstance.project({
-            x:
-              (event.active.data.current?.hvFlow?.x || 0) -
-              event.over.rect.left,
-            y:
-              (event.active.data.current?.hvFlow?.y || 0) - event.over.rect.top,
-          });
+      const hvFlow = event.active.data.current?.hvFlow;
+      const type = hvFlow?.type;
 
-          // Node data
-          const data = event.active.data.current?.hvFlow?.data || {};
-
-          // Node to add
-          const newNode: Node = {
-            id: uid(),
-            position,
-            data,
-            type,
-          };
-
-          // Drop override
-          if (onDndDrop) {
-            onDndDrop(event, newNode);
-            return;
-          }
-
-          setNodes((nds) => nds.concat(newNode));
-        } else {
+      // Only known node types can be dropped in the canvas
+      if (!type || !nodeTypes?.[type]) {
+        if (import.meta.env.DEV) {
           // eslint-disable-next-line no-console
           console.error(
             `Could not add node to the flow because of unknown type ${type}. Use nodeTypes to define all the node types.`
           );
         }
+        return;
       }
+
+      // Converts the coordinates to the react flow coordinate system
+      const position = reactFlowInstance.project({
+        x: (hvFlow?.x || 0) - event.over.rect.left,
+        y: (hvFlow?.y || 0) - event.over.rect.top,
+      });
+
+      // Node data
+      const data = hvFlow?.data || {};
+
+      // Node to add
+      const newNode: Node = {
+        id: uid(),
+        position,
+        data,
+        type,
+      };
+
+      // Drop override
+      if (onDndDrop) {
+        onDndDrop(event, newNode);
+        return;
+      }
+
+      setNodes((nds) => nds.concat(newNode));
     },
     [elementId, nodeTypes, onDndDrop, reactFlowInstance]
   );

--- a/packages/lab/src/components/types/global.d.ts
+++ b/packages/lab/src/components/types/global.d.ts
@@ -1,3 +1,0 @@
-declare module "*?raw" {
-  export default "" as string;
-}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,7 +26,14 @@
       "@hitachivantara/uikit-styles": ["packages/styles/src"]
     },
     "preserveSymlinks": true,
-    "noImplicitAny": false
+    "noImplicitAny": false,
+    "types": [
+      "node",
+      "jest",
+      "@testing-library/jest-dom",
+      "vite/client",
+      "vitest"
+    ]
   },
   "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
- add vite typing references
- use import.meta.env instead of process.env
- wrap missing console warnings
  - remove unused `isValidLocale`