### PR TITLE
chore: a11y tests added to PR workflow

### DIFF
--- a/.github/actions/build-artifacts/action.yml
+++ b/.github/actions/build-artifacts/action.yml
@@ -1,13 +1,6 @@
 name: Artifacts
 description: Build UI Kit Documentation and App
 
-inputs:
-  build-app:
-    description: "Whether the app should be built or not."
-    required: false
-    type: boolean
-    default: true
-
 runs:
   using: "composite"
   steps:
@@ -31,13 +24,11 @@ runs:
         retention-days: 2
 
     - name: Build App
-      if: ${{ inputs.build-app == 'true' }}
       run: npm run build:app -- --base=${{ env.APP_BASE_PATH }}
       shell: bash
 
     - name: Archive App
       uses: actions/upload-artifact@v3
-      if: ${{ inputs.build-app == 'true' }}
       with:
         name: app
         path: ${{ github.workspace }}/app/dist

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -13,18 +13,16 @@ jobs:
   static-checks:
     name: Static Checks
     uses: ./.github/workflows/static-checks.yml
+    secrets:
+      ORG_GHPAGES_DEPLOY_KEY: ${{ secrets.ORG_GHPAGES_DEPLOY_KEY }}
+    with:
+      a11y-publish: true
 
   applitools:
     name: Applitools Tests
     uses: ./.github/workflows/tests-applitools.yml
     secrets:
       APPLITOOLS_API_KEY: ${{ secrets.APPLITOOLS_API_KEY }}
-
-  a11y:
-    name: a11y Tests
-    uses: ./.github/workflows/tests-a11y.yml
-    secrets:
-      ORG_GHPAGES_DEPLOY_KEY: ${{ secrets.ORG_GHPAGES_DEPLOY_KEY }}
 
   security-scans:
     name: Security Scans

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -10,6 +10,8 @@ jobs:
   static-checks:
     name: Static Checks
     uses: ./.github/workflows/static-checks.yml
+    with:
+      a11y-exit: true
 
   applitools:
     name: Applitools

--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -3,6 +3,18 @@ name: Checks
 on:
   workflow_dispatch:
   workflow_call:
+    secrets:
+      ORG_GHPAGES_DEPLOY_KEY:
+        required: false
+    inputs:
+      a11y-publish:
+        type: boolean
+        default: false
+        required: false
+      a11y-exit:
+        type: boolean
+        default: false
+        required: false
 
 env:
   LICENSES_WHITELIST: Apache-2.0\;ISC\;BSD-2-Clause\;BSD-3-Clause\;MIT\;W3C\;Zlib\;CC-BY-4.0
@@ -42,6 +54,15 @@ jobs:
 
       - name: Run Test
         run: npm run test
+
+  a11y:
+    name: A11y Tests
+    uses: ./.github/workflows/tests-a11y.yml
+    secrets:
+      ORG_GHPAGES_DEPLOY_KEY: ${{ secrets.ORG_GHPAGES_DEPLOY_KEY }}
+    with:
+      publish: ${{ inputs.a11y-publish }}
+      exit: ${{ inputs.a11y-exit }}
 
   build:
     name: Build

--- a/.github/workflows/tests-a11y.yml
+++ b/.github/workflows/tests-a11y.yml
@@ -1,15 +1,24 @@
-name: a11y
+name: A11y Tests
 
 on:
   workflow_dispatch:
   workflow_call:
     secrets:
       ORG_GHPAGES_DEPLOY_KEY:
-        required: true
+        required: false
+    inputs:
+      publish:
+        type: boolean
+        default: false
+        required: false
+      exit:
+        type: boolean
+        default: false
+        required: false
 
 jobs:
   run-tests:
-    name: Run Tests
+    name: A11y Tests
     runs-on: ubuntu-latest
 
     steps:
@@ -29,10 +38,10 @@ jobs:
         run: |
           npx concurrently -k -s first -n "SB,TEST" -c "magenta,blue" \
           "npx serve dist -l 6006 -L" \
