### PR TITLE
chore: add husky to devDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -62,6 +62,7 @@
         "eslint-plugin-storybook": "^0.6.15",
         "formik": "^2.4.5",
         "html-react-parser": "^3.0.16",
+        "husky": "^8.0.3",
         "jsdom": "^21.1.2",
         "leaflet": "^1.9.4",
         "lerna": "^7.4.2",
@@ -20616,6 +20617,21 @@
       "dev": true,
       "dependencies": {
         "ms": "^2.0.0"
+      }
+    },
+    "node_modules/husky": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.3.tgz",
+      "integrity": "sha512-+dQSyqPh4x1hlO1swXBiNb2HzTDN1I2IGLQx1GrBuiqFJfoMrnZWwVmatvSiO+Iz8fBUnf+lekwNo4c2LlXItg==",
+      "dev": true,
+      "bin": {
+        "husky": "lib/bin.js"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/i18next": {

--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "eslint-plugin-storybook": "^0.6.15",
     "formik": "^2.4.5",
     "html-react-parser": "^3.0.16",
+    "husky": "^8.0.3",
     "jsdom": "^21.1.2",
     "leaflet": "^1.9.4",
     "lerna": "^7.4.2",


### PR DESCRIPTION
- `husky` is missing from `devDependencies` (it's being used in setup)

With this, tools like pr.new work out-of-the-box: https://pr.new/lumada-design/hv-uikit-react/pull/3954