### PR TITLE
docs: remove duplicated & unnecessary ids

### DIFF
--- a/packages/core/src/components/Accordion/Accordion.stories.tsx
+++ b/packages/core/src/components/Accordion/Accordion.stories.tsx
@@ -64,7 +64,7 @@ export const Main: StoryObj<HvAccordionProps> = {
   render: (args) => {
     return (
       <HvBox sx={{ maxWidth: 300 }}>
-        <HvAccordion id="item1" {...args}>
+        <HvAccordion id="main" {...args}>
           <HvListContainer
             className={css(styles.listContainer)}
             interactive
@@ -194,112 +194,46 @@ export const Controlled: StoryObj<HvAccordionProps> = {
         </HvSimpleGrid>
         <HvBox sx={{ maxWidth: 300 }}>
           <HvAccordion
-            id="controlled-item1"
             label="Personal Information"
             onChange={() => handleToggle("personalInformation")}
             expanded={expandedState.personalInformation}
           >
             <div className={css(styles.formContainer)}>
+              <HvInput label="Name" placeholder="Insert first name" required />
+              <HvInput label="Email" placeholder="Insert your email" required />
+              <HvInput label="Phone" placeholder="Insert your phone number" />
+              <HvInput label="Extension" placeholder="Insert phone extension" />
+              <HvInput label="Country" placeholder="Insert country name" />
               <HvInput
-                id="input-name"
-                label="Name"
-                placeholder="Insert first name"
-                required
-              />
-              <HvInput
-                id="input-email"
-                label="Email"
-                placeholder="Insert your email"
-                required
-              />
-              <HvInput
-                id="input-phone"
-                label="Phone"
-                placeholder="Insert your phone number"
-              />
-              <HvInput
-                id="input-extension"
-                label="Extension"
-                placeholder="Insert phone extension"
-              />
-              <HvInput
-                id="input-country"
-                label="Country"
-                placeholder="Insert country name"
-              />
-              <HvInput
-                id="input-province"
                 label="City/Province"
                 placeholder="Insert province name"
               />
             </div>
           </HvAccordion>
           <HvAccordion
-            id="controlled-item2"
             label="Billing Address"
             onChange={() => handleToggle("billingAddress")}
             expanded={expandedState.billingAddress}
           >
             <div className={css(styles.formContainer)}>
-              <HvInput
-                id="input-address"
-                label="Address 1"
-                placeholder="Insert first name"
-              />
-              <HvInput
-                id="input-address2"
-                label="Address 2"
-                placeholder="Insert address"
-              />
-              <HvInput
-                id="input-city"
-                label="City"
-                placeholder="Insert city name"
-              />
-              <HvInput
-                id="input-state"
-                label="State"
-                placeholder="Insert state"
-              />
-              <HvInput
-                id="input-code"
-                label="Zip Code"
-                placeholder="Insert code"
-              />
+              <HvInput label="Address 1" placeholder="Insert first name" />
+              <HvInput label="Address 2" placeholder="Insert address" />
+              <HvInput label="City" placeholder="Insert city name" />
+              <HvInput label="State" placeholder="Insert state" />
+              <HvInput label="Zip Code" placeholder="Insert code" />
             </div>
           </HvAccordion>
           <HvAccordion
-            id="controlled-item3"
             label="Shipping Address"
             onChange={() => handleToggle("shippingAddress")}
             expanded={expandedState.shippingAddress}
           >
             <div className={css(styles.formContainer)}>
-              <HvInput
-                id="input-address-bill"
-                label="Address 1"
-                placeholder="Insert first name"
-              />
-              <HvInput
-                id="input-address2-bill"
-                label="Address 2"
-                placeholder="Insert address"
-              />
-              <HvInput
-                id="input-city-bill"
-                label="City"
-                placeholder="Insert city name"
-              />
-              <HvInput
-                id="input-state-bill"
-                label="State"
-                placeholder="Insert state"
-              />
-              <HvInput
-                id="input-code-bill"
-                label="Zip Code"
-                placeholder="Insert code"
-              />
+              <HvInput label="Address 1" placeholder="Insert first name" />
+              <HvInput label="Address 2" placeholder="Insert address" />
+              <HvInput label="City" placeholder="Insert city name" />
+              <HvInput label="State" placeholder="Insert state" />
+              <HvInput label="Zip Code" placeholder="Insert code" />
             </div>
           </HvAccordion>
         </HvBox>
@@ -393,13 +327,12 @@ export const Typography: StoryObj<HvAccordionProps> = {
     return (
       <HvBox sx={{ width: "100%" }}>
         <HvAccordion
-          id="item1"
           label="Films"
           labelVariant="title4"
           headingLevel={2}
           expanded
         >
-          <HvTable id="accordion-table" {...getTableProps()}>
+          <HvTable {...getTableProps()}>
             <HvTableHead {...getTableHeadProps?.()}>
               {headerGroups.map((headerGroup) => (
                 <HvTableRow {...headerGroup.getHeaderGroupProps()}>

--- a/packages/core/src/components/BreadCrumb/BreadCrumb.stories.tsx
+++ b/packages/core/src/components/BreadCrumb/BreadCrumb.stories.tsx
@@ -38,12 +38,7 @@ export const Main: StoryObj<HvBreadCrumbProps> = {
   },
   render: (args) => {
     return (
-      <HvBreadCrumb
-        listRoute={data}
-        id="breadcrumb1"
-        aria-label="Breadcrumb"
-        {...args}
-      >
+      <HvBreadCrumb listRoute={data} aria-label="Breadcrumb" {...args}>
         List
       </HvBreadCrumb>
     );
@@ -62,7 +57,6 @@ export const WithURL: StoryObj<HvBreadCrumbProps> = {
     return (
       <HvBreadCrumb
         url="https://hitachivantara.sharepoint.com/sites/DesignSystem/Pattern%20Library/Home.aspx"
-        id="breadcrumb4"
         aria-label="Breadcrumb"
         {...args}
       />
@@ -83,7 +77,6 @@ export const WithURLLimited: StoryObj<HvBreadCrumbProps> = {
     return (
       <HvBreadCrumb
         url="https://hitachivantara.sharepoint.com/sites/DesignSystem/Pattern%20Library/Home.aspx"
-        id="breadcrumb5"
         maxVisible={2}
         aria-label="Breadcrumb"
         {...args}
@@ -122,7 +115,6 @@ export const WithCustomComponent: StoryObj<HvBreadCrumbProps> = {
           to: `#${path}`,
           ariaLabel: label,
         }))}
-        id="breadcrumb6"
         aria-label="Breadcrumb"
         component={CustomNavLink}
       />
@@ -148,12 +140,7 @@ export const WithLongLabels: StoryObj<HvBreadCrumbProps> = {
     ];
 
     return (
-      <HvBreadCrumb
-        listRoute={longData}
-        id="breadcrumb7"
-        aria-label="Breadcrumb"
-        {...args}
-      />
+      <HvBreadCrumb listRoute={longData} aria-label="Breadcrumb" {...args} />
     );
   },
 };

--- a/packages/core/src/components/BulkActions/BulkActions.stories.tsx
+++ b/packages/core/src/components/BulkActions/BulkActions.stories.tsx
@@ -61,7 +61,6 @@ const SampleComponent = ({ data, onChange }: SampleComponentProps) => (
     {data.map((el, i) => (
       <div key={el.id}>
         <HvCheckBox
-          id={el.id.toString()}
           label={el.value}
           checked={el.checked}
           onChange={(e, checked) => onChange(e, i, checked)}
@@ -173,7 +172,6 @@ export const WithActions: StoryObj<HvBulkActionsProps> = {
       actions && (
         <div>
           <HvBulkActions
-            id="bulkActions"
             numTotal={data.length}
             numSelected={data.filter((el) => el.checked).length}
             onSelectAll={handleSelectAll}
@@ -268,7 +266,6 @@ export const WithPagination: StoryObj<HvBulkActionsProps> = {
     return (
       <>
         <HvBulkActions
-          id="bulkActions"
           numTotal={data.length}
           numSelected={data.filter((el) => el.checked).length}
           onSelectAll={handleSelectAll}
@@ -284,7 +281,6 @@ export const WithPagination: StoryObj<HvBulkActionsProps> = {
         />
         <p />
         <HvPagination
-          id="pagination"
           pages={numPages}
           page={page}
           canPrevious={page > 0}

--- a/packages/core/src/components/Card/Card.stories.tsx
+++ b/packages/core/src/components/Card/Card.stories.tsx
@@ -210,7 +210,6 @@ export const AllComponents: StoryObj<HvCardProps> = {
         <HvCardMedia component="img" alt="Leaves" height={160} image={leaf} />
         <HvActionBar>
           <HvCheckBox
-            id="controller"
             onChange={() => setChecked(!checked)}
             checked={checked}
             value="value"

--- a/packages/core/src/components/CheckBoxGroup/CheckBoxGroup.stories.tsx
+++ b/packages/core/src/components/CheckBoxGroup/CheckBoxGroup.stories.tsx
@@ -33,7 +33,7 @@ export const Main: StoryObj<HvCheckBoxGroupProps> = {
   },
   render: (args) => {
     return (
-      <HvCheckBoxGroup id="main" {...args}>
+      <HvCheckBoxGroup {...args}>
         <HvCheckBox label="Checkbox 1" value="1" />
         <HvCheckBox label="Checkbox 2" value="2" checked />
         <HvCheckBox label="Checkbox 3" value="3" />

--- a/packages/core/src/components/DatePicker/DatePicker.stories.tsx
+++ b/packages/core/src/components/DatePicker/DatePicker.stories.tsx
@@ -148,7 +148,6 @@ export const Localized: StoryObj<HvDatePickerProps> = {
         <HvDatePicker
           placeholder={`Select a date in ${locale}`}
           locale={locale}
-          id="DatePicker"
           aria-label="Date"
         />
       </>
@@ -170,7 +169,6 @@ export const WithActions: StoryObj<HvDatePickerProps> = {
       <HvDatePicker
         showActions
         value={new Date(1970, 1, 2)}
-        id="DatePicker"
         placeholder="Select date"
         aria-label="Date"
       />
@@ -383,7 +381,6 @@ export const WithSelectionList: StoryObj<HvDatePickerProps> = {
 
     return (
       <HvDatePicker
-        id="DatePicker"
         aria-label="Date"
         startAdornment={options}
         rangeMode

--- a/packages/core/src/components/FilterGroup/FilterGroup.stories.tsx
+++ b/packages/core/src/components/FilterGroup/FilterGroup.stories.tsx
@@ -92,7 +92,6 @@ export const Main: StoryObj<HvFilterGroupProps> = {
     return (
       <div style={{ width: 180 }}>
         <HvFilterGroup
-          id="filter-group-main"
           aria-label="Main filter group"
           value={value}
           filters={filters}
@@ -117,7 +116,6 @@ export const ResetToDefault: StoryObj<HvFilterGroupProps> = {
     return (
       <div style={{ width: 180 }}>
         <HvFilterGroup
-          id="filter-group-reset-default"
           aria-label="Reset to default filter group"
           value={value}
           defaultValue={[["category1"], [], []]}
@@ -140,7 +138,6 @@ export const Uncontrolled: StoryObj<HvFilterGroupProps> = {
     return (
       <div style={{ width: 180 }}>
         <HvFilterGroup
-          id="filter-group-uncontrolled"
           aria-label="Uncontrolled filter group"
           filters={filters}
         />
@@ -180,7 +177,6 @@ const EmptyFiltersStory = () => {
     <div style={{ display: "flex", alignItems: "center", gap: 20 }}>
       <div style={{ width: 180 }}>
         <HvFilterGroup
-          id="filter-group-empty"
           aria-label="Empty filter group"
           filters={myFilters}
           filterContentProps={{ leftEmptyElement, rightEmptyElement }}
@@ -234,7 +230,6 @@ return (
     <div style={{ display: "flex", alignItems: "center", gap: 20 }}>
     <div style={{ width: 180 }}>
         <HvFilterGroup
-        id="filter-group-empty"
         aria-label="Empty filter group"
         filters={myFilters}
         filterContentProps={{ leftEmptyElement, rightEmptyElement }}

--- a/packages/core/src/components/Input/SearchBox.stories.tsx
+++ b/packages/core/src/components/Input/SearchBox.stories.tsx
@@ -157,7 +157,6 @@ export const DynamicSearch: StoryObj = {
     return (
       <>
         <HvInput
-          id="dynamic"
           type="search"
           label="Search country data"
           placeholder="Search"
@@ -367,7 +366,6 @@ export const SearchAsYouType: StoryObj = {
     return (
       <>
         <HvInput
-          id="dynamic"
           type="search"
           label="Filter countries"
           placeholder="Search"

--- a/packages/core/src/components/MultiButton/MultiButton.stories.tsx
+++ b/packages/core/src/components/MultiButton/MultiButton.stories.tsx
@@ -63,7 +63,6 @@ export const OnlyLabels: StoryObj<HvMultiButtonProps> = {
       <HvMultiButton style={{ width: "210px" }}>
         {buttons.map((button, i) => (
           <HvButton
-            id={button.toLowerCase()}
             key={`${buttons[i]}`}
             selected={selection === i}
             onClick={() => setSelection(i)}
@@ -95,7 +94,6 @@ export const OnlyIcons: StoryObj<HvMultiButtonProps> = {
       <HvMultiButton style={{ width: "64px" }}>
         {buttons.map(({ name, icon }, i) => (
           <HvButton
-            id={name.toLowerCase()}
             key={`${buttons[i].name}`}
             icon
             aria-label={name}
@@ -259,7 +257,6 @@ export const EnforcedSelection: StoryObj<HvMultiButtonProps> = {
         <HvMultiButton>
           {range(5).map((i) => (
             <HvButton
-              id={`location${i + 1 || ""}`}
               key={`ef-${i}`}
               startIcon={<LocationPin />}
               selected={selection.includes(i)}
@@ -299,7 +296,6 @@ export const MinimumSelection: StoryObj<HvMultiButtonProps> = {
         <HvMultiButton>
           {range(5).map((i) => (
             <HvButton
-              id={`location${i + 1}`}
               key={`ms-${i}`}
               startIcon={<LocationPin />}
               selected={selection.includes(i)}
@@ -339,7 +335,6 @@ export const MaximumSelection: StoryObj<HvMultiButtonProps> = {
         <HvMultiButton>
           {range(5).map((i) => (
             <HvButton
-              id={`location${i + 1}`}
               key={`maxse-${i}`}
               startIcon={<LocationPin />}
               selected={selection.includes(i)}

--- a/packages/core/src/components/Pagination/Pagination.stories.tsx
+++ b/packages/core/src/components/Pagination/Pagination.stories.tsx
@@ -52,7 +52,6 @@ export const Main: StoryObj<HvPaginationProps> = {
         </StyledBox>
         <p />
         <HvPagination
-          id="pagination"
           pages={numPages}
           page={page}
           canPrevious={page > 0}

--- a/packages/core/src/components/TagsInput/TagsInput.stories.tsx
+++ b/packages/core/src/components/TagsInput/TagsInput.stories.tsx
@@ -78,7 +78,6 @@ export const Variants: StoryObj<HvTagsInputProps> = {
     return (
       <div className={css(styles.root)}>
         <HvTagsInput
-          id="tags-list-variants-1"
           label="Required"
           aria-label="Required"
           placeholder="Enter value"
@@ -86,7 +85,6 @@ export const Variants: StoryObj<HvTagsInputProps> = {
           value={[{ label: "tag 1" }, { label: "tag 2" }, { label: "tag 3" }]}
         />
         <HvTagsInput
-          id="tags-list-variants-2"
           label="Disabled"
           aria-label="Disabled"
           placeholder="Enter value"
@@ -98,7 +96,6 @@ export const Variants: StoryObj<HvTagsInputProps> = {
           ]}
         />
         <HvTagsInput
-          id="tags-list-variants-3"
           label="Readonly"
           aria-label="Readonly"
           placeholder="Enter value"
@@ -106,7 +103,6 @@ export const Variants: StoryObj<HvTagsInputProps> = {
           value={[{ label: "tag 7" }, { label: "tag 8" }, { label: "tag 9" }]}
         />
         <HvTagsInput
-          id="tags-list-variants-4"
           label="Invalid"
           aria-label="Invalid"
           placeholder="Enter value"
@@ -141,7 +137,6 @@ export const ControlledStringArray: StoryObj<HvTagsInputProps> = {
     return (
       <>
         <HvTagsInput
-          id="tags-list-2"
           label="Controlled with array of strings"
           aria-label="Controlled with array of string"
           description="A list of strings will result in semantic tags"
@@ -199,7 +194,6 @@ export const ControlledTagArray = () => {
       </StyledButtonWrapper>
 
       <HvTagsInput
-        id="tags-list-4"
         label="Controlled with array of tags"
         aria-label="Controlled with array of tags"
         placeholder="Enter value"
@@ -245,7 +239,6 @@ export const ControlledWithValidation: StoryObj<HvTagsInputProps> = {
     return (
       <>
         <HvTagsInput
-          id="tags-list-10"
           label="Controlled with validation"
           aria-label="Controlled with validation"
           description="A tag with a dash (-) will be invalid"
@@ -298,7 +291,6 @@ export const AddTagOnBlur: StoryObj<HvTagsInputProps> = {
 
     return (
       <HvTagsInput
-        id="tags-list-4"
         label="Adding tags on blur"
         aria-label="Adding tags on blur"
         placeholder="Enter value"
@@ -326,7 +318,6 @@ export const Multiline: StoryObj<HvTagsInputProps> = {
   render: () => {
     return (
       <StyledMultilineTagsInput
-        id="tags-list-9"
         label="MultiLine"
         aria-label="The label"
         placeholder="Enter value"
@@ -348,7 +339,6 @@ export const NotResizable: StoryObj<HvTagsInputProps> = {
   render: () => {
     return (
       <HvTagsInput
-        id="tags-list-7"
         label="Fixed size not resizable"
         aria-label="The label"
         placeholder="Enter value"
@@ -381,7 +371,6 @@ export const TagsCounterValidation: StoryObj<HvTagsInputProps> = {
 
     return (
       <HvTagsInput
-        id="tags-list-8"
         label="Tags"
         description="Maximum 3 tags"
         aria-label="The label"
@@ -410,7 +399,6 @@ export const CustomCommitCharacter: StoryObj<HvTagsInputProps> = {
   render: () => {
     return (
       <HvTagsInput
-        id="tags-list-11"
         label="Custom commit character"
         description="Will only add a tag when a space or comma is entered or when the user clicks outside the input box and there's text that's not been commited"
         aria-label="Custom commit character"
@@ -451,7 +439,6 @@ export const Suggestions: StoryObj<HvTagsInputProps> = {
 
     return (
       <StyledSuggestionsTagsInput
-        id="tags-list-12"
         label="Suggestions"
         description="A list of suggestions is presented when text is entered."
         aria-label="Suggestions"

--- a/packages/core/src/components/TextArea/TextArea.stories.tsx
+++ b/packages/core/src/components/TextArea/TextArea.stories.tsx
@@ -203,7 +203,6 @@ export const Variants: StoryObj<HvTextAreaProps> = {
     return (
       <div className={css(styles.root)}>
         <HvTextArea
-          id="required"
           rows={5}
           label="Required"
           placeholder="Enter value"
@@ -211,7 +210,6 @@ export const Variants: StoryObj<HvTextAreaProps> = {
           required
         />
         <HvTextArea
-          id="disabled"
           rows={5}
           label="Disabled"
           placeholder="Enter value"
@@ -219,7 +217,6 @@ export const Variants: StoryObj<HvTextAreaProps> = {
           disabled
         />
         <HvTextArea
-          id="readonly"
           rows={5}
           label="Readonly"
           placeholder="Enter value"
@@ -227,7 +224,6 @@ export const Variants: StoryObj<HvTextAreaProps> = {
           readOnly
         />
         <HvTextArea
-          id="invalid"
           rows={5}
           label="Invalid"
           placeholder="Enter value"
@@ -255,7 +251,6 @@ export const LimitedWithCustomLabels: StoryObj<HvTextAreaProps> = {
 
     return (
       <HvTextArea
-        id="limited-custom-label"
         rows={5}
         label="Label"
         description="You can write past the limit"
@@ -281,7 +276,6 @@ export const LimitedBlocking: StoryObj<HvTextAreaProps> = {
   render: () => {
     return (
       <HvTextArea
-        id="limited-blocking"
         defaultValue="Some text"
         rows={5}
         label="Label"
@@ -303,7 +297,6 @@ export const Resizable: StoryObj<HvTextAreaProps> = {
   render: () => {
     return (
       <HvTextArea
-        id="resize"
         label="Label"
         placeholder="Enter value"
         rows={5}
@@ -348,7 +341,6 @@ export const CustomValidation: StoryObj<HvTextAreaProps> = {
 
     return (
       <HvTextArea
-        id="custom-validation"
         rows={5}
         label="Label"
         placeholder="Enter value"

--- a/packages/core/src/components/VerticalNavigation/VerticalNavigation.stories.tsx
+++ b/packages/core/src/components/VerticalNavigation/VerticalNavigation.stories.tsx
@@ -285,7 +285,7 @@ export const WithoutActions: StoryObj<HvVerticalNavigationProps> = {
 
     return (
       <div style={{ display: "flex", width: 220 }}>
-        <HvVerticalNavigation id="sample2">
+        <HvVerticalNavigation>
           <HvVerticalNavigationTree
             aria-label="Example 1 navigation"
             selected={value}

--- a/packages/lab/src/components/StepNavigation/StepNavigation.stories.tsx
+++ b/packages/lab/src/components/StepNavigation/StepNavigation.stories.tsx
@@ -124,14 +124,12 @@ export const WithTooltip = () => (
     <HvStepNavigation
       type="Simple"
       steps={steps}
-      id="Simple-WithTooltip"
       showTitles={false}
       aria-label="Simple step navigation with tooltip"
     />
     <HvStepNavigation
       type="Default"
       steps={steps}
-      id="Default-WithTooltip"
       showTitles={false}
       aria-label="Default step navigation with tooltip"
     />
@@ -149,7 +147,6 @@ WithTooltip.parameters = {
 export const Width = () => (
   <HvStepNavigation
     steps={steps}
-    id="Width"
     width={{
       xs: 200,
       sm: 400,
@@ -196,7 +193,6 @@ export const Customized = () => {
         separatorClassName: separator,
         titleClassName: title,
       }))}
-      id="SeparatorWidth"
     />
   );
 };

--- a/packages/viz/src/components/BarChart/stories/BarChart.stories.tsx
+++ b/packages/viz/src/components/BarChart/stories/BarChart.stories.tsx
@@ -207,7 +207,6 @@ export const CustomStackedBarChart: StoryObj<HvBarChartProps> = {
           </HvTypography>
           <div className={css(styles.controllerGroup)}>
             <HvDropdown
-              id="dropdown1"
               label="Time Period"
               placement="left"
               classes={{

--- a/packages/viz/src/components/DonutChart/DonutChart.stories.tsx
+++ b/packages/viz/src/components/DonutChart/DonutChart.stories.tsx
@@ -210,7 +210,6 @@ export const WithControls: StoryObj<HvDonutChartProps> = {
           </HvTypography>
           <div className={css(styles.controllerGroup)}>
             <HvDropdown
-              id="dropdown1"
               aria-label="Time Period"
               placement="left"
               classes={{

--- a/packages/viz/src/components/LineChart/LineChart.stories.tsx
+++ b/packages/viz/src/components/LineChart/LineChart.stories.tsx
@@ -280,7 +280,6 @@ export const CustomMultipleLinesChart: StoryObj<HvLineChartProps> = {
           <div className={css(styles.controllerGroup)}>
             <HvDropdown
               className={css(styles.selectorPadding)}
-              id="dropdown1"
               classes={{
                 root: css(styles.root),
                 dropdown: css(styles.root),
@@ -292,7 +291,6 @@ export const CustomMultipleLinesChart: StoryObj<HvLineChartProps> = {
               onChange={(item) => setCountry((item as HvListValue).value)}
             />
             <HvDropdown
-              id="dropdown2"
               aria-label="Time Period"
               placement="left"
               classes={{


### PR DESCRIPTION
Duplicate `id`s in samples is leading to issues. In most cases, the `id`s are not necessary - this PR removes those ids.