### PR TITLE
fix(Grid): item container spacing

### DIFF
--- a/packages/core/src/components/CheckBox/CheckBox.stories.tsx
+++ b/packages/core/src/components/CheckBox/CheckBox.stories.tsx
@@ -162,39 +162,38 @@ export const ExternalErrorMessage: StoryObj<HvCheckBoxProps> = {
 
     return (
       <HvGrid container>
-        <HvGrid item xs={12} md={6}>
-          <HvGrid container>
-            <HvGrid item xs={12}>
-              <HvCheckBox
-                required
-                defaultChecked
-                aria-errormessage="firstCheckbox-error"
-                onChange={(_, checked) => {
-                  if (checked) {
-                    setFirstCheckboxErrorMessage(null);
-                  } else if (!checked) {
-                    setFirstCheckboxErrorMessage(
-                      "You must check the first checkbox"
-                    );
-                  }
-                }}
-                label="First Checkbox"
-              />
-            </HvGrid>
-            <HvGrid item xs={12}>
-              <HvCheckBox
-                status="invalid"
-                aria-errormessage="secondCheckbox-error"
-                onChange={() => {
-                  setSecondCheckboxErrorMessage(
-                    "No way for the second checkbox to be valid! I told you!"
+        <HvGrid container item xs={12} md={6}>
+          <HvGrid item xs={12}>
+            <HvCheckBox
+              required
+              defaultChecked
+              aria-errormessage="firstCheckbox-error"
+              onChange={(_, checked) => {
+                if (checked) {
+                  setFirstCheckboxErrorMessage(null);
+                } else if (!checked) {
+                  setFirstCheckboxErrorMessage(
+                    "You must check the first checkbox"
                   );
-                }}
-                label="Second Checkbox"
-              />
-            </HvGrid>
+                }
+              }}
+              label="First Checkbox"
+            />
+          </HvGrid>
+          <HvGrid item xs={12}>
+            <HvCheckBox
+              status="invalid"
+              aria-errormessage="secondCheckbox-error"
+              onChange={() => {
+                setSecondCheckboxErrorMessage(
+                  "No way for the second checkbox to be valid! I told you!"
+                );
+              }}
+              label="Second Checkbox"
+            />
           </HvGrid>
         </HvGrid>
+
         <HvGrid item xs={12} md={6}>
           <div
             className={css({

--- a/packages/core/src/components/DatePicker/DatePicker.stories.tsx
+++ b/packages/core/src/components/DatePicker/DatePicker.stories.tsx
@@ -423,41 +423,39 @@ export const ExternalErrorMessage: StoryObj<HvDatePickerProps> = {
 
     return (
       <HvGrid container>
-        <HvGrid item xs={12} md={6}>
-          <HvGrid container>
-            <HvGrid item xs={12}>
-              <HvDatePicker
-                label="Start date"
-                description="Enter a start date"
-                placeholder="Choose a date"
-                required
-                aria-errormessage="start-error"
-                onChange={(value) => {
-                  setStartErrorMessage(
-                    value ? undefined : "Start date is required."
-                  );
-                }}
-              />
-            </HvGrid>
-            <HvGrid item xs={12}>
-              <HvDatePicker
-                label="End date"
-                description="Enter an end date"
-                placeholder="Choose a date"
-                required
-                status={endValidationState}
-                aria-errormessage="end-error"
-                onChange={(value) => {
-                  setEndValidationState("invalid");
+        <HvGrid container item xs={12} md={6}>
+          <HvGrid item xs={12}>
+            <HvDatePicker
+              label="Start date"
+              description="Enter a start date"
+              placeholder="Choose a date"
+              required
+              aria-errormessage="start-error"
+              onChange={(value) => {
+                setStartErrorMessage(
+                  value ? undefined : "Start date is required."
+                );
+              }}
+            />
+          </HvGrid>
+          <HvGrid item xs={12}>
+            <HvDatePicker
+              label="End date"
+              description="Enter an end date"
+              placeholder="Choose a date"
+              required
+              status={endValidationState}
+              aria-errormessage="end-error"
+              onChange={(value) => {
+                setEndValidationState("invalid");
 
-                  setEndErrorMessage(
-                    value
-                      ? "The end date will always be invalid."
-                      : "You can try choosing an end date."
-                  );
-                }}
-              />
-            </HvGrid>
+                setEndErrorMessage(
+                  value
+                    ? "The end date will always be invalid."
+                    : "You can try choosing an end date."
+                );
+              }}
+            />
           </HvGrid>
         </HvGrid>
         <HvGrid item xs={12} md={6}>

--- a/packages/core/src/components/Dropdown/Dropdown.stories.tsx
+++ b/packages/core/src/components/Dropdown/Dropdown.stories.tsx
@@ -262,51 +262,49 @@ export const ExternalErrorMessage: StoryObj<HvDropdownProps> = {
 
     return (
       <HvGrid container>
-        <HvGrid item xs={12} md={6}>
-          <HvGrid container>
-            <HvGrid item xs={12}>
-              <HvDropdown
-                label="Dropdown 1"
-                multiSelect
-                values={values1}
-                required
-                aria-errormessage="birth-error"
-                onChange={(value) => {
-                  if ((value as HvListValue[]).length === 0) {
-                    setBirthErrorMessage(
-                      "Select at least one value from dropdown 1."
-                    );
-                  } else {
-                    setBirthErrorMessage(null);
-                  }
-                }}
-              />
-            </HvGrid>
-            <HvGrid item xs={12}>
-              <HvDropdown
-                label="Dropdown 2"
-                multiSelect
-                values={values2}
-                required
-                status={deathValidationState as HvDropdownStatus}
-                aria-errormessage="death-error"
-                onChange={(value) => {
-                  setDeathValidationState("invalid");
+        <HvGrid container item xs={12} md={6}>
+          <HvGrid item xs={12}>
+            <HvDropdown
+              label="Dropdown 1"
+              multiSelect
+              values={values1}
+              required
+              aria-errormessage="birth-error"
+              onChange={(value) => {
+                if ((value as HvListValue[]).length === 0) {
+                  setBirthErrorMessage(
+                    "Select at least one value from dropdown 1."
+                  );
+                } else {
+                  setBirthErrorMessage(null);
+                }
+              }}
+            />
+          </HvGrid>
+          <HvGrid item xs={12}>
+            <HvDropdown
+              label="Dropdown 2"
+              multiSelect
+              values={values2}
+              required
+              status={deathValidationState as HvDropdownStatus}
+              aria-errormessage="death-error"
+              onChange={(value) => {
+                setDeathValidationState("invalid");
 
-                  if ((value as HvListValue[]).length === 0) {
-                    setDeathErrorMessage(
-                      "Select at least one value from dropdown 2."
-                    );
-                  } else {
-                    setDeathErrorMessage(
-                      `Dropdown 2 is always invalid, even with ${
-                        (value as HvListValue[]).length
-                      } items selected.`
-                    );
-                  }
-                }}
-              />
-            </HvGrid>
+                if ((value as HvListValue[]).length === 0) {
+                  setDeathErrorMessage(
+                    "Select at least one value from dropdown 2."
+                  );
+                } else {
+                  setDeathErrorMessage(
+                    `Dropdown 2 is always invalid, even with ${
+                      (value as HvListValue[]).length
+                    } items selected.`
+                  );
+                }
+              }}
+            />
           </HvGrid>
         </HvGrid>
         <HvGrid item xs={12} md={6}>

--- a/packages/core/src/components/Input/Input.stories.tsx
+++ b/packages/core/src/components/Input/Input.stories.tsx
@@ -302,52 +302,50 @@ export const ExternalErrorMessage: StoryObj<HvInputProps> = {
 
     return (
       <HvGrid container>
-        <HvGrid item xs={12} md={6}>
-          <HvGrid container>
-            <HvGrid item xs={12}>
-              <HvInput
-                label="First name"
-                description="Please enter your first name"
-                placeholder="Insert first name"
-                required
-                minCharQuantity={2}
-                aria-errormessage="firstName-error"
-                onBlur={(_e, _value, inputValidity) => {
-                  if (inputValidity.valid) {
-                    setFirstNameErrorMessage(undefined);
-                  } else if (inputValidity.valueMissing) {
-                    setFirstNameErrorMessage("You must provide a first name");
-                  } else if (inputValidity.tooShort) {
-                    setFirstNameErrorMessage("The first name is too short");
-                  }
-                }}
-              />
-            </HvGrid>
-            <HvGrid item xs={12}>
-              <HvInput
-                label="Last name"
-                description="Please enter your last name"
-                placeholder="Insert last name"
-                defaultValue="Not a name!"
-                required
-                status={lastNameValidationState}
-                aria-errormessage="lastName-error"
-                onFocus={(_, value) => {
-                  setLastNameValidationState(value ? "standBy" : "empty");
-                }}
-                onBlur={(_e, _value, inputValidity) => {
-                  setLastNameValidationState("invalid");
+        <HvGrid container item xs={12} md={6}>
+          <HvGrid item xs={12}>
+            <HvInput
+              label="First name"
+              description="Please enter your first name"
+              placeholder="Insert first name"
+              required
+              minCharQuantity={2}
+              aria-errormessage="firstName-error"
+              onBlur={(_e, _value, inputValidity) => {
+                if (inputValidity.valid) {
+                  setFirstNameErrorMessage(undefined);
+                } else if (inputValidity.valueMissing) {
+                  setFirstNameErrorMessage("You must provide a first name");
+                } else if (inputValidity.tooShort) {
+                  setFirstNameErrorMessage("The first name is too short");
+                }
+              }}
+            />
+          </HvGrid>
+          <HvGrid item xs={12}>
+            <HvInput
+              label="Last name"
+              description="Please enter your last name"
+              placeholder="Insert last name"
+              defaultValue="Not a name!"
+              required
+              status={lastNameValidationState}
+              aria-errormessage="lastName-error"
+              onFocus={(_, value) => {
+                setLastNameValidationState(value ? "standBy" : "empty");
+              }}
+              onBlur={(_e, _value, inputValidity) => {
+                setLastNameValidationState("invalid");
 
-                  if (inputValidity.valueMissing) {
-                    setLastNameErrorMessage("You must provide a last name");
-                  } else {
-                    setLastNameErrorMessage(
-                      "Nice try, but the last name will always be invalid. I told you!"
-                    );
-                  }
-                }}
-              />
-            </HvGrid>
+                if (inputValidity.valueMissing) {
+                  setLastNameErrorMessage("You must provide a last name");
+                } else {
+                  setLastNameErrorMessage(
+                    "Nice try, but the last name will always be invalid. I told you!"
+                  );
+                }
+              }}
+            />
           </HvGrid>
         </HvGrid>
         <HvGrid item xs={12} md={6}>

--- a/packages/core/src/components/Radio/Radio.stories.tsx
+++ b/packages/core/src/components/Radio/Radio.stories.tsx
@@ -134,36 +134,34 @@ export const ExternalErrorMessage: StoryObj<HvRadioProps> = {
 
     return (
       <HvGrid container>
-        <HvGrid item xs={12} md={6}>
-          <HvGrid container>
-            <HvGrid item xs={12}>
-              <HvRadio
-                status={secondRadioStatus}
-                aria-errormessage="firstRadio-error"
-                onChange={(_e, checked) => {
-                  if (checked) {
-                    setSecondRadioStatus("invalid");
-                    setFirstRadioErrorMessage("Don't choose the first radio.");
-                  } else if (!checked) {
-                    setSecondRadioStatus("valid");
-                    setFirstRadioErrorMessage(null);
-                  }
-                }}
-                label="First Radio"
-              />
-            </HvGrid>
-            <HvGrid item xs={12}>
-              <HvRadio
-                status="invalid"
-                aria-errormessage="secondRadio-error"
-                onChange={() => {
-                  setSecondRadioErrorMessage(
-                    "No way for the second radio to be valid! I told you!"
-                  );
-                }}
-                label="Second Radio"
-              />
-            </HvGrid>
+        <HvGrid container item xs={12} md={6}>
+          <HvGrid item xs={12}>
+            <HvRadio
+              status={secondRadioStatus}
+              aria-errormessage="firstRadio-error"
+              onChange={(_e, checked) => {
+                if (checked) {
+                  setSecondRadioStatus("invalid");
+                  setFirstRadioErrorMessage("Don't choose the first radio.");
+                } else if (!checked) {
+                  setSecondRadioStatus("valid");
+                  setFirstRadioErrorMessage(null);
+                }
+              }}
+              label="First Radio"
+            />
+          </HvGrid>
+          <HvGrid item xs={12}>
+            <HvRadio
+              status="invalid"
+              aria-errormessage="secondRadio-error"
+              onChange={() => {
+                setSecondRadioErrorMessage(
+                  "No way for the second radio to be valid! I told you!"
+                );
+              }}
+              label="Second Radio"
+            />
           </HvGrid>
         </HvGrid>
         <HvGrid item xs={12} md={6}>

--- a/packages/core/src/components/Switch/Switch.stories.tsx
+++ b/packages/core/src/components/Switch/Switch.stories.tsx
@@ -232,33 +232,31 @@ export const ExternalErrorMessage: StoryObj<HvSwitchProps> = {
 
     return (
       <HvGrid container>
-        <HvGrid item xs={12} md={6}>
-          <HvGrid container>
-            <HvGrid item xs={12}>
-              <HvSwitch
-                required
-                defaultChecked
-                aria-errormessage="firstSwitch-error"
-                onChange={(_e, checked) => {
-                  setFirstSwitchErrorMessage(
-                    checked ? "" : "You must turn on the first switch"
-                  );
-                }}
-                label="First Switch"
-              />
-            </HvGrid>
-            <HvGrid item xs={12}>
-              <HvSwitch
-                status="invalid"
-                aria-errormessage="secondSwitch-error"
-                onChange={() => {
-                  setSecondSwitchErrorMessage(
-                    "No way for the second switch to be valid! I told you!"
-                  );
-                }}
-                label="Second Switch"
-              />
-            </HvGrid>
+        <HvGrid container item xs={12} md={6}>
+          <HvGrid item xs={12}>
+            <HvSwitch
+              required
+              defaultChecked
+              aria-errormessage="firstSwitch-error"
+              onChange={(_e, checked) => {
+                setFirstSwitchErrorMessage(
+                  checked ? "" : "You must turn on the first switch"
+                );
+              }}
+              label="First Switch"
+            />
+          </HvGrid>
+          <HvGrid item xs={12}>
+            <HvSwitch
+              status="invalid"
+              aria-errormessage="secondSwitch-error"
+              onChange={() => {
+                setSecondSwitchErrorMessage(
+                  "No way for the second switch to be valid! I told you!"
+                );
+              }}
+              label="Second Switch"
+            />
           </HvGrid>
         </HvGrid>
         <HvGrid item xs={12} md={6}>


### PR DESCRIPTION
- When using `spacing`, `rowSpacing`, or `columnSpacing` as an object, a width is set (`xs`, `sm`, etc...), and the grid is a `container` as well as an `item`, the following MUI error is shown: `MUI: Expected spacing argument to be a number or a string, got [object Object].`. It seems that this is a [MUI limitation](https://github.com/mui/material-ui/issues/29349) and this was leading to unexpected grid behaviours.
   - Since this [PR](https://github.com/lumada-design/hv-uikit-react/pull/3533), the error started to appear more frequently because, when `spacing` is set to `auto`, which is the default value, `spacing` is converted to an object (instead of a number like it previously was). I believe this was done to remove the need for `useWidth` and to avoid re-rendering the grid on width changes unnecessarily. 

This PR fixes the situation mentioned above when any spacing is set to `auto` and the grid is a `container` as well as an `item`. In this case, the `useWidth` hook is used to provide a number to spacing and not an object. 