### PR TITLE
chore(Flow): small refactors & type fix

### DIFF
--- a/apps/app/src/pages/Flow/Nodes/Dashboard.tsx
+++ b/apps/app/src/pages/Flow/Nodes/Dashboard.tsx
@@ -96,8 +96,6 @@ export const Dashboard: HvFlowNodeFC = (props) => {
       open={open}
       layout={config?.layout}
       labels={{
-        title: "Dashboard",
-        description: "Dashboard",
         emptyMessage: "No visualizations connected to the dashboard.",
         dialogTitle: "Configure dashboard",
         dialogSubtitle:

--- a/packages/lab/src/Flow/Node/Parameters/Select.tsx
+++ b/packages/lab/src/Flow/Node/Parameters/Select.tsx
@@ -20,23 +20,21 @@ const Select = ({ nodeId, param, data }: SelectProps) => {
   );
 
   const onSelectChange: HvDropdownProps["onChange"] = (item) => {
-    const nodes = reactFlowInstance.getNodes();
-
     const newOpts = Array.isArray(item)
       ? item.map((x) => x.label as string)
       : (item?.label as string) ?? undefined;
 
-    const newNodes = nodes.map((node) => {
-      if (node.id === nodeId) {
-        node.data = {
-          ...node.data,
-          [id]: newOpts,
-        };
-      }
-      return node;
-    });
-
-    reactFlowInstance.setNodes(newNodes);
+    reactFlowInstance.setNodes((nodes) =>
+      nodes.map((node) => {
+        if (node.id === nodeId) {
+          node.data = {
+            ...node.data,
+            [id]: newOpts,
+          };
+        }
+        return node;
+      })
+    );
     setOpts(
       newOpts ? (Array.isArray(newOpts) ? newOpts : [newOpts]) : undefined
     );

--- a/packages/lab/src/Flow/Node/Parameters/Slider.tsx
+++ b/packages/lab/src/Flow/Node/Parameters/Slider.tsx
@@ -32,20 +32,20 @@ const Slider = ({ nodeId, param, data }: SliderProps) => {
   const [value, setValue] = useState(data[id]);
 
   const onSliderChange: HvSliderProps["onChange"] = (val) => {
-    const nodes = reactFlowInstance.getNodes();
-    const newNodes = nodes.map((node) => {
-      if (node.id === nodeId) {
-        node.data = { ...node.data, [id]: val };
-      }
-      return node;
-    });
-    reactFlowInstance.setNodes(newNodes);
+    reactFlowInstance.setNodes((nodes) =>
+      nodes.map((node) => {
+        if (node.id === nodeId) {
+          node.data = { ...node.data, [id]: val };
+        }
+        return node;
+      })
+    );
     setValue(val);
   };
 
   return (
     <HvSlider
-      className="nodrag"
+      className="nodrag" // Prevents dragging within the input field
       defaultValues={value}
       onChange={onSliderChange}
       classes={{

--- a/packages/lab/src/Flow/Node/Parameters/Text.tsx
+++ b/packages/lab/src/Flow/Node/Parameters/Text.tsx
@@ -18,16 +18,14 @@ const Text = ({ nodeId, param, data }: TextProps) => {
   const [text, setText] = useState(data[id]);
 
   const onTextChange: HvInputProps["onChange"] = (event, val) => {
-    const nodes = reactFlowInstance.getNodes();
-
-    const newNodes = nodes.map((node) => {
-      if (node.id === nodeId) {
-        node.data = { ...node.data, [id]: val };
-      }
-      return node;
-    });
-
-    reactFlowInstance.setNodes(newNodes);
+    reactFlowInstance.setNodes((nodes) =>
+      nodes.map((node) => {
+        if (node.id === nodeId) {
+          node.data = { ...node.data, [id]: val };
+        }
+        return node;
+      })
+    );
     setText(val);
   };
 

--- a/packages/lab/src/Flow/nodes/DashboardNode.tsx
+++ b/packages/lab/src/Flow/nodes/DashboardNode.tsx
@@ -30,8 +30,6 @@ const { staticClasses, useClasses } = createClasses("HvDashboardNode", {
 export { staticClasses as hvDashboardNodeClasses };
 
 const DEFAULT_LABELS = {
-  title: "Dashboard",
-  description: "Dashboard",
   emptyMessage: "No visualizations connected to the dashboard.",
   dialogTitle: "Configure dashboard",
   dialogSubtitle: "Please configure the layout of your dashboard as needed.",
@@ -48,7 +46,7 @@ export interface HvDashboardNodeProps
     Pick<HvDialogProps, "open" | "onClose">,
     Pick<HvDashboardProps, "layout"> {
   classes?: HvDashboardNodeClasses;
-  labels?: typeof DEFAULT_LABELS;
+  labels?: Partial<typeof DEFAULT_LABELS>;
   previewItems?: React.ReactNode;
   onApply?: () => void;
   onCancel?: () => void;

--- a/packages/lab/src/Flow/nodes/DashboardNode.tsx
+++ b/packages/lab/src/Flow/nodes/DashboardNode.tsx
@@ -78,7 +78,7 @@ export const HvDashboardNode = (props: HvDashboardNodeProps) => {
 
   return (
     <HvFlowNode id={id} classes={classes as any} {...others}>
-      <div className={classes.actions}>{children}</div>
+      {children && <div className={classes.actions}>{children}</div>}
       <HvDialog
         open={open}
         maxWidth="lg"

--- a/packages/lab/src/Flow/stories/Usage.stories.mdx
+++ b/packages/lab/src/Flow/stories/Usage.stories.mdx
@@ -243,10 +243,10 @@ interface HvFlowNodeSelectParam {
   options?: string[];
 }
 
-export interface HvFlowNodeSliderParam
-  extends HvFlowNodeSharedParam,
-    Omit<HvSliderProps, keyof HvFlowNodeSharedParam> {
+interface HvFlowNodeSharedParam extends Omit<HvSliderProps, "id" | "label"> {
   type: "slider";
+  id: string;
+  label: string;
 }
 
 type HvFlowNodeParam =


### PR DESCRIPTION
- The node parameters were refactored to simplify the code: there was no need for `reactFlowInstance.getNodes()`
- `HvDashboardNode` updates:
   - `Partial` added to `labels` to not make it mandatory to fill all the labels
   - `title` and `description` removed from `labels` since they weren't used
   - `children` only rendered when defined to avoid adding unnecessary space
- The `HvFlowNodeSharedParam` type was simplified in the docs 