### PR TITLE
fix(TimePicker): allow empty controlled value with null

### DIFF
--- a/packages/core/src/TimePicker/TimePicker.stories.tsx
+++ b/packages/core/src/TimePicker/TimePicker.stories.tsx
@@ -11,6 +11,7 @@ import {
   HvTimePicker,
   HvTimePickerProps,
   HvTimePickerValue,
+  HvTypography,
 } from "@hitachivantara/uikit-react-core";
 
 import { CSSInterpolation, css } from "@emotion/css";
@@ -131,30 +132,39 @@ export const Controlled: StoryObj<HvTimePickerProps> = {
     docs: {
       description: {
         story:
-          "Using `HvTimePicker` with _controlled_ state, using the `value` property.",
+          "Using `HvTimePicker` with _controlled_ state, using the `value` with initial `null` state to render the placeholder.",
       },
     },
     eyes: { include: false },
   },
   decorators: [makeDecorator({ minHeight: 200, width: 200 })],
   render: () => {
-    const [value, setValue] = useState<HvTimePickerValue>({
-      hours: 19,
-      minutes: 30,
-      seconds: 14,
-    });
+    const [value, setValue] = useState<HvTimePickerProps["value"]>(null);
 
-    const prettyValue = `${value.hours}:${value.minutes}:${value.seconds}`;
+    const prettyValue = value
+      ? `${value.hours}h ${value.minutes}'${value.seconds}"`
+      : "—";
 
     return (
       <>
-        <div>{prettyValue}</div>
+        <HvTypography variant="title4">Date: {prettyValue}</HvTypography>
         <br />
         <HvTimePicker
           label="Time Picker"
-          defaultValue={value}
+          placeholder="Select a time"
+          value={value}
           onChange={setValue}
         />
+        <br />
+        <HvButton
+          variant="secondarySubtle"
+          disabled={!value}
+          onClick={() => {
+            setValue((d) => d && { ...d, minutes: (d.minutes + 1) % 60 });
+          }}
+        >
+          +1 minute
+        </HvButton>
       </>
     );
   },

--- a/packages/core/src/TimePicker/TimePicker.test.tsx
+++ b/packages/core/src/TimePicker/TimePicker.test.tsx
@@ -46,6 +46,11 @@ describe("TimePicker", () => {
     assertTime(inputs, defaultValue);
   });
 
+  it("renders the placeholder when value is null", () => {
+    setup({ value: null });
+    expect(screen.getByText(defaultProps.placeholder)).toBeInTheDocument();
+  });
+
   it("renders selectors when clicking on the dropdown", async () => {
     const defaultValue = { hours: 19, minutes: 30, seconds: 14 };
     setup({ timeFormat: "12", defaultValue });

--- a/packages/core/src/TimePicker/TimePicker.tsx
+++ b/packages/core/src/TimePicker/TimePicker.tsx
@@ -30,8 +30,8 @@ import { Unit } from "./Unit";
 import { Placeholder } from "./Placeholder";
 import { staticClasses, useClasses } from "./TimePicker.styles";
 
-const toTime = (value?: HvTimePickerValue) => {
-  if (!value) return undefined;
+const toTime = (value?: HvTimePickerValue | null) => {
+  if (!value) return value;
   const { hours, minutes, seconds } = value;
   return new Time(hours, minutes, seconds);
 };
@@ -79,9 +79,9 @@ export interface HvTimePickerProps
   /** A Jss Object used to override or extend the styles applied to the component. */
   classes?: HvTimePickerClasses;
   /** Current value of the element when _controlled_. Follows the 24-hour format. */
-  value?: HvTimePickerValue;
+  value?: HvTimePickerValue | null;
   /** Initial value of the element when _uncontrolled_. Follows the 24-hour format. */
-  defaultValue?: HvTimePickerValue;
+  defaultValue?: HvTimePickerValue | null;
   /** The placeholder value when no time is selected. */
   placeholder?: string;
   /** The placeholder of the hours input. */


### PR DESCRIPTION
Allow passing `null` to `TimePicker`'s controlled state `value` to represent an "empty" controlled value