### PR TITLE
build: rename ESM files to `.mjs`

### DIFF
--- a/.config/vite.config.ts
+++ b/.config/vite.config.ts
@@ -6,7 +6,7 @@ import tsconfigPaths from "vite-tsconfig-paths";
 
 const pkg = require(resolve(process.cwd(), "package.json"));
 
-// dependecies that should not be bundled.
+// dependencies that should not be bundled.
 const external = [
   ...Object.keys(pkg.dependencies || {}),
   ...Object.keys(pkg.peerDependencies || {}),
@@ -36,7 +36,7 @@ export default defineConfig({
           format: "esm",
           preserveModules: true,
           dir: "dist/esm",
-          entryFileNames: "[name].js",
+          entryFileNames: "[name].mjs",
           sourcemap: true,
           exports: "named",
           interop: "auto",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "scripts": {
     "dev": "npm run dev -w app",
     "doc": "storybook dev -p 6006",
+    "clean": "lerna run clean",
     "build": "lerna run build",
     "build:doc": "storybook build -o dist --quiet && node scripts/storybook-title",
     "build:app": "vite build app",

--- a/packages/code-editor/package.json
+++ b/packages/code-editor/package.json
@@ -56,12 +56,12 @@
     "access": "public",
     "directory": "package",
     "main": "dist/cjs/index.cjs",
-    "module": "dist/esm/index.js",
+    "module": "dist/esm/index.mjs",
     "types": "dist/types/index.d.ts",
     "exports": {
       ".": {
         "require": "./dist/cjs/index.cjs",
-        "import": "./dist/esm/index.js"
+        "import": "./dist/esm/index.mjs"
       }
     }
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -88,12 +88,12 @@
     "access": "public",
     "directory": "package",
     "main": "dist/cjs/index.cjs",
-    "module": "dist/esm/index.js",
+    "module": "dist/esm/index.mjs",
     "types": "dist/types/index.d.ts",
     "exports": {
       ".": {
         "require": "./dist/cjs/index.cjs",
-        "import": "./dist/esm/index.js"
+        "import": "./dist/esm/index.mjs"
       }
     }
   },

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -66,12 +66,12 @@
     "access": "public",
     "directory": "package",
     "main": "dist/cjs/index.cjs",
-    "module": "dist/esm/index.js",
+    "module": "dist/esm/index.mjs",
     "types": "dist/types/index.d.ts",
     "exports": {
       ".": {
         "require": "./dist/cjs/index.cjs",
-        "import": "./dist/esm/index.js"
+        "import": "./dist/esm/index.mjs"
       }
     }
   },

--- a/packages/lab/package.json
+++ b/packages/lab/package.json
@@ -72,12 +72,12 @@
     "access": "public",
     "directory": "package",
     "main": "dist/cjs/index.cjs",
-    "module": "dist/esm/index.js",
+    "module": "dist/esm/index.mjs",
     "types": "dist/types/index.d.ts",
     "exports": {
       ".": {
         "require": "./dist/cjs/index.cjs",
-        "import": "./dist/esm/index.js"
+        "import": "./dist/esm/index.mjs"
       }
     }
   },

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -49,12 +49,12 @@
     "access": "public",
     "directory": "package",
     "main": "dist/cjs/index.cjs",
-    "module": "dist/esm/index.js",
+    "module": "dist/esm/index.mjs",
     "types": "dist/types/index.d.ts",
     "exports": {
       ".": {
         "require": "./dist/cjs/index.cjs",
-        "import": "./dist/esm/index.js"
+        "import": "./dist/esm/index.mjs"
       },
       "./package.json": "./package.json",
       "./bundles/*": "./dist/bundles/*"

--- a/packages/styles/package.json
+++ b/packages/styles/package.json
@@ -33,12 +33,12 @@
     "access": "public",
     "directory": "package",
     "main": "dist/cjs/index.cjs",
-    "module": "dist/esm/index.js",
+    "module": "dist/esm/index.mjs",
     "types": "dist/types/index.d.ts",
     "exports": {
       ".": {
         "require": "./dist/cjs/index.cjs",
-        "import": "./dist/esm/index.js"
+        "import": "./dist/esm/index.mjs"
       }
     }
   },

--- a/packages/uno-preset/package.json
+++ b/packages/uno-preset/package.json
@@ -42,12 +42,12 @@
     "access": "public",
     "directory": "package",
     "main": "dist/cjs/index.cjs",
-    "module": "dist/esm/index.js",
+    "module": "dist/esm/index.mjs",
     "types": "dist/types/index.d.ts",
     "exports": {
       ".": {
         "require": "./dist/cjs/index.cjs",
-        "import": "./dist/esm/index.js"
+        "import": "./dist/esm/index.mjs"
       }
     }
   },

--- a/packages/viz/package.json
+++ b/packages/viz/package.json
@@ -56,12 +56,12 @@
     "access": "public",
     "directory": "package",
     "main": "dist/cjs/index.cjs",
-    "module": "dist/esm/index.js",
+    "module": "dist/esm/index.mjs",
     "types": "dist/types/index.d.ts",
     "exports": {
       ".": {
         "require": "./dist/cjs/index.cjs",
-        "import": "./dist/esm/index.js"
+        "import": "./dist/esm/index.mjs"
       }
     }
   },


### PR DESCRIPTION
Our packages are CJS by default, but our `.js` files have ESM code. This leads to errors in ESM packages (`type: "module"` in the `package.json`)

Examples of this issue:
- [Minimal NodeJS package](https://stackblitz.com/edit/stackblitz-starters-vwjs5a?file=index.js)
- [App Shell vite configuration](https://stackblitz.com/edit/github-agjraf?file=vite.config.ts) (requires an ESM package)

This PR
- adds the `.mjs` to the ESM files
- adds top-level clean script
  - useful to cleanup the `dist` & `package` folders

validated by publishing packages to verdaccio