### PR TITLE
refactor(Flow): replace deprecated project for screenToFlowPosition

### DIFF
--- a/packages/lab/src/Flow/DroppableFlow.tsx
+++ b/packages/lab/src/Flow/DroppableFlow.tsx
@@ -162,10 +162,10 @@ export const HvDroppableFlow = ({
         return;
       }
 
-      // Converts the coordinates to the react flow coordinate system
-      const position = reactFlowInstance.project({
-        x: (hvFlow?.x || 0) - event.over.rect.left,
-        y: (hvFlow?.y || 0) - event.over.rect.top,
+      // Position node in the flow
+      const position = reactFlowInstance.screenToFlowPosition({
+        x: hvFlow?.x || 0,
+        y: hvFlow?.y || 0,
       });
 
       // Node data


### PR DESCRIPTION
- `project` replaced by `screenToFlowPosition` since it's now deprecated as mentioned [here](https://github.com/xyflow/xyflow/releases/tag/11.10.0)