### PR TITLE
docs: color picker samples not expanded

### DIFF
--- a/packages/core/src/components/CheckBox/CheckBox.stories.tsx
+++ b/packages/core/src/components/CheckBox/CheckBox.stories.tsx
@@ -160,62 +160,64 @@ export const ExternalErrorMessage: StoryObj<HvCheckBoxProps> = {
     const [secondCheckboxErrorMessage, setSecondCheckboxErrorMessage] =
       useState<string | null>("No way for the second checkbox to be valid!");
 
-    const StyledList = styled("ul")({
-      margin: "16px 0px",
-      paddingLeft: "40px",
-    });
-
-    const StyledTitle = styled(HvTypography)({
-      color: theme.colors.base_dark,
-    });
-
     return (
       <HvGrid container>
-        <HvGrid item xs={5} container>
-          <HvGrid item xs={12}>
-            <HvCheckBox
-              required
-              defaultChecked
-              aria-errormessage="firstCheckbox-error"
-              onChange={(_, checked) => {
-                if (checked) {
-                  setFirstCheckboxErrorMessage(null);
-                } else if (!checked) {
-                  setFirstCheckboxErrorMessage(
-                    "You must check the first checkbox"
+        <HvGrid item xs={12} md={6}>
+          <HvGrid container>
+            <HvGrid item xs={12}>
+              <HvCheckBox
+                required
+                defaultChecked
+                aria-errormessage="firstCheckbox-error"
+                onChange={(_, checked) => {
+                  if (checked) {
+                    setFirstCheckboxErrorMessage(null);
+                  } else if (!checked) {
+                    setFirstCheckboxErrorMessage(
+                      "You must check the first checkbox"
+                    );
+                  }
+                }}
+                label="First Checkbox"
+              />
+            </HvGrid>
+            <HvGrid item xs={12}>
+              <HvCheckBox
+                status="invalid"
+                aria-errormessage="secondCheckbox-error"
+                onChange={() => {
+                  setSecondCheckboxErrorMessage(
+                    "No way for the second checkbox to be valid! I told you!"
                   );
-                }
-              }}
-              label="First Checkbox"
-            />
-          </HvGrid>
-          <HvGrid item xs={12}>
-            <HvCheckBox
-              status="invalid"
-              aria-errormessage="secondCheckbox-error"
-              onChange={() => {
-                setSecondCheckboxErrorMessage(
-                  "No way for the second checkbox to be valid! I told you!"
-                );
-              }}
-              label="Second Checkbox"
-            />
+                }}
+                label="Second Checkbox"
+              />
+            </HvGrid>
           </HvGrid>
         </HvGrid>
-        <HvGrid item xs={7} container>
-          <HvGrid
-            style={{
+        <HvGrid item xs={12} md={6}>
+          <div
+            className={css({
               backgroundColor: theme.colors.negative_20,
               color: theme.colors.base_dark,
-            }}
-            item
-            xs={12}
-            alignItems="center"
+              padding: theme.space.md,
+            })}
           >
-            <StyledTitle component="h4" variant="title4">
+            <HvTypography
+              component="h4"
+              variant="title4"
+              style={{
+                color: theme.colors.base_dark,
+              }}
+            >
               Form errors:
-            </StyledTitle>
-            <StyledList>
+            </HvTypography>
+            <ul
+              className={css({
+                margin: theme.spacing("sm", 0),
+                paddingLeft: theme.space.md,
+              })}
+            >
               {firstCheckboxErrorMessage && (
                 <li id="firstCheckbox-error" aria-live="polite">
                   {firstCheckboxErrorMessage}
@@ -226,8 +228,8 @@ export const ExternalErrorMessage: StoryObj<HvCheckBoxProps> = {
                   {secondCheckboxErrorMessage}
                 </li>
               )}
-            </StyledList>
-          </HvGrid>
+            </ul>
+          </div>
         </HvGrid>
       </HvGrid>
     );

--- a/packages/core/src/components/ColorPicker/ColorPicker.stories.tsx
+++ b/packages/core/src/components/ColorPicker/ColorPicker.stories.tsx
@@ -1,5 +1,6 @@
 import { CSSProperties, useState } from "react";
 import { Meta, StoryObj } from "@storybook/react";
+import { fireEvent, screen } from "@storybook/testing-library";
 import {
   HvColorPicker,
   HvColorPickerProps,
@@ -14,13 +15,19 @@ const makeDecorator = (styles: CSSProperties) => (Story) =>
 const meta: Meta<typeof HvColorPicker> = {
   title: "Widgets/Color Picker",
   component: HvColorPicker,
+  parameters: {
+    eyes: {
+      runBefore() {
+        fireEvent.click(screen.getByRole("combobox"));
+      },
+    },
+  },
 };
 export default meta;
 
 export const Main: StoryObj<HvColorPickerProps> = {
   args: {
     label: "Color",
-    expanded: true,
   },
   argTypes: {
     classes: { control: { disable: true } },
@@ -29,7 +36,7 @@ export const Main: StoryObj<HvColorPickerProps> = {
     "aria-describedby": { table: { disable: true } },
     "aria-labelledby": { table: { disable: true } },
   },
-  decorators: [makeDecorator({ height: 600 })],
+  decorators: [makeDecorator({ height: 550 })],
   render: (args) => {
     return (
       <div style={{ width: "134px" }}>
@@ -52,13 +59,12 @@ export const WithoutSavedColors: StoryObj<HvColorPickerProps> = {
       },
     },
   },
-  decorators: [makeDecorator({ height: 500 })],
+  decorators: [makeDecorator({ height: 480 })],
   render: () => {
     return (
       <div style={{ width: "134px" }}>
         <HvColorPicker
           aria-label="Color"
-          expanded
           showSavedColors={false}
           onChange={(color) => console.log(color)}
           defaultValue="#C62828"
@@ -76,13 +82,12 @@ export const OnlyRecommendedColors: StoryObj<HvColorPickerProps> = {
       },
     },
   },
-  decorators: [makeDecorator({ height: 200 })],
+  decorators: [makeDecorator({ height: 180 })],
   render: () => {
     return (
       <div style={{ width: "134px" }}>
         <HvColorPicker
           aria-label="Color"
-          expanded
           showSavedColors={false}
           showCustomColors={false}
           onChange={(color) => console.log(color)}
@@ -101,14 +106,13 @@ export const IconOnly: StoryObj<HvColorPickerProps> = {
       },
     },
   },
-  decorators: [makeDecorator({ height: 500 })],
+  decorators: [makeDecorator({ height: 550 })],
   render: () => {
     return (
       <div style={{ width: "134px" }}>
         <HvColorPicker
           aria-label="Color"
           iconOnly
-          expanded
           onChange={(color) => console.log(color)}
         />
       </div>
@@ -125,14 +129,13 @@ export const IconOnlyWithoutSavedColors: StoryObj<HvColorPickerProps> = {
       },
     },
   },
-  decorators: [makeDecorator({ height: 500 })],
+  decorators: [makeDecorator({ height: 480 })],
   render: () => {
     return (
       <div style={{ width: "134px" }}>
         <HvColorPicker
           aria-label="Color"
           iconOnly
-          expanded
           showSavedColors={false}
           defaultValue="#477DBD"
           onChange={(color) => console.log(color)}
@@ -151,14 +154,13 @@ export const IconOnlyRecommendedColors: StoryObj<HvColorPickerProps> = {
       },
     },
   },
-  decorators: [makeDecorator({ height: 200 })],
+  decorators: [makeDecorator({ height: 180 })],
   render: () => {
     return (
       <div style={{ width: "134px" }}>
         <HvColorPicker
           aria-label="Color"
           iconOnly
-          expanded
           showSavedColors={false}
           showCustomColors={false}
           defaultValue="#59941B"
@@ -184,7 +186,6 @@ export const CustomizedColorPicker: StoryObj<HvColorPickerProps> = {
       <div style={{ width: "240px" }}>
         <HvColorPicker
           aria-label="Color"
-          expanded
           showLabels={false}
           showSavedColors={false}
           dropdownIcon="arrow"
@@ -224,7 +225,7 @@ export const ControlledColorPicker: StoryObj<HvColorPickerProps> = {
       },
     },
   },
-  decorators: [makeDecorator({ height: 450 })],
+  decorators: [makeDecorator({ height: 480 })],
   render: () => {
     const [color, setColor] = useState<string | undefined>("#95AFE8");
 
@@ -249,7 +250,6 @@ export const ControlledColorPicker: StoryObj<HvColorPickerProps> = {
         <div style={{ width: "134px" }}>
           <HvColorPicker
             aria-label="Color"
-            expanded
             showSavedColors={false}
             onChange={(value) => {
               setColor(value);

--- a/packages/core/src/components/DatePicker/DatePicker.stories.tsx
+++ b/packages/core/src/components/DatePicker/DatePicker.stories.tsx
@@ -17,6 +17,7 @@ import {
   HvListItem,
   HvRadio,
   HvRadioGroup,
+  HvTypography,
   theme,
 } from "@hitachivantara/uikit-react-core";
 
@@ -425,9 +426,9 @@ export const ExternalErrorMessage: StoryObj<HvDatePickerProps> = {
 
     return (
       <HvGrid container>
-        <HvGrid item xs={12}>
+        <HvGrid item xs={12} md={6}>
           <HvGrid container>
-            <HvGrid item xs={12} sm={6}>
+            <HvGrid item xs={12}>
               <HvDatePicker
                 label="Start date"
                 description="Enter a start date"
@@ -441,7 +442,7 @@ export const ExternalErrorMessage: StoryObj<HvDatePickerProps> = {
                 }}
               />
             </HvGrid>
-            <HvGrid item xs={12} sm={6}>
+            <HvGrid item xs={12}>
               <HvDatePicker
                 label="End date"
                 description="Enter an end date"
@@ -462,20 +463,26 @@ export const ExternalErrorMessage: StoryObj<HvDatePickerProps> = {
             </HvGrid>
           </HvGrid>
         </HvGrid>
-        <HvGrid item xs={12}>
+        <HvGrid item xs={12} md={6}>
           <div
-            style={{
-              display: "inline-block",
-              padding: theme.space.md,
+            className={css({
               backgroundColor: theme.colors.negative_20,
               color: theme.colors.base_dark,
-              height: "100%",
-            }}
+              padding: theme.space.md,
+            })}
           >
-            <h4>Form errors:</h4>
+            <HvTypography
+              component="h4"
+              variant="title4"
+              style={{
+                color: theme.colors.base_dark,
+              }}
+            >
+              Form errors:
+            </HvTypography>
             <ul
               className={css({
-                marginTop: theme.space.xs,
+                margin: theme.spacing("sm", 0),
                 paddingLeft: theme.space.md,
               })}
             >

--- a/packages/core/src/components/Dropdown/Dropdown.stories.tsx
+++ b/packages/core/src/components/Dropdown/Dropdown.stories.tsx
@@ -15,6 +15,7 @@ import {
   HvDropdownStatus,
   HvGrid,
   HvListValue,
+  HvTypography,
   theme,
 } from "@hitachivantara/uikit-react-core";
 
@@ -261,62 +262,76 @@ export const ExternalErrorMessage: StoryObj<HvDropdownProps> = {
 
     return (
       <HvGrid container>
-        <HvGrid item xs={12} sm={6}>
-          <HvDropdown
-            label="Dropdown 1"
-            multiSelect
-            values={values1}
-            required
-            aria-errormessage="birth-error"
-            onChange={(value) => {
-              if ((value as HvListValue[]).length === 0) {
-                setBirthErrorMessage(
-                  "Select at least one value from dropdown 1."
-                );
-              } else {
-                setBirthErrorMessage(null);
-              }
-            }}
-          />
-        </HvGrid>
-        <HvGrid item xs={12} sm={6}>
-          <HvDropdown
-            label="Dropdown 2"
-            multiSelect
-            values={values2}
-            required
-            status={deathValidationState as HvDropdownStatus}
-            aria-errormessage="death-error"
-            onChange={(value) => {
-              setDeathValidationState("invalid");
+        <HvGrid item xs={12} md={6}>
+          <HvGrid container>
+            <HvGrid item xs={12}>
+              <HvDropdown
+                label="Dropdown 1"
+                multiSelect
+                values={values1}
+                required
+                aria-errormessage="birth-error"
+                onChange={(value) => {
+                  if ((value as HvListValue[]).length === 0) {
+                    setBirthErrorMessage(
+                      "Select at least one value from dropdown 1."
+                    );
+                  } else {
+                    setBirthErrorMessage(null);
+                  }
+                }}
+              />
+            </HvGrid>
+            <HvGrid item xs={12}>
+              <HvDropdown
+                label="Dropdown 2"
+                multiSelect
+                values={values2}
+                required
+                status={deathValidationState as HvDropdownStatus}
+                aria-errormessage="death-error"
+                onChange={(value) => {
+                  setDeathValidationState("invalid");
 
-              if ((value as HvListValue[]).length === 0) {
-                setDeathErrorMessage(
-                  "Select at least one value from dropdown 2."
-                );
-              } else {
-                setDeathErrorMessage(
-                  `Dropdown 2 is always invalid, even with ${
-                    (value as HvListValue[]).length
-                  } items selected.`
-                );
-              }
-            }}
-          />
+                  if ((value as HvListValue[]).length === 0) {
+                    setDeathErrorMessage(
+                      "Select at least one value from dropdown 2."
+                    );
+                  } else {
+                    setDeathErrorMessage(
+                      `Dropdown 2 is always invalid, even with ${
+                        (value as HvListValue[]).length
+                      } items selected.`
+                    );
+                  }
+                }}
+              />
+            </HvGrid>
+          </HvGrid>
         </HvGrid>
-        <HvGrid item xs={12}>
+        <HvGrid item xs={12} md={6}>
           <div
             style={{
-              maxWidth: 600,
-              paddingTop: "10px",
-              paddingLeft: "20px",
               backgroundColor: theme.colors.negative_20,
               color: theme.colors.base_dark,
-              height: "100%",
+              padding: theme.space.md,
             }}
           >
-            <h4>Form errors:</h4>
-            <ul>
+            <HvTypography
+              component="h4"
+              variant="title4"
+              style={{
+                color: theme.colors.base_dark,
+              }}
+            >
+              Form errors:
+            </HvTypography>
+            <ul
+              className={css({
+                margin: theme.spacing("sm", 0),
+                paddingLeft: theme.space.md,
+              })}
+            >
               {birthErrorMessage && (
                 <li id="birth-error" aria-live="polite">
                   {birthErrorMessage}

--- a/packages/core/src/components/Input/Input.stories.tsx
+++ b/packages/core/src/components/Input/Input.stories.tsx
@@ -302,9 +302,9 @@ export const ExternalErrorMessage: StoryObj<HvInputProps> = {
 
     return (
       <HvGrid container>
-        <HvGrid item xs={12}>
+        <HvGrid item xs={12} md={6}>
           <HvGrid container>
-            <HvGrid item xs={12} sm={6}>
+            <HvGrid item xs={12}>
               <HvInput
                 label="First name"
                 description="Please enter your first name"
@@ -323,7 +323,7 @@ export const ExternalErrorMessage: StoryObj<HvInputProps> = {
                 }}
               />
             </HvGrid>
-            <HvGrid item xs={12} sm={6}>
+            <HvGrid item xs={12}>
               <HvInput
                 label="Last name"
                 description="Please enter your last name"
@@ -350,17 +350,29 @@ export const ExternalErrorMessage: StoryObj<HvInputProps> = {
             </HvGrid>
           </HvGrid>
         </HvGrid>
-        <HvGrid item xs={12}>
+        <HvGrid item xs={12} md={6}>
           <div
             style={{
-              padding: theme.spacing("xs", "md"),
               backgroundColor: theme.colors.negative_20,
               color: theme.colors.base_dark,
-              height: "100%",
+              padding: theme.space.md,
             }}
           >
-            <h4>Form errors:</h4>
-            <ul>
+            <HvTypography
+              component="h4"
+              variant="title4"
+              style={{
+                color: theme.colors.base_dark,
+              }}
+            >
+              Form errors:
+            </HvTypography>
+            <ul
+              className={css({
+                margin: theme.spacing("sm", 0),
+                paddingLeft: theme.space.md,
+              })}
+            >
               {firstNameErrorMessage && (
                 <li id="firstName-error" aria-live="polite">
                   {firstNameErrorMessage}

--- a/packages/core/src/components/Radio/Radio.stories.tsx
+++ b/packages/core/src/components/Radio/Radio.stories.tsx
@@ -5,6 +5,7 @@ import {
   HvRadio,
   HvRadioProps,
   HvRadioStatus,
+  HvTypography,
   theme,
 } from "@hitachivantara/uikit-react-core";
 import { css } from "@emotion/css";
@@ -133,45 +134,61 @@ export const ExternalErrorMessage: StoryObj<HvRadioProps> = {
 
     return (
       <HvGrid container>
-        <HvGrid item xs={12} sm={3}>
-          <HvRadio
-            status={secondRadioStatus}
-            aria-errormessage="firstRadio-error"
-            onChange={(_e, checked) => {
-              if (checked) {
-                setSecondRadioStatus("invalid");
-                setFirstRadioErrorMessage("Don't choose the first radio.");
-              } else if (!checked) {
-                setSecondRadioStatus("valid");
-                setFirstRadioErrorMessage(null);
-              }
-            }}
-            label="First Radio"
-          />
+        <HvGrid item xs={12} md={6}>
+          <HvGrid container>
+            <HvGrid item xs={12}>
+              <HvRadio
+                status={secondRadioStatus}
+                aria-errormessage="firstRadio-error"
+                onChange={(_e, checked) => {
+                  if (checked) {
+                    setSecondRadioStatus("invalid");
+                    setFirstRadioErrorMessage("Don't choose the first radio.");
+                  } else if (!checked) {
+                    setSecondRadioStatus("valid");
+                    setFirstRadioErrorMessage(null);
+                  }
+                }}
+                label="First Radio"
+              />
+            </HvGrid>
+            <HvGrid item xs={12}>
+              <HvRadio
+                status="invalid"
+                aria-errormessage="secondRadio-error"
+                onChange={() => {
+                  setSecondRadioErrorMessage(
+                    "No way for the second radio to be valid! I told you!"
+                  );
+                }}
+                label="Second Radio"
+              />
+            </HvGrid>
+          </HvGrid>
         </HvGrid>
-        <HvGrid item xs={12} sm={3}>
-          <HvRadio
-            status="invalid"
-            aria-errormessage="secondRadio-error"
-            onChange={() => {
-              setSecondRadioErrorMessage(
-                "No way for the second radio to be valid! I told you!"
-              );
-            }}
-            label="Second Radio"
-          />
-        </HvGrid>
-        <HvGrid item xs={12} alignItems="center">
+        <HvGrid item xs={12} md={6}>
           <div
-            style={{
+            className={css({
               backgroundColor: theme.colors.negative_20,
               color: theme.colors.base_dark,
-              paddingBottom: theme.space.xs,
-              maxWidth: 400,
-            }}
+              padding: theme.space.md,
+            })}
           >
-            <h4>Form errors:</h4>
-            <ul style={{ listStyle: "none" }}>
+            <HvTypography
+              component="h4"
+              variant="title4"
+              style={{
+                color: theme.colors.base_dark,
+              }}
+            >
+              Form errors:
+            </HvTypography>
+            <ul
+              className={css({
+                margin: theme.spacing("sm", 0),
+                paddingLeft: theme.space.md,
+              })}
+            >
               {firstRadioErrorMessage && (
                 <li id="firstRadio-error" aria-live="polite">
                   {firstRadioErrorMessage}

--- a/packages/core/src/components/Switch/Switch.stories.tsx
+++ b/packages/core/src/components/Switch/Switch.stories.tsx
@@ -232,50 +232,70 @@ export const ExternalErrorMessage: StoryObj<HvSwitchProps> = {
 
     return (
       <HvGrid container>
-        <HvGrid item xs={6} display="flex" flexDirection="column">
-          <HvSwitch
-            required
-            defaultChecked
-            aria-errormessage="firstSwitch-error"
-            onChange={(_e, checked) => {
-              setFirstSwitchErrorMessage(
-                checked ? "" : "You must turn on the first switch"
-              );
-            }}
-            label="First Switch"
-          />
-          <HvSwitch
-            status="invalid"
-            aria-errormessage="secondSwitch-error"
-            onChange={() => {
-              setSecondSwitchErrorMessage(
-                "No way for the second switch to be valid! I told you!"
-              );
-            }}
-            label="Second Switch"
-          />
+        <HvGrid item xs={12} md={6}>
+          <HvGrid container>
+            <HvGrid item xs={12}>
+              <HvSwitch
+                required
+                defaultChecked
+                aria-errormessage="firstSwitch-error"
+                onChange={(_e, checked) => {
+                  setFirstSwitchErrorMessage(
+                    checked ? "" : "You must turn on the first switch"
+                  );
+                }}
+                label="First Switch"
+              />
+            </HvGrid>
+            <HvGrid item xs={12}>
+              <HvSwitch
+                status="invalid"
+                aria-errormessage="secondSwitch-error"
+                onChange={() => {
+                  setSecondSwitchErrorMessage(
+                    "No way for the second switch to be valid! I told you!"
+                  );
+                }}
+                label="Second Switch"
+              />
+            </HvGrid>
+          </HvGrid>
         </HvGrid>
-        <HvGrid
-          item
-          xs={6}
-          style={{
-            backgroundColor: theme.colors.negative_20,
-            color: theme.colors.base_dark,
-          }}
-        >
-          <h4>Form errors:</h4>
-          <ul>
-            {firstSwitchErrorMessage && (
-              <li id="firstSwitch-error" aria-live="polite">
-                {firstSwitchErrorMessage}
-              </li>
-            )}
-            {secondSwitchErrorMessage && (
-              <li id="secondSwitch-error" aria-live="polite">
-                {secondSwitchErrorMessage}
-              </li>
-            )}
-          </ul>
+        <HvGrid item xs={12} md={6}>
+          <div
+            className={css({
+              backgroundColor: theme.colors.negative_20,
+              color: theme.colors.base_dark,
+              padding: theme.space.md,
+            })}
+          >
+            <HvTypography
+              component="h4"
+              variant="title4"
+              style={{
+                color: theme.colors.base_dark,
+              }}
+            >
+              Form errors:
+            </HvTypography>
+            <ul
+              className={css({
+                margin: theme.spacing("sm", 0),
+                paddingLeft: theme.space.md,
+              })}
+            >
+              {firstSwitchErrorMessage && (
+                <li id="firstSwitch-error" aria-live="polite">
+                  {firstSwitchErrorMessage}
+                </li>
+              )}
+              {secondSwitchErrorMessage && (
+                <li id="secondSwitch-error" aria-live="polite">
+                  {secondSwitchErrorMessage}
+                </li>
+              )}
+            </ul>
+          </div>
         </HvGrid>
       </HvGrid>
     );


### PR DESCRIPTION
- The color picker samples are no longer expanded by default because it was quite difficult to use this page when they were all expanded:
   - Applitools opens the pickers before taking the screenshots
- Samples with form errors were uniformized and fixed:
   - The checkbox sample was throwing an error
   - Problems with the font color in dark mode