### PR TITLE
fix(Dashboard): types

### DIFF
--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -18,7 +18,6 @@
     "@hitachivantara/uikit-react-viz": "*",
     "@hitachivantara/uikit-styles": "*",
     "@mui/material": "^5.14.20",
-    "@types/react-grid-layout": "^1.3.5",
     "arquero": "^5.3.0",
     "clsx": "^2.0.0",
     "formik": "^2.4.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -150,7 +150,6 @@
         "@hitachivantara/uikit-react-viz": "*",
         "@hitachivantara/uikit-styles": "*",
         "@mui/material": "^5.14.20",
-        "@types/react-grid-layout": "^1.3.5",
         "arquero": "^5.3.0",
         "clsx": "^2.0.0",
         "formik": "^2.4.5",
@@ -36612,6 +36611,7 @@
         "@hitachivantara/uikit-react-core": "^5.44.0",
         "@hitachivantara/uikit-react-icons": "^5.7.13",
         "@hitachivantara/uikit-styles": "^5.17.2",
+        "@types/react-grid-layout": "^1.3.5",
         "lodash": "^4.17.21",
         "react-grid-layout": "^1.4.4",
         "reactflow": "^11.10.1",
@@ -36626,7 +36626,6 @@
         "@testing-library/user-event": "^14.5.1",
         "@types/react": "^18.2.43",
         "@types/react-dom": "^18.2.17",
-        "@types/react-grid-layout": "^1.3.5",
         "npm-run-all": "^4.1.5",
         "vite": "^4.5.1",
         "vitest": "^0.34.6"

--- a/packages/lab/package.json
+++ b/packages/lab/package.json
@@ -46,6 +46,7 @@
     "@hitachivantara/uikit-react-core": "^5.44.0",
     "@hitachivantara/uikit-react-icons": "^5.7.13",
     "@hitachivantara/uikit-styles": "^5.17.2",
+    "@types/react-grid-layout": "^1.3.5",
     "lodash": "^4.17.21",
     "react-grid-layout": "^1.4.4",
     "reactflow": "^11.10.1",
@@ -60,7 +61,6 @@
     "@testing-library/user-event": "^14.5.1",
     "@types/react": "^18.2.43",
     "@types/react-dom": "^18.2.17",
-    "@types/react-grid-layout": "^1.3.5",
     "npm-run-all": "^4.1.5",
     "vite": "^4.5.1",
     "vitest": "^0.34.6"


### PR DESCRIPTION
- `@types/react-grid-layout` switched to the `dependencies` instead of `devDependencies` to resolve the types correctly (we do the same for the table types). Otherwise we get the following in production:

<img src="https://github.com/lumada-design/hv-uikit-react/assets/43220251/4bac16c7-31a3-40ed-b7f3-8dd039b9b710" height="250"/>

<img src="https://github.com/lumada-design/hv-uikit-react/assets/43220251/8efd0387-d7e9-42c1-b86c-a61e95443644" height="250"/>

(1) several types are missing
(2) `layout` resolved to `any`