### PR TITLE
fix(Flow): set value as string if select is not multiple

### DIFF
--- a/app/src/pages/Flow/config.tsx
+++ b/app/src/pages/Flow/config.tsx
@@ -57,8 +57,8 @@ export const nodes = [
     data: {
       title: "Number of customers",
       unit: "",
-      measure: ["Customer"],
-      aggregation: ["distinct"],
+      measure: "Customer",
+      aggregation: "distinct",
     },
     type: "kpi",
   },
@@ -68,8 +68,8 @@ export const nodes = [
     data: {
       title: "Number of products",
       unit: "",
-      measure: ["Product"],
-      aggregation: ["distinct"],
+      measure: "Product",
+      aggregation: "distinct",
     },
     type: "kpi",
   },
@@ -110,8 +110,8 @@ export const nodes = [
     data: {
       title: "Total of sales",
       unit: "$",
-      measure: ["Sales"],
-      aggregation: ["sum"],
+      measure: "Sales",
+      aggregation: "sum",
     },
     type: "kpi",
   },
@@ -142,7 +142,7 @@ export const nodes = [
     position: { x: 182, y: 786 },
     data: {
       title: "Sales per territory",
-      measure: ["EMEA"],
+      measure: "EMEA",
     },
     type: "table",
   },

--- a/packages/lab/src/components/Flow/Node/Parameters/Select.tsx
+++ b/packages/lab/src/components/Flow/Node/Parameters/Select.tsx
@@ -24,9 +24,7 @@ const Select = ({ nodeId, param, data }: SelectProps) => {
 
     const newOpts = Array.isArray(item)
       ? item.map((x) => x.label as string)
-      : item?.label
-      ? [item.label as string]
-      : undefined;
+      : (item?.label as string) ?? undefined;
 
     const newNodes = nodes.map((node) => {
       if (node.id === nodeId) {
@@ -39,7 +37,9 @@ const Select = ({ nodeId, param, data }: SelectProps) => {
     });
 
     reactFlowInstance.setNodes(newNodes);
-    setOpts(newOpts);
+    setOpts(
+      newOpts ? (Array.isArray(newOpts) ? newOpts : [newOpts]) : undefined
+    );
   };
 
   return (


### PR DESCRIPTION
- When a select parameter with `multiple={false}` was used on a node and a value was selected, the value was added as an array on the node `data`. This doesn't make sense as it should be added as a string. This was a regression from this [PR](https://github.com/lumada-design/hv-uikit-react/pull/3801) when the multiple select was added. 