### PR TITLE
fix(OverflowTooltip): paragraph overflow

### DIFF
--- a/.github/workflows/pr-close.yml
+++ b/.github/workflows/pr-close.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   DOCUMENTATION_PUBLISH_REPO: ${{ github.repository_owner }}/${{ github.repository_owner }}.github.io
-  DOCUMENTATION_PUBLISH_BRANCH: v3.x
+  DOCUMENTATION_PUBLISH_BRANCH: master
   DOCUMENTATION_PUBLISH_FOLDER: uikit/pr-${{ github.event.number }}
   DOCUMENTATION_PUBLISH_MESSAGE: "docs: remove PR ${{ github.event.number }} of ${{ github.repository }}"
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -7,7 +7,7 @@ on:
 
 env:
   DOCUMENTATION_PUBLISH_REPO: ${{ github.repository_owner }}/${{ github.repository_owner }}.github.io
-  DOCUMENTATION_PUBLISH_BRANCH: v3.x
+  DOCUMENTATION_PUBLISH_BRANCH: master
   DOCUMENTATION_PUBLISH_FOLDER: uikit/pr-${{ github.event.number }}
   DOCUMENTATION_PUBLISH_MESSAGE: "docs: storybook for PR ${{ github.event.number }} of ${{ github.repository }}"
   DOCUMENTATION_URL: https://${{ github.repository_owner }}.github.io/uikit/pr-${{ github.event.number }}/

--- a/packages/core/src/OverflowTooltip/OverflowTooltip.js
+++ b/packages/core/src/OverflowTooltip/OverflowTooltip.js
@@ -37,21 +37,35 @@ const HvOverflowTooltip = ({
   placement = "top-start",
   tooltipsProps,
 }) => {
-  const { width = 0, ref } = useResizeDetector({
+  const {
+    height = 0,
+    width = 0,
+    ref,
+  } = useResizeDetector({
     refreshMode: "debounce",
     refreshOptions: {
       trailing: true,
     },
     handleHeight: false,
   });
-  const scrollWidth = ref.current?.scrollWidth || 0;
-  // The difference should be higher than a pixel to be considered as overflowing
-  const isOverflowing = scrollWidth - width >= 1;
 
   const isParag = useMemo(
     () => paragraphOverflow && isParagraph(data.toString()),
     [data, paragraphOverflow]
   );
+
+  // The difference should be higher than a pixel to be considered as overflowing
+  const isOverflowing = useMemo(() => {
+    if (isParag) {
+      const scrollHeight = ref.current?.scrollHeight || 0;
+
+      return scrollHeight - height >= 1;
+    }
+
+    const scrollWidth = ref.current?.scrollWidth || 0;
+
+    return scrollWidth - width >= 1;
+  }, [height, isParag, ref, width]);
 
   const content = useMemo(
     () => (

--- a/packages/core/src/OverflowTooltip/stories/OverflowTooltip.stories.js
+++ b/packages/core/src/OverflowTooltip/stories/OverflowTooltip.stories.js
@@ -20,13 +20,10 @@ export const Main = () => {
     },
     textContainer: {
       display: "flex",
-      textAlign: "center",
-      justifyContent: "space-between",
-      maxWidth: 200,
-      overflow: "hidden",
-      textOverflow: "ellipsis",
+      alignItems: "center",
       margin: "0 auto",
       paddingTop: 80,
+      maxWidth: 200,
     },
   };
 
@@ -40,6 +37,9 @@ export const Main = () => {
       </div>
       <div style={styling.textContainer}>
         <HvOverflowTooltip data={shortText} />
+      </div>
+      <div style={styling.textContainer}>
+        <HvOverflowTooltip data={longText} paragraphOverflow />
       </div>
       <div style={styling.textContainer}>
         <HvOverflowTooltip data={longText} placement="top" open />

--- a/packages/core/src/OverflowTooltip/tests/tests/OverflowTooltip.test.js
+++ b/packages/core/src/OverflowTooltip/tests/tests/OverflowTooltip.test.js
@@ -28,7 +28,7 @@ describe("Overflow tooltip", () => {
         "This is a very long text that should be cut because it so long that it doesn't fit";
       const shortText = "This text is short";
       const text = await findAllByText(longText);
-      expect(text.length).toBe(3);
+      expect(text.length).toBe(4);
       expect(getByText(shortText)).toBeInTheDocument();
     });
   });


### PR DESCRIPTION
- v3.x workflows fixed: the documentation was not deployed when opening a PR
- Backports part of [this fix](https://github.com/lumada-design/hv-uikit-react/pull/3820) to v3: `HvOverflowTooltip` fixed when `paragraphOverflow` is set to true: the tooltip was not showing.
   - I didn't update the line clamp to 3 (instead 2) in this PR since I don't think it's needed. But let me know if you think otherwise. 