### PR TITLE
chore(Flow): samples refactored and simplified

### DIFF
--- a/packages/lab/src/Flow/stories/CustomDrop/BarChart.tsx
+++ b/packages/lab/src/Flow/stories/CustomDrop/BarChart.tsx
@@ -1,17 +1,18 @@
 import { css } from "@emotion/css";
-import { HvFlowNode, HvFlowNodeFC } from "@hitachivantara/uikit-react-lab";
+import {
+  HvFlowNode,
+  HvFlowNodeFC,
+  useFlowInputNodes,
+} from "@hitachivantara/uikit-react-lab";
 import { HvBarChart } from "@hitachivantara/uikit-react-viz";
-import { useEdges, useNodes } from "reactflow";
 
 import { NodeData, data } from "./data";
 import type { NodeGroups } from ".";
 
 export const BarChart: HvFlowNodeFC<NodeGroups> = (props) => {
   const { id } = props;
-  const nodes = useNodes<NodeData>();
-  const edges = useEdges();
-  const dataNodeId = edges.find((e) => e.target === id)?.source;
-  const dataNode = nodes.find((n) => n.id === dataNodeId);
+  const inputNodes = useFlowInputNodes<NodeData>(id);
+  const country = inputNodes[0]?.data.country;
 
   return (
     <HvFlowNode
@@ -23,18 +24,19 @@ export const BarChart: HvFlowNodeFC<NodeGroups> = (props) => {
           label: "Data",
           isMandatory: true,
           accepts: ["data"],
+          maxConnections: 1,
         },
       ]}
       {...props}
     >
