### PR TITLE
fix(QueryBuilder): buttons not disabled in read only and tests updated

### DIFF
--- a/packages/core/src/QueryBuilder/QueryBuilder.styles.tsx
+++ b/packages/core/src/QueryBuilder/QueryBuilder.styles.tsx
@@ -106,10 +106,14 @@ export const { useClasses, staticClasses } = createClasses("HvQueryBuilder", {
     cursor: "pointer",
     backgroundColor: "transparent",
     padding: 0,
+
+    "&:disabled": { cursor: "not-allowed", pointerEvents: "none" },
   },
   createGroupButton: {
     cursor: "pointer",
     backgroundColor: "transparent",
     padding: 0,
+
+    "&:disabled": { cursor: "not-allowed", pointerEvents: "none" },
   },
 });

--- a/packages/core/src/QueryBuilder/QueryBuilder.test.tsx
+++ b/packages/core/src/QueryBuilder/QueryBuilder.test.tsx
@@ -1,48 +1,10 @@
-import { useMemo, useState } from "react";
-import { render } from "@testing-library/react";
+import { useMemo } from "react";
+import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
-import { HvQueryBuilder } from ".";
-import { defaultOperators } from "./Context";
-import queryToMongo from "./stories/queryToMongo";
+import { HvQueryBuilder, HvQueryBuilderProps } from ".";
 
