### PR TITLE
feat(VerticalNavigation): allow passing icons to use when in collapsible mode

### DIFF
--- a/packages/core/src/VerticalNavigation/Header/Header.tsx
+++ b/packages/core/src/VerticalNavigation/Header/Header.tsx
@@ -53,8 +53,8 @@ export interface HvVerticalNavigationHeaderProps {
 
 export const HvVerticalNavigationHeader = ({
   title,
-  openIcon = <Forwards />,
-  closeIcon = <Backwards />,
+  openIcon: openIconProp,
+  closeIcon: closeIconProp,
   collapseButtonProps,
   backButtonProps,
   className,
@@ -73,7 +73,8 @@ export const HvVerticalNavigationHeader = ({
 
   const { classes, cx } = useClasses(classesProp);
 
-  openIcon = !useIcons ? <Menu /> : openIcon;
+  const openIcon = openIconProp ?? (!useIcons ? <Menu /> : <Forwards />);
+  const closeIcon = closeIconProp ?? <Backwards />;
 
   const backButtonClickHandler = () => {
     if (navigateToParentHandler) navigateToParentHandler();


### PR DESCRIPTION
- I opted to simply remove the limitation we had on what open icon to use so now we can set an `openIcon` and a `closeIcon` to use in all cases