### PR TITLE
build: remove paths override

### DIFF
--- a/packages/icons/lib/IconBase.tsx
+++ b/packages/icons/lib/IconBase.tsx
@@ -1,6 +1,6 @@
 import React, { HTMLAttributes, AllHTMLAttributes, useMemo } from "react";
 import styled from "@emotion/styled";
-import { theme, getColor } from "@hitachivantara/uikit-styles";
+import { theme, getColor, HvColorAny } from "@hitachivantara/uikit-styles";
 
 import { isSemantic, isXS } from "./utils";
 
@@ -39,17 +39,17 @@ export const getIconSize = (
 
 export const getIconColors = (
   palette: string[] = [],
-  color?: string | string[],
+  color?: HvColorAny | HvColorAny[],
   semantic?: string,
   inverted = false
 ) => {
   const colorArray = palette;
 
   if (typeof color === "string") {
-    colorArray[0] = getColor(color) as string;
+    colorArray[0] = getColor(color)!;
   } else if (Array.isArray(color)) {
     colorArray.forEach((_, i) => {
-      colorArray[i] = getColor(color[i]) as string;
+      colorArray[i] = getColor(color[i])!;
     });
   }
 
@@ -153,7 +153,7 @@ export interface IconBaseProps extends HTMLDivProps {
    * Each element inside the array will override a different color.
    * You can use either an HEX or color name from the palette.
    */
-  color?: string | string[];
+  color?: HvColorAny | HvColorAny[];
   /** Sets one of the standard sizes of the icons */
   iconSize?: IconSize;
   /** A string that will override the viewbox of the svg */

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,15 +16,7 @@
     "jsx": "react-jsx",
     "jsxImportSource": "@emotion/react",
     "baseUrl": ".",
-    "paths": {
-      "@hitachivantara/uikit-react-code-editor": ["packages/code-editor/src"],
-      "@hitachivantara/uikit-react-core": ["packages/core/src"],
-      "@hitachivantara/uikit-react-icons": ["packages/icons/bin"],
-      "@hitachivantara/uikit-react-lab": ["packages/lab/src"],
-      "@hitachivantara/uikit-react-shared": ["packages/shared/src"],
-      "@hitachivantara/uikit-react-viz": ["packages/viz/src"],
-      "@hitachivantara/uikit-styles": ["packages/styles/src"]
-    },
+    "paths": {},
     "preserveSymlinks": true,
     "noImplicitAny": false,
     "types": [


### PR DESCRIPTION
The `paths` defined in the global `tsconfig.json` file is leading to wrongly replaced imports (see https://github.com/lumada-design/hv-uikit-react/pull/3828#pullrequestreview-1739496099)

![image](https://github.com/lumada-design/hv-uikit-react/assets/638946/1a55ac25-9e1b-4ace-af68-c992e109b911)

This error isn't happening in most cases, because each package has a `paths` override (which squashes those defined in the root `tsconfig.json`), but is happening in `shared` and `icons` package

We alternatively override (do `paths: {}`) for every package, but we'd be essentially overriding something that (probably) shouldn't be there in the first place.

Let me know if there's something global `paths` is being used for - according to our CI (and manual checks) it looks like it isn't 