### PR TITLE
fix(TableHeader): keep header sticky when sticky and resizable

### DIFF
--- a/packages/core/src/Table/TableHeader/TableHeader.tsx
+++ b/packages/core/src/Table/TableHeader/TableHeader.tsx
@@ -88,7 +88,7 @@ export const HvTableHeader = forwardRef<HTMLElement, HvTableHeaderProps>(
       children,
       component,
       className,
-      style,
+      style: styleProp,
       classes: classesProp,
       scope: scopeProp,
       align = "inherit",
@@ -135,6 +135,11 @@ export const HvTableHeader = forwardRef<HTMLElement, HvTableHeaderProps>(
         ? "columnheader"
         : "rowheader";
     const paragraph = isParagraph(children);
+
+    // Keep the header sticky
+    const style = stickyColumn
+      ? { ...styleProp, position: "sticky" }
+      : styleProp;
 
     return (
       <Component


### PR DESCRIPTION
Addresses bug #1 of https://github.com/lumada-design/hv-uikit-react/issues/3933

After:

https://github.com/lumada-design/hv-uikit-react/assets/43220251/5e6f2cbc-63f8-4834-b379-854ddf8eb8dd

