### PR TITLE
fix(TableCell): transparent background for sorted sticky columns

### DIFF
--- a/packages/core/src/Table/TableCell/TableCell.styles.tsx
+++ b/packages/core/src/Table/TableCell/TableCell.styles.tsx
@@ -37,7 +37,7 @@ export const { staticClasses, useClasses } = createClasses("HvTableCell", {
     fontFamily: theme.fontFamily.body,
 
     "&$sorted": {
-      backgroundColor: sortedColor,
+      backgroundImage: `linear-gradient(to right, ${sortedColor}, ${sortedColor})`,
     },
   },
   /** Styles applied to the cell when it's in the table footer. */
@@ -125,14 +125,10 @@ export const { staticClasses, useClasses } = createClasses("HvTableCell", {
   stickyColumn: {
     position: "sticky",
     zIndex: 2,
-    background: theme.colors.atmo2,
+    backgroundColor: theme.colors.atmo2,
 
     "&$groupColumnMostRight+$stickyColumn": {
       borderLeft: 0,
-    },
-
-    "&$sorted": {
-      backgroundImage: `linear-gradient(to right, ${sortedColor}, ${sortedColor})`,
     },
   },
   /** Styles applied to the cell when it's part of the last sticky to the left column. */

--- a/packages/styles/src/themes/ds3.ts
+++ b/packages/styles/src/themes/ds3.ts
@@ -1244,7 +1244,10 @@ const ds3 = makeTheme((theme) => ({
         },
         body: {
           "&.HvTableCell-sorted": {
-            backgroundColor: theme.alpha("atmo1", 0.4),
+            backgroundImage: `linear-gradient(to right, ${theme.alpha(
+              "atmo1",
+              0.4
+            )}, ${theme.alpha("atmo1", 0.4)})`,
           },
         },
         variantListactions: {
@@ -1252,14 +1255,6 @@ const ds3 = makeTheme((theme) => ({
         },
         variantListcheckbox: {
           borderRight: `solid 2px ${theme.colors.atmo2}`,
-        },
-        stickyColumn: {
-          "&.HvTableCell-sorted": {
-            backgroundImage: `linear-gradient(to right, ${theme.alpha(
-              "atmo1",
-              0.4
-            )}, ${theme.alpha("atmo1", 0.4)})`,
-          },
         },
       },
     },


### PR DESCRIPTION
Addresses bug 2 of https://github.com/lumada-design/hv-uikit-react/issues/3933

After:

https://github.com/lumada-design/hv-uikit-react/assets/43220251/28bee0a8-3d70-4d4b-84e4-447289ab1236