-      {dataNode && dataNode.data && dataNode.data.country && (
+      {country && (
         <div
           className={css({
             height: 300,
           })}
         >
           <HvBarChart
-            data={data[dataNode.data.country]}
+            data={data[country]}
             groupBy="Month"
             measures="Precipitation"
             yAxis={{

--- a/packages/lab/src/Flow/stories/CustomDrop/LineChart.tsx
+++ b/packages/lab/src/Flow/stories/CustomDrop/LineChart.tsx
@@ -1,17 +1,18 @@
 import { css } from "@emotion/css";
-import { HvFlowNode, HvFlowNodeFC } from "@hitachivantara/uikit-react-lab";
+import {
+  HvFlowNode,
+  HvFlowNodeFC,
+  useFlowInputNodes,
+} from "@hitachivantara/uikit-react-lab";
 import { HvLineChart } from "@hitachivantara/uikit-react-viz";
-import { useEdges, useNodes } from "reactflow";
 
 import { NodeData, data } from "./data";
 import type { NodeGroups } from ".";
 
 export const LineChart: HvFlowNodeFC<NodeGroups> = (props) => {
   const { id } = props;
-  const nodes = useNodes<NodeData>();
-  const edges = useEdges();
-  const dataNodeId = edges.find((e) => e.target === id)?.source;
-  const dataNode = nodes.find((n) => n.id === dataNodeId);
+  const inputNodes = useFlowInputNodes<NodeData>(id);
+  const country = inputNodes[0]?.data.country;
 
   return (
     <HvFlowNode
@@ -23,18 +24,19 @@ export const LineChart: HvFlowNodeFC<NodeGroups> = (props) => {
           label: "Data",
           isMandatory: true,
           accepts: ["data"],
+          maxConnections: 1,
         },
       ]}
       {...props}
     >
-      {dataNode && dataNode.data && dataNode.data.country && (
+      {country && (
         <div
           className={css({
             height: 300,
           })}
         >
           <HvLineChart
-            data={data[dataNode.data.country]}
+            data={data[country]}
             groupBy="Month"
             measures="Precipitation"
             yAxis={{

--- a/packages/lab/src/Flow/stories/Visualizations/BarChart.tsx
+++ b/packages/lab/src/Flow/stories/Visualizations/BarChart.tsx
@@ -1,18 +1,18 @@
 import { css } from "@emotion/css";
-import { HvFlowNode, HvFlowNodeFC } from "@hitachivantara/uikit-react-lab";
+import {
+  HvFlowNode,
+  HvFlowNodeFC,
+  useFlowInputNodes,
+} from "@hitachivantara/uikit-react-lab";
 import { HvBarChart } from "@hitachivantara/uikit-react-viz";
-import { useEdges, useNodes } from "reactflow";
 
 import type { NodeData } from "./data";
 import type { NodeGroups } from ".";
 
 export const BarChart: HvFlowNodeFC<NodeGroups> = (props) => {
   const { id } = props;
-  const nodes = useNodes<NodeData>();
-  const edges = useEdges();
-  const dataNodeId = edges.find((e) => e.target === id)?.source;
-
-  const dataNode = nodes.find((n) => n.id === dataNodeId);
+  const inputNodes = useFlowInputNodes<NodeData>(id);
+  const jsonData = inputNodes[0]?.data.jsonData;
 
   return (
     <HvFlowNode
@@ -24,14 +24,15 @@ export const BarChart: HvFlowNodeFC<NodeGroups> = (props) => {
           label: "Data",
           isMandatory: true,
           accepts: ["jsonData"],
+          maxConnections: 1,
         },
       ]}
       {...props}
     >
-      {dataNode?.data?.jsonData && dataNode.data.jsonData.length > 0 && (
+      {jsonData && jsonData.length > 0 && (
         <div className={css({ height: 300 })}>
           <HvBarChart
-            data={dataNode.data.jsonData}
+            data={jsonData}
             splitBy="country"
             groupBy="year"
             measures="population"

--- a/packages/lab/src/Flow/stories/Visualizations/JsonInput.tsx
+++ b/packages/lab/src/Flow/stories/Visualizations/JsonInput.tsx
@@ -1,5 +1,7 @@
 import { HvFlowNode, HvFlowNodeFC } from "@hitachivantara/uikit-react-lab";
 
+import { data } from "./data";
+
 export const JsonInput: HvFlowNodeFC = (props) => {
   return (
     <HvFlowNode
@@ -19,4 +21,7 @@ export const JsonInput: HvFlowNodeFC = (props) => {
 JsonInput.meta = {
   label: "Json Input",
   groupId: "inputs",
+  data: {
+    jsonData: data,
+  },
 };

--- a/packages/lab/src/Flow/stories/Visualizations/LineChart.tsx
+++ b/packages/lab/src/Flow/stories/Visualizations/LineChart.tsx
@@ -1,17 +1,17 @@
 import { css } from "@emotion/css";
-import { useEdges, useNodes } from "reactflow";
-import { HvFlowNode, HvFlowNodeFC } from "@hitachivantara/uikit-react-lab";
+import {
+  HvFlowNode,
+  HvFlowNodeFC,
+  useFlowInputNodes,
+} from "@hitachivantara/uikit-react-lab";
 import { HvLineChart } from "@hitachivantara/uikit-react-viz";
 
 import { NodeData } from "./data";
 
 export const LineChart: HvFlowNodeFC = (props) => {
   const { id } = props;
-  const nodes = useNodes<NodeData>();
-  const edges = useEdges();
-  const dataNodeId = edges.find((e) => e.target === id)?.source;
-
-  const dataNode = nodes.find((n) => n.id === dataNodeId);
+  const inputNodes = useFlowInputNodes<NodeData>(id);
+  const jsonData = inputNodes[0]?.data.jsonData;
 
   return (
     <HvFlowNode
@@ -23,14 +23,15 @@ export const LineChart: HvFlowNodeFC = (props) => {
           label: "Data",
           isMandatory: true,
           accepts: ["jsonData"],
+          maxConnections: 1,
         },
       ]}
       {...props}
     >
-      {dataNode?.data?.jsonData && dataNode.data.jsonData.length > 0 && (
+      {jsonData && jsonData.length > 0 && (
         <div className={css({ height: 300 })}>
           <HvLineChart
-            data={dataNode.data.jsonData}
+            data={jsonData}
             splitBy="country"
             groupBy="year"
             measures="population"


### PR DESCRIPTION
- The flow samples were refactored to use our internal hooks and simplify the code
- The `JsonInput` node from the "Visualizations" sample was fixed: when new json input nodes were added, the data was not linked to them.