### PR TITLE
fix(types): polymorphic components

### DIFF
--- a/packages/core/src/components/Box/Box.tsx
+++ b/packages/core/src/components/Box/Box.tsx
@@ -11,6 +11,7 @@ type HvBoxBaseProps<C extends React.ElementType> = PolymorphicComponentRef<
   { style?: React.CSSProperties; sx?: SxProps }
 >;
 
+// v6 - This shouldn't be named HvBoxProps
 export type HvBoxProps = <C extends React.ElementType = "div">(
   props: HvBoxBaseProps<C>
 ) => React.ReactElement | null;

--- a/packages/core/src/components/Section/Section.tsx
+++ b/packages/core/src/components/Section/Section.tsx
@@ -29,7 +29,7 @@ export interface HvSectionProps
   actions?: React.ReactNode;
   /** Section onExpand callback */
   onToggle?: (
-    event: React.MouseEventHandler<HTMLButtonElement>,
+    event: React.MouseEvent<HTMLButtonElement>,
     open: boolean
   ) => void;
   /** Props to be passed to the expand button */

--- a/packages/core/src/types/generic.ts
+++ b/packages/core/src/types/generic.ts
@@ -13,11 +13,17 @@ type AsProp<C extends React.ElementType> = {
 
 type PropsToOmit<C extends React.ElementType, P> = keyof (AsProp<C> & P);
 
+// Workaround to fix the use of Omit with ComponentPropsWithoutRef
+// Without this the event handlers return any instead of the type for the chosen element
+type FixComponentProps<T> = T extends any ? T : never;
+
 type PolymorphicComponent<
   C extends React.ElementType,
   Props = {}
 > = React.PropsWithChildren<Props & AsProp<C>> &
-  Omit<React.ComponentPropsWithoutRef<C>, PropsToOmit<C, Props>>;
+  FixComponentProps<
+    Omit<React.ComponentPropsWithoutRef<C>, PropsToOmit<C, Props>>
+  >;
 
 export type PolymorphicRef<C extends React.ElementType> =
   React.ComponentPropsWithRef<C>["ref"];


### PR DESCRIPTION
Our polymorphic components weren't inferring the types for the event handlers as shown below. 

https://github.com/lumada-design/hv-uikit-react/assets/43220251/bba7f382-0d90-433f-b349-fe7d80a84395

The problem was in our `PolymorphicComponentRef` type when doing `Omit<React.ComponentPropsWithoutRef<C>, PropsToOmit<C, Props>>`. Using `Omit` in combination with `React.ComponentPropsWithoutRef<C>` was preventing TypeScript of inferring the events types. 
I tried several solutions but they didn't work. In the end, I found [this workaround](https://github.com/microsoft/TypeScript/issues/44596#issuecomment-1447648600) that solved the problem. 

https://github.com/lumada-design/hv-uikit-react/assets/43220251/b2094566-9c0e-4faf-8d97-ee8e0dc46ffd

