### PR TITLE
docs(Typography): add link to samples

### DIFF
--- a/packages/core/src/Typography/Typography.stories.tsx
+++ b/packages/core/src/Typography/Typography.stories.tsx
@@ -1,4 +1,4 @@
-import { StoryObj } from "@storybook/react";
+import { StoryFn, StoryObj } from "@storybook/react";
 import {
   HvBox,
   HvTypography,
@@ -42,13 +42,6 @@ export const Main: StoryObj<HvTypographyProps> = {
         type: { summary: "boolean" },
       },
     },
-    paragraph: {
-      description: "If `true`, the text will have a bottom margin.",
-      table: {
-        defaultValue: { summary: "false" },
-        type: { summary: "boolean" },
-      },
-    },
     noWrap: {
       description:
         "If `true`, the text will not wrap, but instead will truncate with a text overflow ellipsis. Note that text overflow can only happen with block or inline-block level elements (the element needs to have a width in order to overflow).",
@@ -81,17 +74,19 @@ export const Main: StoryObj<HvTypographyProps> = {
 
 export const Variants = () => {
   return (
-    <HvBox sx={{ marginBottom: theme.spacing(7) }}>
+    <div
+      style={{ display: "flex", flexDirection: "column", gap: theme.space.sm }}
+    >
       {typographyVariants.map((variant) => (
-        <HvBox key={variant} sx={{ marginBottom: theme.space.sm }}>
+        <div key={variant}>
           <HvTypography variant="label">{variant}</HvTypography>
           <br />
           <HvTypography variant={variant}>
             Welcome to NEXT Design System!
           </HvTypography>
-        </HvBox>
+        </div>
       ))}
-    </HvBox>
+    </div>
   );
 };
 
@@ -105,17 +100,19 @@ const CustomLink = ({ to, children, ...others }: CustomLinkProps) => (
   </a>
 );
 
-export const CustomRootComponent = () => {
+export const CustomRootComponent: StoryFn = () => {
   return (
     <HvBox sx={{ display: "flex", gap: 20, padding: 20 }}>
-      <HvTypography>Typography</HvTypography>
+      <HvTypography component="span">Typography</HvTypography>
       <HvTypography
+        link
         component="a"
         href="https://lumada-design.github.io/uikit/master"
       >
         Link
       </HvTypography>
       <HvTypography
+        link
         component={CustomLink}
         to="https://lumada-design.github.io/uikit/master"
       >
@@ -123,4 +120,13 @@ export const CustomRootComponent = () => {
       </HvTypography>
     </HvBox>
   );
+};
+
+CustomRootComponent.parameters = {
+  docs: {
+    description: {
+      story:
+        "The `component` prop can be used to change the root element, like an `a` element or a `CustomLink` component.",
+    },
+  },
 };

--- a/packages/core/src/Typography/Typography.styles.ts
+++ b/packages/core/src/Typography/Typography.styles.ts
@@ -10,6 +10,7 @@ export const { useClasses, staticClasses } = createClasses("HvTypography", {
     color: theme.colors.secondary_60,
   },
   isLink: {
+    cursor: "pointer",
     color: theme.colors.primary,
     textDecoration: "underline",
   },

--- a/packages/core/src/Typography/Typography.tsx
+++ b/packages/core/src/Typography/Typography.tsx
@@ -61,7 +61,10 @@ export type HvTypographyProps<C extends React.ElementType = "p"> =
       link?: boolean;
       /** If `true` the typography will display the look of a disabled state. */
       disabled?: boolean;
-      /** If `true`, the text will have a bottom margin. */
+      /**
+       * If `true`, the typography will render a "p" element
+       * @deprecated use `component="p"` instead
+       * */
       paragraph?: boolean;
       /**
        * If `true`, the text will not wrap, but instead will truncate with a text overflow ellipsis.


### PR DESCRIPTION
- showcase `link` prop usage in samples
  - also now covered by Applitools (changes are expected)
  - add pointer cursor to `link`
- deprecate `paragraph` prop in favour of `component="p"`:
  - there are no styles or classes associated with this; current docs are wrong
  - `p` is already the default component for most (non-title) variants