### PR TITLE
fix(Table): stop propagation for resizer

### DIFF
--- a/packages/core/src/Table/hooks/useResizeColumns.ts
+++ b/packages/core/src/Table/hooks/useResizeColumns.ts
@@ -1,3 +1,4 @@
+import { HTMLAttributes } from "react";
 import { ensurePluginOrder, Hooks } from "react-table";
 
 // #region ##### TYPES #####
@@ -6,6 +7,7 @@ import { ensurePluginOrder, Hooks } from "react-table";
 export interface UseHvResizeColumnProps {
   resizable?: boolean;
   resizing?: boolean;
+  resizerProps?: HTMLAttributes<HTMLDivElement>;
 }
 
 // getCellProps:
@@ -24,7 +26,13 @@ export type UseHvResizeColumnsProps = (<
 
 // props target: <table><thead><tr><th>
 const getHeaderPropsHook = (props, { column }) => {
-  const resizerProps: UseHvResizeColumnProps = column.getResizerProps?.() || {};
+  const resizerProps: NonNullable<UseHvResizeColumnProps["resizerProps"]> =
+    column.getResizerProps?.() || {};
+
+  resizerProps.onClick = (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+  };
 
   const nextProps = {
     resizable: column.canResize,


### PR DESCRIPTION
Addresses bug #3 of https://github.com/lumada-design/hv-uikit-react/issues/3933

After:

https://github.com/lumada-design/hv-uikit-react/assets/43220251/5dafac91-7250-4009-84a6-211e5e88a6e2

