### PR TITLE
fix(DatePicker): unnecessary onChange removed when closing picker

### DIFF
--- a/packages/core/src/DatePicker/DatePicker.test.tsx
+++ b/packages/core/src/DatePicker/DatePicker.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
@@ -89,6 +89,22 @@ describe("HvDatePicker", () => {
       expect(firstDayOfTheMonth.length).toBe(2);
       expect(datePickerDropdownValue.length).toBe(1);
       expect(dateInput).toBeInTheDocument();
+    });
+    it("should not call onChange when closing", async () => {
+      const onChangeSpy = vi.fn();
+      render(<HvDatePicker onChange={onChangeSpy} />);
+
+      let picker = screen.getByRole("combobox");
+
+      await userEvent.click(picker);
+
+      expect(picker).toHaveAttribute("aria-expanded", "true");
+
+      await userEvent.click(document.body);
+
+      picker = screen.getByRole("combobox");
+      expect(picker).toHaveAttribute("aria-expanded", "false");
+      expect(onChangeSpy).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/core/src/DatePicker/DatePicker.tsx
+++ b/packages/core/src/DatePicker/DatePicker.tsx
@@ -312,10 +312,7 @@ export const HvDatePicker = forwardRef<HTMLDivElement, HvDatePickerProps>(
     };
 
     const handleCalendarClose = () => {
-      const shouldSave = !(rangeMode || showActions);
-      if (shouldSave) {
-        handleApply();
-      } else {
+      if (rangeMode || showActions) {
         handleCancel();
       }
     };


### PR DESCRIPTION
Addresses part of https://github.com/lumada-design/hv-uikit-react/issues/3935:
- `onChange` is no longer called when the picker is closed: there's no need to re-apply the changes when closing the picker