### PR TITLE
feat(styles): theme alpha util 

### DIFF
--- a/app/src/components/common/Tutorial/Tutorial.tsx
+++ b/app/src/components/common/Tutorial/Tutorial.tsx
@@ -1,5 +1,5 @@
 import { Dispatch, SetStateAction } from "react";
-import { hexToRgbA, useTheme } from "@hitachivantara/uikit-react-core";
+import { theme } from "@hitachivantara/uikit-react-core";
 
 import { Step } from "./Step";
 import classes from "./tutorialStyles";
@@ -13,8 +13,6 @@ export const Tutorial = ({
   currentStep: number | undefined;
   setCurrentStep: Dispatch<SetStateAction<number>> | undefined;
 }) => {
-  const { activeTheme, selectedMode } = useTheme();
-
   const nextHandler = (close = false) => {
     if (close) {
       setTutorialOpen?.(false);
@@ -32,10 +30,7 @@ export const Tutorial = ({
     <div
       className={classes.root}
       style={{
-        backgroundColor: hexToRgbA(
-          activeTheme?.colors.modes[selectedMode].base_dark,
-          0.5
-        ),
+        backgroundColor: theme.alpha("base_dark", 0.5),
       }}
     >
       <Step

--- a/docs/guides/theming/Alpha.tsx
+++ b/docs/guides/theming/Alpha.tsx
@@ -1,0 +1,13 @@
+import { css } from "@emotion/css";
+import { HvButton, theme } from "@hitachivantara/uikit-react-core";
+
+const styles = {
+  button: css({
+    backgroundColor: theme.colors.brand,
+    ":hover": { backgroundColor: theme.alpha("brand", 0.6) },
+  }),
+};
+
+export const Alpha = () => (
+  <HvButton className={styles.button}>Click me</HvButton>
+);

--- a/docs/guides/theming/Spacing.tsx
+++ b/docs/guides/theming/Spacing.tsx
@@ -1,18 +1,18 @@
-import styled from "@emotion/styled";
+import { css } from "@emotion/css";
 import { HvButton, theme } from "@hitachivantara/uikit-react-core";
 
-const StyledContainer = styled("div")({
-  "& > *": {
-    margin: theme.spacing("xs", "6px"),
-  },
-});
-
-export const Spacing = () => {
-  return (
-    <StyledContainer>
-      <HvButton variant="primary">Button 1</HvButton>
-      <HvButton variant="primarySubtle">Button 2</HvButton>
-      <HvButton variant="primaryGhost">Button 3</HvButton>
-    </StyledContainer>
-  );
+const classes = {
+  root: css({
+    "& > *": {
+      margin: theme.spacing("xs", "6px"),
+    },
+  }),
 };
+
+export const Spacing = () => (
+  <div className={classes.root}>
+    <HvButton variant="primary">Button 1</HvButton>
+    <HvButton variant="primarySubtle">Button 2</HvButton>
+    <HvButton variant="primaryGhost">Button 3</HvButton>
+  </div>
+);

--- a/docs/guides/theming/Theming.stories.mdx
+++ b/docs/guides/theming/Theming.stories.mdx
@@ -2,6 +2,7 @@ import { Meta, Story, Canvas } from "@storybook/addon-docs";
 import { HvProvider, ds3 } from "@hitachivantara/uikit-react-core";
 import { ThemeSample } from "./ThemeSample";
 import { Spacing } from "./Spacing";
+import { Alpha } from "./Alpha";
 import { ThemeStructure } from "./ThemeStructure";
 import { CssVariables } from "./CssVariables";
 import { CreateTheme } from "./CreateTheme";
@@ -18,9 +19,11 @@ Here's what there is to know about the NEXT UI Kit theming:
 - [Theme structure](#theme-structure)
 - [Theme configuration](#theme-configuration)
 - [Theme context](#theme-context)
-- [CSS variable](#css-variables)
+- [CSS variables](#css-variables)
 - [Default props](#default-props)
-- [Spacing](#spacing)
+- [Theme utilities](#theme-utils)
+  - [Spacing](#spacing)
+  - [Alpha colors](#alpha-colors)
 
 ## Default themes <a id="default-themes" />
 
@@ -350,9 +353,9 @@ const MyComponent = () => {
   return (
     <HvTypography
       style={{
-        color: theme.colors.neutral, // Same as var(--uikit-colors-neutral)
-        fontWeight: theme.fontWeights.semibold, // Same as var(--uikit-fontWeights-semibold)
-        fontSize: theme.fontSizes.lg, // Same as var(--uikit-fontSizes-lg)
+        color: theme.colors.neutral,
+        fontWeight: theme.fontWeights.semibold,
+        fontSize: theme.fontSizes.lg,
       }}
     >
       CSS variables!
@@ -438,7 +441,9 @@ export const MyApp = () => {
   <DefaultPropsClassOverwrite />
 </Story>
 
-## Spacing <a id="spacing" />
+## Theme utilities <a id="theme-utils" />
+
+### Spacing <a id="spacing" />
 
 The NEXT UI Kit provides a spacing helper function named `spacing`. This function helps generate the spacing values for the UI elements when required
 and is contained within the `theme` object provided by the `uikit-react-core` package.
@@ -485,26 +490,59 @@ const ds3Spaces = {
 Find below an example on how to use the spacing helper function.
 
 ```tsx
-import styled from "@emotion/styled";
+import { css } from "@emotion/css";
 import { HvButton, theme } from "@hitachivantara/uikit-react-core";
 
-const StyledContainer = styled("div")({
-  "& > *": {
-    margin: theme.spacing("xs", "6px"),
-  },
-});
-
-export const Spacing = () => {
-  return (
-    <StyledContainer>
-      <HvButton variant="primary">Button 1</HvButton>
-      <HvButton variant="primarySubtle">Button 2</HvButton>
-      <HvButton variant="primaryGhost">Button 3</HvButton>
-    </StyledContainer>
-  );
+const classes = {
+  root: css({
+    "& > *": {
+      margin: theme.spacing("xs", "6px"),
+    },
+  }),
 };
+
+export const Spacing = () => (
+  <div className={classes.root}>
+    <HvButton variant="primary">Button 1</HvButton>
+    <HvButton variant="primarySubtle">Button 2</HvButton>
+    <HvButton variant="primaryGhost">Button 3</HvButton>
+  </div>
+);
 ```
 
 <Story name="Spacing">
   <Spacing />
+</Story>
+
+### Alpha colors <a id="alpha-colors" />
+
+An alpha helper function named `alpha` is also provided and contained within the `theme` object exported by the `uikit-react-core` package.
+This utility function accepts a color name from the theme and an alpha value and applies the transparency to the color.
+
+Example:
+
+```tsx
+theme.alpha("primary", 0.5); // applies a transparency of 50% to the primary color
+```
+
+Find an example below.
+
+```tsx
+import { css } from "@emotion/css";
+import { HvButton, theme } from "@hitachivantara/uikit-react-core";
+
+const styles = {
+  button: css({
+    backgroundColor: theme.colors.brand,
+    ":hover": { backgroundColor: theme.alpha("brand", 0.6) },
+  }),
+};
+
+export const Alpha = () => (
+  <HvButton className={styles.button}>Click me</HvButton>
+);
+```
+
+<Story name="Alpha">
+  <Alpha />
 </Story>

--- a/docs/guides/theming/WhiteLabeling.stories.mdx
+++ b/docs/guides/theming/WhiteLabeling.stories.mdx
@@ -103,7 +103,8 @@ const MyApp = ({ children }) => {
 };
 ```
 
-By customizing the theme variables, we are able to change the default styling of the HvHeader, HvButton, HvHeaderBrand, HvHeaderNavigation, HvHeaderMenuItem, and HvHeaderMenuBarBar components to meet the desired UI guidelines.
+By customizing the theme variables, we are able to change the default styling of the `HvHeader`, `HvButton`, `HvHeaderBrand`, `HvHeaderNavigation`,
+`HvHeaderMenuItem`, and `HvHeaderMenuBarBar` components to meet the desired UI guidelines.
 
 <Unstyled>
   <WhiteLabeling />

--- a/packages/core/src/components/ActionsGeneric/ActionsGeneric.styles.tsx
+++ b/packages/core/src/components/ActionsGeneric/ActionsGeneric.styles.tsx
@@ -8,6 +8,9 @@ export const { staticClasses, useClasses } = createClasses("HvActionsGeneric", {
     "&:not(:last-child)": {
       marginRight: theme.space.xs,
     },
+    "&:hover": {
+      backgroundColor: theme.alpha("base_light", 0.3),
+    },
   },
   actionContainer: { display: "flex", alignItems: "center", float: "right" },
   dropDownMenu: {},

--- a/packages/core/src/components/ActionsGeneric/ActionsGeneric.tsx
+++ b/packages/core/src/components/ActionsGeneric/ActionsGeneric.tsx
@@ -1,17 +1,12 @@
 import React, { isValidElement } from "react";
-
 import { MoreOptionsVertical } from "@hitachivantara/uikit-react-icons";
-import { theme } from "@hitachivantara/uikit-styles";
 
 import { useDefaultProps } from "@core/hooks/useDefaultProps";
-
-import { hexToRgbA } from "@core/utils/hexToRgbA";
 import { HvButton, HvButtonVariant } from "@core/components/Button";
 import { HvDropDownMenu } from "@core/components/DropDownMenu";
 import { setId } from "@core/utils/setId";
 import { ExtractNames } from "@core/utils/classes";
 import { HvBaseProps } from "@core/types/generic";
-import { useTheme } from "@core/hooks/useTheme";
 
 import { staticClasses, useClasses } from "./ActionsGeneric.styles";
 
@@ -60,9 +55,7 @@ export const HvActionsGeneric = (props: HvActionsGenericProps) => {
     ...others
   } = useDefaultProps("HvActionsGeneric", props);
 
-  const { classes, cx, css } = useClasses(classesProp);
-
-  const { colors } = useTheme();
+  const { classes, cx } = useClasses(classesProp);
 
   if (!Array.isArray(actions)) return isValidElement(actions) ? actions : null;
 
@@ -79,17 +72,7 @@ export const HvActionsGeneric = (props: HvActionsGenericProps) => {
         id={actionId}
         key={actionId || idx}
         variant={category}
-        className={cx(
-          css({
-            "&:hover": {
-              backgroundColor: hexToRgbA(
-                colors?.base_light || theme.colors.base_light,
-                0.3
-              ),
-            },
-          }),
-          classes.button
-        )}
+        className={classes.button}
         disabled={actDisabled ?? disabled}
         onClick={(event) => actionsCallback?.(event, id || "", action)}
         startIcon={renderedIcon}

--- a/packages/core/src/components/BulkActions/BulkActions.styles.tsx
+++ b/packages/core/src/components/BulkActions/BulkActions.styles.tsx
@@ -16,10 +16,18 @@ export const { staticClasses, useClasses } = createClasses("HvBulkActions", {
     "& $selectAll div": {
       color: "inherit",
 
+      "&:hover:not(:disabled)": {
+        backgroundColor: theme.alpha("base_light", 0.3),
+      },
+
       "& *": {
         color: "inherit",
         backgroundColor: "transparent",
       },
+    },
+
+    "& $selectAll:focus-within div": {
+      backgroundColor: theme.alpha("base_light", 0.3),
     },
   },
   actions: { display: "inline-flex", marginLeft: "auto" },

--- a/packages/core/src/components/BulkActions/BulkActions.tsx
+++ b/packages/core/src/components/BulkActions/BulkActions.tsx
@@ -1,5 +1,3 @@
-import { theme } from "@hitachivantara/uikit-styles";
-
 import { useDefaultProps } from "@core/hooks/useDefaultProps";
 import { setId } from "@core/utils/setId";
 import { useTheme } from "@core/hooks/useTheme";
@@ -17,7 +15,6 @@ import {
 } from "@core/components/ActionsGeneric";
 import { HvTypography } from "@core/components/Typography";
 import { ExtractNames } from "@core/utils/classes";
-import { hexToRgbA } from "@core/utils/hexToRgbA";
 
 import { staticClasses, useClasses } from "./BulkActions.styles";
 
@@ -116,11 +113,10 @@ export const HvBulkActions = (props: HvBulkActionsProps) => {
     ...others
   } = useDefaultProps("HvBulkActions", props);
 
-  const { classes, cx, css } = useClasses(classesProp);
+  const { classes, cx } = useClasses(classesProp);
 
-  const { activeTheme, colors } = useTheme();
+  const { activeTheme } = useTheme();
 
-  const baseColor = colors?.base_light || theme.colors.base_light;
   const anySelected = numSelected > 0;
   const isSemantic = semantic && anySelected;
 
@@ -150,17 +146,6 @@ export const HvBulkActions = (props: HvBulkActionsProps) => {
       className={cx(
         classes.root,
         { [classes.semantic]: isSemantic },
-        isSemantic &&
-          css({
-            [`& .${staticClasses.selectAll} div`]: {
-              "&:hover:not(:disabled)": {
-                backgroundColor: hexToRgbA(baseColor, 0.3),
-              },
-            },
-            [`& .${staticClasses.selectAll}:focus-within div`]: {
-              backgroundColor: hexToRgbA(baseColor, 0.3),
-            },
-          }),
         className
       )}
       {...others}

--- a/packages/core/src/components/Dialog/Dialog.styles.tsx
+++ b/packages/core/src/components/Dialog/Dialog.styles.tsx
@@ -4,7 +4,7 @@ import { createClasses } from "@core/utils/classes";
 
 export const { staticClasses, useClasses } = createClasses("HvDialog", {
   root: {},
-  background: {},
+  background: { background: theme.alpha("atmo4", 0.8) },
   paper: {
     color: theme.colors.secondary,
     backgroundColor: theme.colors.atmo1,

--- a/packages/core/src/components/Dialog/Dialog.tsx
+++ b/packages/core/src/components/Dialog/Dialog.tsx
@@ -1,19 +1,14 @@
 import { useCallback, useMemo } from "react";
-
 import MuiDialog, { DialogProps as MuiDialogProps } from "@mui/material/Dialog";
-
 import { Close } from "@hitachivantara/uikit-react-icons";
-import { theme } from "@hitachivantara/uikit-styles";
 
 import { useDefaultProps } from "@core/hooks/useDefaultProps";
-
 import { HvButton } from "@core/components/Button";
 import { HvTooltip } from "@core/components/Tooltip";
 import { getElementById } from "@core/utils/document";
 import { ExtractNames } from "@core/utils/classes";
 import { setId } from "@core/utils/setId";
 import { useTheme } from "@core/hooks/useTheme";
-import { hexToRgbA } from "@core/utils/hexToRgbA";
 
 import { staticClasses, useClasses } from "./Dialog.styles";
 import { DialogContext } from "./context";
@@ -71,7 +66,7 @@ export const HvDialog = (props: HvDialogProps) => {
   } = useDefaultProps("HvDialog", props);
 
   const { classes, css, cx } = useClasses(classesProp);
-  const { rootId, colors } = useTheme();
+  const { rootId } = useTheme();
 
   const measuredRef = useCallback(() => {
     if (!firstFocusable) return;
@@ -101,12 +96,7 @@ export const HvDialog = (props: HvDialogProps) => {
       slotProps={{
         backdrop: {
           classes: {
-            root: cx(
-              css({
-                background: hexToRgbA(colors?.atmo4 || theme.colors.atmo4, 0.8),
-              }),
-              classes.background
-            ),
+            root: classes.background,
           },
         },
       }}

--- a/packages/core/src/components/Drawer/Drawer.styles.tsx
+++ b/packages/core/src/components/Drawer/Drawer.styles.tsx
@@ -10,7 +10,9 @@ export const { staticClasses, useClasses } = createClasses("HvDrawer", {
     overflow: "auto",
     boxShadow: theme.colors.shadow,
   },
-  background: {},
+  background: {
+    background: theme.alpha("atmo4", 0.8),
+  },
   closeButton: {
     position: "absolute",
     top: theme.spacing("sm"),

--- a/packages/core/src/components/Drawer/Drawer.tsx
+++ b/packages/core/src/components/Drawer/Drawer.tsx
@@ -1,16 +1,10 @@
 import MuiDrawer, { DrawerProps as MuiDrawerProps } from "@mui/material/Drawer";
-
 import { Close } from "@hitachivantara/uikit-react-icons";
 
-import { theme } from "@hitachivantara/uikit-styles";
-
 import { useDefaultProps } from "@core/hooks/useDefaultProps";
-
 import { IconButton } from "@core/utils/IconButton";
 import { setId } from "@core/utils/setId";
 import { ExtractNames } from "@core/utils/classes";
-import { useTheme } from "@core/hooks/useTheme";
-import { hexToRgbA } from "@core/utils/hexToRgbA";
 
 import { staticClasses, useClasses } from "./Drawer.styles";
 
@@ -92,8 +86,7 @@ export const HvDrawer = (props: HvDrawerProps) => {
     ...others
   } = useDefaultProps("HvDrawer", props);
 
-  const { classes, cx, css } = useClasses(classesProp);
-  const { colors } = useTheme();
+  const { classes, cx } = useClasses(classesProp);
 
   const handleOnClose: MuiDrawerProps["onClose"] = (
     event: React.SyntheticEvent,
@@ -122,12 +115,7 @@ export const HvDrawer = (props: HvDrawerProps) => {
         slotProps: {
           backdrop: {
             classes: {
-              root: cx(
-                css({
-                  background: hexToRgbA(colors?.atmo4 || theme.colors.atmo4),
-                }),
-                classes.background
-              ),
+              root: classes.background,
             },
             onClick: (event) => {
               if (disableBackdropClick) return;

--- a/packages/core/src/components/ScrollTo/Horizontal/ScrollToHorizontal.styles.tsx
+++ b/packages/core/src/components/ScrollTo/Horizontal/ScrollToHorizontal.styles.tsx
@@ -2,46 +2,48 @@ import { theme } from "@hitachivantara/uikit-styles";
 
 import { createClasses } from "@core/utils/classes";
 
-const name = "HvScrollToHorizontal";
-
-export const { staticClasses, useClasses } = createClasses(name, {
-  root: {
-    display: "flex",
-    padding: "0 30px",
-    listStyleType: "none",
-    flexWrap: "wrap",
-    backdropFilter: `blur(4px)`,
-  },
-  positionSticky: {
-    position: "sticky",
-    zIndex: `calc(${theme.zIndices.banner} - 2)`,
-    top: 0,
-    left: 0,
-  },
-  positionFixed: {
-    position: "fixed",
-    zIndex: `calc(${theme.zIndices.banner} - 2)`,
-    top: 0,
-    left: 0,
-  },
-  notSelectedRoot: {
-    display: "flex",
-    justifyContent: "center",
-    alignItems: "center",
-    height: "16px",
-    width: "16px",
-    borderRadius: "50%",
-  },
-  notSelected: {
-    height: "4px",
-    width: "4px",
-    borderRadius: "50%",
-    display: "inline-block",
-    backgroundColor: theme.colors.secondary_60,
-  },
-  selected: {
-    display: "flex",
-    height: "16px",
-    width: "16px",
-  },
-});
+export const { staticClasses, useClasses } = createClasses(
+  "HvScrollToHorizontal",
+  {
+    root: {
+      display: "flex",
+      padding: "0 30px",
+      listStyleType: "none",
+      flexWrap: "wrap",
+      backdropFilter: `blur(4px)`,
+      backgroundColor: theme.alpha("atmo2", 0.9),
+    },
+    positionSticky: {
+      position: "sticky",
+      zIndex: `calc(${theme.zIndices.banner} - 2)`,
+      top: 0,
+      left: 0,
+    },
+    positionFixed: {
+      position: "fixed",
+      zIndex: `calc(${theme.zIndices.banner} - 2)`,
+      top: 0,
+      left: 0,
+    },
+    notSelectedRoot: {
+      display: "flex",
+      justifyContent: "center",
+      alignItems: "center",
+      height: "16px",
+      width: "16px",
+      borderRadius: "50%",
+    },
+    notSelected: {
+      height: "4px",
+      width: "4px",
+      borderRadius: "50%",
+      display: "inline-block",
+      backgroundColor: theme.colors.secondary_60,
+    },
+    selected: {
+      display: "flex",
+      height: "16px",
+      width: "16px",
+    },
+  }
+);

--- a/packages/core/src/components/ScrollTo/Horizontal/ScrollToHorizontal.tsx
+++ b/packages/core/src/components/ScrollTo/Horizontal/ScrollToHorizontal.tsx
@@ -1,20 +1,16 @@
 import { useCallback, useMemo } from "react";
-
 import { useTheme as useMuiTheme } from "@mui/material/styles";
 import { useMediaQuery } from "@mui/material";
-
 import { theme } from "@hitachivantara/uikit-styles";
 import { CurrentStep } from "@hitachivantara/uikit-react-icons";
 
 import { useDefaultProps } from "@core/hooks/useDefaultProps";
-
 import { HvBaseProps } from "@core/types/generic";
 import { useUniqueId } from "@core/hooks/useUniqueId";
 import { useTheme } from "@core/hooks/useTheme";
 import { ExtractNames } from "@core/utils/classes";
 import { isKey } from "@core/utils/keyboardUtils";
 import { setId } from "@core/utils/setId";
-import { hexToRgbA } from "@core/utils/hexToRgbA";
 
 import { HvScrollToTooltipPositions } from "../types";
 import { withTooltip } from "../withTooltip";
@@ -104,7 +100,7 @@ export const HvScrollToHorizontal = (props: HvScrollToHorizontalProps) => {
   const downSm = useMediaQuery(muiTheme.breakpoints.down("sm"));
   const upMd = useMediaQuery(muiTheme.breakpoints.up("md"));
 
-  const { activeTheme, colors } = useTheme();
+  const { activeTheme } = useTheme();
 
   const elementId = useUniqueId(id, "hvHorizontalScrollto");
 
@@ -202,10 +198,6 @@ export const HvScrollToHorizontal = (props: HvScrollToHorizontalProps) => {
             position === "fixed" && (upMd || downSm)
               ? theme.spacing(upMd ? 4 : 2)
               : 0,
-          backgroundColor: hexToRgbA(
-            colors?.atmo2,
-            activeTheme?.scrollTo.backgroundColorOpacity
-          ),
         }),
         classes.root,
         {

--- a/packages/core/src/components/ScrollTo/Vertical/ScrollToVertical.styles.tsx
+++ b/packages/core/src/components/ScrollTo/Vertical/ScrollToVertical.styles.tsx
@@ -2,32 +2,34 @@ import { theme } from "@hitachivantara/uikit-styles";
 
 import { createClasses } from "@core/utils/classes";
 
-const name = "HvScrollToVertical";
-
-export const { staticClasses, useClasses } = createClasses(name, {
-  root: {
-    display: "flex",
-    width: "32px",
-    padding: "0",
-    margin: 0,
-    listStyleType: "none",
-    flexWrap: "wrap",
-    flexDirection: "column",
-    backdropFilter: `blur(4px)`,
-  },
-  positionAbsolute: {
-    width: "32px",
-    position: "absolute",
-    zIndex: `calc(${theme.zIndices.banner} - 2)`,
-    right: "0",
-  },
-  positionFixed: {
-    width: "32px",
-    position: "fixed",
-    zIndex: `calc(${theme.zIndices.banner} - 2)`,
-    right: "0",
-  },
-});
+export const { staticClasses, useClasses } = createClasses(
+  "HvScrollToVertical",
+  {
+    root: {
+      display: "flex",
+      width: "32px",
+      padding: "0",
+      margin: 0,
+      listStyleType: "none",
+      flexWrap: "wrap",
+      flexDirection: "column",
+      backdropFilter: `blur(4px)`,
+      backgroundColor: theme.alpha("atmo2", 0.9),
+    },
+    positionAbsolute: {
+      width: "32px",
+      position: "absolute",
+      zIndex: `calc(${theme.zIndices.banner} - 2)`,
+      right: "0",
+    },
+    positionFixed: {
+      width: "32px",
+      position: "fixed",
+      zIndex: `calc(${theme.zIndices.banner} - 2)`,
+      right: "0",
+    },
+  }
+);
 
 export const calculateOffset = (quantityOfOptions: number) => {
   const itemSize = 32;

--- a/packages/core/src/components/ScrollTo/Vertical/ScrollToVertical.tsx
+++ b/packages/core/src/components/ScrollTo/Vertical/ScrollToVertical.tsx
@@ -1,14 +1,11 @@
 import { useMemo } from "react";
 
 import { useDefaultProps } from "@core/hooks/useDefaultProps";
-
 import { HvBaseProps } from "@core/types/generic";
-import { useTheme } from "@core/hooks/useTheme";
 import { useUniqueId } from "@core/hooks/useUniqueId";
 import { ExtractNames } from "@core/utils/classes";
 import { isKey } from "@core/utils/keyboardUtils";
 import { setId } from "@core/utils/setId";
-import { hexToRgbA } from "@core/utils/hexToRgbA";
 
 import {
   staticClasses,
@@ -92,8 +89,7 @@ export const HvScrollToVertical = (props: HvScrollToVerticalProps) => {
     ...others
   } = useDefaultProps("HvScrollToVertical", props);
 
-  const { classes, css, cx } = useClasses(classesProp);
-  const { activeTheme, colors } = useTheme();
+  const { classes, cx } = useClasses(classesProp);
 
   const elementId = useUniqueId(id, "hvVerticalScrollto");
 
@@ -154,15 +150,10 @@ export const HvScrollToVertical = (props: HvScrollToVerticalProps) => {
   });
 
   const positionOffset = calculateOffset(options.length);
-  const backgroundColor = hexToRgbA(
-    colors?.atmo2,
-    activeTheme?.scrollTo.backgroundColorOpacity
-  );
 
   return (
     <ol
       className={cx(
-        css({ backgroundColor }),
         classes.root,
         {
           [classes.positionFixed]: position === "fixed",

--- a/packages/core/src/components/Table/TableCell/TableCell.styles.tsx
+++ b/packages/core/src/components/Table/TableCell/TableCell.styles.tsx
@@ -4,6 +4,8 @@ import { theme } from "@hitachivantara/uikit-styles";
 
 import { createClasses } from "@core/utils/classes";
 
+const sortedColor = theme.alpha("primary", 0.1);
+
 export const { staticClasses, useClasses } = createClasses("HvTableCell", {
   /** Styles applied to the component root class. */
   root: {
@@ -33,6 +35,10 @@ export const { staticClasses, useClasses } = createClasses("HvTableCell", {
     backgroundColor: "inherit",
     ...(theme.typography.body as CSSProperties),
     fontFamily: theme.fontFamily.body,
+
+    "&$sorted": {
+      backgroundColor: sortedColor,
+    },
   },
   /** Styles applied to the cell when it's in the table footer. */
   footer: {},
@@ -123,6 +129,10 @@ export const { staticClasses, useClasses } = createClasses("HvTableCell", {
 
     "&$groupColumnMostRight+$stickyColumn": {
       borderLeft: 0,
+    },
+
+    "&$sorted": {
+      backgroundImage: `linear-gradient(to right, ${sortedColor}, ${sortedColor})`,
     },
   },
   /** Styles applied to the cell when it's part of the last sticky to the left column. */

--- a/packages/core/src/components/Table/TableCell/TableCell.tsx
+++ b/packages/core/src/components/Table/TableCell/TableCell.tsx
@@ -1,18 +1,7 @@
-import {
-  CSSProperties,
-  forwardRef,
-  TdHTMLAttributes,
-  useContext,
-  useMemo,
-} from "react";
+import { CSSProperties, forwardRef, TdHTMLAttributes, useContext } from "react";
 import capitalize from "lodash/capitalize";
-import { theme } from "@hitachivantara/uikit-styles";
 
-import { checkValidHexColorValue } from "@core/utils/checkValidHexColorValue";
 import { ExtractNames } from "@core/utils/classes";
-import { getVarValue } from "@core/utils/theme";
-import { hexToRgbA } from "@core/utils/hexToRgbA";
-import { useTheme } from "@core/hooks/useTheme";
 import { useDefaultProps } from "@core/hooks";
 
 import {
@@ -64,12 +53,6 @@ export interface HvTableCellProps
 
 const defaultComponent = "td";
 
-const getSortedColor = (color?: string, alpha?: string) => {
-  return checkValidHexColorValue(color) && alpha
-    ? hexToRgbA(color, parseFloat(alpha))
-    : color;
-};
-
 /**
  * `HvTableCell` acts as a `td` element and inherits styles from its context
  */
@@ -94,8 +77,9 @@ export const HvTableCell = forwardRef<HTMLElement, HvTableCellProps>(
       resizing = false,
       ...others
     } = useDefaultProps("HvTableCell", props);
-    const { classes, cx, css } = useClasses(classesProp);
-    const { colors, rootId } = useTheme();
+
+    const { classes, cx } = useClasses(classesProp);
+
     const tableContext = useContext(TableContext);
     const tableSectionContext = useContext(TableSectionContext);
 
@@ -103,16 +87,6 @@ export const HvTableCell = forwardRef<HTMLElement, HvTableCellProps>(
 
     const Component =
       component || tableContext?.components?.Td || defaultComponent;
-
-    const sortedColor = useMemo(() => {
-      // "colors" makes the "sortedColor" change with the color mode and theme
-      const color =
-        getVarValue(theme.table.rowSortedColor, rootId) || colors?.primary_20;
-      const alpha =
-        getVarValue(theme.table.rowSortedColorAlpha, rootId) || "0.1";
-
-      return getSortedColor(color, alpha);
-    }, [colors, rootId]);
 
     return (
       <Component
@@ -122,18 +96,6 @@ export const HvTableCell = forwardRef<HTMLElement, HvTableCellProps>(
         className={cx(
           classes.root,
           classes[type],
-          type === "body" &&
-            css({
-              [`&.${staticClasses.sorted}`]: {
-                backgroundColor: sortedColor,
-              },
-            }),
-          stickyColumn &&
-            css({
-              [`&.${staticClasses.sorted}`]: {
-                backgroundImage: `linear-gradient(to right, ${sortedColor}, ${sortedColor})`,
-              },
-            }),
           {
             [classes[`align${capitalize(align)}`]]: align !== "inherit",
             [classes.variantList]: tableContext.variant === "listrow",

--- a/packages/core/src/components/Table/TableRow/TableRow.styles.tsx
+++ b/packages/core/src/components/Table/TableRow/TableRow.styles.tsx
@@ -32,11 +32,15 @@ export const { staticClasses, useClasses } = createClasses("HvTableRow", {
   /** Styles applied to the component root when striped. */
   striped: {
     "&:nth-of-type(even)": {
+      backgroundColor: theme.alpha("atmo1", 0.6),
+
       "&:hover": {
         backgroundColor: theme.colors.containerBackgroundHover,
       },
     },
     "&:nth-of-type(odd)": {
+      backgroundColor: "transparent",
+
       "&:hover": {
         backgroundColor: theme.colors.containerBackgroundHover,
       },

--- a/packages/core/src/components/Table/TableRow/TableRow.tsx
+++ b/packages/core/src/components/Table/TableRow/TableRow.tsx
@@ -1,9 +1,7 @@
 import { forwardRef, useContext } from "react";
 
 import { ExtractNames } from "@core/utils/classes";
-import { hexToRgbA } from "@core/utils/hexToRgbA";
 import { HvBaseProps } from "@core/types/generic";
-import { useTheme } from "@core/hooks/useTheme";
 import { useDefaultProps } from "@core/hooks";
 
 import TableContext from "../TableContext";
@@ -49,8 +47,9 @@ export const HvTableRow = forwardRef<HTMLElement, HvTableRowProps>(
       striped = false,
       ...others
     } = useDefaultProps("HvTableRow", props);
-    const { classes, cx, css } = useClasses(classesProp);
-    const { colors } = useTheme();
+
+    const { classes, cx } = useClasses(classesProp);
+
     const tableContext = useContext(TableContext);
     const tableSectionContext = useContext(TableSectionContext);
 
@@ -68,15 +67,6 @@ export const HvTableRow = forwardRef<HTMLElement, HvTableRowProps>(
           tableSectionContext.filterClassName,
           classes.root,
           classes[type],
-          striped &&
-            css({
-              "&:nth-of-type(even)": {
-                backgroundColor: hexToRgbA(colors?.atmo1, 0.6),
-              },
-              "&:nth-of-type(odd)": {
-                backgroundColor: "transparent",
-              },
-            }),
           {
             [classes.hover]: hover,
             [classes.selected]: selected,

--- a/packages/core/src/components/Table/stories/TableSamples/LoadingContainer.tsx
+++ b/packages/core/src/components/Table/stories/TableSamples/LoadingContainer.tsx
@@ -3,8 +3,6 @@ import {
   HvLoading,
   HvLoadingProps,
   theme,
-  useTheme,
-  hexToRgbA,
 } from "@hitachivantara/uikit-react-core";
 
 const classes = {
@@ -16,6 +14,7 @@ const classes = {
     position: "absolute",
     inset: 0,
     zIndex: `calc(${theme.zIndices.banner} - 1)`,
+    backgroundColor: theme.alpha("atmo1", 0.8),
   }),
   opaque: css({
     backgroundColor: theme.colors.atmo1,
@@ -40,28 +39,19 @@ export const LoadingContainer = ({
   opaque = false,
   transparent = false,
   ...others
-}: LoadingContainerProps) => {
-  const { colors } = useTheme();
-
-  return (
-    <div className={classes.root}>
-      <HvLoading
-        role="progressbar"
-        aria-label="Loading items..."
-        className={cx(
-          css({ backgroundColor: hexToRgbA(colors?.atmo1) }),
-          classes.loading,
-          className,
-          {
-            [classes.opaque]: opaque,
-            [classes.transparent]: transparent,
-          }
-        )}
-        label={label}
-        hidden={!loading}
-        {...others}
-      />
-      {children}
-    </div>
-  );
-};
+}: LoadingContainerProps) => (
+  <div className={classes.root}>
+    <HvLoading
+      role="progressbar"
+      aria-label="Loading items..."
+      className={cx(classes.loading, className, {
+        [classes.opaque]: opaque,
+        [classes.transparent]: transparent,
+      })}
+      label={label}
+      hidden={!loading}
+      {...others}
+    />
+    {children}
+  </div>
+);

--- a/packages/core/src/components/Tag/Tag.styles.tsx
+++ b/packages/core/src/components/Tag/Tag.styles.tsx
@@ -3,7 +3,6 @@ import { theme } from "@hitachivantara/uikit-styles";
 
 import { outlineStyles } from "@core/utils/focusUtils";
 import { createClasses } from "@core/utils/classes";
-import { hexToRgbA } from "@core/utils/hexToRgbA";
 
 export const { staticClasses, useClasses } = createClasses("HvTag", {
   root: {},
@@ -16,7 +15,7 @@ export const { staticClasses, useClasses } = createClasses("HvTag", {
       fontFamily: theme.fontFamily.body,
 
       "&:focus-visible": {
-        backgroundColor: hexToRgbA(theme.colors.base_light, 0.3),
+        backgroundColor: theme.alpha("base_light", 0.3),
       },
 
       "&$categorical": {

--- a/packages/core/src/utils/hexToRgbA.ts
+++ b/packages/core/src/utils/hexToRgbA.ts
@@ -1,3 +1,4 @@
 import { hexToRgb, alpha } from "@mui/material";
 
+// TODO - remove in v6 in favor of theme.alpha()
 export const hexToRgbA = (hex, factor = 0.8) => alpha(hexToRgb(hex), factor);

--- a/packages/lab/src/components/Wizard/WizardContent/LoadingContainer.styles.tsx
+++ b/packages/lab/src/components/Wizard/WizardContent/LoadingContainer.styles.tsx
@@ -1,10 +1,4 @@
-import {
-  createClasses,
-  hexToRgbA,
-  theme,
-} from "@hitachivantara/uikit-react-core";
-
-import { alpha } from "@mui/material";
+import { createClasses, theme } from "@hitachivantara/uikit-react-core";
 
 export const { staticClasses, useClasses } = createClasses(
   "HvWizard-LoadingContainer",
@@ -19,7 +13,7 @@ export const { staticClasses, useClasses } = createClasses(
       zIndex: -1,
     },
     blur: {
-      backgroundColor: alpha(hexToRgbA(theme.colors.atmo2), 0.8),
+      backgroundColor: theme.alpha("atmo2", 0.8),
       zIndex: theme.zIndices.modal,
     },
   }

--- a/packages/styles/src/theme.ts
+++ b/packages/styles/src/theme.ts
@@ -90,17 +90,27 @@ const typographySpec: DeepString<HvThemeTypography> = {
   },
 };
 
+const colorTokens = {
+  containerBackgroundHover: tokens.colors.light.primary_20,
+  backgroundColor: tokens.colors.light.atmo2,
+  ...tokens.colors.common,
+  ...tokens.colors.light,
+};
+
 const themeVars: HvThemeVars = mapCSSVars({
   ...tokens,
   colors: {
     type: "light",
-    containerBackgroundHover: tokens.colors.light.primary_20,
-    backgroundColor: tokens.colors.light.atmo2,
-    ...tokens.colors.common,
-    ...tokens.colors.light,
+    ...colorTokens,
   }, // Flatten colors and add background color
   ...componentsSpec,
   ...typographySpec,
+});
+
+const rgbVars = mapCSSVars({
+  rgb: {
+    ...colorTokens,
+  },
 });
 
 const spacing: HvThemeUtils["spacing"] = (...args) => {
@@ -124,9 +134,13 @@ const spacing: HvThemeUtils["spacing"] = (...args) => {
   }
 };
 
+const alpha: HvThemeUtils["alpha"] = (color, factor) =>
+  `rgb(${rgbVars.rgb[color]} / ${factor})`;
+
 export const theme: HvTheme = {
   ...themeVars,
   spacing,
+  alpha,
 };
 
 const getColorOrFallback = (color: HvColorAny | undefined) => {

--- a/packages/styles/src/themes/ds3.ts
+++ b/packages/styles/src/themes/ds3.ts
@@ -1112,6 +1112,9 @@ const ds3 = makeTheme((theme) => ({
     },
     HvScrollToHorizontal: {
       classes: {
+        root: {
+          backgroundColor: theme.alpha("atmo2", 0.8),
+        },
         notSelectedRoot: {
           display: "none",
           height: "32px",
@@ -1127,6 +1130,13 @@ const ds3 = makeTheme((theme) => ({
           display: "none",
           height: "32px",
           width: "32px",
+        },
+      },
+    },
+    HvScrollToVertical: {
+      classes: {
+        root: {
+          backgroundColor: theme.alpha("atmo2", 0.8),
         },
       },
     },
@@ -1232,11 +1242,24 @@ const ds3 = makeTheme((theme) => ({
         head: {
           borderTop: `1px solid ${theme.colors.atmo4}`,
         },
+        body: {
+          "&.HvTableCell-sorted": {
+            backgroundColor: theme.alpha("atmo1", 0.4),
+          },
+        },
         variantListactions: {
           borderLeft: `solid 2px ${theme.colors.atmo2}`,
         },
         variantListcheckbox: {
           borderRight: `solid 2px ${theme.colors.atmo2}`,
+        },
+        stickyColumn: {
+          "&.HvTableCell-sorted": {
+            backgroundImage: `linear-gradient(to right, ${theme.alpha(
+              "atmo1",
+              0.4
+            )}, ${theme.alpha("atmo1", 0.4)})`,
+          },
         },
       },
     },
@@ -1424,8 +1447,8 @@ const ds3 = makeTheme((theme) => ({
     rowStripedBackgroundColorEven: theme.colors.atmo1, // TODO - remove in v6
     rowStripedBackgroundColorOdd: "transparent", // TODO - remove in v6
     rowExpandBackgroundColor: theme.colors.atmo2,
-    rowSortedColor: theme.colors.atmo1,
-    rowSortedColorAlpha: "0.4",
+    rowSortedColor: theme.colors.atmo1, // TODO - remove in v6
+    rowSortedColorAlpha: "0.4", // TODO - remove in v6
   },
   stepNavigation: {
     separatorMargin: "0px",
@@ -1438,7 +1461,7 @@ const ds3 = makeTheme((theme) => ({
   },
   scrollTo: {
     dotSelectedSize: 10,
-    backgroundColorOpacity: 0.8,
+    backgroundColorOpacity: 0.8, // TODO - remove in v6
   },
   colorPicker: {
     hueDirection: "vertical",

--- a/packages/styles/src/themes/ds5.ts
+++ b/packages/styles/src/themes/ds5.ts
@@ -188,8 +188,8 @@ const ds5 = makeTheme((theme) => ({
     rowStripedBackgroundColorEven: theme.colors.atmo1, // TODO - remove in v6
     rowStripedBackgroundColorOdd: "transparent", // TODO - remove in v6
     rowExpandBackgroundColor: theme.colors.atmo2,
-    rowSortedColor: theme.colors.primary,
-    rowSortedColorAlpha: "0.1",
+    rowSortedColor: theme.colors.primary, // TODO - remove in v6
+    rowSortedColorAlpha: "0.1", // TODO - remove in v6
   },
   stepNavigation: {
     separatorMargin: "4px",
@@ -202,7 +202,7 @@ const ds5 = makeTheme((theme) => ({
   },
   scrollTo: {
     dotSelectedSize: 6,
-    backgroundColorOpacity: 0.9,
+    backgroundColorOpacity: 0.9, // TODO - remove in v6
   },
   colorPicker: {
     hueDirection: "horizontal",

--- a/packages/styles/src/types.ts
+++ b/packages/styles/src/types.ts
@@ -117,6 +117,16 @@ export type HvThemeUtils = {
    * theme.spacing("md", "inherit", "42px") // 24px inherit 42px
    */
   spacing: (...args: [SpacingValue[]] | SpacingValue[]) => string;
+  /**
+   * Utility function to apply an alpha channel to a color from the theme.
+   *
+   * @example
+   * theme.alpha("atmo1", 0.5) // rgb( R G B / 0.5)
+   * */
+  alpha: (
+    color: Exclude<keyof HvThemeTokens["colors"], "type" | "shadow">, // "type" and "shadow" are not actual colors
+    alpha: number | string
+  ) => string;
 };
 
 // Theme colors

--- a/packages/styles/src/utils.ts
+++ b/packages/styles/src/utils.ts
@@ -145,6 +145,52 @@ export const getThemesList = (themes: object) => {
   return list;
 };
 
+/**
+ * Takes a color and returns the R G B channels if possible
+ * @param color - Color
+ * @returns R G B channels if possible
+ */
+const colorToRgb = (color: string) => {
+  // Matches rgba
+  const rgbaRegex =
+    /^rgba\(\s*(-?\d+|-?\d*\.\d+(?=%))(%?)\s*,\s*(-?\d+|-?\d*\.\d+(?=%))(\2)\s*,\s*(-?\d+|-?\d*\.\d+(?=%))(\2)\s*,\s*(-?\d+|-?\d*.\d+)\s*\)$/g;
+
+  // Matches rgb
+  const rgbRegex =
+    /^rgb\(\s*(-?\d+|-?\d*\.\d+(?=%))(%?)\s*,\s*(-?\d+|-?\d*\.\d+(?=%))(\2)\s*,\s*(-?\d+|-?\d*\.\d+(?=%))(\2)\s*\)$/g;
+
+  const match = color.trim().match(rgbaRegex) || color.trim().match(rgbRegex);
+
+  if (match) {
+    const channels = match[0].replace(/rgba|rgb|\(|\)/g, "").split(",");
+    if (channels.length > 3) {
+      channels.pop();
+    }
+    return channels.join(" ");
+  }
+
+  // Matches hex color with 3, 4, 6 or 8 digits
+  const hexRegex =
+    /^(?:#)(?:[a-f0-9]{3}|[a-f0-9]{4}|[a-f0-9]{6}|[a-f0-9]{8})$/gi;
+
+  const hexMatch = color.trim().match(hexRegex);
+
+  if (!hexMatch) return;
+
+  let value = hexMatch[0].replace("#", "");
+  if (value.length === 3 || value.length === 4) {
+    value = Array.from(value)
+      .map((d) => `${d}${d}`)
+      .join("");
+  }
+
+  return [
+    parseInt(value.substring(0, 2), 16),
+    parseInt(value.substring(2, 4), 16),
+    parseInt(value.substring(4, 6), 16),
+  ].join(" ");
+};
+
 export const getThemesVars = (themes: HvThemeStructure[]) => {
   const vars = {};
 
@@ -155,12 +201,25 @@ export const getThemesVars = (themes: HvThemeStructure[]) => {
       const styleName = `[data-theme="${theme.name}"][data-color-mode="${colorMode}"]`;
 
       // Extracting "components" and "name" because they shouldn't be mapped to CSS vars
-      const { components, name, ...rest } = theme;
+      const { components, name, colors, ...rest } = theme;
+
+      const rgbColors = Object.entries(colors.modes[colorMode]).reduce(
+        (acc, [key, value]) => {
+          const rgb = colorToRgb(value);
+          if (rgb) acc[key] = rgb;
+          return acc;
+        },
+        {}
+      );
 
       vars[styleName] = toCSSVars({
         ...rest,
         colors: {
-          ...rest.colors.modes[colorMode],
+          ...colors.modes[colorMode],
+        },
+        // Colors as R G B channels
+        rgb: {
+          ...rgbColors,
         },
       });
     });

--- a/templates/utils/LoadingContainer.tsx
+++ b/templates/utils/LoadingContainer.tsx
@@ -1,14 +1,7 @@
 import React from "react";
-
 import { css } from "@emotion/css";
-
 import { theme } from "@hitachivantara/uikit-styles";
-import {
-  HvLoading,
-  HvLoadingProps,
-  hexToRgbA,
-  useTheme,
-} from "@hitachivantara/uikit-react-core";
+import { HvLoading, HvLoadingProps } from "@hitachivantara/uikit-react-core";
 
 interface LoadingContainerProps extends HvLoadingProps {
   children: React.ReactNode;
@@ -20,8 +13,6 @@ export const LoadingContainer = ({
   loading,
   ...others
 }: LoadingContainerProps) => {
-  const { colors } = useTheme();
-
   return (
     <div
       className={css({
@@ -34,7 +25,7 @@ export const LoadingContainer = ({
           root: css({
             position: "absolute",
             inset: -2, // cover borders/outlines
-            backgroundColor: hexToRgbA(colors?.atmo2, 0.8),
+            backgroundColor: theme.alpha("atmo2", 0.8),
             zIndex: theme.zIndices.popover,
           }),
         }}


### PR DESCRIPTION
- `alpha` util added to the `theme`:
   - Applies a transparency to a color from the theme. For this, the color name must be passed as a parameter as well as the alpha value to be applied. Example: `theme.alpha("atmo4", 0.5)`
   - New CSS vars named `--uikit-rgb-COLOR` were added to list the colors' RGB channels. New vars were created instead of updating the color vars because, otherwise, we would need to add more overhead (in `mapCSSVars`) when using a color with `theme.colors.COLOR` since we would need to apply the `rgb`.  Also, the color vars would stop having "meaning".
   - Adding the alpha to the HEX color was not possible (example adding 10% alpha to a color: `var(--uikit-colors-COLOR)19`).
- Docs updated to document this new feature
- All usage of `hexToRgbA` replaced by the new utility

➡️ Let me know if you think there's a better way to implement this instead of adding new vars.