### PR TITLE
chore: add Table node to the app flow

### DIFF
--- a/app/src/pages/Flow/DashboardPreview/Renderers/Renderer.tsx
+++ b/app/src/pages/Flow/DashboardPreview/Renderers/Renderer.tsx
@@ -7,12 +7,14 @@ import {
 import { useData } from "../../utils";
 import { ChartContainer } from "./ChartContainer";
 import { Kpi } from "./Kpi";
+import { Table } from "./Table";
 
 export type DashboardContentType =
   | "line-chart"
   | "bar-chart"
   | "donut-chart"
-  | "kpi";
+  | "kpi"
+  | "table";
 
 interface RendererProps {
   type: DashboardContentType;
@@ -90,6 +92,17 @@ export const Renderer = ({
         data={data}
         unit={unit}
         aggregation={aggregation}
+      />
+    );
+  }
+
+  if (type === "table") {
+    return (
+      <Table
+        loading={loading}
+        title={title || ""}
+        data={data}
+        measure={measure as string}
       />
     );
   }

--- a/app/src/pages/Flow/DashboardPreview/Renderers/Table.tsx
+++ b/app/src/pages/Flow/DashboardPreview/Renderers/Table.tsx
@@ -1,0 +1,152 @@
+import { useMemo, useState, useEffect } from "react";
+import { css } from "@emotion/css";
+import {
+  HvSection,
+  HvTypography,
+  useHvData,
+  HvTableColumnConfig,
+  useHvSortBy,
+  useHvPagination,
+  HvTableContainer,
+  HvTable,
+  HvTableHead,
+  HvTableRow,
+  HvTableHeader,
+  HvTableBody,
+  HvTableCell,
+  HvPagination,
+  useHvFilters,
+} from "@hitachivantara/uikit-react-core";
+import { table } from "arquero";
+import type ColumnTable from "arquero/dist/types/table/column-table";
+
+interface TableProps {
+  loading: boolean;
+  title: string;
+  measure: string;
+  data?: ColumnTable;
+}
+export const getColumns = (): HvTableColumnConfig<any, string>[] => [
+  {
+    Header: "Territory",
+    accessor: "Territory",
+  },
+  { Header: "Country", accessor: "Country" },
+  { Header: "State Province", accessor: "State Province" },
+  { Header: "City", accessor: "City" },
+  { Header: "Years", accessor: "Years" },
+  { Header: "Quarters", accessor: "Quarters" },
+  { Header: "Months", accessor: "Months" },
+  { Header: "Quantity", accessor: "Quantity" },
+  { Header: "Sales", accessor: "Sales" },
+];
+
+export const Table = ({
+  loading,
+  title,
+  measure,
+  data: dataProp,
+}: TableProps) => {
+  const columns = useMemo(() => getColumns(), []);
+  const [data, setData] = useState<object[]>([]);
+
+  const {
+    getTableProps,
+    getTableBodyProps,
+    prepareRow,
+    headerGroups,
+    page,
+    getHvPaginationProps,
+    setFilter,
+  } = useHvData(
+    {
+      data,
+      columns,
+      initialState: {
+        filters: [{ id: "Territory", value: measure }],
+        hiddenColumns: ["Territory"],
+      },
+    },
+    useHvFilters,
+    useHvSortBy,
+    useHvPagination
+  );
+
+  useEffect(() => {
+    if (dataProp) {
+      const tableData = table(dataProp);
+      const arr = tableData.objects();
+      setData(arr);
+    }
+  }, [dataProp]);
+
+  useEffect(() => {
+    setFilter?.("Territory", measure);
+  }, [measure, setFilter]);
+
+  return (
+    <HvSection
+      title={
+        !loading && (
+          <HvTypography variant="title4">
+            {title}: {measure}
+          </HvTypography>
+        )
+      }
+      className={
+        loading
+          ? css({
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              height: "100%",
+            })
+          : undefined
+      }
+      classes={{
+        content: css({
+          height: "100%",
+          overflow: "scroll",
+        }),
+      }}
+    >
+      <HvTableContainer>
+        <HvTable {...getTableProps()}>
+          <HvTableHead>
+            {headerGroups.map((headerGroup) => (
+              <HvTableRow {...headerGroup.getHeaderGroupProps()}>
+                {headerGroup.headers.map((col) => (
+                  <HvTableHeader {...col.getHeaderProps()}>
+                    {col.render("Header")}
+                  </HvTableHeader>
+                ))}
+              </HvTableRow>
+            ))}
+          </HvTableHead>
+          <HvTableBody {...getTableBodyProps()}>
+            {page?.length ? (
+              page.map((row) => {
+                prepareRow(row);
+
+                return (
+                  <HvTableRow {...row.getRowProps()}>
+                    {row.cells.map((cell) => (
+                      <HvTableCell {...cell.getCellProps()}>
+                        {cell.render("Cell")}
+                      </HvTableCell>
+                    ))}
+                  </HvTableRow>
+                );
+              })
+            ) : (
+              <span>Nothing to show</span>
+            )}
+          </HvTableBody>
+        </HvTable>
+      </HvTableContainer>
+      {page?.length ? (
+        <HvPagination {...getHvPaginationProps?.()} />
+      ) : undefined}
+    </HvSection>
+  );
+};

--- a/app/src/pages/Flow/DashboardPreview/utils.tsx
+++ b/app/src/pages/Flow/DashboardPreview/utils.tsx
@@ -11,6 +11,7 @@ const getType = (type?: string): DashboardContentType | undefined => {
     case "lineChart":
       return "line-chart";
     case "kpi":
+    case "table":
       return type;
     default:
       break;

--- a/app/src/pages/Flow/Flow.tsx
+++ b/app/src/pages/Flow/Flow.tsx
@@ -29,7 +29,14 @@ import {
   LAYOUT_COLS,
   NodeGroup,
 } from "./types";
-import { BarChart, Dashboard, DonutChart, Kpi, LineChart } from "./Nodes";
+import {
+  BarChart,
+  Dashboard,
+  DonutChart,
+  Kpi,
+  LineChart,
+  Table,
+} from "./Nodes";
 import { buildLayout, createDataset, useDatasets } from "./utils";
 import { DashboardProps } from "./Dashboard";
 
@@ -62,6 +69,7 @@ const baseNodeTypes = {
   barChart: BarChart,
   kpi: Kpi,
   donutChart: DonutChart,
+  table: Table,
 } satisfies HvFlowProps["nodeTypes"];
 
 // Initial Flow
@@ -132,7 +140,7 @@ const nodes = [
   },
   {
     id: "fe4f454c946",
-    position: { x: 4.7733747459412825, y: 786.979108359152 },
+    position: { x: -183.21149999999977, y: 786.979108359152 },
     data: {
       title: "Sales per territory over the years",
       measure: ["Quantity"],
@@ -151,6 +159,15 @@ const nodes = [
       splitBy: ["Years"],
     },
     type: "lineChart",
+  },
+  {
+    id: "7",
+    position: { x: 182.2801875, y: 786.979108359152 },
+    data: {
+      title: "Sales per territory",
+      measure: ["EMEA"],
+    },
+    type: "table",
   },
 ] satisfies HvFlowProps["nodes"];
 const edges = [
@@ -224,6 +241,20 @@ const edges = [
     targetHandle: "0",
     id: "reactflow__edge-fe4f454c9460-e5ffe4f454c0",
   },
+  {
+    source: "5ffe4f454c9",
+    sourceHandle: "0",
+    target: "7",
+    targetHandle: "0",
+    id: "reactflow__edge-5ffe4f454c90-60",
+  },
+  {
+    source: "7",
+    sourceHandle: "0",
+    target: "e5ffe4f454c",
+    targetHandle: "0",
+    id: "reactflow__edge-5ffe4f454c90-70",
+  },
 ] satisfies HvFlowProps["edges"];
 
 // Initial Layout
@@ -250,18 +281,25 @@ const layout = [
     i: "ffe4f454c94",
   },
   {
-    w: 12,
+    w: 6,
     h: 3,
     x: 0,
     y: 1,
     i: "e4f454c9469",
   },
   {
-    w: 12,
+    w: 6,
     h: 3,
+    x: 7,
+    y: 1,
+    i: "fe4f454c946",
+  },
+  {
+    w: 12,
+    h: 4,
     x: 0,
     y: 4,
-    i: "fe4f454c946",
+    i: "7",
   },
 ] satisfies DashboardProps["layout"];
 

--- a/app/src/pages/Flow/Nodes/Table.tsx
+++ b/app/src/pages/Flow/Nodes/Table.tsx
@@ -1,0 +1,50 @@
+import { useMemo } from "react";
+import {
+  HvFlowNode,
+  HvFlowNodeTypeMeta,
+  HvFlowNodeProps,
+  HvFlowNodeFC,
+} from "@hitachivantara/uikit-react-lab";
+
+import { NodeGroup } from "../types";
+
+export const Table: HvFlowNodeFC = (props) => {
+  const params: HvFlowNodeProps["params"] = useMemo(() => {
+    return [
+      { label: "Title", id: "title", type: "text" },
+      {
+        label: "Territory",
+        id: "measure",
+        type: "select",
+        options: ["APAC", "EMEA", "NA", "Japan"],
+      },
+    ];
+  }, []);
+
+  return <HvFlowNode params={params} description="Table" expanded {...props} />;
+};
+
+Table.meta = {
+  label: "Table",
+  groupId: "visualization",
+  inputs: [
+    {
+      label: "Dataset",
+      isMandatory: true,
+      accepts: ["dataset"],
+      maxConnections: 1,
+    },
+  ],
+  outputs: [
+    {
+      label: "Visualization",
+      isMandatory: true,
+      provides: "visualizations",
+    },
+  ],
+  data: {
+    title: "",
+    columns: undefined,
+    measure: "EMEA",
+  },
+} satisfies HvFlowNodeTypeMeta<NodeGroup>;

--- a/app/src/pages/Flow/Nodes/index.ts
+++ b/app/src/pages/Flow/Nodes/index.ts
@@ -3,3 +3,4 @@ export * from "./BarChart";
 export * from "./LineChart";
 export * from "./Kpi";
 export * from "./DonutChart";
+export * from "./Table";


### PR DESCRIPTION
Added a `Table` node to the `Flow` in the app. I think it gives it a bit more variety and is useful to illustrate scenarios with tables in dashboards. The node itself has a filter for a specific field (that part could be improved, probably) that's used to filter what is shown on the table in the dashboard.