### PR TITLE
feat(QueryBuilder): custom operator renderer

### DIFF
--- a/packages/core/src/QueryBuilder/Context.tsx
+++ b/packages/core/src/QueryBuilder/Context.tsx
@@ -325,6 +325,7 @@ export interface HvQueryBuilderContextValue {
   readOnly: boolean;
   disableConfirmation: boolean;
   renderers?: HvQueryBuilderRenderers;
+  emptyRenderer?: string[];
 }
 
 export const HvQueryBuilderContext = createContext<HvQueryBuilderContextValue>({

--- a/packages/core/src/QueryBuilder/QueryBuilder.tsx
+++ b/packages/core/src/QueryBuilder/QueryBuilder.tsx
@@ -53,14 +53,14 @@ export interface HvQueryBuilderProps {
    * Operators that should use the empty value renderer when selected.
    *
    * When one of the listed operators is selected, the rule value is reset and an empty component is rendered.
-   * This property takes priority to the `renderers` property.
+   * This property takes priority over `renderers`.
    *
-   * Defaults to `["Empty", "IsNotEmpty"]`.
+   * @default ["Empty", "IsNotEmpty"]
    * */
   emptyRenderer?: string[];
-  /** Custom renderers for the values. */
+  /** Custom renderers for the rules' value. */
   renderers?: HvQueryBuilderRenderers;
-  /** Whether to opt-out of the confirmation dialogs shown before removing rules and rule groups. Default to `false`. */
+  /** Whether to opt-out of the confirmation dialogs shown before removing rules and rule groups. @default false. */
   disableConfirmation?: boolean;
   /** A Jss Object used to override or extend the styles applied. */
   classes?: HvQueryBuilderClasses;
@@ -75,6 +75,8 @@ export interface HvQueryBuilderProps {
 /**
  * This component allows you to create conditions and group them using logical operators.
  * It outputs a structured set of rules which can be easily parsed to create SQL/NoSQL/whatever queries.
+ *
+ * Take a look at the [usage page](https://lumada-design.github.io/uikit/master/?path=/docs/widgets-query-builder-usage--docs) to learn more about this component.
  */
 export const HvQueryBuilder = (props: HvQueryBuilderProps) => {
   const {

--- a/packages/core/src/QueryBuilder/QueryBuilder.tsx
+++ b/packages/core/src/QueryBuilder/QueryBuilder.tsx
@@ -49,7 +49,16 @@ export interface HvQueryBuilderProps {
   labels?: HvQueryBuilderLabels;
   /** Whether the query builder is in read-only mode. */
   readOnly?: boolean;
-  /** Renderers for custom attribute types. */
+  /**
+   * Operators that should use the empty value renderer when selected.
+   *
+   * When one of the listed operators is selected, the rule value is reset and an empty component is rendered.
+   * This property takes priority to the `renderers` property.
+   *
+   * Defaults to `["Empty", "IsNotEmpty"]`.
+   * */
+  emptyRenderer?: string[];
+  /** Custom renderers for the values. */
   renderers?: HvQueryBuilderRenderers;
   /** Whether to opt-out of the confirmation dialogs shown before removing rules and rule groups. Default to `false`. */
   disableConfirmation?: boolean;
@@ -61,6 +70,7 @@ export interface HvQueryBuilderProps {
 // - uncontrolled vs controlled: users should be able to control the state
 // - "query" renamed to "initialQuery" and "query" used to control the state
 // - "query" provided with ids by the user but removed through "onChange"
+// - "range", "Empty", and "IsNotEmpty" operators with internal/built-in logic
 
 /**
  * This component allows you to create conditions and group them using logical operators.
@@ -78,6 +88,7 @@ export const HvQueryBuilder = (props: HvQueryBuilderProps) => {
     maxDepth = 1,
     labels = defaultLabels,
     readOnly = false,
+    emptyRenderer = ["Empty", "IsNotEmpty"],
     classes: classesProp,
   } = useDefaultProps("HvQueryBuilder", props);
 
@@ -129,6 +140,7 @@ export const HvQueryBuilder = (props: HvQueryBuilderProps) => {
       readOnly,
       renderers,
       disableConfirmation,
+      emptyRenderer,
     }),
     [
       attributes,
@@ -140,6 +152,7 @@ export const HvQueryBuilder = (props: HvQueryBuilderProps) => {
       initialState,
       renderers,
       disableConfirmation,
+      emptyRenderer,
     ]
   );
 

--- a/packages/core/src/QueryBuilder/QueryBuilder.tsx
+++ b/packages/core/src/QueryBuilder/QueryBuilder.tsx
@@ -22,6 +22,7 @@ import {
   HvQueryBuilderQueryOperator,
   HvQueryBuilderChangedQuery,
   HvQueryBuilderRenderers,
+  defaultRendererKey,
 } from "./types";
 import { clearNodeIds, emptyGroup } from "./utils";
 import reducer from "./utils/reducer";
@@ -79,6 +80,23 @@ export const HvQueryBuilder = (props: HvQueryBuilderProps) => {
     readOnly = false,
     classes: classesProp,
   } = useDefaultProps("HvQueryBuilder", props);
+
+  if (
+    import.meta.env.DEV &&
+    [
+      Object.values(attributes || {}).map(({ type }) => type),
+      Object.values(operators || {})
+        .map((ops) => ops.map(({ operator }) => operator))
+        .flat(),
+    ]
+      .flat()
+      ?.find((key) => key === defaultRendererKey)
+  ) {
+    // eslint-disable-next-line no-console
+    console.error(
+      `${defaultRendererKey} is a restricted key and shouldn't be used as an attribute or operator type. Update the key to avoid unexpected behaviors.`
+    );
+  }
 
   const { classes } = useClasses(classesProp);
 

--- a/packages/core/src/QueryBuilder/Rule/Operator/Operator.tsx
+++ b/packages/core/src/QueryBuilder/Rule/Operator/Operator.tsx
@@ -55,12 +55,7 @@ export const Operator = ({
             id,
             operator: selected.id.toString(),
             value:
-              value === "range" ||
-              selected.id === "range" ||
-              selected.id === "IsNotEmpty" ||
-              selected.id === "Empty"
-                ? null
-                : undefined,
+              value === "range" || selected.id === "range" ? null : undefined,
           });
         } else {
           dispatchAction({

--- a/packages/core/src/QueryBuilder/Rule/Rule.styles.tsx
+++ b/packages/core/src/QueryBuilder/Rule/Rule.styles.tsx
@@ -62,7 +62,7 @@ export const { useClasses, staticClasses } = createClasses(
       "&>div:not(:last-child)": {
         paddingRight: 0,
       },
-      "&>div:not(:first-child)": {
+      "&>div:not(:first-of-type)": {
         marginTop: theme.space.xs,
       },
     },

--- a/packages/core/src/QueryBuilder/Rule/Rule.tsx
+++ b/packages/core/src/QueryBuilder/Rule/Rule.tsx
@@ -74,9 +74,6 @@ export const Rule = (props: RuleProps) => {
     return -1;
   }, [attribute, attributes, combinator, operators]);
 
-  const shouldShowValueInput =
-    operator !== "Empty" && operator !== "IsNotEmpty";
-
   return (
     <HvGrid
       container
@@ -103,14 +100,12 @@ export const Rule = (props: RuleProps) => {
       )}
       {attribute != null && (operator != null || availableOperators === 0) && (
         <HvGrid item xs={12} md>
-          {shouldShowValueInput && (
-            <Value
-              attribute={attribute}
-              id={id}
-              operator={operator}
-              value={value}
-            />
-          )}
+          <Value
+            attribute={attribute}
+            id={id}
+            operator={operator}
+            value={value}
+          />
         </HvGrid>
       )}
       <HvGrid item className={classes.actionsContainer}>

--- a/packages/core/src/QueryBuilder/Rule/Value/EmptyValue/EmptyValue.tsx
+++ b/packages/core/src/QueryBuilder/Rule/Value/EmptyValue/EmptyValue.tsx
@@ -1,0 +1,22 @@
+import { useEffect } from "react";
+
+import { useQueryBuilderContext } from "../../../Context";
+
+export interface EmptyValueProps {
+  id: React.Key;
+}
+
+export const EmptyValue = ({ id }: EmptyValueProps) => {
+  const { dispatchAction } = useQueryBuilderContext();
+
+  // Clear value on first render
+  useEffect(() => {
+    dispatchAction({
+      type: "set-value",
+      id,
+      value: null,
+    });
+  }, [dispatchAction, id]);
+
+  return null;
+};

--- a/packages/core/src/QueryBuilder/Rule/Value/EmptyValue/index.ts
+++ b/packages/core/src/QueryBuilder/Rule/Value/EmptyValue/index.ts
@@ -1,0 +1,1 @@
+export * from "./EmptyValue";

--- a/packages/core/src/QueryBuilder/Rule/Value/Value.tsx
+++ b/packages/core/src/QueryBuilder/Rule/Value/Value.tsx
@@ -5,7 +5,11 @@ import { BooleanValue } from "./BooleanValue";
 import { NumericValue } from "./NumericValue";
 import { TextValue } from "./TextValue";
 import { DateTimeValue } from "./DateTimeValue";
-import { HvQueryBuilderRendererProps, defaultRendererKey } from "../../types";
+import {
+  HvQueryBuilderRendererProps,
+  ValueRenderer,
+  defaultRendererKey,
+} from "../../types";
 import { EmptyValue } from "./EmptyValue";
 
 export interface ValueProps {
@@ -14,6 +18,14 @@ export interface ValueProps {
   operator?: string;
   value?: any;
 }
+
+const getRenderer = (renderer: ValueRenderer, operator?: string) =>
+  // 1. Custom renderer
+  (typeof renderer === "function" && renderer) ||
+  // 2. Custom operator renderer
+  (typeof renderer === "object" && operator && renderer[operator]) ||
+  // 3. Custom DEFAULT renderer
+  (typeof renderer === "object" && renderer[defaultRendererKey]);
 
 export const Value = ({
   id,
@@ -42,19 +54,8 @@ export const Value = ({
     // 5. Custom master DEFAULT-operator renderer
     // 6. Custom master DEFAULT-DEFAULT renderer
     const Renderer: React.FC<HvQueryBuilderRendererProps> | undefined =
-      (typeof renderers[attrType] === "function" && renderers[attrType]) ||
-      (typeof renderers[attrType] === "object" &&
-        operator &&
-        renderers[attrType][operator]) ||
-      (typeof renderers[attrType] === "object" &&
-        renderers[attrType][defaultRendererKey]) ||
-      (typeof renderers[defaultRendererKey] === "function" &&
-        renderers[defaultRendererKey]) ||
-      (typeof renderers[defaultRendererKey] === "object" &&
-        operator &&
-        renderers[defaultRendererKey][operator]) ||
-      (typeof renderers[defaultRendererKey] === "object" &&
-        renderers[defaultRendererKey][defaultRendererKey]) ||
+      getRenderer(renderers[attrType], operator) ||
+      getRenderer(renderers[defaultRendererKey], operator) ||
       undefined;
 
     if (Renderer) {

--- a/packages/core/src/QueryBuilder/Rule/Value/Value.tsx
+++ b/packages/core/src/QueryBuilder/Rule/Value/Value.tsx
@@ -21,10 +21,16 @@ export const Value = ({
   operator,
   value: valueProp,
 }: ValueProps) => {
-  const { attributes, initialTouched, renderers } = useQueryBuilderContext();
+  const { attributes, initialTouched, renderers, emptyRenderer } =
+    useQueryBuilderContext();
 
   const attrType =
     attribute && attributes ? attributes[attribute].type : undefined;
+
+  // Empty value renderer
+  if (emptyRenderer?.find((op) => op === operator)) {
+    return <EmptyValue id={id} />;
+  }
 
   // Custom renderer
   if (attrType && renderers?.[attrType]) {
@@ -61,11 +67,6 @@ export const Value = ({
         />
       );
     }
-  }
-
-  // Built-in behavior for "Empty" and "IsNotEmpty" operators
-  if (operator === "Empty" || operator === "IsNotEmpty") {
-    return <EmptyValue id={id} />;
   }
 
   // Built-in attributes

--- a/packages/core/src/QueryBuilder/Rule/Value/Value.tsx
+++ b/packages/core/src/QueryBuilder/Rule/Value/Value.tsx
@@ -6,6 +6,7 @@ import { NumericValue } from "./NumericValue";
 import { TextValue } from "./TextValue";
 import { DateTimeValue } from "./DateTimeValue";
 import { HvQueryBuilderRendererProps } from "../../types";
+import { EmptyValue } from "./EmptyValue";
 
 export interface ValueProps {
   id: React.Key;
@@ -44,6 +45,11 @@ export const Value = ({
         />
       );
     }
+  }
+
+  // Built-in behavior for "Empty" and "IsNotEmpty" operators
+  if (operator === "Empty" || operator === "IsNotEmpty") {
+    return <EmptyValue id={id} />;
   }
 
   // Built-in attributes

--- a/packages/core/src/QueryBuilder/Rule/Value/Value.tsx
+++ b/packages/core/src/QueryBuilder/Rule/Value/Value.tsx
@@ -5,7 +5,7 @@ import { BooleanValue } from "./BooleanValue";
 import { NumericValue } from "./NumericValue";
 import { TextValue } from "./TextValue";
 import { DateTimeValue } from "./DateTimeValue";
-import { HvQueryBuilderRendererProps } from "../../types";
+import { HvQueryBuilderRendererProps, defaultRendererKey } from "../../types";
 import { EmptyValue } from "./EmptyValue";
 
 export interface ValueProps {
@@ -28,11 +28,27 @@ export const Value = ({
 
   // Custom renderer
   if (attrType && renderers?.[attrType]) {
+    // Renderer to be used by order:
+    // 1. Custom attribute renderer
+    // 2. Custom attribute-operator renderer
+    // 3. Custom attribute-DEFAULT renderer
+    // 4. Custom master DEFAULT renderer
+    // 5. Custom master DEFAULT-operator renderer
+    // 6. Custom master DEFAULT-DEFAULT renderer
     const Renderer: React.FC<HvQueryBuilderRendererProps> | undefined =
+      (typeof renderers[attrType] === "function" && renderers[attrType]) ||
       (typeof renderers[attrType] === "object" &&
         operator &&
         renderers[attrType][operator]) ||
-      (typeof renderers[attrType] === "function" && renderers[attrType]) ||
+      (typeof renderers[attrType] === "object" &&
+        renderers[attrType][defaultRendererKey]) ||
+      (typeof renderers[defaultRendererKey] === "function" &&
+        renderers[defaultRendererKey]) ||
+      (typeof renderers[defaultRendererKey] === "object" &&
+        operator &&
+        renderers[defaultRendererKey][operator]) ||
+      (typeof renderers[defaultRendererKey] === "object" &&
+        renderers[defaultRendererKey][defaultRendererKey]) ||
       undefined;
 
     if (Renderer) {

--- a/packages/core/src/QueryBuilder/stories/CustomRenderers.tsx
+++ b/packages/core/src/QueryBuilder/stories/CustomRenderers.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useEffect, useMemo } from "react";
 import {
   HvDropdown,
   HvQueryBuilder,
@@ -7,10 +7,13 @@ import {
   theme,
   hvQueryBuilderDefaultOperators,
   HvSlider,
+  HvQueryBuilderProps,
+  HvTagsInputProps,
+  HvTagsInput,
 } from "@hitachivantara/uikit-react-core";
 import { css } from "@emotion/css";
 
-const attributes = {
+const attributes: HvQueryBuilderProps["attributes"] = {
   month: {
     label: "Month",
     type: "select",
@@ -30,7 +33,7 @@ const attributes = {
 };
 
 const operators = {
-  ...hvQueryBuilderDefaultOperators,
+  text: [...hvQueryBuilderDefaultOperators.text],
   select: [
     {
       operator: "equalsTo",
@@ -226,9 +229,56 @@ const SliderRenderer = ({
   );
 };
 
+const textContainsRenderers = {
+  name: {
+    label: "Value",
+  },
+};
+
+const TextContainsRenderer = ({
+  id,
+  attribute,
+  value,
+}: HvQueryBuilderRendererProps<HvTagsInputProps["value"] | string>) => {
+  const { dispatchAction } = useQueryBuilderContext();
+
+  // Clear value when "Contains" is unselected and the renderer unmounts
+  useEffect(() => {
+    return () => {
+      dispatchAction({
+        type: "set-value",
+        id,
+        value: null,
+      });
+    };
+  }, [dispatchAction, id]);
+
+  return (
+    <HvTagsInput
+      label={textContainsRenderers[attribute].label}
+      defaultValue={
+        typeof value === "string" ? [{ label: value, type: "semantic" }] : value
+      }
+      onChange={(event, tags) => {
+        dispatchAction({
+          type: "set-value",
+          id,
+          value: tags.length > 0 ? tags : null,
+        });
+      }}
+    />
+  );
+};
+
 const renderers = {
+  // Renderers for the custom attribute types "select" and "slider"
   select: SelectRenderer,
   slider: SliderRenderer,
+
+  // Renderer to customize the "Contains" operator of the "text" attribute type
+  text: {
+    Contains: TextContainsRenderer,
+  },
 };
 
 export const CustomRenderers = () => (

--- a/packages/core/src/QueryBuilder/stories/QueryBuilder.stories.tsx
+++ b/packages/core/src/QueryBuilder/stories/QueryBuilder.stories.tsx
@@ -48,7 +48,7 @@ export const InitialQuery: StoryObj<HvQueryBuilderProps> = {
     docs: {
       description: {
         story:
-          "Query Builder that parses the query to Mongo. You can also control whether you want the confirmation dialogs, which are shown before removing rules and rule groups, to appear or not by clicking on the button. This button controls the `disableConfirmation` property of the query builder.",
+          "Query builder that parses the query to Mongo. You can also control whether you want the confirmation dialogs, which are shown before removing rules and rule groups, to appear or not by clicking on the button at the top of the sample. This button controls the query builder's `disableConfirmation` property.",
       },
       source: {
         code: InitialQueryRaw,
@@ -62,7 +62,7 @@ export const ReadOnly: StoryObj<HvQueryBuilderProps> = {
   parameters: {
     docs: {
       description: {
-        story: "Query Builder in read only mode.",
+        story: "Query builder in read only mode.",
       },
       source: {
         code: ReadOnlyRaw,
@@ -77,7 +77,7 @@ export const CustomRenderers: StoryObj<HvQueryBuilderProps> = {
     docs: {
       description: {
         story:
-          "If the default attributes types (`boolean`, `numeric`, `text`, `textarea`, and `dateandtime`) are not enough to cover your use case, custom ones can be used. For these custom types, if no corresponding renderer is provided through the `renderers` property, a text input will be rendered.",
+          "If the default attribute types (`boolean`, `numeric`, `text`, `textarea`, and `dateandtime`) are not enough to cover your use case, custom ones can be used. For these custom types, if no corresponding renderer is provided through the `renderers` property, a text input will be rendered. The `renderers` property can also be used to customize the value renderers for specific operators of an attribute type.",
       },
       source: {
         code: CustomRenderersRaw,

--- a/packages/core/src/QueryBuilder/stories/Usage.stories.mdx
+++ b/packages/core/src/QueryBuilder/stories/Usage.stories.mdx
@@ -1,0 +1,280 @@
+import { Meta } from "@storybook/addon-docs";
+
+<Meta title="Widgets/Query Builder/Usage" />
+
+# Query Builder
+
+The query builder component enables you to create conditions and then group them using logical operators to create structured sets of rules.
+The output of this component can be easily parsed to create SQL, NoSQL, or any other type of query depending on your use case.
+
+Summary:
+
+- [Attributes](#attributes)
+- [Combinators](#combinators)
+- [Operators](#operators)
+- [Renderers](#renderers)
+  - [Defining renderers](#defining-renderers)
+
+## Attributes <a id="attributes" />
+
+To use this component, you'll need to define your attributes using the `attributes` property. This property receives an object with all the
+attributes you'll be able to choose from to create conditions in the query builder.
+
+An attribute has the following specification:
+
+```tsx
+interface HvQueryBuilderAttribute {
+  id?: string;
+  label: string;
+  type: "boolean" | "numeric" | "dateandtime" | "text" | "textarea" | string;
+}
+```
+
+The query builder already has 5 built-in attribute types, `boolean`, `numeric`, `text`, `textarea`, and `dateandtime`, but custom ones can be created if needed.
+
+Find below an example for the `attributes` property using custom and built-in attribute types.
+
+```tsx
+const attributes: HvQueryBuilderProps["attributes"] = {
+  attr1: {
+    label: "Numeric",
+    type: "numeric",
+  },
+  attr2: {
+    label: "Text",
+    type: "text",
+  },
+  attr3: {
+    label: "Text Area",
+    type: "textarea",
+  },
+  attr4: {
+    label: "Boolean",
+    type: "boolean",
+  },
+  attr5: {
+    label: "Date & Time",
+    type: "dateandtime",
+  },
+  attr6: {
+    label: "Custom",
+    type: "custom",
+  },
+};
+```
+
+## Combinators <a id="combinators" />
+
+The query builder already has 2 default combinator operands used out of the box: `or` and `and`. This set of combinators enables you to define how your
+conditions can be combined together.
+
+If you want to override the default combinators and define new ones, you can use the `combinators` property that receives an array of combinators
+where each combinator has the following specification:
+
+```tsx
+interface HvQueryBuilderQueryCombinator {
+  operand: string;
+  label: string;
+}
+```
+
+Find an example of `combinators` below.
+
+```tsx
+const combinators: HvQueryBuilderProps["combinators"] = [
+  { operand: "or", label: "OR" },
+  { operand: "and", label: "AND" },
+];
+```
+
+## Operators <a id="operators" />
+
+After defining your `attributes`, you'll need to specify the operators for each one of your attribute types through the `operators` property.
+This property enables you to define the conditions' operators by attribute type and combinator.
+
+The query builder already has default `operators` for each built-in attribute type and they are used out of the box.
+The default operators are available through the `hvQueryBuilderDefaultOperators` object exported by the `core` package.
+However, you'll most likely need to override these operators depending on your use case.
+
+An operator has the following specification:
+
+```tsx
+interface HvQueryBuilderQueryOperator {
+  operator: string;
+  label: string;
+  combinators: string[];
+}
+```
+
+Find below an example for the `operators` property.
+
+```tsx
+const operators: HvQueryBuilderProps["operators"] = {
+  // Using the default operators for the "boolean", "numeric", "text", "textarea", and "dateandtime" attribute types
+  ...hvQueryBuilderDefaultOperators,
+  // Defining the operators for the "custom" attribute type
+  custom: [
+    {
+      operator: "equalsTo",
+      label: "Equal to (=)",
+      combinators: ["and", "or"],
+    },
+    {
+      operator: "notEqual",
+      label: "Not equal to (!=)",
+      combinators: ["and", "or"],
+    },
+    {
+      operator: "Empty",
+      label: "Empty",
+      combinators: ["and", "or"],
+    },
+  ],
+};
+```
+
+## Renderers <a id="renderers" />
+
+Having `attributes`, `operators`, and `combinators` enables you to have a fully functional query builder since this component already has
+some intrinsic behavior.
+
+For instance, the query builder already has built-in value renderers, i.e. inputs to type the condition's value, for the default attribute types
+`boolean`, `numeric`, `text`, `textarea`, and `dateandtime`. For custom attribute types, a basic text input is rendered by default.
+Moreover, if the `range` operator is selected, the condition's value is cleared automatically, and the value renderer updates to range inputs
+for the `numeric` and `dateandtime` attribute types.
+
+This component also has a default behavior for the `Empty` and `IsNotEmpty` operators. When they are selected, the condition's value is cleared
+and an empty component is rendered for the value. This behavior is configured through the `emptyRenderer` property, which enables you to define
+the operators that should reset the condition's value and render an empty component when selected.
+
+If you don't want to rely on the default behavior provided by the query builder and the built-in value renderers are not enough to cover your use case,
+it's possible to customize them through the `renderers` property. This property enables you to customize the value renderers for specific operators and
+attribute types.
+
+When customizing the query builder, you should note that `emptyRenderer` takes priority over `renderers`.
+
+Find below an example on how to customize the value renderers through the `renderers` property.
+
+```tsx
+const renderers: HvQueryBuilderProps["renderers"] = {
+  // Renderer for the custom attribute type "custom"
+  custom: CustomRenderer,
+
+  text: {
+    // Renderer to customize the "Contains" operator of the "text" attribute type
+    Contains: ContainsRenderer,
+  },
+
+  numeric: {
+    // Renderer to customize the "numeric" attribute type
+    DEFAULT: NumericRenderer,
+    // Renderer to customize the "range" operator of the "numeric" attribute type
+    range: RangeRenderer,
+  },
+};
+```
+
+In the example above, 4 renderers were provided:
+
+- `CustomRenderer` will be used to render the value for the `custom` attribute type overriding the default text input used for custom
+  attribute types.
+- `ContainsRenderer` will be used to render the value for the `text` attribute type when the `Contains` operator is selected overriding
+  the default for this operator. When any other operator is selected for this attribute, the query builder relies on its default behavior.
+- `NumericRenderer` will be used to render the value for the `numeric` attribute type overriding the default renderer for this attribute
+  type.
+- `RangeRenderer` will be used to render the value for the `numeric` attribute type when the `range` operator is selected. This renderer
+  takes precedence over `NumericRenderer` when overriding the default renderer.
+
+If necessary, it's also possible to define value renderers at a more broad level using the `DEFAULT` key at the root of the `renderers`
+object like shown below. You should be aware that `DEFAULT` is a reserved key you shouldn't use to define your own attribute or operator
+types.
+
+```tsx
+// Example 1
+const renderers: HvQueryBuilderProps["renderers"] = {
+  // Renderer to customize all attribute types and operators
+  DEFAULT: DefaultRenderer,
+};
+
+// Example 2
+const renderers: HvQueryBuilderProps["renderers"] = {
+  DEFAULT: {
+    // Renderer to customize all attribute types and operators
+    DEFAULT: DefaultRenderer,
+    // Renderer to customize the "range" operator of all attribute types
+    range: DefaultRangeRenderer,
+  },
+};
+```
+
+In the first example, the `DefaultRenderer` will be used to render the value for all attribute types and operators. However, in the second example,
+the `DefaultRenderer` is used for all attribute types and operators except the `range` operator since the `DefaultRangeRenderer` will be used.
+These customizations have the lowest priority meaning that any renderer defined at the attribute type level will take precedence.
+
+Find below an example where the priorities are annotated.
+
+```tsx
+const renderers: HvQueryBuilderProps["renderers"] = {
+  DEFAULT: {
+    DEFAULT: DefaultRenderer, // 4
+    range: DefaultRangeRenderer, // 3
+  },
+
+  numeric: {
+    DEFAULT: NumericRenderer, // 2
+    range: RangeRenderer, // 1
+  },
+};
+```
+
+Lastly, the depth of the query, i.e. the number of nested query groups, can be controlled through the `maxDepth` where the default value is `1`.
+Furthermore, confirmation dialogs will always be shown by default when removing a condition or group. To change this behavior, the `disableConfirmation`
+property is available.
+
+### Defining renderers <a id="defining-renderers" />
+
+The value renderers are function components that receive the following properties:
+
+```tsx
+interface HvQueryBuilderRendererProps<V = any> {
+  id: React.Key;
+  attribute: string;
+  operator?: string;
+  value?: V;
+}
+```
+
+Find below an example of a value renderer.
+
+```tsx
+const Renderer = ({ id }: HvQueryBuilderRendererProps) => {
+  const { dispatchAction } = useQueryBuilderContext();
+
+  return (
+    <HvSlider
+      required
+      label="Slider"
+      onChange={(value) => {
+        dispatchAction({
+          type: "set-value",
+          id,
+          value,
+        });
+      }}
+    />
+  );
+};
+```
+
+`dispatchAction` is needed to update the query and can be accessed through the `useQueryBuilderContext` hook exported by the `core` package.
+This utility can be used to dispatch several action types such as: `reset-query`, `reset-group`, `add-rule`, `add-group`, `remove-node`,
+`set-combinator`, `set-attribute`, `set-operator`, and `set-value`. However, you'll most likely only need the `set-value` action that enables
+you to set the value of a condition. This action has the following specification:
+
+```tsx
+{
+  type: "set-value";
+  id: React.Key;
+  value: any;
+}
+```

--- a/packages/core/src/QueryBuilder/types.ts
+++ b/packages/core/src/QueryBuilder/types.ts
@@ -231,5 +231,6 @@ export interface HvQueryBuilderRendererProps<V = any> {
 
 export type HvQueryBuilderRenderers = Record<
   string,
-  React.FC<HvQueryBuilderRendererProps>
+  | React.FC<HvQueryBuilderRendererProps>
+  | Record<string, React.FC<HvQueryBuilderRendererProps>>
 >;

--- a/packages/core/src/QueryBuilder/types.ts
+++ b/packages/core/src/QueryBuilder/types.ts
@@ -1,3 +1,5 @@
+export const defaultRendererKey = "DEFAULT";
+
 const defaultAttributes = [
   "boolean",
   "numeric",

--- a/packages/core/src/QueryBuilder/types.ts
+++ b/packages/core/src/QueryBuilder/types.ts
@@ -1,9 +1,16 @@
-import { FC } from "react";
+const defaultAttributes = [
+  "boolean",
+  "numeric",
+  "dateandtime",
+  "text",
+  "textarea",
+] as const;
+type DefaultAttributes = (typeof defaultAttributes)[number];
 
 export interface HvQueryBuilderAttribute extends Record<string, unknown> {
   id?: string;
   label: string;
-  type: string;
+  type: DefaultAttributes | (string & {});
 }
 
 export interface HvQueryBuilderNumericRange {
@@ -47,7 +54,7 @@ export type HvQueryBuilderQuery = HvQueryBuilderQueryGroup;
 export interface HvQueryBuilderChangedQuery
   extends Omit<HvQueryBuilderQuery, "id" | "rules"> {
   rules: Array<
-    Omit<HvQueryBuilderQueryRule, "id"> | Omit<HvQueryBuilderQueryGroup, "id">
+    Omit<HvQueryBuilderQueryRule, "id"> | HvQueryBuilderChangedQuery
   >;
 }
 
@@ -224,5 +231,5 @@ export interface HvQueryBuilderRendererProps<V = any> {
 
 export type HvQueryBuilderRenderers = Record<
   string,
-  FC<HvQueryBuilderRendererProps>
+  React.FC<HvQueryBuilderRendererProps>
 >;

--- a/packages/core/src/QueryBuilder/types.ts
+++ b/packages/core/src/QueryBuilder/types.ts
@@ -231,8 +231,8 @@ export interface HvQueryBuilderRendererProps<V = any> {
   value?: V;
 }
 
-export type HvQueryBuilderRenderers = Record<
-  string,
+export type ValueRenderer =
   | React.FC<HvQueryBuilderRendererProps>
-  | Record<string, React.FC<HvQueryBuilderRendererProps>>
->;
+  | Record<string, React.FC<HvQueryBuilderRendererProps>>;
+
+export type HvQueryBuilderRenderers = Record<string, ValueRenderer>;

--- a/packages/lab/src/Flow/Flow.tsx
+++ b/packages/lab/src/Flow/Flow.tsx
@@ -41,6 +41,8 @@ export interface HvFlowProps<
  * This implementation leverages [React Flow](https://reactflow.dev).
  * The drag and drop functionality leverages [Dnd Kit](https://docs.dndkit.com)
  *
+ * Take a look at the [usage page](https://lumada-design.github.io/uikit/master/?path=/docs/lab-flow-usage--docs) to learn more about this component.
+ *
  * DISCLAIMER: This component is a work in progress and there might be breaking changes.
  */
 export const HvFlow = ({


### PR DESCRIPTION
- Value renderers are now configurable per operator:
   - Previously, if a custom renderer was passed for one of the default attribute types (`boolean`, `numeric`, `text`, `textarea`, and `dateandtime`), the renderer was not used. This was fixed since it should be possible to customise these attribute types.
   - As discussed, the `DEFAULT` key can be used in the `renderers` prop to customise the value renderers at a more broad level.  
      - ℹ️ I was not able to update the `type` and `operator` props in the `HvQueryBuilderAttribute` and `HvQueryBuilderQueryOperator` types, respectively, to accept all `string` except `DEFAULT`. I added a `console.error` in DEV mode because of this. ❓**Let me know if you know a solution for this.** 
   - Previously, when defining a custom renderer for an attribute type, the `Empty` and `IsNotEmpty` operators were overridden internally and the custom renderer was not used. This was changed since it should be possible to control these operators. Thus, as discussed, the internal logic for these operators was removed and an `EmptyValue` component was created to render `null` and clear the rule `value`.  
      - ➡️ To avoid introducing breaking changes to those that are currently relying on the previous behaviour when using  `renderers`, a `emptyRenderer` property that defaults to `["Empty", "IsNotEmpty"]` was created. This property defines which operators should use the empty value renderer when selected: to reset the rule value and render an empty component.  ❓**Let me know if you think differently.** 
- Type `HvQueryBuilderChangedQuery` fixed: `id` was not omitted inside `rules`
- `:first-child` replaced by `first-of-type` to remove the errors in the console
- Docs updated for the query builder and a new usage page was added