### PR TITLE
feat(DashboardNode): add node

### DIFF
--- a/packages/lab/src/Flow/index.ts
+++ b/packages/lab/src/Flow/index.ts
@@ -8,4 +8,5 @@ export * from "./Node";
 export type { HvFlowClasses } from "./DroppableFlow";
 export { flowClasses } from "./DroppableFlow";
 export * from "./types";
+export * from "./nodes";
 export * from "./hooks";

--- a/packages/lab/src/Flow/nodes/DashboardNode.tsx
+++ b/packages/lab/src/Flow/nodes/DashboardNode.tsx
@@ -1,0 +1,123 @@
+import {
+  ExtractNames,
+  HvButton,
+  HvDialog,
+  HvDialogActions,
+  HvDialogContent,
+  HvDialogProps,
+  HvDialogTitle,
+  HvEmptyState,
+  createClasses,
+  theme,
+  useLabels,
+} from "@hitachivantara/uikit-react-core";
+import { Info } from "@hitachivantara/uikit-react-icons";
+
+import { HvDashboard, HvDashboardProps } from "../../Dashboard";
+import { HvFlowNode, HvFlowNodeProps, HvFlowNodeClasses } from "../Node";
+
+const { staticClasses, useClasses } = createClasses("HvDashboardNode", {
+  actions: {
+    display: "flex",
+    justifyContent: "space-around",
+    padding: theme.space.xs,
+  },
+  empty: {
+    padding: theme.spacing("sm", 0, 0, 0),
+  },
+});
+
+export { staticClasses as hvDashboardNodeClasses };
+
+const DEFAULT_LABELS = {
+  title: "Dashboard",
+  description: "Dashboard",
+  emptyMessage: "No visualizations connected to the dashboard.",
+  dialogTitle: "Configure dashboard",
+  dialogSubtitle: "Please configure the layout of your dashboard as needed.",
+  dialogApply: "Apply",
+  dialogCancel: "Cancel",
+};
+
+export interface HvDashboardNodeClasses
+  extends ExtractNames<typeof useClasses>,
+    HvFlowNodeClasses {}
+
+export interface HvDashboardNodeProps
+  extends HvFlowNodeProps,
+    Pick<HvDialogProps, "open" | "onClose">,
+    Pick<HvDashboardProps, "layout"> {
+  classes?: HvDashboardNodeClasses;
+  labels?: typeof DEFAULT_LABELS;
+  previewItems?: React.ReactNode;
+  onApply?: () => void;
+  onCancel?: () => void;
+
+  dashboardProps?: Omit<HvDashboardProps, "children">;
+  dialogProps?: HvDialogProps;
+}
+
+export const HvDashboardNode = (props: HvDashboardNodeProps) => {
+  const {
+    id,
+    open,
+    layout,
+    labels: labelsProp,
+    classes: classesProp,
+    previewItems,
+    children,
+    dialogProps,
+    dashboardProps,
+    onApply,
+    onCancel,
+    onClose,
+    ...others
+  } = props;
+  const labels = useLabels(DEFAULT_LABELS, labelsProp);
+  const { classes } = useClasses(classesProp);
+
+  return (
+    <HvFlowNode id={id} classes={classes as any} {...others}>
+      <div className={classes.actions}>{children}</div>
+      <HvDialog
+        open={open}
+        maxWidth="lg"
+        fullWidth
+        onClose={onClose}
+        {...dialogProps}
+      >
+        <HvDialogTitle variant="info">{labels?.dialogTitle}</HvDialogTitle>
+        <HvDialogContent indentContent>
+          {labels?.dialogSubtitle}
+          {layout && layout?.length > 0 ? (
+            <HvDashboard
+              cols={12}
+              layout={layout}
+              compactType="vertical"
+              rowHeight={80}
+              margin={[16, 16]}
+              containerPadding={[0, 16]}
+              {...dashboardProps}
+            >
+              {previewItems}
+            </HvDashboard>
+          ) : (
+            <HvEmptyState
+              className={classes.empty}
+              icon={<Info role="none" />}
+              message={labels?.emptyMessage}
+            />
+          )}
+        </HvDialogContent>
+        <HvDialogActions>
+          <HvButton variant="primary" onClick={onApply}>
+            {labels?.dialogApply}
+          </HvButton>
+          <HvButton variant="secondarySubtle" onClick={onCancel}>
+            {labels?.dialogCancel}
+          </HvButton>
+        </HvDialogActions>
+      </HvDialog>
+    </HvFlowNode>
+  );
+};

--- a/packages/lab/src/Flow/nodes/index.ts
+++ b/packages/lab/src/Flow/nodes/index.ts
@@ -1,0 +1,1 @@
+export * from "./DashboardNode";

--- a/packages/lab/src/Flow/stories/Base/Dashboard.tsx
+++ b/packages/lab/src/Flow/stories/Base/Dashboard.tsx
@@ -1,11 +1,51 @@
-import { HvFlowNode, HvFlowNodeFC } from "@hitachivantara/uikit-react-lab";
+import { useState } from "react";
+import { Layout } from "react-grid-layout";
+import {
+  HvButton,
+  HvSection,
+  HvTypography,
+} from "@hitachivantara/uikit-react-core";
+import {
+  HvFlowNodeFC,
+  HvDashboardNode,
+  useFlowInputNodes,
+} from "@hitachivantara/uikit-react-lab";
 
 import type { NodeGroups } from ".";
 
 export const Dashboard: HvFlowNodeFC<NodeGroups> = (props) => {
+  const { id: idProp } = props;
+  const [open, setOpen] = useState(false);
+
+  const inputNodes = useFlowInputNodes(idProp);
+
+  const nodeLayout = inputNodes.map<Layout>((node, i) => {
+    const { type, data } = node;
+    const fullWidth = node.type !== "kpi";
+    const h = 2;
+    const w = fullWidth ? 12 : 4;
+    const x = fullWidth ? 0 : i * 4;
+    const y = fullWidth ? h * i : Math.floor((h * i) / 2);
+    return { i: node.id, type, data, w, h, x, y };
+  });
+
+  const previewItems = inputNodes.map((node) => (
+    <div key={node.id} className="flex">
+      <HvSection
+        title={<HvTypography variant="title3">{node.type}</HvTypography>}
+      >
+        Preview for the <code>`{node.type}`</code> node
+      </HvSection>
+    </div>
+  ));
+
   return (
-    <HvFlowNode
+    <HvDashboardNode
       description="Dashboard description"
+      open={open}
+      onClose={() => setOpen(false)}
+      onCancel={() => setOpen(false)}
+      layout={nodeLayout}
       expanded
       params={[
         {
@@ -22,8 +62,13 @@ export const Dashboard: HvFlowNodeFC<NodeGroups> = (props) => {
           accepts: ["insight"],
         },
       ]}
+      previewItems={previewItems}
       {...props}
-    />
+    >
+      <HvButton variant="secondarySubtle" onClick={() => setOpen(true)}>
+        Preview Dashboard
+      </HvButton>
+    </HvDashboardNode>
   );
 };
 


### PR DESCRIPTION
- Add `HvDashboardNode`
  - Extends `HvFlowNode` and adds the Dialog+Dashboard with a few defaults:
    - Apply+Cancel buttons, Dashboard layout+margins, full screen dialog with title + label
  - Dashboard preview is user-defined: `previewItems`
  - Node content is user-defined: `children`
  - Node Inputs/Outputs is user-defined
- Refactor dashboard nodes to use `HvDashboardNode`