### PR TITLE
fix(Flow): transfer node inputs/outputs to props

### DIFF
--- a/app/src/pages/Flow/Nodes/BarChart.tsx
+++ b/app/src/pages/Flow/Nodes/BarChart.tsx
@@ -49,28 +49,33 @@ export const BarChart: HvFlowNodeFC = (props) => {
   }, [edges, id, nodes]);
 
   return (
-    <HvFlowNode params={params} description="Bar Chart" expanded {...props} />
+    <HvFlowNode
+      params={params}
+      description="Bar Chart"
+      expanded
+      inputs={[
+        {
+          label: "Dataset",
+          isMandatory: true,
+          accepts: ["dataset"],
+          maxConnections: 1,
+        },
+      ]}
+      outputs={[
+        {
+          label: "Visualization",
+          isMandatory: true,
+          provides: "visualizations",
+        },
+      ]}
+      {...props}
+    />
   );
 };
 
 BarChart.meta = {
   label: "Bar Chart",
   groupId: "visualization",
-  inputs: [
-    {
-      label: "Dataset",
-      isMandatory: true,
-      accepts: ["dataset"],
-      maxConnections: 1,
-    },
-  ],
-  outputs: [
-    {
-      label: "Visualization",
-      isMandatory: true,
-      provides: "visualizations",
-    },
-  ],
   data: {
     title: "",
     measure: undefined,

--- a/app/src/pages/Flow/Nodes/Dashboard.tsx
+++ b/app/src/pages/Flow/Nodes/Dashboard.tsx
@@ -124,7 +124,17 @@ export const Dashboard: HvFlowNodeFC = (props) => {
 
   return (
     <>
-      <HvFlowNode description="Dashboard" {...props}>
+      <HvFlowNode
+        description="Dashboard"
+        inputs={[
+          {
+            label: "Visualizations",
+            isMandatory: true,
+            accepts: ["visualizations"],
+          },
+        ]}
+        {...props}
+      >
         <div
           className={css({
             display: "flex",
@@ -197,11 +207,4 @@ export const Dashboard: HvFlowNodeFC = (props) => {
 Dashboard.meta = {
   label: "Dashboard",
   groupId: "dashboard",
-  inputs: [
-    {
-      label: "Visualizations",
-      isMandatory: true,
-      accepts: ["visualizations"],
-    },
-  ],
 } satisfies HvFlowNodeTypeMeta<NodeGroup>;

--- a/app/src/pages/Flow/Nodes/DonutChart.tsx
+++ b/app/src/pages/Flow/Nodes/DonutChart.tsx
@@ -41,28 +41,33 @@ export const DonutChart: HvFlowNodeFC = (props) => {
   }, [edges, id, nodes]);
 
   return (
-    <HvFlowNode params={params} description="Donut Chart" expanded {...props} />
+    <HvFlowNode
+      params={params}
+      description="Donut Chart"
+      expanded
+      inputs={[
+        {
+          label: "Dataset",
+          isMandatory: true,
+          accepts: ["dataset"],
+          maxConnections: 1,
+        },
+      ]}
+      outputs={[
+        {
+          label: "Visualization",
+          isMandatory: true,
+          provides: "visualizations",
+        },
+      ]}
+      {...props}
+    />
   );
 };
 
 DonutChart.meta = {
   label: "Donut Chart",
   groupId: "visualization",
-  inputs: [
-    {
-      label: "Dataset",
-      isMandatory: true,
-      accepts: ["dataset"],
-      maxConnections: 1,
-    },
-  ],
-  outputs: [
-    {
-      label: "Visualization",
-      isMandatory: true,
-      provides: "visualizations",
-    },
-  ],
   data: {
     title: "",
     measure: undefined,

--- a/app/src/pages/Flow/Nodes/Kpi.tsx
+++ b/app/src/pages/Flow/Nodes/Kpi.tsx
@@ -40,27 +40,35 @@ export const Kpi: HvFlowNodeFC = (props) => {
       : undefined;
   }, [edges, id, nodes]);
 
-  return <HvFlowNode params={params} description="KPI" expanded {...props} />;
+  return (
+    <HvFlowNode
+      params={params}
+      description="KPI"
+      expanded
+      inputs={[
+        {
+          label: "Dataset",
+          isMandatory: true,
+          accepts: ["dataset"],
+          maxConnections: 1,
+        },
+      ]}
+      outputs={[
+        {
+          label: "Visualization",
+          isMandatory: true,
+          provides: "visualizations",
+        },
+      ]}
+      {...props}
+    />
+  );
 };
 
 Kpi.meta = {
   label: "KPI",
   groupId: "visualization",
-  inputs: [
-    {
-      label: "Dataset",
-      isMandatory: true,
-      accepts: ["dataset"],
-      maxConnections: 1,
-    },
-  ],
-  outputs: [
-    {
-      label: "Visualization",
-      isMandatory: true,
-      provides: "visualizations",
-    },
-  ],
+
   data: {
     title: "",
     unit: "",

--- a/app/src/pages/Flow/Nodes/LineChart.tsx
+++ b/app/src/pages/Flow/Nodes/LineChart.tsx
@@ -49,28 +49,33 @@ export const LineChart: HvFlowNodeFC = (props) => {
   }, [edges, id, nodes]);
 
   return (
-    <HvFlowNode params={params} description="Line Chart" expanded {...props} />
+    <HvFlowNode
+      params={params}
+      description="Line Chart"
+      expanded
+      inputs={[
+        {
+          label: "Dataset",
+          isMandatory: true,
+          accepts: ["dataset"],
+          maxConnections: 1,
+        },
+      ]}
+      outputs={[
+        {
+          label: "Visualization",
+          isMandatory: true,
+          provides: "visualizations",
+        },
+      ]}
+      {...props}
+    />
   );
 };
 
 LineChart.meta = {
   label: "Line Chart",
   groupId: "visualization",
-  inputs: [
-    {
-      label: "Dataset",
-      isMandatory: true,
-      accepts: ["dataset"],
-      maxConnections: 1,
-    },
-  ],
-  outputs: [
-    {
-      label: "Visualization",
-      isMandatory: true,
-      provides: "visualizations",
-    },
-  ],
   data: {
     title: "",
     measure: undefined,

--- a/app/src/pages/Flow/Nodes/Table.tsx
+++ b/app/src/pages/Flow/Nodes/Table.tsx
@@ -21,27 +21,34 @@ export const Table: HvFlowNodeFC = (props) => {
     ];
   }, []);
 
-  return <HvFlowNode params={params} description="Table" expanded {...props} />;
+  return (
+    <HvFlowNode
+      params={params}
+      description="Table"
+      expanded
+      inputs={[
+        {
+          label: "Dataset",
+          isMandatory: true,
+          accepts: ["dataset"],
+          maxConnections: 1,
+        },
+      ]}
+      outputs={[
+        {
+          label: "Visualization",
+          isMandatory: true,
+          provides: "visualizations",
+        },
+      ]}
+      {...props}
+    />
+  );
 };
 
 Table.meta = {
   label: "Table",
   groupId: "visualization",
-  inputs: [
-    {
-      label: "Dataset",
-      isMandatory: true,
-      accepts: ["dataset"],
-      maxConnections: 1,
-    },
-  ],
-  outputs: [
-    {
-      label: "Visualization",
-      isMandatory: true,
-      provides: "visualizations",
-    },
-  ],
   data: {
     title: "",
     columns: undefined,

--- a/app/src/pages/Flow/utils.tsx
+++ b/app/src/pages/Flow/utils.tsx
@@ -51,13 +51,18 @@ export const createDataset = ({
   data: any;
 }) => {
   const Dataset: HvFlowNodeFC = (props) => {
-    return <HvFlowNode description={description} {...props} />;
+    return (
+      <HvFlowNode
+        outputs={[{ label: "Dataset", isMandatory: true, provides: "dataset" }]}
+        description={description}
+        {...props}
+      />
+    );
   };
 
   Dataset.meta = {
     label,
     groupId: "dataset",
-    outputs: [{ label: "Dataset", isMandatory: true, provides: "dataset" }],
     data,
   };
 

--- a/packages/lab/src/components/Flow/Node/Node.tsx
+++ b/packages/lab/src/components/Flow/Node/Node.tsx
@@ -13,13 +13,14 @@ import {
 import { getColor } from "@hitachivantara/uikit-styles";
 import { Down, Info, Up } from "@hitachivantara/uikit-react-icons";
 
-import { useFlowContext, useFlowNode } from "../hooks/index";
-import { HvFlowNodeParam } from "../types/index";
+import { useFlowContext, useFlowNode } from "../hooks";
+import { HvFlowNodeInput, HvFlowNodeOutput, HvFlowNodeParam } from "../types";
 import { staticClasses, useClasses } from "./Node.styles";
 import ParamRenderer from "./Parameters/ParamRenderer";
 import { HvFlowBaseNode, HvFlowBaseNodeProps } from "./BaseNode";
 
 export { staticClasses as flowNodeClasses };
+
 // TODO How to include here the types from the parent component?
 export type HvFlowNodeClasses = ExtractNames<typeof useClasses>;
 
@@ -48,6 +49,10 @@ export interface HvFlowNodeProps<T = any>
   nodeDefaults?: HvFlowNodeDefaults;
   /** Props to be passed to the expand parameters button. */
   expandParamsButtonProps?: HvButtonProps;
+  /** Node outputs. */
+  outputs?: HvFlowNodeOutput[];
+  /** Node inputs. */
+  inputs?: HvFlowNodeInput[];
   /** A Jss Object used to override or extend the styles applied to the component. */
   classes?: HvFlowNodeClasses | HvFlowBaseNodeProps<T>["classes"];
 }
@@ -61,6 +66,8 @@ export const HvFlowNode = ({
   headerItems,
   description,
   actions,
+  outputs,
+  inputs,
   actionCallback,
   maxVisibleActions = 1,
   expanded = false,
@@ -72,17 +79,18 @@ export const HvFlowNode = ({
   ...props
 }: HvFlowNodeProps<unknown>) => {
   const { classes } = useClasses(classesProp as HvFlowNodeClasses);
+
   const [showParams, setShowParams] = useState(expanded);
+
   const node = useFlowNode(id);
 
   const { nodeGroups, nodeTypes, defaultActions } = useFlowContext();
-  const groupId = nodeTypes?.[type].meta?.groupId;
+
   const subtitle = nodeTypes?.[type].meta?.label || nodeDefaults?.subTitle;
+  const groupId = nodeTypes?.[type].meta?.groupId;
+
   const groupLabel =
     (groupId && nodeGroups && nodeGroups[groupId].label) || nodeDefaults?.title;
-
-  const inputs = nodeTypes?.[type]?.meta?.inputs;
-  const outputs = nodeTypes?.[type]?.meta?.outputs;
   const icon =
     (groupId && nodeGroups && nodeGroups[groupId].icon) || nodeDefaults?.icon;
   const colorProp =

--- a/packages/lab/src/components/Flow/stories/Base/Asset.tsx
+++ b/packages/lab/src/components/Flow/stories/Base/Asset.tsx
@@ -1,5 +1,4 @@
 import { useState } from "react";
-
 import { css } from "@emotion/css";
 import {
   HvButton,
@@ -16,7 +15,7 @@ import {
 } from "@hitachivantara/uikit-react-lab";
 import { Node } from "reactflow";
 
-import type { NodeGroups } from "./index";
+import type { NodeGroups } from ".";
 
 export const Asset: HvFlowNodeFC<NodeGroups> = (props) => {
   const { id } = props;
@@ -96,6 +95,18 @@ export const Asset: HvFlowNodeFC<NodeGroups> = (props) => {
             options: ["Option 1", "Option 2", "Option 3"],
           },
         ]}
+        outputs={[
+          {
+            label: "Sensor Group 1",
+            isMandatory: true,
+            provides: "sensorData",
+          },
+          {
+            label: "Sensor Group 2",
+            isMandatory: true,
+            provides: "sensorData",
+          },
+        ]}
         {...props}
       />
     </>
@@ -105,16 +116,4 @@ export const Asset: HvFlowNodeFC<NodeGroups> = (props) => {
 Asset.meta = {
   label: "My Asset",
   groupId: "assets",
-  outputs: [
-    {
-      label: "Sensor Group 1",
-      isMandatory: true,
-      provides: "sensorData",
-    },
-    {
-      label: "Sensor Group 2",
-      isMandatory: true,
-      provides: "sensorData",
-    },
-  ],
 };

--- a/packages/lab/src/components/Flow/stories/Base/Dashboard.tsx
+++ b/packages/lab/src/components/Flow/stories/Base/Dashboard.tsx
@@ -15,6 +15,13 @@ export const Dashboard: HvFlowNodeFC<NodeGroups> = (props) => {
           options: ["Time Series", "KPI", "Table"],
         },
       ]}
+      inputs={[
+        {
+          label: "Insights",
+          isMandatory: true,
+          accepts: ["insight"],
+        },
+      ]}
       {...props}
     />
   );
@@ -23,12 +30,4 @@ export const Dashboard: HvFlowNodeFC<NodeGroups> = (props) => {
 Dashboard.meta = {
   label: "Dashboard",
   groupId: "dashboard",
-  inputs: [
-    {
-      label: "Insights",
-      isMandatory: true,
-      accepts: ["insight"],
-    },
-  ],
-  outputs: [],
 };

--- a/packages/lab/src/components/Flow/stories/Base/KPI.tsx
+++ b/packages/lab/src/components/Flow/stories/Base/KPI.tsx
@@ -3,24 +3,29 @@ import { HvFlowNode, HvFlowNodeFC } from "@hitachivantara/uikit-react-lab";
 import type { NodeGroups } from ".";
 
 export const KPI: HvFlowNodeFC<NodeGroups> = (props) => {
-  return <HvFlowNode description="KPI description" {...props} />;
+  return (
+    <HvFlowNode
+      description="KPI description"
+      inputs={[
+        {
+          label: "Data",
+          isMandatory: true,
+          accepts: ["prediction", "detection"],
+        },
+      ]}
+      outputs={[
+        {
+          label: "Insight",
+          isMandatory: true,
+          provides: "insight",
+        },
+      ]}
+      {...props}
+    />
+  );
 };
 
 KPI.meta = {
   label: "KPI",
   groupId: "insights",
-  inputs: [
-    {
-      label: "Data",
-      isMandatory: true,
-      accepts: ["prediction", "detection"],
-    },
-  ],
-  outputs: [
-    {
-      label: "Insight",
-      isMandatory: true,
-      provides: "insight",
-    },
-  ],
 };

--- a/packages/lab/src/components/Flow/stories/Base/LineChart.tsx
+++ b/packages/lab/src/components/Flow/stories/Base/LineChart.tsx
@@ -3,24 +3,29 @@ import { HvFlowNode, HvFlowNodeFC } from "@hitachivantara/uikit-react-lab";
 import type { NodeGroups } from ".";
 
 export const LineChart: HvFlowNodeFC<NodeGroups> = (props) => {
-  return <HvFlowNode description="LineChart description" {...props} />;
+  return (
+    <HvFlowNode
+      description="LineChart description"
+      inputs={[
+        {
+          label: "Data",
+          isMandatory: true,
+          accepts: ["prediction", "detection"],
+        },
+      ]}
+      outputs={[
+        {
+          label: "Insight",
+          isMandatory: true,
+          provides: "insight",
+        },
+      ]}
+      {...props}
+    />
+  );
 };
 
 LineChart.meta = {
   label: "LineChart",
   groupId: "insights",
-  inputs: [
-    {
-      label: "Data",
-      isMandatory: true,
-      accepts: ["prediction", "detection"],
-    },
-  ],
-  outputs: [
-    {
-      label: "Insight",
-      isMandatory: true,
-      provides: "insight",
-    },
-  ],
 };

--- a/packages/lab/src/components/Flow/stories/Base/MLModelDetection.tsx
+++ b/packages/lab/src/components/Flow/stories/Base/MLModelDetection.tsx
@@ -3,24 +3,29 @@ import { HvFlowNode, HvFlowNodeFC } from "@hitachivantara/uikit-react-lab";
 import type { NodeGroups } from ".";
 
 export const MLModelDetection: HvFlowNodeFC<NodeGroups> = (props) => {
-  return <HvFlowNode description="Anomaly detection description" {...props} />;
+  return (
+    <HvFlowNode
+      description="Anomaly detection description"
+      inputs={[
+        {
+          label: "Sensor Data",
+          isMandatory: true,
+          accepts: ["sensorData"],
+        },
+      ]}
+      outputs={[
+        {
+          label: "Detection",
+          isMandatory: true,
+          provides: "detection",
+        },
+      ]}
+      {...props}
+    />
+  );
 };
 
 MLModelDetection.meta = {
   label: "ML Model Detection",
   groupId: "models",
-  inputs: [
-    {
-      label: "Sensor Data",
-      isMandatory: true,
-      accepts: ["sensorData"],
-    },
-  ],
-  outputs: [
-    {
-      label: "Detection",
-      isMandatory: true,
-      provides: "detection",
-    },
-  ],
 };

--- a/packages/lab/src/components/Flow/stories/Base/MLModelPrediction.tsx
+++ b/packages/lab/src/components/Flow/stories/Base/MLModelPrediction.tsx
@@ -3,24 +3,29 @@ import { HvFlowNode, HvFlowNodeFC } from "@hitachivantara/uikit-react-lab";
 import type { NodeGroups } from ".";
 
 export const MLModelPrediction: HvFlowNodeFC<NodeGroups> = (props) => {
-  return <HvFlowNode description="Anomaly Prediction description" {...props} />;
+  return (
+    <HvFlowNode
+      description="Anomaly Prediction description"
+      inputs={[
+        {
+          label: "Sensor Data",
+          isMandatory: true,
+          accepts: ["sensorData"],
+        },
+      ]}
+      outputs={[
+        {
+          label: "Prediction",
+          isMandatory: true,
+          provides: "prediction",
+        },
+      ]}
+      {...props}
+    />
+  );
 };
 
 MLModelPrediction.meta = {
   label: "ML Model Prediction",
   groupId: "models",
-  inputs: [
-    {
-      label: "Sensor Data",
-      isMandatory: true,
-      accepts: ["sensorData"],
-    },
-  ],
-  outputs: [
-    {
-      label: "Prediction",
-      isMandatory: true,
-      provides: "prediction",
-    },
-  ],
 };

--- a/packages/lab/src/components/Flow/stories/Base/NoGroup/Asset.tsx
+++ b/packages/lab/src/components/Flow/stories/Base/NoGroup/Asset.tsx
@@ -19,6 +19,18 @@ export const Asset: HvFlowNodeFC = (props) => {
         subTitle: "Asset",
         color: "cat11_80",
       }}
+      outputs={[
+        {
+          label: "Sensor Group 1",
+          isMandatory: true,
+          provides: "sensorData",
+        },
+        {
+          label: "Sensor Group 2",
+          isMandatory: true,
+          provides: "sensorData",
+        },
+      ]}
       {...props}
     />
   );
@@ -26,16 +38,4 @@ export const Asset: HvFlowNodeFC = (props) => {
 
 Asset.meta = {
   label: "My Asset",
-  outputs: [
-    {
-      label: "Sensor Group 1",
-      isMandatory: true,
-      provides: "sensorData",
-    },
-    {
-      label: "Sensor Group 2",
-      isMandatory: true,
-      provides: "sensorData",
-    },
-  ],
 };

--- a/packages/lab/src/components/Flow/stories/Base/NoGroup/LineChart.tsx
+++ b/packages/lab/src/components/Flow/stories/Base/NoGroup/LineChart.tsx
@@ -9,6 +9,13 @@ export const LineChart: HvFlowNodeFC = (props) => {
         subTitle: "Visualization",
         color: "cat12_80",
       }}
+      inputs={[
+        {
+          label: "Data",
+          isMandatory: true,
+          accepts: ["prediction", "detection"],
+        },
+      ]}
       {...props}
     />
   );
@@ -16,11 +23,4 @@ export const LineChart: HvFlowNodeFC = (props) => {
 
 LineChart.meta = {
   label: "LineChart",
-  inputs: [
-    {
-      label: "Data",
-      isMandatory: true,
-      accepts: ["prediction", "detection"],
-    },
-  ],
 };

--- a/packages/lab/src/components/Flow/stories/Base/NoGroup/MLModelPrediction.tsx
+++ b/packages/lab/src/components/Flow/stories/Base/NoGroup/MLModelPrediction.tsx
@@ -9,6 +9,20 @@ export const MLModelPrediction: HvFlowNodeFC = (props) => {
         subTitle: "ML Model Prediction",
         color: "cat10_80",
       }}
+      outputs={[
+        {
+          label: "Prediction",
+          isMandatory: true,
+          provides: "prediction",
+        },
+      ]}
+      inputs={[
+        {
+          label: "Sensor Data",
+          isMandatory: true,
+          accepts: ["sensorData"],
+        },
+      ]}
       {...props}
     />
   );
@@ -16,18 +30,4 @@ export const MLModelPrediction: HvFlowNodeFC = (props) => {
 
 MLModelPrediction.meta = {
   label: "ML Model Prediction",
-  inputs: [
-    {
-      label: "Sensor Data",
-      isMandatory: true,
-      accepts: ["sensorData"],
-    },
-  ],
-  outputs: [
-    {
-      label: "Prediction",
-      isMandatory: true,
-      provides: "prediction",
-    },
-  ],
 };

--- a/packages/lab/src/components/Flow/stories/Base/Table.tsx
+++ b/packages/lab/src/components/Flow/stories/Base/Table.tsx
@@ -3,24 +3,29 @@ import { HvFlowNode, HvFlowNodeFC } from "@hitachivantara/uikit-react-lab";
 import type { NodeGroups } from ".";
 
 export const Table: HvFlowNodeFC<NodeGroups> = (props) => {
-  return <HvFlowNode description="Table description" {...props} />;
+  return (
+    <HvFlowNode
+      description="Table description"
+      inputs={[
+        {
+          label: "Data",
+          isMandatory: true,
+          accepts: ["prediction", "detection"],
+        },
+      ]}
+      outputs={[
+        {
+          label: "Insight",
+          isMandatory: true,
+          provides: "insight",
+        },
+      ]}
+      {...props}
+    />
+  );
 };
 
 Table.meta = {
   label: "Table",
   groupId: "insights",
-  inputs: [
-    {
-      label: "Data",
-      isMandatory: true,
-      accepts: ["prediction", "detection"],
-    },
-  ],
-  outputs: [
-    {
-      label: "Insight",
-      isMandatory: true,
-      provides: "insight",
-    },
-  ],
 };

--- a/packages/lab/src/components/Flow/stories/CustomDrop/BarChart.tsx
+++ b/packages/lab/src/components/Flow/stories/CustomDrop/BarChart.tsx
@@ -18,6 +18,13 @@ export const BarChart: HvFlowNodeFC<NodeGroups> = (props) => {
       description="Bar Chart"
       expanded
       classes={{ root: css({ width: 500 }) }}
+      inputs={[
+        {
+          label: "Data",
+          isMandatory: true,
+          accepts: ["data"],
+        },
+      ]}
       {...props}
     >
       {dataNode && dataNode.data && dataNode.data.country && (
@@ -44,11 +51,4 @@ export const BarChart: HvFlowNodeFC<NodeGroups> = (props) => {
 BarChart.meta = {
   label: "Bar Chart",
   groupId: "visualizations",
-  inputs: [
-    {
-      label: "Data",
-      isMandatory: true,
-      accepts: ["data"],
-    },
-  ],
 };

--- a/packages/lab/src/components/Flow/stories/CustomDrop/LineChart.tsx
+++ b/packages/lab/src/components/Flow/stories/CustomDrop/LineChart.tsx
@@ -18,6 +18,13 @@ export const LineChart: HvFlowNodeFC<NodeGroups> = (props) => {
       description="Line Chart"
       expanded
       classes={{ root: css({ width: 500 }) }}
+      inputs={[
+        {
+          label: "Data",
+          isMandatory: true,
+          accepts: ["data"],
+        },
+      ]}
       {...props}
     >
       {dataNode && dataNode.data && dataNode.data.country && (
@@ -44,11 +51,4 @@ export const LineChart: HvFlowNodeFC<NodeGroups> = (props) => {
 LineChart.meta = {
   label: "Line Chart",
   groupId: "visualizations",
-  inputs: [
-    {
-      label: "Data",
-      isMandatory: true,
-      accepts: ["data"],
-    },
-  ],
 };

--- a/packages/lab/src/components/Flow/stories/CustomDrop/Precipitation.tsx
+++ b/packages/lab/src/components/Flow/stories/CustomDrop/Precipitation.tsx
@@ -16,6 +16,13 @@ export const Precipitation: HvFlowNodeFC<NodeGroups> = (props) => {
           options: Object.keys(data),
         },
       ]}
+      outputs={[
+        {
+          label: "Data",
+          isMandatory: true,
+          provides: "data",
+        },
+      ]}
       {...props}
     />
   );
@@ -24,11 +31,4 @@ export const Precipitation: HvFlowNodeFC<NodeGroups> = (props) => {
 Precipitation.meta = {
   label: "Precipitation",
   groupId: "sources",
-  outputs: [
-    {
-      label: "Data",
-      isMandatory: true,
-      provides: "data",
-    },
-  ],
 };

--- a/packages/lab/src/components/Flow/stories/DynamicHandles/Asset.tsx
+++ b/packages/lab/src/components/Flow/stories/DynamicHandles/Asset.tsx
@@ -1,0 +1,115 @@
+import { useEffect, useMemo, useRef } from "react";
+import { useReactFlow } from "reactflow";
+import {
+  HvFlowNodeFC,
+  HvFlowNodeInput,
+  HvFlowNodeOutput,
+  HvFlowNode,
+  HvFlowNodeTypeMeta,
+} from "@hitachivantara/uikit-react-lab";
+
+// Inputs and outputs info
+export const types: Record<
+  string,
+  { inputs: HvFlowNodeInput[]; outputs: HvFlowNodeOutput[] }
+> = {
+  "Type 1": {
+    inputs: [
+      {
+        label: "Data",
+        isMandatory: true,
+        accepts: ["data1", "data2", "data3"],
+        maxConnections: 1,
+      },
+    ],
+    outputs: [],
+  },
+  "Type 2": {
+    outputs: [
+      {
+        label: "Data 3",
+        provides: "data3",
+      },
+    ],
+    inputs: [],
+  },
+  "Type 3": {
+    outputs: [
+      {
+        label: "Data 1",
+        provides: "data1",
+      },
+      {
+        label: "Data 2",
+        provides: "data2",
+      },
+    ],
+    inputs: [],
+  },
+};
+
+// Node data type
+export interface NodeData {
+  type?: string;
+  inputs?: HvFlowNodeInput[];
+  outputs?: HvFlowNodeOutput[];
+}
+
+export const Asset: HvFlowNodeFC<string, NodeData> = (props) => {
+  const { data, id } = props;
+
+  const curType = useRef(data.type);
+
+  const reactFlowInstance = useReactFlow();
+
+  useEffect(() => {
+    if (data.type !== curType.current) {
+      // Update type
+      curType.current = data.type;
+
+      // Update inputs and outputs for the node
+      reactFlowInstance?.setNodes((nds) =>
+        nds.map((nd) => {
+          if (nd.id === id) {
+            nd.data = {
+              ...nd.data,
+              ...types[nd.data.type],
+            };
+          }
+          return nd;
+        })
+      );
+
+      // Clean up the edges for this node since the inputs and outputs changed
+      reactFlowInstance?.setEdges((eds) =>
+        eds.filter((ed) => ed.source !== id && ed.target !== id)
+      );
+    }
+  }, [data.type, id, reactFlowInstance]);
+
+  const inputs = useMemo(() => data.inputs, [data.inputs]);
+
+  const outputs = useMemo(() => data.outputs, [data.outputs]);
+
+  return (
+    <HvFlowNode
+      params={[
+        {
+          id: "type",
+          label: "Type",
+          type: "select",
+          options: Object.keys(types),
+        },
+      ]}
+      inputs={inputs}
+      outputs={outputs}
+      expanded
+      {...props}
+    />
+  );
+};
+
+Asset.meta = {
+  label: "Asset",
+  groupId: "assets",
+} satisfies HvFlowNodeTypeMeta;

--- a/packages/lab/src/components/Flow/stories/DynamicHandles/index.tsx
+++ b/packages/lab/src/components/Flow/stories/DynamicHandles/index.tsx
@@ -1,0 +1,222 @@
+import { useMemo, useState } from "react";
+import { css } from "@emotion/css";
+import { restrictToWindowEdges } from "@dnd-kit/modifiers";
+import { Node, ReactFlowInstance } from "reactflow";
+import {
+  HvButton,
+  HvDialog,
+  HvDialogActions,
+  HvDialogContent,
+  HvDialogTitle,
+  HvDropdown,
+  HvDropdownProps,
+  HvGlobalActions,
+  theme,
+  useTheme,
+} from "@hitachivantara/uikit-react-core";
+import { Add, DataSource } from "@hitachivantara/uikit-react-icons";
+import {
+  HvFlow,
+  HvFlowProps,
+  HvFlowSidebar,
+  HvFlowControls,
+} from "@hitachivantara/uikit-react-lab";
+
+// The code for these utils are available here: https://github.com/lumada-design/hv-uikit-react/tree/master/packages/lab/src/components/Flow/stories/Base
+import { restrictToSample } from "../Base";
+// The code for these utils are available here: https://github.com/lumada-design/hv-uikit-react/tree/master/packages/lab/src/components/Flow/stories/CustomNode
+import { Asset, NodeData, types } from "./Asset";
+
+// Classes
+const classes = {
+  root: css({ height: "100vh" }),
+  globalActions: css({ paddingBottom: theme.space.md }),
+  flow: css({
+    height: "calc(100% - 90px)",
+  }),
+};
+
+// Node groups
+export const nodeGroups = {
+  assets: {
+    label: "Asset",
+    color: "cat3_80",
+    description: "Find here all the available assets.",
+    icon: <DataSource />,
+  },
+} satisfies HvFlowProps["nodeGroups"];
+
+// Node types
+export const nodeTypes = {
+  asset: Asset,
+} satisfies HvFlowProps["nodeTypes"];
+
+// Flow
+const nodes: HvFlowProps["nodes"] = [
+  {
+    id: "22b4a205d16",
+    position: { x: 539, y: 142 },
+    data: {
+      type: "Type 1",
+      inputs: [
+        {
+          label: "Data",
+          isMandatory: true,
+          accepts: ["data1", "data2", "data3"],
+          maxConnections: 1,
+        },
+      ],
+      outputs: [],
+    },
+    type: "asset",
+  },
+  {
+    id: "2b4a205d16b",
+    position: { x: 117, y: 147 },
+    data: {
+      type: "Type 2",
+      outputs: [{ label: "Data 3", provides: "data3" }],
+      inputs: [],
+    },
+    type: "asset",
+  },
+];
+const edges: HvFlowProps["edges"] = [
+  {
+    source: "2b4a205d16b",
+    sourceHandle: "0",
+    target: "22b4a205d16",
+    targetHandle: "0",
+    id: "reactflow__edge-2b4a205d16b0-22b4a205d160",
+  },
+];
+
+export const DynamicHandles = () => {
+  const { rootId } = useTheme();
+
+  const [reactFlowInstance, setReactFlowInstance] =
+    useState<ReactFlowInstance>();
+
+  const [open, setOpen] = useState(false);
+  const [nodeConfig, setNodeConfig] = useState<Node<NodeData>>();
+
+  const options = useMemo(
+    () =>
+      Object.keys(types).map((key) => {
+        return { id: key, label: key };
+      }),
+    []
+  );
+
+  const handleCloseConfig = () => {
+    setNodeConfig(undefined);
+  };
+
+  const handleChangeConfig: HvDropdownProps["onChange"] = (value) => {
+    if (
+      value &&
+      !Array.isArray(value) &&
+      nodeConfig &&
+      typeof value.label === "string"
+    ) {
+      setNodeConfig({
+        ...nodeConfig,
+        data: {
+          ...nodeConfig.data,
+          type: value.label,
+        },
+      });
+    }
+  };
+
+  const handleApplyConfig = () => {
+    if (nodeConfig?.data.type) {
+      // Add node to flow and set inputs and outputs
+      const ndConfig = {
+        ...nodeConfig,
+        data: {
+          ...nodeConfig.data,
+          ...types[nodeConfig.data.type],
+        },
+      };
+      reactFlowInstance?.setNodes((nds) => nds.concat(ndConfig));
+
+      setNodeConfig(undefined);
+    }
+  };
+
+  const handleDrop: HvFlowProps["onDndDrop"] = (event, node) => {
+    if (node.type === "asset") {
+      setNodeConfig(node);
+    } else {
+      reactFlowInstance?.setNodes((nds) => nds.concat(node));
+    }
+  };
+
+  return (
+    <div className={classes.root}>
+      <HvGlobalActions
+        className={classes.globalActions}
+        position="relative"
+        title="New Flow"
+      >
+        <HvButton
+          variant="primary"
+          startIcon={<Add role="none" />}
+          onClick={() => setOpen(true)}
+        >
+          Add Node
+        </HvButton>
+      </HvGlobalActions>
+      <div className={classes.flow}>
+        <HvFlow
+          nodes={nodes}
+          edges={edges}
+          nodeTypes={nodeTypes}
+          nodeGroups={nodeGroups}
+          sidebar={
+            <HvFlowSidebar
+              title="Add Node"
+              description="Please choose within the options below"
+              open={open}
+              onClose={() => setOpen(false)}
+              // Needed to fix storybook
+              dragOverlayProps={{
+                modifiers: [
+                  restrictToWindowEdges,
+                  (args) => restrictToSample(rootId || "", args),
+                ],
+              }}
+            />
+          }
+          onInit={setReactFlowInstance}
+          onDndDrop={handleDrop}
+        >
+          <HvFlowControls />
+        </HvFlow>
+      </div>
+      <HvDialog open={!!nodeConfig} onClose={handleCloseConfig}>
+        <HvDialogTitle variant="info">Configure the node</HvDialogTitle>
+        <HvDialogContent>
+          <HvDropdown
+            label="Select the type"
+            values={options}
+            onChange={handleChangeConfig}
+          />
+        </HvDialogContent>
+        <HvDialogActions>
+          <HvButton
+            disabled={!nodeConfig?.data.type}
+            variant="primary"
+            onClick={handleApplyConfig}
+          >
+            Apply
+          </HvButton>
+          <HvButton variant="secondarySubtle" onClick={handleCloseConfig}>
+            Cancel
+          </HvButton>
+        </HvDialogActions>
+      </HvDialog>
+    </div>
+  );
+};

--- a/packages/lab/src/components/Flow/stories/Flow.stories.tsx
+++ b/packages/lab/src/components/Flow/stories/Flow.stories.tsx
@@ -21,6 +21,8 @@ import { CustomDrop as CustomDropStory } from "./CustomDrop";
 import CustomDropRaw from "./CustomDrop?raw";
 import { NoGroups as NoGroupStory } from "./NoGroups";
 import NoGroupsRaw from "./NoGroups?raw";
+import { DynamicHandles as DynamicHandlesStory } from "./DynamicHandles";
+import DynamicHandlesRaw from "./DynamicHandles?raw";
 
 const meta: Meta<typeof HvFlow> = {
   title: "Lab/Flow",
@@ -141,4 +143,20 @@ export const NoGroups: StoryObj<HvFlowProps> = {
     eyes: { include: false },
   },
   render: () => <NoGroupStory />,
+};
+
+export const DynamicHandles: StoryObj<HvFlowProps> = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "In this sample nodes' inputs and outputs are dynamically generated.",
+      },
+      source: {
+        code: DynamicHandlesRaw,
+      },
+    },
+    eyes: { include: false },
+  },
+  render: () => <DynamicHandlesStory />,
 };

--- a/packages/lab/src/components/Flow/stories/Usage.stories.mdx
+++ b/packages/lab/src/components/Flow/stories/Usage.stories.mdx
@@ -7,7 +7,7 @@ import { Meta } from "@storybook/addon-docs";
 The NEXT UI Kit Flow component allows users to create dynamic and interactive flow diagrams to visualize, for example, business processes, data workflows or user journeys.
 It leverages the [ReactFlow](https://reactflow.dev/) library under the hood.
 
-This is a lab component, please keep in mind that it can be changed in the future.
+Since this is a lab component, please keep in mind that it can be changed in the future.
 
 Summary:
 
@@ -16,18 +16,18 @@ Summary:
   - [Background](#background)
   - [Controls](#controls)
   - [Minimap](#minimap)
-  - [Empty State](#empty-state)
+  - [Empty state](#empty-state)
 - [Custom nodes and node types](#custom-nodes-and-node-types)
-- [Inputs and Outputs](#inputs-and-outputs)
+- [Inputs and outputs](#inputs-and-outputs)
 - [Parameters](#parameters)
 - [Actions](#actions)
-  - [Default Actions](#default-actions)
-  - [Custom Actions](#custom-actions)
-- [Advanced Use](#advanced-use)
+  - [Default actions](#default-actions)
+  - [Custom actions](#custom-actions)
+- [Custom content](#custom-content)
+- [Advanced use](#advanced-use)
   - [Accessing the React Flow instance](#react-flow-instance)
   - [Saving and exporting data](#saving-and-exporting-data)
-- [Custom Content](#custom-content)
-- [Custom Node Example](#custom-node-example)
+- [Custom node example](#custom-node-example)
 
 To use the `HvFlow` component you'll need to define:
 
@@ -63,13 +63,13 @@ const nodeGroups = {
   assets: {
     label: "Assets",
     color: "cat3_80",
-    description: "This is my description for assets.",
+    description: "Find here all the available assets.",
     icon: <Heart />,
   },
   models: {
     label: "ML Model",
     color: "cat1_80",
-    description: "This is my description for models.",
+    description: "Find here all the available models.",
     icon: <Favorite />,
   },
 } satisfies HvFlowProps<NodeGroups>["nodeGroups"];
@@ -94,7 +94,7 @@ You can then create the sidebar by using the `HvFlowSidebar` component as a prop
 </HvFlow>
 ```
 
-But node groups are not mandatory. If you don't pass a `nodeGroups` prop to the `HvFlow` component, then all node types will be listed
+However, node groups are not mandatory. If you don't pass a `nodeGroups` prop to the `HvFlow` component, then all node types will be listed
 in the sidebar in a simple list of nodes.
 
 ## Layout <a id="layout" />
@@ -117,18 +117,18 @@ documentation](./?path=/docs/lab-flow--docs) for the `HvFlowControls` component 
 
 To add the minimap of the flow, just add the `<HvFlowMinimap />` component as a child of the `HvFlow` component.
 
-### Empty State <a id="#empty-state" />
+### Empty state <a id="empty-state" />
 
 To add an empty state panel, you can add the `<HvFlowEmpty />` component as a child of the `HvFlow` component. This wraps UI Kit's `HvEmptyState`
-component and shares the same interface.
+component and shares the same API.
 
 ## Custom nodes and node types <a id="custom-nodes-and-node-types" />
 
 The `HvFlowNode` component allows you to create your own nodes. It provides a base for your own custom nodes and is not to be used directly as a node on the flow.
-There are a few properties that should be set on your node `meta` property: the label, the list of inputs and outputs and, optionally, the id of the group it belongs to.
-The parameters are passed as a property of the `HvFlowNode` component.
+There are a few properties that should be set on your node `meta` property: the label, and, optionally, the id of the group it belongs to.
+The parameters and the list of inputs and outputs are passed as a property of the `HvFlowNode` component.
 
-Example custom node:
+Find an example of a custom node below.
 
 ```tsx
 import { HvFlowNode } from "@hitachivantara/uikit-react-lab";
@@ -138,6 +138,20 @@ export const CustomNode = (props) => {
     <HvFlowNode
       description="CustomNode description"
       expanded
+      inputs={[
+        {
+          label: "Data",
+          isMandatory: true,
+          accepts: ["prediction", "detection"],
+        },
+      ]}
+      outputs={[
+        {
+          label: "Insight",
+          isMandatory: true,
+          provides: "insight",
+        },
+      ]}
       params={[
         {
           id: "myParam",
@@ -156,25 +170,11 @@ export const CustomNode = (props) => {
 CustomNode.meta = {
   label: "CustomNode",
   groupId: "someNodeGroup",
-  inputs: [
-    {
-      label: "Data",
-      isMandatory: true,
-      accepts: ["prediction", "detection"],
-    },
-  ],
-  outputs: [
-    {
-      label: "Insight",
-      isMandatory: true,
-      provides: ["insight"],
-    },
-  ],
 };
 ```
 
 If you don't set a group id for any given node, then it will be added to a `Default` group that will serve as a repository to all nodes
-that are not in a group. The `Default` group is customizable via the `defaultGroupProps` on the `HvFlowSidebar` component. Example:
+that are not in a group. This default group is customizable via the `defaultGroupProps` on the `HvFlowSidebar` component as shown below.
 
 ```tsx
 <HvFlow
@@ -192,10 +192,10 @@ that are not in a group. The `Default` group is customizable via the `defaultGro
 </HvFlow>
 ```
 
-## Inputs and Outputs <a id="inputs-and-outputs" />
+## Inputs and outputs <a id="inputs-and-outputs" />
 
-Nodes need inputs and/or outputs to connect to other nodes. Inputs and outputs can be defined on the `meta` property of the component and they
-follow specific types:
+Nodes need inputs and/or outputs to connect to other nodes. Inputs and outputs can be defined as properties of the component and they
+follow specific types as shown below.
 
 ```typescript
 type HvFlowNodeInput = {
@@ -224,17 +224,25 @@ the number of connections an input accepts as well as the number of connections 
 
 ## Parameters <a id="parameters" />
 
-A node can also have parameters of several types and will be rendered in the node as an element that corresponds to the parameter type.
-The parameters follow the type:
+A node can also have parameters of several types and they will be rendered in the node as an element that corresponds to the parameter type.
+The parameters follow the following types:
 
 ```typescript
-type HvFlowNodeParam = {
+interface HvFlowNodeTextParam {
+  type: "text";
   id: string;
-  type: "text" | "select";
   label: string;
+}
+
+interface HvFlowNodeSelectParam {
+  type: "select";
+  id: string;
+  label: string;
+  multiple?: boolean;
   options?: string[];
-  value?: string;
-};
+}
+
+type HvFlowNodeParam = HvFlowNodeSelectParam | HvFlowNodeTextParam;
 ```
 
 Whenever a change is made on a parameter while using the flow, that change is saved on the node's `data` property in the `reactflow` instance.
@@ -248,13 +256,15 @@ data: {
 
 Current parameter types supported by the `HvFlow` component:
 
-- `text`: renders an input box
-- `select`: renders a dropdown and uses the `options` array to create the dropdown options
+- `text`: renders an input box;
+- `select`: renders a dropdown and uses the `options` array to create the dropdown options. If `multiple` is set to `true`, a multiple select dropdown is used.
 
 ## Actions <a id="actions" />
 
-Nodes can have two types of actions: default actions that are a set of pre-defined actions that all nodes share (right now: delete and duplicate)
-and custom actions that are set at the (custom) node level.
+Nodes can have two types of actions:
+
+- Default actions that are a set of pre-defined actions that all nodes share. At the moment, the default actions are delete and duplicate;
+- Custom actions that are set at the (custom) node level.
 
 ### Default actions <a id="default-actions" />
 
@@ -280,9 +290,9 @@ The `id` property will be typed to be one of the allowed default actions.
 
 At the node level you can specify other actions. To achieve this you'll have to define:
 
-- a set of actions;
-- a callback to handle these actions;
-- optionally, specify a maximum number of visible actions (the others will be placed in a dropdown menu)
+- A set of actions;
+- A callback to handle these actions;
+- Optionally, a maximum number of visible actions and the others will be placed in a dropdown menu.
 
 ```tsx
 const handleAction = (event: any, id: string, action: any) => {
@@ -326,7 +336,7 @@ const handleAction = (event: any, id: string, action: any) => {
 />;
 ```
 
-## Custom Content <a id="custom-content" />
+## Custom content <a id="custom-content" />
 
 If any of the previous topics are not enough for your use case, you can also pass some custom content to the `HvFlowNode` component:
 
@@ -351,7 +361,7 @@ To facilitate this, we provide a set of specialized hooks:
 - `useFlowNodeOutputEdges(id: string)`: Gives the output edges connected from the node.
 - `useFlowNodeEdges(id: string)`: Offers both input and output edges of the node.
 
-Example usage in a custom node component:
+Find below an example usage in a custom node component.
 
 ```tsx
 export const Asset = (props) => {
@@ -388,7 +398,7 @@ export const Asset = (props) => {
 };
 ```
 
-Other hooks are also available depending on your needs, like the `useNodes` and `useEdges` hooks. However it's important to note that components using `useNodes` and `useEdges` will re-render whenever any node or edge changes. This includes selections and movements of nodes, which can affect performance in complex flows.
+Other hooks are also available depending on your needs, like the `useNodes` and `useEdges` hooks. However, it's important to note that components using `useNodes` and `useEdges` will re-render whenever any node or edge changes. This includes selections and movements of nodes, which can affect performance in complex flows.
 
 Prefer using `useStore` with specific selectors to reduce the number of re-renders, ensuring that components only update when necessary.
 
@@ -397,15 +407,15 @@ specially on the hooks section.
 
 ### Saving and exporting data <a id="saving-and-exporting-data" />
 
-Like we mentioned in the [Parameters](#parameters) section, data is saved in the `data` property of the node object in the `reactflow` instance.
+Like mentioned in the [Parameters](#parameters) section, data is saved in the `data` property of the node object in the `reactflow` instance.
 If you need to have more complex use cases for your nodes and need to store data, you should follow the same logic and use the `data` property.
 The `reactflow`instance provides the `setNodes` function to save and update the nodes list.
 
 If you need to export your data at any point you can use the `toObject` function on the `instance` object.
 
-## Custom Node Example <a id="custom-node-example" />
+## Custom node example <a id="custom-node-example" />
 
-Below you can find a full example of a custom Node that exercises the topics we talked about before:
+Below you can find a full example of a custom Node that exercises the topics approached in this page.
 
 ```tsx
 export const Asset = (props) => {
@@ -454,7 +464,6 @@ export const Asset = (props) => {
           </HvButton>
         </HvDialogActions>
       </HvDialog>
-
       <HvFlowNode
         title="Asset"
         description="Asset asset description"
@@ -487,6 +496,25 @@ export const Asset = (props) => {
             options: ["Way Side", "Cars"],
           },
         ]}
+        inputs={[
+          {
+            label: "Asset Config",
+            isMandatory: true,
+            accepts: ["assetConfig"],
+          },
+        ]}
+        outputs={[
+          {
+            label: "Sensor Group 1",
+            isMandatory: true,
+            provides: "sensorData",
+          },
+          {
+            label: "Sensor Group 2",
+            isMandatory: true,
+            provides: "sensorData",
+          },
+        ]}
         {...props}
       />
     </>
@@ -496,27 +524,8 @@ export const Asset = (props) => {
 Asset.meta = {
   label: "Asset",
   groupId: "someNodeGroup",
-  inputs: [
-    {
-      label: "Asset Config",
-      isMandatory: true,
-      accepts: ["assetConfig"],
-    },
-  ],
-  outputs: [
-    {
-      label: "Sensor Group 1",
-      isMandatory: true,
-      provides: ["sensorData"],
-    },
-    {
-      label: "Sensor Group 2",
-      isMandatory: true,
-      provides: ["sensorData"],
-    },
-  ],
 };
 ```
 
-You can view other examples of custom nodes by checking
+Other examples of custom nodes can be found on
 [our repository](https://github.com/lumada-design/hv-uikit-react/tree/master/packages/lab/src/components/Flow/stories).

--- a/packages/lab/src/components/Flow/stories/Visualizations/BarChart.tsx
+++ b/packages/lab/src/components/Flow/stories/Visualizations/BarChart.tsx
@@ -19,6 +19,13 @@ export const BarChart: HvFlowNodeFC<NodeGroups> = (props) => {
       description="Bar Chart description"
       expanded
       classes={{ root: css({ width: 500 }) }}
+      inputs={[
+        {
+          label: "Data",
+          isMandatory: true,
+          accepts: ["jsonData"],
+        },
+      ]}
       {...props}
     >
       {dataNode?.data?.jsonData && dataNode.data.jsonData.length > 0 && (
@@ -43,12 +50,4 @@ export const BarChart: HvFlowNodeFC<NodeGroups> = (props) => {
 BarChart.meta = {
   label: "Bar Chart",
   groupId: "visualizations",
-  inputs: [
-    {
-      label: "Data",
-      isMandatory: true,
-      accepts: ["jsonData"],
-    },
-  ],
-  outputs: [],
 };

--- a/packages/lab/src/components/Flow/stories/Visualizations/Filter.tsx
+++ b/packages/lab/src/components/Flow/stories/Visualizations/Filter.tsx
@@ -69,7 +69,25 @@ export const Filter: HvFlowNodeFC = (props) => {
   };
 
   return (
-    <HvFlowNode description="Filtering data" expanded {...props}>
+    <HvFlowNode
+      description="Filtering data"
+      expanded
+      inputs={[
+        {
+          label: "Data",
+          isMandatory: true,
+          accepts: ["jsonData"],
+        },
+      ]}
+      outputs={[
+        {
+          label: "Filtered Data",
+          isMandatory: false,
+          provides: "jsonData",
+        },
+      ]}
+      {...props}
+    >
       <HvCheckBoxGroup
         onChange={handleCheck}
         style={{
@@ -94,18 +112,4 @@ export const Filter: HvFlowNodeFC = (props) => {
 Filter.meta = {
   label: "Filter",
   groupId: "transformations",
-  inputs: [
-    {
-      label: "Data",
-      isMandatory: true,
-      accepts: ["jsonData"],
-    },
-  ],
-  outputs: [
-    {
-      label: "Filtered Data",
-      isMandatory: false,
-      provides: "jsonData",
-    },
-  ],
 };

--- a/packages/lab/src/components/Flow/stories/Visualizations/JsonInput.tsx
+++ b/packages/lab/src/components/Flow/stories/Visualizations/JsonInput.tsx
@@ -1,17 +1,22 @@
 import { HvFlowNode, HvFlowNodeFC } from "@hitachivantara/uikit-react-lab";
 
 export const JsonInput: HvFlowNodeFC = (props) => {
-  return <HvFlowNode description="Population Datakky7" {...props} />;
+  return (
+    <HvFlowNode
+      description="Population Datakky7"
+      outputs={[
+        {
+          label: "Json Data",
+          isMandatory: true,
+          provides: "jsonData",
+        },
+      ]}
+      {...props}
+    />
+  );
 };
 
 JsonInput.meta = {
   label: "Json Input",
   groupId: "inputs",
-  outputs: [
-    {
-      label: "Json Data",
-      isMandatory: true,
-      provides: "jsonData",
-    },
-  ],
 };

--- a/packages/lab/src/components/Flow/stories/Visualizations/LineChart.tsx
+++ b/packages/lab/src/components/Flow/stories/Visualizations/LineChart.tsx
@@ -18,6 +18,13 @@ export const LineChart: HvFlowNodeFC = (props) => {
       description="Line Chart description"
       expanded
       classes={{ root: css({ width: 500 }) }}
+      inputs={[
+        {
+          label: "Data",
+          isMandatory: true,
+          accepts: ["jsonData"],
+        },
+      ]}
       {...props}
     >
       {dataNode?.data?.jsonData && dataNode.data.jsonData.length > 0 && (
@@ -42,12 +49,4 @@ export const LineChart: HvFlowNodeFC = (props) => {
 LineChart.meta = {
   label: "Line Chart",
   groupId: "visualizations",
-  inputs: [
-    {
-      label: "Data",
-      isMandatory: true,
-      accepts: ["jsonData"],
-    },
-  ],
-  outputs: [],
 };

--- a/packages/lab/src/components/Flow/types/flow.ts
+++ b/packages/lab/src/components/Flow/types/flow.ts
@@ -15,7 +15,7 @@ type NodeExtras<GroupId extends keyof any = string, NodeData = any> = {
 export interface HvFlowNodeFC<
   GroupId extends keyof any = string,
   NodeData = any
-> extends FC<NodeProps>,
+> extends FC<NodeProps<NodeData>>,
     NodeExtras<GroupId, NodeData> {}
 
 export interface HvFlowNodeComponentClass<

--- a/packages/lab/src/components/Flow/types/flow.ts
+++ b/packages/lab/src/components/Flow/types/flow.ts
@@ -55,8 +55,6 @@ export type HvFlowNodeTypeMeta<
 > = {
   label: string;
   groupId?: GroupId;
-  inputs?: HvFlowNodeInput[];
-  outputs?: HvFlowNodeOutput[];
   data?: NodeData;
 };
 


### PR DESCRIPTION
- The node `inputs` and `outputs` were transferred to the component's props:
   - They were previously added to `meta` because of the `isValidConnection` validation in the `HvDroppableFlow`. This is no longer needed since this [PR](https://github.com/lumada-design/hv-uikit-react/pull/3784).
   - Making this change enables to create `inputs` and `outputs` dynamically. 
   - The node type `meta` is now used only for the sidebar.
- Flow docs updated:
   - Usage page
   - Dynamic handles sample added  