### PR TITLE
chore(styles): infer theme color modes

### DIFF
--- a/packages/styles/src/makeTheme.ts
+++ b/packages/styles/src/makeTheme.ts
@@ -10,9 +10,9 @@ import type { HvCustomTheme, HvTheme, HvThemeStructure } from "./types";
  * @param options The options to generate the theme
  * @returns The generated theme
  */
-export const makeTheme = (
-  options: HvCustomTheme | ((theme: HvTheme) => HvCustomTheme)
-): HvThemeStructure => {
+export const makeTheme = <Mode extends string = string>(
+  options: HvCustomTheme<Mode> | ((theme: HvTheme) => HvCustomTheme<Mode>)
+): HvThemeStructure<Mode> => {
   const customTheme = typeof options === "function" ? options(theme) : options;
   const newTheme = mergeTheme(tokens, customTheme);
 

--- a/packages/styles/src/types.ts
+++ b/packages/styles/src/types.ts
@@ -139,31 +139,29 @@ export type HvThemeColorModeStructure = HvThemeColors & {
 };
 
 // Theme structure
-export type HvThemeStructure = {
+export interface HvThemeStructure<Mode extends string = string>
+  extends HvThemeComponents,
+    HvThemeComponentsProps,
+    HvThemeTypography,
+    Omit<HvThemeTokens, "colors"> {
   name: string;
   base?: HvBaseTheme;
-} & HvThemeComponents &
-  HvThemeComponentsProps &
-  HvThemeTypography &
-  Omit<HvThemeTokens, "colors"> & {
-    colors: {
-      modes: {
-        [key: string]: HvThemeColorModeStructure;
-      };
-    };
+  colors: {
+    modes: Record<Mode, HvThemeColorModeStructure>;
   };
+}
 
 // Custom theme
-export type HvCustomTheme = { name: string } & HvThemeComponents &
-  HvThemeComponentsProps &
-  HvThemeTypography &
-  Partial<Omit<HvThemeTokens, "colors">> & {
-    colors: {
-      modes: {
-        [key: string]: Partial<HvThemeColorModeStructure>;
-      };
-    };
+export interface HvCustomTheme<Mode extends string = string>
+  extends HvThemeComponents,
+    HvThemeComponentsProps,
+    HvThemeTypography,
+    Partial<Omit<HvThemeTokens, "colors">> {
+  name: string;
+  colors: {
+    modes: Record<Mode, Partial<HvThemeColorModeStructure>>;
   };
+}
 
 // Deep string: set all props to strings
 export type DeepString<T> = {


### PR DESCRIPTION
allow `createTheme` and theme types to define or infer the color modes