### PR TITLE
chore(Icons): improve color types & generation

### DIFF
--- a/packages/icons/lib/IconBase.tsx
+++ b/packages/icons/lib/IconBase.tsx
@@ -83,7 +83,7 @@ export const splitIconProps = (iconName: string, props: IconBaseProps) => {
   const iconSize = iconSizeProp ?? (isXS(iconName) ? "XS" : "S");
   const size = getIconSize(iconSize, isSemantic(iconName), width, height);
 
-  const newSvgProps = {
+  const newSvgProps: HTMLAttributes<SVGElement> = {
     focusable: false,
     // pass size props
     ...size,
@@ -95,12 +95,12 @@ export const splitIconProps = (iconName: string, props: IconBaseProps) => {
     "aria-describedby": ariaDescribedBy,
     // pass all other `svgProps`
     ...svgProps,
-  } satisfies HTMLAttributes<SVGElement>;
+  };
 
-  const newOtherProps = {
+  const newOtherProps: IconBaseProps = {
     iconSize,
     ...rest,
-  } satisfies IconBaseProps;
+  };
 
   return [newSvgProps, newOtherProps] as const;
 };
@@ -189,6 +189,8 @@ export const StyledIconBase = styled("div")(
     ...(iconSize === "L" && getDims(112)),
   })
 );
+
+export type IconType = React.FC<IconBaseProps>;
 
 export const IconBase = ({
   children,

--- a/packages/icons/src/utils/converter/generateComponent.ts
+++ b/packages/icons/src/utils/converter/generateComponent.ts
@@ -36,15 +36,13 @@ export const generateComponent = (
     .replace(/"#f0f0f0"/g, "theme.colors.atmo2")
     .replace(/"#ccced0"/g, "theme.colors.atmo4");
   const palette = replaceColorsWithTheme(themedPalette, lightPalette);
+  const defaultViewBox = defaultSizes.viewBoxRegexp.join(" ");
 
   return `
 import { theme } from "@hitachivantara/uikit-styles";
-import { IconBase, IconBaseProps, splitIconProps } from "${basePath}/IconBase";
+import { IconBase, IconType, splitIconProps } from "${basePath}/IconBase";
 
-export const ${iconName} = ({
-  viewbox = "${defaultSizes.viewBoxRegexp.join(" ")}",
-  ...others
-}: IconBaseProps) => {
+export const ${iconName}: IconType = ({ viewbox = "${defaultViewBox}", ...others }) => {
   const [svgProps, rest] = splitIconProps("${iconName}", others);
 
   return (

--- a/packages/icons/tsconfig.json
+++ b/packages/icons/tsconfig.json
@@ -4,13 +4,7 @@
     "composite": true,
     "baseUrl": "bin",
     "rootDir": "bin",
-    "outDir": "dist",
-    "allowJs": true
+    "outDir": "dist"
   },
-  "include": ["bin"],
-  "ts-node": {
-    "compilerOptions": {
-      "module": "CommonJS"
-    }
-  }
+  "include": ["bin"]
 }


### PR DESCRIPTION
- ~add color completions~ there's issues with `dts` linking to styles packages
- reduce types size from 109kB to 38kB
- cleanup tsconfig