### PR TITLE
build: revert `.mjs` change in react packages

### DIFF
--- a/.config/vite.config.ts
+++ b/.config/vite.config.ts
@@ -36,7 +36,10 @@ export default defineConfig({
           format: "esm",
           preserveModules: true,
           dir: "dist/esm",
-          entryFileNames: "[name].mjs",
+          // keep react-based packages as `.js` for backwards compatibility
+          entryFileNames: pkg.name.includes("react")
+            ? "[name].js"
+            : "[name].mjs",
           sourcemap: true,
           exports: "named",
           interop: "auto",

--- a/packages/code-editor/package.json
+++ b/packages/code-editor/package.json
@@ -56,12 +56,12 @@
     "access": "public",
     "directory": "package",
     "main": "dist/cjs/index.cjs",
-    "module": "dist/esm/index.mjs",
+    "module": "dist/esm/index.js",
     "types": "dist/types/index.d.ts",
     "exports": {
       ".": {
         "require": "./dist/cjs/index.cjs",
-        "import": "./dist/esm/index.mjs"
+        "import": "./dist/esm/index.js"
       }
     }
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -88,12 +88,12 @@
     "access": "public",
     "directory": "package",
     "main": "dist/cjs/index.cjs",
-    "module": "dist/esm/index.mjs",
+    "module": "dist/esm/index.js",
     "types": "dist/types/index.d.ts",
     "exports": {
       ".": {
         "require": "./dist/cjs/index.cjs",
-        "import": "./dist/esm/index.mjs"
+        "import": "./dist/esm/index.js"
       }
     }
   },

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -66,12 +66,12 @@
     "access": "public",
     "directory": "package",
     "main": "dist/cjs/index.cjs",
-    "module": "dist/esm/index.mjs",
+    "module": "dist/esm/index.js",
     "types": "dist/types/index.d.ts",
     "exports": {
       ".": {
         "require": "./dist/cjs/index.cjs",
-        "import": "./dist/esm/index.mjs"
+        "import": "./dist/esm/index.js"
       }
     }
   },

--- a/packages/lab/package.json
+++ b/packages/lab/package.json
@@ -72,12 +72,12 @@
     "access": "public",
     "directory": "package",
     "main": "dist/cjs/index.cjs",
-    "module": "dist/esm/index.mjs",
+    "module": "dist/esm/index.js",
     "types": "dist/types/index.d.ts",
     "exports": {
       ".": {
         "require": "./dist/cjs/index.cjs",
-        "import": "./dist/esm/index.mjs"
+        "import": "./dist/esm/index.js"
       }
     }
   },

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -49,12 +49,12 @@
     "access": "public",
     "directory": "package",
     "main": "dist/cjs/index.cjs",
-    "module": "dist/esm/index.mjs",
+    "module": "dist/esm/index.js",
     "types": "dist/types/index.d.ts",
     "exports": {
       ".": {
         "require": "./dist/cjs/index.cjs",
-        "import": "./dist/esm/index.mjs"
+        "import": "./dist/esm/index.js"
       },
       "./package.json": "./package.json",
       "./bundles/*": "./dist/bundles/*"

--- a/packages/viz/package.json
+++ b/packages/viz/package.json
@@ -56,12 +56,12 @@
     "access": "public",
     "directory": "package",
     "main": "dist/cjs/index.cjs",
-    "module": "dist/esm/index.mjs",
+    "module": "dist/esm/index.js",
     "types": "dist/types/index.d.ts",
     "exports": {
       ".": {
         "require": "./dist/cjs/index.cjs",
-        "import": "./dist/esm/index.mjs"
+        "import": "./dist/esm/index.js"
       }
     }
   },


### PR DESCRIPTION
Reverts the https://github.com/lumada-design/hv-uikit-react/pull/3927 changes for the react pages:
- Only the `uikit-styles` and `uikit-uno-preset` require the fix
- Changes in React pages are exposing us unexpected issues:
  - eg. `attr-accept` - see https://github.com/lumada-design/hv-uikit-react/pull/3942

Validated it resolves the `vitest` and `HvFileUploader` that arose