### PR TITLE
fix(uno): fix spacing units & add Tests/* samples

### DIFF
--- a/docs/foundation/Icons/Sprites.stories.tsx
+++ b/docs/foundation/Icons/Sprites.stories.tsx
@@ -1,7 +1,6 @@
 import {
   HvIconSprite,
   HvIconSpriteProps,
-  icons,
 } from "@hitachivantara/uikit-react-icons";
 import { Meta, StoryObj } from "@storybook/react";
 
@@ -90,27 +89,4 @@ CustomSize.parameters = {
   docs: {
     description: { story: "Overrides Icon size using non standard sizes" },
   },
-};
-
-export const IconLibraryTest = () => {
-  const colors = ["secondary", "negative", "positive"];
-
-  return (
-    <div style={{ display: "flex", flexWrap: "wrap" }}>
-      {Object.entries(icons).map(([name]) => (
-        <HvIconSprite
-          key={name}
-          spriteUrl="./assets/icons.svg"
-          iconName={name}
-          iconSize="M"
-          color={colors}
-        />
-      ))}
-    </div>
-  );
-};
-
-IconLibraryTest.parameters = {
-  eyes: { include: false },
-  docs: { disable: true },
 };

--- a/docs/foundation/Icons/Usage.stories.tsx
+++ b/docs/foundation/Icons/Usage.stories.tsx
@@ -5,7 +5,6 @@ import {
   Machine,
   IconBase,
   IconBaseProps,
-  icons,
 } from "@hitachivantara/uikit-react-icons";
 import { Meta, StoryObj } from "@storybook/react";
 
@@ -86,21 +85,4 @@ CustomSize.parameters = {
   docs: {
     description: { story: "Overrides Icon size using non standard sizes" },
   },
-};
-
-export const IconLibraryTest = () => {
-  const colors = ["secondary", "negative", "positive"];
-
-  return (
-    <div style={{ display: "flex", flexWrap: "wrap" }}>
-      {Object.entries(icons).map(([name, Icon]) => (
-        <Icon key={name} iconSize="M" color={colors} />
-      ))}
-    </div>
-  );
-};
-
-IconLibraryTest.parameters = {
-  eyes: { include: true },
-  docs: { disable: true },
 };

--- a/docs/tests/Icons.stories.tsx
+++ b/docs/tests/Icons.stories.tsx
@@ -1,0 +1,44 @@
+import { StoryObj } from "@storybook/react";
+import {
+  HvIconSprite,
+  HvIconSpriteProps,
+  IconBaseProps,
+  icons,
+} from "@hitachivantara/uikit-react-icons";
+
+export default {
+  title: "Tests/Icons",
+  parameters: {
+    eyes: { include: true },
+    docs: { disable: true },
+  },
+};
+
+export const IconLibrary: StoryObj<IconBaseProps> = {
+  args: {
+    iconSize: "M",
+    color: ["secondary", "negative", "positive"],
+  },
+  render: (args) => (
+    <div style={{ display: "flex", flexWrap: "wrap" }}>
+      {Object.entries(icons).map(([name, Icon]) => (
+        <Icon key={name} {...args} />
+      ))}
+    </div>
+  ),
+};
+
+export const IconSpriteLibrary: StoryObj<HvIconSpriteProps> = {
+  args: {
+    iconSize: "M",
+    spriteUrl: "./assets/icons.svg",
+    color: ["secondary", "negative", "positive"],
+  },
+  render: (args) => (
+    <div style={{ display: "flex", flexWrap: "wrap" }}>
+      {Object.entries(icons).map(([name]) => (
+        <HvIconSprite key={name} {...args} iconName={name} />
+      ))}
+    </div>
+  ),
+};

--- a/docs/tests/Uno.stories.tsx
+++ b/docs/tests/Uno.stories.tsx
@@ -1,0 +1,49 @@
+import { StoryObj } from "@storybook/react";
+import { Abacus } from "@hitachivantara/uikit-react-icons";
+import { HvTypography } from "@hitachivantara/uikit-react-core";
+
+export default {
+  title: "Tests/Uno",
+  parameters: {
+    eyes: { include: true },
+    docs: { disable: true },
+  },
+};
+
+export const UnoClasses: StoryObj = {
+  render: () => (
+    <>
+      <HvTypography variant="title4">Z-Index & Colors</HvTypography>
+      <section className="flex bg-default [&>div]:-mr-2">
+        <div className="w-12 h-12 bg-positive z-modal" />
+        <div className="w-11 h-11 bg-warning z-docked" />
+        <div className="w-10 h-10 bg-warning_120 z-8" />
+        <div className="w-9 h-9 bg-base_dark" />
+        <div className="w-8 h-8 bg-negative -z-1" />
+      </section>
+      <br />
+      <HvTypography variant="title4">Radius & Spacing</HvTypography>
+      <section className="flex gap-xs">
+        {[
+          "rounded-none m-1",
+          "rounded-base my-sm",
+          "rounded mr-md",
+          "rounded-2",
+          "rounded-circle",
+        ].map((classes) => (
+          <div key={classes} className="bg-secondary p-xs">
+            <div className={`w-8 h-8 bg-primary ${classes}`} />
+          </div>
+        ))}
+      </section>
+      <br />
+      <HvTypography variant="title4">Text & icons</HvTypography>
+      <section>
+        <div className="flex items-center text-warning">
+          <Abacus color="currentColor" />
+          <span>Text goes here</span>
+        </div>
+      </section>
+    </>
+  ),
+};

--- a/packages/uno-preset/src/index.ts
+++ b/packages/uno-preset/src/index.ts
@@ -12,6 +12,7 @@ export { rules, extendTheme, themeModes };
 export interface HvUnoOptions extends PresetUnoOptions {}
 
 export const presetHv = definePreset<HvUnoOptions, Theme>((options) => {
+  /** HV base theme configuration */
   const hvConfig: UserConfig<Theme> = {
     extendTheme,
     rules,
@@ -22,11 +23,12 @@ export const presetHv = definePreset<HvUnoOptions, Theme>((options) => {
     ...mergeConfigs([
       // base uno config
       presetUno(options),
-      // convert rem to px & make 1 unit 8px (32px = 1rem => 1/4rem = 8px)
-      presetRemToPx({ baseFontSize: 32 }),
-      hvConfig,
       // allows theme variants (light/dark) via CSS vars - aligned with UI Kit's
       presetTheme<Theme>({ prefix: "--hv", theme: themeModes }),
+      // convert rem to px & make 1 unit 8px (32px = 1rem => 1/4rem = 8px)
+      presetRemToPx({ baseFontSize: 32 }),
+
+      hvConfig,
     ]),
   };
 });

--- a/packages/uno-preset/src/theme.ts
+++ b/packages/uno-preset/src/theme.ts
@@ -22,7 +22,7 @@ export const extendTheme: ThemeExtender<Theme> = (baseTheme) => ({
   ...baseTheme,
 
   borderRadius: {
-    DEFAULT: hvTheme.radii.round,
+    DEFAULT: hvTheme.radii.base,
     ...hvTheme.radii,
   },
   breakpoints: Object.fromEntries(hvBreakpoints),
@@ -30,7 +30,7 @@ export const extendTheme: ThemeExtender<Theme> = (baseTheme) => ({
     hvBreakpoints.map(([k, v]) => [k, `(min-width: ${v})`])
   ),
   spacing: {
-    DEFAULT: hvSpacing.sm,
+    DEFAULT: hvSpacing.xs,
     ...hvSpacing,
   },
   zIndex: Object.fromEntries(hvZIndex),


### PR DESCRIPTION
- fix UnoCSS plugin spacing units
  - `presetRemToPx` must be applied after Uno & Theme presets
- add Storybook "Tests/*" folder for samples **only used** in visual testing
  - Add UnoCSS test sample
  - move IconLibraryTest samples