### PR TITLE
fix(FilerGroup): error when all option is selected & wrong counter

### DIFF
--- a/packages/core/src/FilterGroup/Counter/Counter.tsx
+++ b/packages/core/src/FilterGroup/Counter/Counter.tsx
@@ -54,11 +54,9 @@ export const HvFilterGroupCounter = (props: HvFilterGroupCounterProps) => {
   const optionIdx = filterOptions.findIndex((option) => option.id === id);
 
   let groupsCounter = 0;
-  appliedFilters
-    .filter((elem) => elem !== undefined)
-    .forEach((fg, i) => {
-      groupsCounter += getExistingFiltersById(i, filterValues, filterOptions);
-    });
+  appliedFilters.forEach((fg, i) => {
+    groupsCounter += getExistingFiltersById(i, filterValues, filterOptions);
+  });
 
   const partialCounter = id
     ? getExistingFiltersById(optionIdx, filterValues, filterOptions) || 0

--- a/packages/core/src/FilterGroup/FilterGroup.test.tsx
+++ b/packages/core/src/FilterGroup/FilterGroup.test.tsx
@@ -56,12 +56,12 @@ const filters: HvFilterGroupProps["filters"] = [
   },
 ];
 
-const Main = () => {
-  const [value, setValue] = useState<HvFilterGroupValue | undefined>([
-    ["category1", 2],
-    [],
-    [1, "subsubcategory2", "subsubcategory8"],
-  ]);
+const Main = ({ emptyValue }: { emptyValue?: boolean }) => {
+  const [value, setValue] = useState<HvFilterGroupValue | undefined>(
+    emptyValue
+      ? undefined
+      : [["category1", 2], [], [1, "subsubcategory2", "subsubcategory8"]]
+  );
 
   return (
     <div style={{ width: 180 }}>
@@ -317,5 +317,34 @@ describe("FilterGroup", () => {
     await userEvent.click(cancelButton);
 
     expect(getAllByText("4").length).toBe(1);
+  });
+
+  it("with an initial empty state, can select all options and counter is updated when changes are applied", async () => {
+    render(<Main emptyValue />);
+
+    const dropdownElement = screen.getByRole("combobox");
+
+    await userEvent.click(dropdownElement);
+
+    expect(dropdownElement).toHaveAttribute("aria-expanded", "true");
+
+    const [leftList] = screen.getAllByRole("list");
+
+    // Select second category
+    await userEvent.click(within(leftList).getAllByRole("listitem")[1]);
+
+    expect(within(leftList).getAllByRole("listitem")[1]).toHaveFocus();
+
+    const checkboxes = screen.getAllByRole("checkbox");
+
+    // Click on "All" checkbox
+    await userEvent.click(checkboxes[0]);
+
+    const applyButton = screen.getByRole("button", { name: /Apply/i });
+
+    // Apply changes
+    await userEvent.click(applyButton);
+
+    expect(screen.getAllByText("4").length).toBe(1);
   });
 });

--- a/packages/core/src/FilterGroup/RightPanel/RightPanel.tsx
+++ b/packages/core/src/FilterGroup/RightPanel/RightPanel.tsx
@@ -114,10 +114,7 @@ export const HvFilterGroupRightPanel = ({
         newFilterValues[activeGroup] = [];
       }
     } else {
-      newFilterValues[activeGroup] = [
-        ...filterValues[activeGroup],
-        ...activeGroupOptions,
-      ];
+      newFilterValues[activeGroup] = [...activeGroupOptions];
     }
 
     setFilterValues(newFilterValues);


### PR DESCRIPTION
This PR fixes the following two bugs:
- When the filter group is empty and the “All” option is selected an error is thrown and the option can’t be selected. It’s only possible to select “All” after selecting another option: 

https://github.com/lumada-design/hv-uikit-react/assets/43220251/2e66556c-aba2-4cd2-be42-d2395d2340d6

- When fixing this bug I noticed the counter was not working as expected:

https://github.com/lumada-design/hv-uikit-react/assets/43220251/84981b12-51ef-4645-8c6d-40af6fc1860c

