### PR TITLE
fix(QueryBuilder): export missing types

### DIFF
--- a/packages/core/src/components/QueryBuilder/index.ts
+++ b/packages/core/src/components/QueryBuilder/index.ts
@@ -18,4 +18,6 @@ export type {
   HvQueryBuilderLabels,
   HvQueryBuilderRendererProps,
   HvQueryBuilderRenderers,
+  HvQueryBuilderChangedQuery,
+  HvQueryBuilderQueryGroup,
 } from "./types";


### PR DESCRIPTION
Types `HvQueryBuilderChangedQuery` and `HvQueryBuilderQueryGroup` exported.