-export const Main = () => {
-  const attributes = {
-    key1: {
-      label: "Numeric",
-      type: "numeric",
-    },
-    key2: {
-      label: "Text",
-      type: "text",
-    },
-    key3: {
-      label: "Text Area",
-      type: "textarea",
-    },
-    key4: {
-      label: "Boolean",
-      type: "boolean",
-    },
-    key5: {
-      label: "Date & Time",
-      type: "dateandtime",
-    },
-    key6: {
-      label: "Custom",
-      type: "customType",
-    },
-  };
-
-  const operators = {
-    ...defaultOperators,
-    customType: [...defaultOperators.text],
-  };
-
-  return <HvQueryBuilder attributes={attributes} operators={operators} />;
-};
-
-export const InitialQuery = () => {
+const QueryBuilder = (props: HvQueryBuilderProps) => {
   const attributes = useMemo(
     () => ({
       price: {
@@ -65,196 +27,106 @@ export const InitialQuery = () => {
     []
   );
 
-  const initialQuery = useMemo(
-    () => ({
-      id: 1,
-      combinator: "and",
-      rules: [
-        {
-          id: 2,
-          attribute: "price",
-          operator: "lessThan",
-          value: 10,
-        },
-        {
-          id: 3,
-          attribute: "category",
-          operator: "equals",
-          value: "Movies",
-        },
-        {
-          id: 4,
-          combinator: "and",
-          rules: [
-            {
-              id: 5,
-              attribute: "in_stock",
-              operator: "equalsTo",
-              value: true,
-            },
-            {
-              id: 6,
-              attribute: "release",
-              operator: "greaterThan",
-              value: {
-                date: "2021-01-01",
-                time: "00:00:00",
-              },
-            },
-          ],
-        },
-        {
-          id: 7,
-          combinator: "or",
-          rules: [
-            {
-              id: 8,
-              attribute: "in_stock",
-              operator: "equalsTo",
-              value: false,
-            },
-          ],
-        },
-      ],
-    }),
-    []
-  );
-
-  const [mongoQuery, setMongoQuery] = useState(queryToMongo(initialQuery));
-
-  return (
-    <>
-      <HvQueryBuilder
-        attributes={attributes}
-        query={initialQuery}
-        onChange={(query) => {
-          setMongoQuery(queryToMongo(query));
-        }}
-      />
-      <pre>{JSON.stringify(mongoQuery, null, 2)}</pre>
-    </>
-  );
+  return <HvQueryBuilder attributes={attributes} {...props} />;
 };
 
-export const ReadOnly = () => {
-  const attributes = useMemo(
-    () => ({
-      price: {
-        label: "Price",
-        type: "numeric",
-      },
-      category: {
-        label: "Category",
-        type: "text",
-      },
-      in_stock: {
-        label: "In stock",
-        type: "boolean",
-      },
-      release: {
-        label: "Release",
-        type: "dateandtime",
-      },
-    }),
-    []
-  );
-
-  const initialQuery = useMemo(
-    () => ({
-      id: 1,
+const initialQuery = {
+  id: 1,
+  combinator: "and",
+  rules: [
+    {
+      id: 2,
+      attribute: "price",
+      operator: "lessThan",
+      value: 10,
+    },
+    {
+      id: 3,
+      attribute: "category",
+      operator: "equals",
+      value: "Movies",
+    },
+    {
+      id: 4,
       combinator: "and",
       rules: [
         {
-          id: 2,
-          attribute: "price",
-          operator: "lessThan",
-          value: 10,
+          id: 5,
+          attribute: "in_stock",
+          operator: "equalsTo",
+          value: true,
         },
         {
-          id: 4,
-          combinator: "and",
-          rules: [
-            {
-              id: 5,
-              attribute: "in_stock",
-              operator: "equalsTo",
-              value: true,
-            },
-            {
-              id: 6,
-              attribute: "release",
-              operator: "greaterThan",
-              value: {
-                date: "2021-01-01",
-                time: "00:00:00",
-              },
-            },
-          ],
+          id: 6,
+          attribute: "release",
+          operator: "greaterThan",
+          value: {
+            date: "2021-01-01",
+            time: "00:00:00",
+          },
         },
       ],
-    }),
-    []
-  );
-
-  const [, setMongoQuery] = useState(queryToMongo(initialQuery));
-
-  return (
-    <HvQueryBuilder
-      readOnly
-      attributes={attributes}
-      query={initialQuery}
-      onChange={(query) => {
-        setMongoQuery(queryToMongo(query));
-      }}
-    />
-  );
+    },
+    {
+      id: 7,
+      combinator: "or",
+      rules: [
+        {
+          id: 8,
+          attribute: "in_stock",
+          operator: "equalsTo",
+          value: false,
+        },
+      ],
+    },
+  ],
 };
 
 describe("QueryBuilder", () => {
   describe("structure", () => {
     it("renders the component as expected", () => {
-      const { getByRole, getByText } = render(<Main />);
+      render(<QueryBuilder />);
 
-      const noConditions = getByText("No conditions created yet");
+      const noConditions = screen.getByText("No conditions created yet");
       expect(noConditions).toBeInTheDocument();
 
-      const andButton = getByRole("button", { name: /AND/i });
+      const andButton = screen.getByRole("button", { name: /AND/i });
       expect(andButton).toBeInTheDocument();
 
-      const orButton = getByRole("button", { name: /OR/i });
+      const orButton = screen.getByRole("button", { name: /OR/i });
       expect(orButton).toBeInTheDocument();
 
-      const addConditionButton = getByRole("button", {
+      const addConditionButton = screen.getByRole("button", {
         name: /Add condition/i,
       });
       expect(addConditionButton).toBeInTheDocument();
 
-      const createConditionLink = getByText("Create a condition");
+      const createConditionLink = screen.getByText("Create a condition");
       expect(createConditionLink).toBeInTheDocument();
 
-      const addGroupButton = getByRole("button", { name: /Add group/i });
+      const addGroupButton = screen.getByRole("button", { name: /Add group/i });
       expect(addGroupButton).toBeInTheDocument();
 
-      const createGroupLink = getByText("condition group");
+      const createGroupLink = screen.getByText("condition group");
       expect(createGroupLink).toBeInTheDocument();
     });
   });
 
   describe("interaction", () => {
     it("adds new condition (button)", async () => {
-      const { getByRole, getByText, findByRole } = render(<Main />);
+      render(<QueryBuilder />);
 
-      const noConditions = getByText("No conditions created yet");
+      const noConditions = screen.getByText("No conditions created yet");
       expect(noConditions).toBeInTheDocument();
 
-      const addConditionButton = getByRole("button", {
+      const addConditionButton = screen.getByRole("button", {
         name: /Add condition/i,
       });
       expect(addConditionButton).toBeInTheDocument();
 
       userEvent.click(addConditionButton);
 
-      const attributeDropdown = await findByRole("combobox", {
+      const attributeDropdown = await screen.findByRole("combobox", {
         name: /Attribute/i,
       });
       expect(attributeDropdown).toBeInTheDocument();
@@ -262,145 +134,153 @@ describe("QueryBuilder", () => {
     });
 
     it("adds new condition (link)", async () => {
-      const { getByText, findByRole } = render(<Main />);
+      render(<QueryBuilder />);
 
-      const noConditions = getByText("No conditions created yet");
+      const noConditions = screen.getByText("No conditions created yet");
       expect(noConditions).toBeInTheDocument();
 
-      const createConditionLink = getByText("Create a condition");
+      const createConditionLink = screen.getByRole("button", {
+        name: /Create a condition/i,
+      });
       expect(createConditionLink).toBeInTheDocument();
 
       userEvent.click(createConditionLink);
 
-      const attributeDropdown = await findByRole("combobox", {
+      const attributeDropdown = await screen.findByRole("combobox", {
         name: /Attribute/i,
       });
       expect(attributeDropdown).toBeInTheDocument();
       expect(noConditions).not.toBeInTheDocument();
     });
-    it("adds new group (button)", async () => {
-      const { getByRole, getByText, findAllByRole, findByRole } = render(
-        <Main />
-      );
 
-      const noConditions = getByText("No conditions created yet");
+    it("adds new group (button)", async () => {
+      render(<QueryBuilder />);
+
+      const noConditions = screen.getByText("No conditions created yet");
       expect(noConditions).toBeInTheDocument();
 
-      const addGroupButton = getByRole("button", { name: /Add group/i });
+      const addGroupButton = screen.getByRole("button", { name: /Add group/i });
       expect(addGroupButton).toBeInTheDocument();
 
       userEvent.click(addGroupButton);
 
-      const attributeDropdown = await findByRole("combobox", {
+      const attributeDropdown = await screen.findByRole("combobox", {
         name: /Attribute/i,
       });
       expect(attributeDropdown).toBeInTheDocument();
       expect(noConditions).not.toBeInTheDocument();
 
-      const andButtons = await findAllByRole("button", { name: /AND/i });
+      const andButtons = await screen.findAllByRole("button", { name: /AND/i });
       expect(andButtons).toHaveLength(2);
 
-      const addConditionButtons = await findAllByRole("button", {
+      const addConditionButtons = await screen.findAllByRole("button", {
         name: /Add condition/i,
       });
       expect(addConditionButtons).toHaveLength(2);
     });
 
     it("adds new group (link)", async () => {
-      const { getByText, findAllByRole, findByRole } = render(<Main />);
+      render(<QueryBuilder />);
 
-      const noConditions = getByText("No conditions created yet");
+      const noConditions = screen.getByText("No conditions created yet");
       expect(noConditions).toBeInTheDocument();
 
-      const createGroupLink = getByText("condition group");
+      const createGroupLink = screen.getByRole("button", {
+        name: /condition group/i,
+      });
       expect(createGroupLink).toBeInTheDocument();
 
       userEvent.click(createGroupLink);
 
-      const attributeDropdown = await findByRole("combobox", {
+      const attributeDropdown = await screen.findByRole("combobox", {
         name: /Attribute/i,
       });
       expect(attributeDropdown).toBeInTheDocument();
       expect(noConditions).not.toBeInTheDocument();
 
-      const andButton = await findAllByRole("button", { name: /AND/i });
+      const andButton = await screen.findAllByRole("button", { name: /AND/i });
       expect(andButton).toHaveLength(2);
 
-      const addConditionButtons = await findAllByRole("button", {
+      const addConditionButtons = await screen.findAllByRole("button", {
         name: /Add condition/i,
       });
       expect(addConditionButtons).toHaveLength(2);
     });
 
     it("removes created condition", async () => {
-      const { getByRole, findByText, findByRole } = render(<Main />);
+      render(<QueryBuilder />);
 
-      const addConditionButton = getByRole("button", {
+      const addConditionButton = screen.getByRole("button", {
         name: /Add condition/i,
       });
       expect(addConditionButton).toBeInTheDocument();
 
       userEvent.click(addConditionButton);
 
-      const attributeDropdown = await findByRole("combobox", {
+      const attributeDropdown = await screen.findByRole("combobox", {
         name: /Attribute/i,
       });
       expect(attributeDropdown).toBeInTheDocument();
 
-      const removeConditionButton = getByRole("button", {
+      const removeConditionButton = screen.getByRole("button", {
         name: /Remove condition/i,
       });
       expect(removeConditionButton).toBeInTheDocument();
 
       userEvent.click(removeConditionButton);
 
-      const confirmButton = await findByRole("button", { name: /Yes/i });
+      const confirmButton = await screen.findByRole("button", { name: /Yes/i });
       expect(confirmButton).toBeInTheDocument();
 
       userEvent.click(confirmButton);
 
-      const noConditions = await findByText("No conditions created yet");
+      const noConditions = await screen.findByText("No conditions created yet");
       expect(noConditions).toBeInTheDocument();
     });
 
     it("removes created group", async () => {
-      const { getByRole, findByRole, findByText } = render(<Main />);
+      render(<QueryBuilder />);
 
-      const addGroupButton = getByRole("button", { name: /Add group/i });
+      const addGroupButton = screen.getByRole("button", { name: /Add group/i });
       expect(addGroupButton).toBeInTheDocument();
 
       userEvent.click(addGroupButton);
 
-      const removeGroupButton = await findByRole("button", {
+      const removeGroupButton = await screen.findByRole("button", {
         name: /Remove group/i,
       });
       expect(removeGroupButton).toBeInTheDocument();
 
       userEvent.click(removeGroupButton);
 
-      const confirmButton = await findByRole("button", { name: /Yes/i });
+      const confirmButton = await screen.findByRole("button", { name: /Yes/i });
       expect(confirmButton).toBeInTheDocument();
 
       userEvent.click(confirmButton);
 
-      const noConditions = await findByText("No conditions created yet");
+      const noConditions = await screen.findByText("No conditions created yet");
       expect(noConditions).toBeInTheDocument();
     });
   });
 
   describe("initial query", () => {
-    it("matches snapshot", () => {
-      const { container } = render(<InitialQuery />);
+    it("renders the query ", () => {
+      render(<QueryBuilder query={initialQuery} />);
 
-      expect(container).toBeDefined();
+      expect(() => screen.getByText("No conditions created yet")).toThrow();
+
+      const attrDropdowns = screen.getAllByRole("combobox", {
+        name: /Attribute/i,
+      });
+      expect(attrDropdowns).toHaveLength(5);
     });
   });
 
   describe("read only", () => {
     it("should not be interactable", () => {
-      const { getAllByRole } = render(<ReadOnly />);
+      render(<QueryBuilder readOnly />);
 
-      const buttons = getAllByRole("button");
+      const buttons = screen.getAllByRole("button");
       buttons.map((b) => expect(b).toBeDisabled());
     });
   });

--- a/packages/core/src/QueryBuilder/RuleGroup/RuleGroup.tsx
+++ b/packages/core/src/QueryBuilder/RuleGroup/RuleGroup.tsx
@@ -7,7 +7,6 @@ import { HvMultiButton } from "../../MultiButton";
 import { HvTypography } from "../../Typography";
 import { IconButton } from "../../utils/IconButton";
 import { ExtractNames } from "../../utils/classes";
-
 import { Rule } from "../Rule";
 import { useQueryBuilderContext } from "../Context";
 import { useClasses } from "../QueryBuilder.styles";
@@ -199,6 +198,7 @@ export const RuleGroup = ({
                   dispatchAction({ type: "add-rule", id });
                 }}
                 className={classes.createConditionButton}
+                disabled={readOnly}
               >
                 {`${labels.empty?.createCondition}`}
               </HvTypography>
@@ -212,6 +212,7 @@ export const RuleGroup = ({
                       dispatchAction({ type: "add-group", id });
                     }}
                     className={classes.createGroupButton}
+                    disabled={readOnly}
                   >
                     {`${labels.empty?.createGroup}`}
                   </HvTypography>

--- a/packages/core/src/Typography/Typography.tsx
+++ b/packages/core/src/Typography/Typography.tsx
@@ -4,7 +4,6 @@ import { PolymorphicComponentRef, PolymorphicRef } from "../types/generic";
 import { ExtractNames } from "../utils/classes";
 import { useTheme } from "../hooks/useTheme";
 import { useDefaultProps } from "../hooks/useDefaultProps";
-
 import {
   HvTypographyLegacyVariants,
   HvTypographyVariants,
@@ -92,9 +91,9 @@ export const HvTypography: <C extends React.ElementType = "p">(
       classes: classesProp,
       variant: variantProp = "body",
       link = false,
-      disabled = false,
       noWrap = false,
       paragraph = false,
+      disabled = false,
       ...others
     } = useDefaultProps("HvTypography", props);
     const { classes, cx } = useClasses(classesProp);
@@ -118,6 +117,7 @@ export const HvTypography: <C extends React.ElementType = "p">(
           },
           className
         )}
+        disabled={disabled}
         {...others}
       />
     );


### PR DESCRIPTION
- New query builder tests added [as requested](https://github.com/lumada-design/hv-uikit-react/pull/3908#pullrequestreview-1789361870)
- Query builder tests updated
- 2 bugs fixed:
   - In read only mode, some buttons were not disabled in the query builder
   - The `disabled` prop was extracted and not passed down to the typography component 