### PR TITLE
fix: remove components props from CSS vars

### DIFF
--- a/packages/core/src/types/generic.ts
+++ b/packages/core/src/types/generic.ts
@@ -40,7 +40,11 @@ export type HvBaseProps<
 > = Omit<HTMLAttributes<E>, K>;
 
 /** This type allows to do a deep partial by applying the Partial type to each key recursively */
-export type DeepPartial<T> = Partial<{ [P in keyof T]: DeepPartial<T[P]> }>;
+export type DeepPartial<T> = T extends Object
+  ? Partial<{
+      [P in keyof T]: DeepPartial<T[P]>;
+    }>
+  : T;
 
 /** This type combines the HvExtraProps and DeepPartial types */
 export type HvExtraDeepPartialProps<T> = Partial<{

--- a/packages/styles/src/utils.ts
+++ b/packages/styles/src/utils.ts
@@ -154,7 +154,8 @@ export const getThemesVars = (themes: HvThemeStructure[]) => {
     colorModes.forEach((colorMode) => {
       const styleName = `[data-theme="${theme.name}"][data-color-mode="${colorMode}"]`;
 
-      const { name, ...rest } = theme;
+      // Extracting "components" and "name" because they shouldn't be mapped to CSS vars
+      const { components, name, ...rest } = theme;
 
       vars[styleName] = toCSSVars({
         ...rest,


### PR DESCRIPTION
Fixes:
- The components props were wrongly mapped to CSS vars. 
- Loop problem in the `DeepPartial` type:

<img src="https://github.com/lumada-design/hv-uikit-react/assets/43220251/10d46f62-fac4-44c7-8f18-f8c8ebc7bebb" width="300" />