### PR TITLE
fix(FileUploader): validate function ESM import

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12595,14 +12595,6 @@
         "node": ">=8.0.0"
       }
     },
-    "node_modules/attr-accept": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/attr-accept/-/attr-accept-2.2.2.tgz",
-      "integrity": "sha512-7prDjvt9HmqiZ0cl5CRjtS84sEyhsHP2coDkaZKRKVfCDo9s7iw7ChVmar78Gu9pC4SoR/28wFu/G5JJhTnqEg==",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
@@ -36536,7 +36528,6 @@
         "@react-aria/datepicker": "^3.9.0",
         "@react-stately/datepicker": "^3.9.0",
         "@types/react-table": "^7.7.18",
-        "attr-accept": "^2.2.2",
         "clsx": "^2.0.0",
         "dayjs": "^1.11.10",
         "detect-browser": "^5.3.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -53,7 +53,6 @@
     "@react-aria/datepicker": "^3.9.0",
     "@react-stately/datepicker": "^3.9.0",
     "@types/react-table": "^7.7.18",
-    "attr-accept": "^2.2.2",
     "clsx": "^2.0.0",
     "dayjs": "^1.11.10",
     "detect-browser": "^5.3.0",

--- a/packages/core/src/FileUploader/DropZone/DropZone.test.tsx
+++ b/packages/core/src/FileUploader/DropZone/DropZone.test.tsx
@@ -14,7 +14,7 @@ const props: HvDropZoneProps = {
     fileSizeError: "The file exceeds the maximum upload size",
     fileTypeError: "File type not allowed for upload",
   },
-  acceptedFiles: ["jpg"],
+  accept: ".jpg",
   maxFileSize: 1,
 };
 