-          "npx wait-on tcp:6006 && npm run test:a11y" || true
+          "npx wait-on tcp:6006 && npm run test:a11y -- --exit ${{ inputs.exit }}"
 
       - name: Archive a11y report
-        if: always()
+        if: success() || failure()
         uses: actions/upload-artifact@v3
         with:
           name: a11y-report
@@ -40,7 +49,7 @@ jobs:
           retention-days: 2
 
       - name: Deploy Artifacts
-        if: always()
+        if: ${{ inputs.publish == true && (success() || failure()) }}
         uses: ./.github/actions/deploy-artifacts
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/tests-applitools.yml
+++ b/.github/workflows/tests-applitools.yml
@@ -39,11 +39,3 @@ jobs:
       - name: Eyes Storybook
         run: npm run test:eyes
         timeout-minutes: 30
-
-      - name: Archive Logs
-        uses: actions/upload-artifact@v3
-        if: failure()
-        with:
-          name: applitools-logs
-          path: ${{ github.workspace }}/applitools-logs.txt
-          retention-days: 2

--- a/scripts/a11y-report/index.js
+++ b/scripts/a11y-report/index.js
@@ -8,7 +8,7 @@ const storybookUrl = process.env.STORYBOOK_URL || "http://localhost:6006";
 
 const outputDir = process.env.A11Y_OUTPUT_DIR || "a11y-report";
 
-// stories to exclude
+// Stories to exclude
 const excludeStories = [
   "Overview/**",
   "Foundation/**",
@@ -23,27 +23,26 @@ const excludeStories = [
   .map((s) => `-e "${s}"`)
   .join(" ");
 
-const buildReport = () => {
+const init = () => {
   try {
-    console.log("⏳ Creating report...");
+    console.log("⏳ Testing a11y...");
 
-    // Create report
+    // Run a11y and create a report
     execSync(
       `npx storybook-a11y-report --storybookUrl ${storybookUrl} --outputFormat html --outDir ${outputDir} ${excludeStories}`
     );
 
-    console.log("⏳ Adding custom CSS to report...");
-
+    // File paths
     const reportDir = path.resolve(__dirname, `../../${outputDir}`);
     const reportFile = [reportDir, "/a11y_report.html"].join("");
     const cssFile = path.resolve(__dirname, "styles.css");
+    const htmlData = fs.readFileSync(reportFile, "utf8");
 
     // Add CSS file to report directory
     fs.mkdirSync([reportDir, "/styles"].join(""));
     fs.copyFileSync(cssFile, [reportDir, "/styles/styles.css"].join(""));
 
     // Customize report
-    const htmlData = fs.readFileSync(reportFile, "utf8");
     const updatedHtml = htmlData
       .replace(
         "<title>Accessibility report</title>",
@@ -76,10 +75,31 @@ const buildReport = () => {
     fs.renameSync(reportFile, [reportDir, "/index.html"].join(""));
 
     console.log("Report created 🚀");
+
+    // Look for violations
+    const regex = /<h2>.* violations have been found/g;
+    const violations = htmlData.match(regex);
+
+    if (violations) {
+      // Violations were found
+      const countStr = violations[0].replace("<h2>", "").trim();
+      console.log(`❌ ${countStr}`);
+
+      // Exit
+      if (
+        process.argv[2] === "--exit" &&
+        process.argv[3]?.toString() === "true"
+      ) {
+        process.exit(1);
+      }
+    } else {
+      // No violations found
+      console.log("✅ No a11y issues found");
+    }
   } catch (error) {
-    console.error("❌ Error creating the report:", error);
+    console.error("❌ A11y error:", error);
     process.exit(1);
   }
 };
 
-buildReport();
+init();


### PR DESCRIPTION
- `a11y` tests added to the PR workflow:
   - The report is not published: the report is archived on the workflow run and can be downloaded if needed
   - The workflow breaks if any `a11y` errors are found
   - The nightly did not change: the workflow doesn't break if issues are found and the report is published 