### PR TITLE
chore(app): decouple generator/header & variable header height

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -3,26 +3,17 @@ import { ds3, ds5, HvProvider } from "@hitachivantara/uikit-react-core";
 
 import "~/lib/i18n";
 import { router } from "~/lib/routes";
-import Sidebar from "~/generator/Sidebar";
-import GeneratorProvider from "~/generator/GeneratorContext";
 
 const App = () => {
   return (
-    <div className="flex flex-row rounded-circle">
-      <HvProvider
-        themes={[ds3, ds5]}
-        theme="ds5"
-        rootElementId="hv-root"
-        cssTheme="scoped"
-      >
-        <GeneratorProvider>
-          <div className="flex-1 overflow-y-auto">
-            <RouterProvider router={router} />
-          </div>
-          <Sidebar />
-        </GeneratorProvider>
-      </HvProvider>
-    </div>
+    <HvProvider
+      themes={[ds3, ds5]}
+      theme="ds5"
+      rootElementId="hv-root"
+      cssTheme="scoped"
+    >
+      <RouterProvider router={router} />
+    </HvProvider>
   );
 };
 

--- a/app/src/components/common/Container/Container.tsx
+++ b/app/src/components/common/Container/Container.tsx
@@ -1,11 +1,26 @@
 import { Suspense } from "react";
-import { HvContainer } from "@hitachivantara/uikit-react-core";
+import {
+  HvContainer,
+  HvContainerProps,
+  theme,
+} from "@hitachivantara/uikit-react-core";
 
 import { Loading, LoadingProps } from "~/components/common/Loading";
+import { useNavigationContext } from "~/lib/context/navigation";
 
