### PR TITLE
chore: tag v4 releases as previous

### DIFF
--- a/packages/code-editor/package.json
+++ b/packages/code-editor/package.json
@@ -53,6 +53,7 @@
     "dist"
   ],
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "previous"
   }
 }

--- a/packages/compat/package.json
+++ b/packages/compat/package.json
@@ -62,6 +62,7 @@
     "dist"
   ],
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "previous"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -82,6 +82,7 @@
     "dist"
   ],
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "previous"
   }
 }

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -60,6 +60,7 @@
     "dist"
   ],
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "previous"
   }
 }

--- a/packages/lab/package.json
+++ b/packages/lab/package.json
@@ -62,6 +62,7 @@
     "dist"
   ],
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "previous"
   }
 }

--- a/packages/themes/package.json
+++ b/packages/themes/package.json
@@ -32,6 +32,7 @@
     "dist"
   ],
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "previous"
   }
 }

--- a/packages/viz/package.json
+++ b/packages/viz/package.json
@@ -61,6 +61,7 @@
     "dist"
   ],
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "previous"
   }
 }


### PR DESCRIPTION
- Tag `v4` releases as `"previous"`, so that they don't override `"latest"` which is currently leading to upgrading issues
  - We can't use tags such as `v4` because tags [can't be semver-compatible](https://docs.npmjs.com/cli/v10/commands/npm-dist-tag#caveats)
  - Configured in each package, as `lerna.json`'s `command.publish` isn't overriding the value