@@ -24,7 +24,7 @@ describe("DropZone", () => {
 
     expect(screen.getByText("Label", { selector: "label" })).toBeVisible();
     expect(
-      screen.getByText("Max. file size: 1.00B (jpg)", { selector: "label" })
+      screen.getByText("Max. file size: 1.00B (.jpg)", { selector: "label" })
     ).toBeVisible();
     expect(screen.getByText("Drag and drop or")).toBeVisible();
     expect(screen.getByText("Select files")).toBeVisible();

--- a/packages/core/src/FileUploader/DropZone/DropZone.tsx
+++ b/packages/core/src/FileUploader/DropZone/DropZone.tsx
@@ -2,7 +2,7 @@ import React, { useRef, useState } from "react";
 
 import uniqueId from "lodash/uniqueId";
 
-import accept from "attr-accept";
+import validateAccept from "attr-accept";
 
 import { Doc } from "@hitachivantara/uikit-react-icons";
 
@@ -78,7 +78,7 @@ export interface HvDropZoneProps {
   /**
    * Files extensions accepted for upload.
    */
-  acceptedFiles: string[];
+  accept?: React.InputHTMLAttributes<HTMLInputElement>["accept"];
   /**
    * Max upload size
    * */
@@ -106,7 +106,7 @@ export const HvDropZone = (props: HvDropZoneProps) => {
     id: idProp,
     classes: classesProp,
     labels,
-    acceptedFiles,
+    accept,
     maxFileSize,
     inputProps,
     hideLabels,
@@ -138,11 +138,9 @@ export const HvDropZone = (props: HvDropZoneProps) => {
 
       const isSizeAllowed = file.size <= maxFileSize;
       const isFileAccepted =
-        !acceptedFiles.length ||
-        acceptedFiles.indexOf(file.type.split("/")[1]) > -1 ||
-        acceptedFiles.some((acceptExtension) =>
-          accept({ name: file.name, type: file.type }, acceptExtension)
-        );
+        !accept ||
+        accept.includes(file.type.split("/")[1]) ||
+        validateAccept(file, accept);
 
       if (!isFileAccepted) {
         newFile.errorMessage = labels?.fileTypeError;
@@ -172,10 +170,9 @@ export const HvDropZone = (props: HvDropZoneProps) => {
           <HvInfoMessage id={setId(id, "description")}>
             {Number.isInteger(maxFileSize) &&
               `${labels?.sizeWarning} ${convertUnits(maxFileSize)}`}
-            {labels?.acceptedFiles && labels.acceptedFiles}
-            {!labels?.acceptedFiles &&
-              acceptedFiles.length > 0 &&
-              `\u00A0(${acceptedFiles.join(", ")})`}
+            {labels?.acceptedFiles
+              ? labels.acceptedFiles
+              : accept && `\u00A0(${accept?.replaceAll(",", ", ")})`}
           </HvInfoMessage>
         </div>
       )}
@@ -230,7 +227,7 @@ export const HvDropZone = (props: HvDropZoneProps) => {
             }
           }}
           ref={inputRef}
-          accept={acceptedFiles.join(",")}
+          accept={accept}
           {...inputProps}
         />
         <div className={classes?.dropArea}>

--- a/packages/core/src/FileUploader/DropZone/DropZone.tsx
+++ b/packages/core/src/FileUploader/DropZone/DropZone.tsx
@@ -2,8 +2,6 @@ import React, { useRef, useState } from "react";
 
 import uniqueId from "lodash/uniqueId";
 
-import validateAccept from "attr-accept";
-
 import { Doc } from "@hitachivantara/uikit-react-icons";
 
 import { setId } from "../../utils/setId";
@@ -99,6 +97,28 @@ export interface HvDropZoneProps {
    * A Jss Object used to override or extend the styles applied to the component.
    */
   classes?: HvDropZoneClasses;
+}
+
+// TODO: remove/review in `v6`: delegate to HTML `accept` and/or add custom validation
+function validateAccept(file?: File, acceptAttr?: string) {
+  if (!file || !acceptAttr) return true;
+
+  const acceptEntries = acceptAttr.split(",");
+  const fileName = file.name || "";
+  const mimeType = (file.type || "").toLowerCase();
+  const baseMimeType = mimeType.replace(/\/.*$/, "");
+
+  return acceptEntries.some((type) => {
+    const validType = type.trim().toLowerCase();
+    if (validType.charAt(0) === ".") {
+      return fileName.toLowerCase().endsWith(validType);
+    }
+    // This is something like a image/* mime type
+    if (validType.endsWith("/*")) {
+      return baseMimeType === validType.replace(/\/.*$/, "");
+    }
+    return mimeType === validType;
+  });
 }
 
 export const HvDropZone = (props: HvDropZoneProps) => {

--- a/packages/core/src/FileUploader/FileUploader.stories.tsx
+++ b/packages/core/src/FileUploader/FileUploader.stories.tsx
@@ -141,7 +141,7 @@ export const Basic: StoryObj<HvFileUploaderProps> = {
 
     return (
       <HvFileUploader
-        acceptedFiles={["jpg", "jpeg", "png"]}
+        acceptedFiles={[".jpg", ".jpeg", ".png"]}
         labels={{ sizeWarning: "Maximum file size:" }}
         maxFileSize={1 * 1000 ** 2}
         fileList={list}
@@ -372,7 +372,7 @@ export const SingleUpload: StoryObj<HvFileUploaderProps> = {
         onFileRemoved={(removedFile) => {
           removeFile(removedFile);
         }}
-        acceptedFiles={["jpg", "jpeg", "png"]}
+        acceptedFiles={[".jpg", ".jpeg", ".png"]}
         maxFileSize={1 * 1000 ** 2}
         multiple={false}
         disabled={list.length === 1}

--- a/packages/core/src/FileUploader/FileUploader.tsx
+++ b/packages/core/src/FileUploader/FileUploader.tsx
@@ -102,7 +102,7 @@ export const HvFileUploader = (props: HvFileUploaderProps) => {
         labels={labels}
         multiple={multiple}
         disabled={disabled}
-        acceptedFiles={acceptedFiles}
+        accept={acceptedFiles.join(",")}
         maxFileSize={maxFileSize}
         onFilesAdded={onFilesAdded}
         inputProps={inputProps}


### PR DESCRIPTION
`attr-accept` ESM build is producing CJS code, leading to runtime issues (see [this sandbox](https://stackblitz.com/edit/github-zugymp?file=src%2FApp.tsx%3AL9))

Furthermore, ~`attr-accept`'s implementation~our custom validation doesn't seem to be equivalent to the native one - see [this issue](https://github.com/lumada-design/hv-uikit-react/issues/3852)

This PR:
- Copies `attr-accept`'s code to our codebase
  - we should evaluate removing this in favour of HTML's accept and allowing a custom validation
- Changes docs to align validation with native APIs
- Some minor refactors