### PR TITLE
feat(Flow): add footer section to the `BaseNode` component

### DIFF
--- a/packages/lab/src/Flow/Node/BaseNode.styles.tsx
+++ b/packages/lab/src/Flow/Node/BaseNode.styles.tsx
@@ -29,16 +29,16 @@ export const { staticClasses, useClasses } = createClasses("HvFlowBaseNode", {
     justifyContent: "center",
     padding: theme.space.xs,
     backgroundColor: theme.colors.atmo2,
-    borderTop: `1px solid ${theme.colors.atmo4}`,
-    borderBottom: `1px solid ${theme.colors.atmo4}`,
+    borderTop: `1px solid ${theme.colors.atmo3}`,
+    borderBottom: `1px solid ${theme.colors.atmo3}`,
   },
   outputsTitleContainer: {
     display: "flex",
     justifyContent: "center",
     padding: theme.space.xs,
     backgroundColor: theme.colors.atmo2,
-    borderTop: `1px solid ${theme.colors.atmo4}`,
-    borderBottom: `1px solid ${theme.colors.atmo4}`,
+    borderTop: `1px solid ${theme.colors.atmo3}`,
+    borderBottom: `1px solid ${theme.colors.atmo3}`,
   },
   contentContainer: {},
   inputsContainer: {
@@ -59,11 +59,19 @@ export const { staticClasses, useClasses } = createClasses("HvFlowBaseNode", {
     display: "flex",
     flexDirection: "row",
     alignItems: "center",
+    position: "relative",
+    "& .react-flow__handle-left": {
+      left: -20,
+    },
   },
   outputContainer: {
     display: "flex",
     flexDirection: "row",
     alignItems: "center",
+    position: "relative",
+    "& .react-flow__handle-right": {
+      right: -20,
+    },
   },
   mandatory: {
     width: 10,
@@ -71,5 +79,9 @@ export const { staticClasses, useClasses } = createClasses("HvFlowBaseNode", {
     margin: theme.spacing(0, theme.space.xs),
     borderRadius: theme.radii.circle,
     backgroundColor: theme.colors.negative_20,
+  },
+  footerContainer: {
+    padding: theme.space.sm,
+    borderTop: `1px solid ${theme.colors.atmo3}`,
   },
 });

--- a/packages/lab/src/Flow/Node/BaseNode.tsx
+++ b/packages/lab/src/Flow/Node/BaseNode.tsx
@@ -1,4 +1,4 @@
-import { isValidElement, useCallback, useEffect, useState } from "react";
+import React, { isValidElement, useCallback, useEffect, useState } from "react";
 import {
   Edge,
   Handle,
@@ -53,6 +53,8 @@ export interface HvFlowBaseNodeProps<T = any>
   outputs?: HvFlowNodeOutput[];
   /** Node actions */
   nodeActions?: HvFlowNodeAction[];
+  /** The content of the Node footer */
+  footer?: React.ReactNode;
   /** A Jss Object used to override or extend the styles applied to the component. */
   classes?: HvFlowBaseNodeClasses;
 }
@@ -90,6 +92,7 @@ export const HvFlowBaseNode = ({
   inputs,
   outputs,
   nodeActions = defaultActions,
+  footer,
   classes: classesProp,
   className,
   children,
@@ -210,13 +213,6 @@ export const HvFlowBaseNode = ({
                     isConnectableStart={false}
                     id={handleId}
                     position={Position.Left}
-                    style={{
-                      top: "auto",
-                      bottom:
-                        (outputs?.length ? 80 : 18) +
-                        (outputs?.length || 0) * 29 +
-                        29 * idx,
-                    }}
                   />
                   <HvTypography>{input.label}</HvTypography>
                   {input.isMandatory &&
@@ -244,10 +240,6 @@ export const HvFlowBaseNode = ({
                     isConnectableEnd={false}
                     id={handleId}
                     position={Position.Right}
-                    style={{
-                      bottom: -10 + 29 * (outputs.length - idx),
-                      top: "auto",
-                    }}
                   />
                   {output.isMandatory &&
                     !isInputConnected(id, "source", handleId, outputEdges) && (
@@ -260,6 +252,7 @@ export const HvFlowBaseNode = ({
           </div>
         </>
       )}
+      {footer && <div className={classes.footerContainer}>{footer}</div>}
     </div>
   );
 };

--- a/packages/lab/src/Flow/stories/Usage.stories.mdx
+++ b/packages/lab/src/Flow/stories/Usage.stories.mdx
@@ -24,6 +24,7 @@ Summary:
   - [Default actions](#default-actions)
   - [Custom actions](#custom-actions)
 - [Custom content](#custom-content)
+- [Footer](#footer)
 - [Advanced use](#advanced-use)
   - [Accessing the React Flow instance](#react-flow-instance)
   - [Saving and exporting data](#saving-and-exporting-data)
@@ -334,6 +335,17 @@ const handleAction = (event: any, id: string, action: any) => {
   actionCallback={handleAction}
   {...props}
 />;
+```
+
+## Footer <a id="footer" />
+
+You can pass any content to the footer of the Node through the `footer` property:
+
+```tsx
+<HvFlowNode
+  (...)
+  footer={<div>My footer content</div>}
+/>
 ```
 
 ## Custom content <a id="custom-content" />


### PR DESCRIPTION
- Added the footer property to allow passing any content to the footer section of the `Node` component.
- Simplified the placing of the handles to remove unnecessary calculations to set it's positioning. 
- Updated docs