### PR TITLE
fix(Slider): fix marks layout

### DIFF
--- a/packages/core/src/Slider/Slider.test.tsx
+++ b/packages/core/src/Slider/Slider.test.tsx
@@ -135,6 +135,31 @@ describe("Slider", () => {
       const text = queryByRole("Failure Rate");
       expect(text).not.toBeInTheDocument();
     });
+
+    it("renders the slider with the correct marks", () => {
+      const { getByText } = render(
+        <HvSlider
+          knobProps={[{ "aria-label": "no-label-knob" }]}
+          hideInput
+          minPointValue={0}
+          maxPointValue={100}
+          divisionQuantity={100}
+          markStep={25}
+        />
+      );
+
+      const zeroMark = getByText("0");
+      const twentyFiveMark = getByText("25");
+      const fiftyMark = getByText("50");
+      const seventyFiveMark = getByText("75");
+      const oneHundredMark = getByText("100");
+
+      expect(zeroMark).toBeInTheDocument();
+      expect(twentyFiveMark).toBeInTheDocument();
+      expect(fiftyMark).toBeInTheDocument();
+      expect(seventyFiveMark).toBeInTheDocument();
+      expect(oneHundredMark).toBeInTheDocument();
+    });
   });
 
   describe("interactions", () => {

--- a/packages/core/src/Slider/Slider.tsx
+++ b/packages/core/src/Slider/Slider.tsx
@@ -245,8 +245,8 @@ export const HvSlider = forwardRef<SliderRef, HvSliderProps>((props, ref) => {
       createMark(
         markProperties,
         markStep,
-        divisionQuantity,
         minPointValue,
+        maxPointValue,
         stepValue,
         markDigits,
         !!disabled,
@@ -254,12 +254,12 @@ export const HvSlider = forwardRef<SliderRef, HvSliderProps>((props, ref) => {
       ),
     [
       disabled,
-      divisionQuantity,
       formatMark,
       markDigits,
       markProperties,
       markStep,
       minPointValue,
+      maxPointValue,
       stepValue,
     ]
   );

--- a/packages/core/src/Slider/utils.ts
+++ b/packages/core/src/Slider/utils.ts
@@ -3,9 +3,11 @@ import { CSSProperties } from "react";
 import { theme } from "@hitachivantara/uikit-styles";
 
 import validationStates from "../Forms/FormElement/validationStates";
+
 import { HvFormStatus } from "../Forms";
 
 import { HvKnobProperty, HvMarkProperty } from "./types";
+
 import { sliderStyles as styles } from "./Slider.styles";
 
 /**
@@ -18,8 +20,11 @@ import { sliderStyles as styles } from "./Slider.styles";
 export const knobsPositionToScaledValue = (
   sliderValue: number,
   minPointValue: number,
-  stepValue: number
-): number => minPointValue + stepValue * sliderValue;
+  stepValue: number,
+  isMark?: boolean
+): number => {
+  return isMark ? sliderValue : minPointValue + stepValue * sliderValue;
+};
 
 /**
  * Transform the scaled values into knobs positions.
@@ -128,8 +133,8 @@ export const calculateStepValue = (
 export const createMark = (
   markProperties: HvMarkProperty[],
   markstep: number,
-  divisionQuantity: number,
   minPointValue: number,
+  maxPointValue: number,
   stepValue: number,
   markDigits: number,
   disabled: boolean,
@@ -168,11 +173,12 @@ export const createMark = (
   } else {
     const roundedMarkStep = Math.floor(markstep);
 
-    for (let index = 0; index <= divisionQuantity; index += roundedMarkStep) {
+    for (let index = 0; index <= maxPointValue; index += roundedMarkStep) {
       let labelValue: React.ReactNode = knobsPositionToScaledValue(
         index,
         minPointValue,
-        stepValue
+        stepValue,
+        true
       ).toFixed(markDigits);
 
       labelValue = formatMark?.(labelValue) || labelValue;
@@ -187,6 +193,7 @@ export const createMark = (
         : {
             label: `${labelValue}`,
             style: {
+              left: `${labelValue}%`,
               ...styles.mark,
             },
           };


### PR DESCRIPTION
- The same function was being used to calculate values for both the knobs and the marks hence why it sometimes worked (actually most of the times it didn't work), but it should be two distinct calculations as the knob might be dragged at one step interval and the marks be drawned at another (even if it doesn't make much sense, those are two different things)