### PR TITLE
chore: fix app shell version in example

### DIFF
--- a/examples/uikit-app-shell/package.json
+++ b/examples/uikit-app-shell/package.json
@@ -21,7 +21,7 @@
   },
   "devDependencies": {
     "@emotion/babel-plugin": "^11.10.6",
-    "@hitachivantara/app-shell-vite-plugin": "latest",
+    "@hitachivantara/app-shell-vite-plugin": "0.17.11",
     "@types/react": "^18.0.28",
     "@types/react-dom": "^18.0.11",
     "@vitejs/plugin-react": "^4.1.1",


### PR DESCRIPTION
Our App Shell example is broken:
- Since v0.18.x `@hitachivantara/app-shell-vite-plugin` has breaking changes. I opened [this PR](https://github.com/lumada-design/hv-uikit-react/pull/3911) to migrate App Shell but the team are still doing tests and don't recommend promoting this version yet. Because of this I fixed the package version. 