-interface ContainerProps {
-  maxWidth?: "xs" | "sm" | "md" | "lg" | "xl" | false;
-  children: NonNullable<React.ReactNode>;
+const useHeaderSpacing = () => {
+  const { activePath, navigation } = useNavigationContext();
+
+  const isFirstLevel = navigation?.some((item) => item.id === activePath?.id);
+
+  const headerSpacing = isFirstLevel
+    ? `${theme.header.height}`
+    : `${theme.header.height} + ${theme.header.secondLevelHeight}`;
+
+  return `calc(${theme.space.sm} + ${headerSpacing})`;
+};
+
+interface ContainerProps extends HvContainerProps {
   loadingProps?: LoadingProps;
 }
 
@@ -13,10 +28,13 @@ export const Container = ({
   maxWidth = "lg",
   children,
   loadingProps,
+  ...others
 }: ContainerProps) => {
+  const spacing = useHeaderSpacing();
+
   return (
-    <div className="flex pb-6 pt-11 min-h-screen">
-      <HvContainer maxWidth={maxWidth} {...{ component: "main" }}>
+    <div className="flex pb-6 min-h-screen" style={{ paddingTop: spacing }}>
+      <HvContainer component="main" maxWidth={maxWidth} {...others}>
         <Suspense fallback={<Loading {...loadingProps} />}>{children}</Suspense>
       </HvContainer>
     </div>

--- a/app/src/lib/routes.tsx
+++ b/app/src/lib/routes.tsx
@@ -6,7 +6,9 @@ import {
   createBrowserRouter,
 } from "react-router-dom";
 
-const Layout = lazy(() => import("~/pages/layout"));
+const RootLayout = lazy(() => import("~/pages/layout/root"));
+const NavigationLayout = lazy(() => import("~/pages/layout/navigation"));
+
 const Root = lazy(() => import("~/pages/Root"));
 const Components = lazy(() => import("~/pages/Components"));
 const Instructions = lazy(() => import("~/pages/Instructions"));
@@ -24,23 +26,25 @@ const Dashboard = lazy(() => import("../../../templates/Dashboard"));
 const Welcome = lazy(() => import("../../../templates/Welcome"));
 
 const routes = createRoutesFromElements(
-  <Route element={<Layout />}>
-    <Route path="/" element={<Root />} />
-    <Route path="/components" element={<Components />} />
-    <Route path="/home" element={<Instructions />} />
-    <Route path="/flow" element={<Flow />} />
+  <Route element={<RootLayout />}>
+    <Route element={<NavigationLayout />}>
+      <Route path="/" element={<Root />} />
+      <Route path="/components" element={<Components />} />
+      <Route path="/home" element={<Instructions />} />
+      <Route path="/flow" element={<Flow />} />
+      <Route
+        path="/templates"
+        element={<Navigate to="/templates/welcome" replace />}
+      />
+      <Route path="/templates/welcome" element={<Welcome />} />
+      <Route path="/templates/dashboard" element={<Dashboard />} />
+      <Route path="/templates/asset-inventory" element={<AssetInventory />} />
+      <Route path="/templates/list-view" element={<ListView />} />
+      <Route path="/templates/form" element={<Form />} />
+      <Route path="/templates/details-view" element={<DetailsView />} />
+      <Route path="/*" element={<NotFound />} />
+    </Route>
     <Route path="/dashboard-preview" element={<DashboardPreview />} />
-    <Route
-      path="/templates"
-      element={<Navigate to="/templates/welcome" replace />}
-    />
-    <Route path="/templates/welcome" element={<Welcome />} />
-    <Route path="/templates/dashboard" element={<Dashboard />} />
-    <Route path="/templates/asset-inventory" element={<AssetInventory />} />
-    <Route path="/templates/list-view" element={<ListView />} />
-    <Route path="/templates/form" element={<Form />} />
-    <Route path="/templates/details-view" element={<DetailsView />} />
-    <Route path="/*" element={<NotFound />} />
   </Route>
 );
 

--- a/app/src/pages/Flow/DashboardPreview/DashboardPreview.tsx
+++ b/app/src/pages/Flow/DashboardPreview/DashboardPreview.tsx
@@ -1,7 +1,11 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { Suspense, useCallback, useEffect, useRef, useState } from "react";
 import { css } from "@emotion/css";
 import { useSearchParams } from "react-router-dom";
-import { HvGlobalActions, theme } from "@hitachivantara/uikit-react-core";
+import {
+  HvContainer,
+  HvGlobalActions,
+  HvLoading,
+} from "@hitachivantara/uikit-react-core";
 import { HvDashboard, HvDashboardProps } from "@hitachivantara/uikit-react-lab";
 import { HvVizProvider } from "@hitachivantara/uikit-react-viz";
 
@@ -85,12 +89,7 @@ const DashboardPreview = () => {
 
   return (
     <HvVizProvider>
-      <div
-        className={css({
-          paddingTop: theme.space.lg,
-          marginTop: `calc(-1 * (2 * ${theme.header.height} + ${theme.space.xs}))`,
-        })}
-      >
+      <div className="pt-md">
         <HvGlobalActions position="relative" title="Dashboard Preview" />
         {config?.items && config?.layout && (
           <HvDashboard
@@ -114,4 +113,10 @@ const DashboardPreview = () => {
   );
 };
 
-export default DashboardPreview;
+export default () => (
+  <Suspense fallback={<HvLoading />}>
+    <HvContainer component="main" maxWidth="xl" className="w-full">
+      <DashboardPreview />
+    </HvContainer>
+  </Suspense>
+);

--- a/app/src/pages/layout/navigation.tsx
+++ b/app/src/pages/layout/navigation.tsx
@@ -1,16 +1,19 @@
-import { Outlet, useLocation } from "react-router-dom";
+import { Outlet } from "react-router-dom";
 import { HvProvider, useTheme } from "@hitachivantara/uikit-react-core";
 
 import { Header } from "~/components/common/Header";
 import { Container } from "~/components/common/Container";
 import { Tutorial } from "~/components/common/Tutorial";
-import { useGeneratorContext } from "~/generator/GeneratorContext";
+import GeneratorProvider, {
+  useGeneratorContext,
+} from "~/generator/GeneratorContext";
+import Sidebar from "~/generator/Sidebar";
 import { NavigationProvider } from "~/lib/context/navigation";
 import navigation from "~/lib/navigation";
 
-const Content = () => {
+/** Navigation layout & provider */
+const Navigation = () => {
   const { selectedMode } = useTheme();
-  const { pathname } = useLocation();
 
   const {
     customTheme,
@@ -44,7 +47,7 @@ const Content = () => {
               />
             )}
             <Container maxWidth="xl">
-              {pathname !== "/dashboard-preview" && <Header />}
+              <Header />
               <Outlet />
             </Container>
           </NavigationProvider>
@@ -54,4 +57,14 @@ const Content = () => {
   );
 };
 
-export default Content;
+/** Navigation + Theme Generator layout & providers */
+export default () => (
+  <div className="flex flex-row rounded-circle">
+    <GeneratorProvider>
+      <div className="flex-1 overflow-y-auto">
+        <Navigation />
+      </div>
+      <Sidebar />
+    </GeneratorProvider>
+  </div>
+);

--- a/app/src/pages/layout/navigation.tsx
+++ b/app/src/pages/layout/navigation.tsx
@@ -29,30 +29,28 @@ const Navigation = () => {
       id="gen-root"
       className={`bg-default ${open ? "w-[calc(100%_-_390px)]" : "w-full"}`}
     >
-      <div>
-        <HvProvider
-          classNameKey="gen-root"
-          rootElementId="gen-root"
-          cssTheme="scoped"
-          themes={[customTheme]}
-          colorMode={selectedMode}
-          cssBaseline="none" // the main provider already applies the baseline styles globally
-        >
-          <NavigationProvider navigation={navigation}>
-            {tutorialOpen && (
-              <Tutorial
-                setTutorialOpen={setTutorialOpen}
-                currentStep={currentStep}
-                setCurrentStep={setCurrentStep}
-              />
-            )}
-            <Container maxWidth="xl">
-              <Header />
-              <Outlet />
-            </Container>
-          </NavigationProvider>
-        </HvProvider>
-      </div>
+      <HvProvider
+        classNameKey="gen-root"
+        rootElementId="gen-root"
+        cssTheme="scoped"
+        themes={[customTheme]}
+        colorMode={selectedMode}
+        cssBaseline="none" // the main provider already applies the baseline styles globally
+      >
+        <NavigationProvider navigation={navigation}>
+          {tutorialOpen && (
+            <Tutorial
+              setTutorialOpen={setTutorialOpen}
+              currentStep={currentStep}
+              setCurrentStep={setCurrentStep}
+            />
+          )}
+          <Header />
+          <Container maxWidth="xl" component="main">
+            <Outlet />
+          </Container>
+        </NavigationProvider>
+      </HvProvider>
     </div>
   );
 };

--- a/app/src/pages/layout/root.tsx
+++ b/app/src/pages/layout/root.tsx
@@ -1,0 +1,7 @@
+import { Outlet } from "react-router-dom";
+
+export const Component = () => {
+  return <Outlet />;
+};
+
+export default Component;


### PR DESCRIPTION
- decouple generator/header from root element
  - `DashboardPreview` doesn't need any of this (and possibly other routes eventually)
- header/content variable spacing
  - extra spacing when 2 levels (templates)
  - addresses [this issue](https://github.com/lumada-design/hv-uikit-react/pull/3905#pullrequestreview-1786310750)
  - addresses excessive padding in some pages
- Add a root layout page (currently empty)