### PR TITLE
feat(Flow): input and output groups

### DIFF
--- a/apps/app/src/pages/Flow/Nodes/Dashboard.tsx
+++ b/apps/app/src/pages/Flow/Nodes/Dashboard.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useState } from "react";
+import { css } from "@emotion/css";
 import {
   HvDashboardNode,
   HvFlowNodeFC,
@@ -10,6 +11,7 @@ import {
   HvButton,
   HvSection,
   HvTypography,
+  theme,
 } from "@hitachivantara/uikit-react-core";
 
 import {
@@ -42,6 +44,14 @@ const nodeInputs: HvFlowNodeInput[] = [
     accepts: ["visualizations"],
   },
 ];
+
+const classes = {
+  footer: css({
+    display: "flex",
+    gap: theme.space.sm,
+    justifyContent: "center",
+  }),
+};
 
 export const Dashboard: HvFlowNodeFC = (props) => {
   const { id } = props;
@@ -117,18 +127,27 @@ export const Dashboard: HvFlowNodeFC = (props) => {
           <PreviewRenderer {...item} />
         </div>
       ))}
+      classes={{
+        footerContainer: classes.footer,
+      }}
+      footer={
+        <>
+          <HvButton size="sm" onClick={handleOpenConfig}>
+            Configure
+          </HvButton>
+          <HvButton
+            size="sm"
+            variant="primarySubtle"
+            component="a"
+            href={`./?dashboard=${id}`}
+            target="_blank"
+          >
+            Preview
+          </HvButton>
+        </>
+      }
       {...props}
-    >
-      <HvButton onClick={handleOpenConfig}>Configure</HvButton>
-      <HvButton
-        variant="primarySubtle"
-        component="a"
-        href={`./?dashboard=${id}`}
-        target="_blank"
-      >
-        Preview
-      </HvButton>
-    </HvDashboardNode>
+    />
   );
 };
 

--- a/packages/lab/src/Flow/DroppableFlow.tsx
+++ b/packages/lab/src/Flow/DroppableFlow.tsx
@@ -22,7 +22,11 @@ import { uid } from "uid";
 
 import { ExtractNames, useUniqueId } from "@hitachivantara/uikit-react-core";
 
-import { HvFlowNodeMetaRegistry } from "./types";
+import {
+  HvFlowNodeInputGroup,
+  HvFlowNodeMetaRegistry,
+  HvFlowNodeOutputGroup,
+} from "./types";
 import { staticClasses, useClasses } from "./Flow.styles";
 import { useFlowContext } from "./hooks";
 import { flowStyles } from "./base";
@@ -85,8 +89,14 @@ const validateEdge = (
   const inputs = nodeMetaRegistry[edge.target]?.inputs || [];
   const outputs = nodeMetaRegistry[edge.source]?.outputs || [];
 
-  const source = outputs.find((out) => out.id === edge.sourceHandle);
-  const target = inputs.find((inp) => inp.id === edge.targetHandle);
+  const source = outputs
+    .map((out) => (out as HvFlowNodeOutputGroup).outputs || out)
+    .flat()
+    .find((out) => out.id === edge.sourceHandle);
+  const target = inputs
+    .map((inp) => (inp as HvFlowNodeInputGroup).inputs || inp)
+    .flat()
+    .find((inp) => inp.id === edge.targetHandle);
 
   const sourceProvides = source?.provides || "";
   const targetAccepts = target?.accepts || [];

--- a/packages/lab/src/Flow/Node/BaseNode.styles.tsx
+++ b/packages/lab/src/Flow/Node/BaseNode.styles.tsx
@@ -55,6 +55,18 @@ export const { staticClasses, useClasses } = createClasses("HvFlowBaseNode", {
     gap: theme.space.xs,
     alignItems: "flex-end",
   },
+  inputGroupContainer: {
+    display: "flex",
+    flexDirection: "column",
+    gap: theme.space.xs,
+    alignItems: "flex-start",
+  },
+  outputGroupContainer: {
+    display: "flex",
+    flexDirection: "column",
+    gap: theme.space.xs,
+    alignItems: "flex-end",
+  },
   inputContainer: {
     display: "flex",
     flexDirection: "row",

--- a/packages/lab/src/Flow/Node/Node.styles.tsx
+++ b/packages/lab/src/Flow/Node/Node.styles.tsx
@@ -1,5 +1,11 @@
 import { createClasses, theme } from "@hitachivantara/uikit-react-core";
 
+import { staticClasses as baseNodeClasses } from "./BaseNode.styles";
+
+const baseClasses = Object.fromEntries(
+  Object.keys(baseNodeClasses).map((key) => [key, {}])
+) as Record<keyof typeof baseNodeClasses, {}>;
+
 export const { staticClasses, useClasses } = createClasses("HvFlowNode", {
   subtitleContainer: {
     minHeight: 48,
@@ -25,4 +31,6 @@ export const { staticClasses, useClasses } = createClasses("HvFlowNode", {
     gap: theme.space.xs,
     padding: theme.space.sm,
   },
+  // Spread here to know if we are overriding classes from parents
+  ...baseClasses,
 });

--- a/packages/lab/src/Flow/Node/Node.tsx
+++ b/packages/lab/src/Flow/Node/Node.tsx
@@ -1,5 +1,4 @@
 import React, { isValidElement, useState } from "react";
-
 import {
   ExtractNames,
   HvActionGeneric,
@@ -13,20 +12,14 @@ import {
 import { Down, Info, Up } from "@hitachivantara/uikit-react-icons";
 
 import { useFlowContext, useFlowNode } from "../hooks";
-import { HvFlowNodeInput, HvFlowNodeOutput, HvFlowNodeParam } from "../types";
+import { HvFlowNodeParam } from "../types";
 import { staticClasses, useClasses } from "./Node.styles";
 import ParamRenderer from "./Parameters/ParamRenderer";
-import {
-  HvFlowBaseNode,
-  HvFlowBaseNodeProps,
-  HvFlowBaseNodeClasses,
-} from "./BaseNode";
+import { HvFlowBaseNode, HvFlowBaseNodeProps } from "./BaseNode";
 
 export { staticClasses as flowNodeClasses };
 
-export interface HvFlowNodeClasses
-  extends ExtractNames<typeof useClasses>,
-    HvFlowBaseNodeClasses {}
+export type HvFlowNodeClasses = ExtractNames<typeof useClasses>;
 
 export type HvFlowNodeDefaults = {
   title?: string;
@@ -39,7 +32,7 @@ export interface HvFlowNodeProps<T = any> extends HvFlowBaseNodeProps<T> {
   /** Node description */
   description?: string;
   /** Node actions */
-  actions?: HvActionGeneric[]; // HvFlowNodeActions[];
+  actions?: HvActionGeneric[];
   /** Node action callback */
   actionCallback?: HvActionsGenericProps["actionsCallback"];
   /** Node maximum number of actions visible */
@@ -52,10 +45,6 @@ export interface HvFlowNodeProps<T = any> extends HvFlowBaseNodeProps<T> {
   nodeDefaults?: HvFlowNodeDefaults;
   /** Props to be passed to the expand parameters button. */
   expandParamsButtonProps?: HvButtonProps;
-  /** Node outputs. */
-  outputs?: HvFlowNodeOutput[];
-  /** Node inputs. */
-  inputs?: HvFlowNodeInput[];
   /** A Jss Object used to override or extend the styles applied to the component. */
   classes?: HvFlowNodeClasses;
 }
@@ -69,8 +58,6 @@ export const HvFlowNode = ({
   headerItems,
   description,
   actions,
-  outputs,
-  inputs,
   actionCallback,
   maxVisibleActions = 1,
   expanded = false,
@@ -81,7 +68,7 @@ export const HvFlowNode = ({
   expandParamsButtonProps,
   ...props
 }: HvFlowNodeProps<unknown>) => {
-  const { classes } = useClasses(classesProp as HvFlowNodeClasses);
+  const { classes } = useClasses(classesProp);
 
   const [showParams, setShowParams] = useState(expanded);
 
@@ -109,10 +96,8 @@ export const HvFlowNode = ({
       title={groupLabel}
       icon={icon}
       color={color}
-      inputs={inputs}
-      outputs={outputs}
       nodeActions={defaultActions}
-      classes={classesProp as HvFlowBaseNodeClasses}
+      classes={classes}
       headerItems={
         <>
           {headerItems}

--- a/packages/lab/src/Flow/Node/utils.ts
+++ b/packages/lab/src/Flow/Node/utils.ts
@@ -1,0 +1,88 @@
+import { isValidElement } from "react";
+import { Edge } from "reactflow";
+import { HvActionGeneric } from "@hitachivantara/uikit-react-core";
+
+import {
+  HvFlowNodeInput,
+  HvFlowNodeInputGroup,
+  HvFlowNodeOutput,
+  HvFlowNodeOutputGroup,
+} from "../types";
+
+export const isInputGroup = (
+  input: HvFlowNodeInput | HvFlowNodeInputGroup
+): input is HvFlowNodeInputGroup => {
+  return "inputs" in input;
+};
+
+export const isOutputGroup = (
+  output: HvFlowNodeOutput | HvFlowNodeOutputGroup
+): output is HvFlowNodeOutputGroup => {
+  return "outputs" in output;
+};
+
+export const isInputConnected = (
+  id: string,
+  type: "target" | "source",
+  handleId: string,
+  edges: Edge[]
+) => {
+  if (type === "target") {
+    return edges.some((e) => e.target === id && e.targetHandle === handleId);
+  }
+  if (type === "source") {
+    return edges.some((e) => e.source === id && e.sourceHandle === handleId);
+  }
+
+  return false;
+};
+
+export const renderedIcon = (actionIcon: HvActionGeneric["icon"]) =>
+  isValidElement(actionIcon) ? actionIcon : (actionIcon as Function)?.();
+
+export const identifyHandles = (
+  handles?:
+    | (HvFlowNodeInput | HvFlowNodeInputGroup)[]
+    | (HvFlowNodeOutput | HvFlowNodeOutputGroup)[]
+) => {
+  let idx = 0;
+
+  return handles?.map(
+    (
+      handle:
+        | HvFlowNodeOutput
+        | HvFlowNodeOutputGroup
+        | HvFlowNodeInput
+        | HvFlowNodeInputGroup
+    ) => {
+      if (isInputGroup(handle)) {
+        return {
+          ...handle,
+          inputs: handle.inputs.map((x) => {
+            const identifiedHandle =
+              x.id != null ? x : { ...x, id: String(idx) };
+            idx += 1;
+            return identifiedHandle;
+          }),
+        } satisfies HvFlowNodeInputGroup;
+      }
+
+      if (isOutputGroup(handle)) {
+        return {
+          ...handle,
+          outputs: handle.outputs.map((x) => {
+            const identifiedHandle =
+              x.id != null ? x : { ...x, id: String(idx) };
+            idx += 1;
+            return identifiedHandle;
+          }),
+        } satisfies HvFlowNodeOutputGroup;
+      }
+
+      const identifiedHandle =
+        handle.id != null ? handle : { ...handle, id: String(idx) };
+      idx += 1;
+      return identifiedHandle;
+    }
+  );
+};

--- a/packages/lab/src/Flow/hooks/useFlowNode.ts
+++ b/packages/lab/src/Flow/hooks/useFlowNode.ts
@@ -82,13 +82,13 @@ export function useFlowOutputNodes<T = any>(id: string) {
 }
 
 /** Utilities to manipulate a node in the flow */
-export function useFlowNodeUtils() {
+export function useFlowNodeUtils<NodeData = any>() {
   const nodeId = useNodeId();
-  const reactFlowInstance = useReactFlow();
+  const reactFlowInstance = useReactFlow<NodeData>();
 
   /** Mutate the node's `.data` object */
   const setNodeData = useCallback(
-    (setNewData: (newData?: any) => any) => {
+    (setNewData: (newData?: NodeData) => NodeData) => {
       if (!nodeId) return;
 
       reactFlowInstance.setNodes((nodes) => {

--- a/packages/lab/src/Flow/nodes/DashboardNode.styles.tsx
+++ b/packages/lab/src/Flow/nodes/DashboardNode.styles.tsx
@@ -1,0 +1,20 @@
+import { createClasses, theme } from "@hitachivantara/uikit-react-core";
+
+import { staticClasses as nodeClasses } from "../Node/Node.styles";
+
+const baseClasses = Object.fromEntries(
+  Object.keys(nodeClasses).map((key) => [key, {}])
+) as Record<keyof typeof nodeClasses, {}>;
+
+export const { staticClasses, useClasses } = createClasses("HvDashboardNode", {
+  content: {
+    display: "flex",
+    justifyContent: "space-around",
+    padding: theme.space.xs,
+  },
+  empty: {
+    padding: theme.spacing("sm", 0, 0, 0),
+  },
+  // Spread here to know if we are overriding classes from parents
+  ...baseClasses,
+});

--- a/packages/lab/src/Flow/nodes/DashboardNode.styles.tsx
+++ b/packages/lab/src/Flow/nodes/DashboardNode.styles.tsx
@@ -7,11 +7,6 @@ const baseClasses = Object.fromEntries(
 ) as Record<keyof typeof nodeClasses, {}>;
 
 export const { staticClasses, useClasses } = createClasses("HvDashboardNode", {
-  content: {
-    display: "flex",
-    justifyContent: "space-around",
-    padding: theme.space.xs,
-  },
   empty: {
     padding: theme.spacing("sm", 0, 0, 0),
   },

--- a/packages/lab/src/Flow/nodes/DashboardNode.tsx
+++ b/packages/lab/src/Flow/nodes/DashboardNode.tsx
@@ -62,7 +62,7 @@ export const HvDashboardNode = (props: HvDashboardNodeProps) => {
 
   return (
     <HvFlowNode id={id} classes={classes} {...others}>
-      {children && <div className={classes.content}>{children}</div>}
+      {children}
       <HvDialog
         open={open}
         maxWidth="lg"

--- a/packages/lab/src/Flow/nodes/DashboardNode.tsx
+++ b/packages/lab/src/Flow/nodes/DashboardNode.tsx
@@ -7,25 +7,13 @@ import {
   HvDialogProps,
   HvDialogTitle,
   HvEmptyState,
-  createClasses,
-  theme,
   useLabels,
 } from "@hitachivantara/uikit-react-core";
 import { Info } from "@hitachivantara/uikit-react-icons";
 
 import { HvDashboard, HvDashboardProps } from "../../Dashboard";
-import { HvFlowNode, HvFlowNodeProps, HvFlowNodeClasses } from "../Node";
-
-const { staticClasses, useClasses } = createClasses("HvDashboardNode", {
-  actions: {
-    display: "flex",
-    justifyContent: "space-around",
-    padding: theme.space.xs,
-  },
-  empty: {
-    padding: theme.spacing("sm", 0, 0, 0),
-  },
-});
+import { HvFlowNode, HvFlowNodeProps } from "../Node";
+import { staticClasses, useClasses } from "./DashboardNode.styles";
 
 export { staticClasses as hvDashboardNodeClasses };
 
@@ -37,9 +25,7 @@ const DEFAULT_LABELS = {
   dialogCancel: "Cancel",
 };
 
-export interface HvDashboardNodeClasses
-  extends ExtractNames<typeof useClasses>,
-    HvFlowNodeClasses {}
+export type HvDashboardNodeClasses = ExtractNames<typeof useClasses>;
 
 export interface HvDashboardNodeProps
   extends HvFlowNodeProps,
@@ -75,8 +61,8 @@ export const HvDashboardNode = (props: HvDashboardNodeProps) => {
   const { classes } = useClasses(classesProp);
 
   return (
-    <HvFlowNode id={id} classes={classes as any} {...others}>
-      {children && <div className={classes.actions}>{children}</div>}
+    <HvFlowNode id={id} classes={classes} {...others}>
+      {children && <div className={classes.content}>{children}</div>}
       <HvDialog
         open={open}
         maxWidth="lg"

--- a/packages/lab/src/Flow/stories/Base/Asset.tsx
+++ b/packages/lab/src/Flow/stories/Base/Asset.tsx
@@ -7,7 +7,12 @@ import {
   HvDialogContent,
   HvDialogTitle,
 } from "@hitachivantara/uikit-react-core";
-import { Favorite, Flag, Search } from "@hitachivantara/uikit-react-icons";
+import {
+  Edit,
+  Favorite,
+  Flag,
+  Search,
+} from "@hitachivantara/uikit-react-icons";
 import {
   HvFlowNode,
   HvFlowNodeFC,
@@ -27,6 +32,11 @@ export const Asset: HvFlowNodeFC<NodeGroups> = (props) => {
     container: css({
       width: "40%",
       minHeight: 200,
+    }),
+    outputLabel: css({
+      display: "flex",
+      alignItems: "center",
+      gap: 2,
     }),
   };
 
@@ -97,14 +107,40 @@ export const Asset: HvFlowNodeFC<NodeGroups> = (props) => {
         ]}
         outputs={[
           {
-            label: "Sensor Group 1",
-            isMandatory: true,
-            provides: "sensorData",
-          },
-          {
-            label: "Sensor Group 2",
-            isMandatory: true,
-            provides: "sensorData",
+            label: (
+              <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
+                Sensors
+                <HvButton size="sm" variant="primarySubtle">
+                  Configure
+                </HvButton>
+              </div>
+            ),
+            outputs: [
+              {
+                label: (
+                  <div className={classes.outputLabel}>
+                    <HvButton icon variant="primaryGhost" aria-label="Edit">
+                      <Edit />
+                    </HvButton>
+                    Sensor Group 1
+                  </div>
+                ),
+                isMandatory: true,
+                provides: "sensorData",
+              },
+              {
+                label: (
+                  <div className={classes.outputLabel}>
+                    <HvButton icon variant="primaryGhost" aria-label="Edit">
+                      <Edit />
+                    </HvButton>
+                    Sensor Group 2
+                  </div>
+                ),
+                isMandatory: true,
+                provides: "sensorData",
+              },
+            ],
           },
         ]}
         {...props}

--- a/packages/lab/src/Flow/stories/Base/Dashboard.tsx
+++ b/packages/lab/src/Flow/stories/Base/Dashboard.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { css } from "@emotion/css";
 import { Layout } from "react-grid-layout";
 import {
   HvButton,
@@ -12,6 +13,10 @@ import {
 } from "@hitachivantara/uikit-react-lab";
 
 import type { NodeGroups } from ".";
+
+const classes = {
+  footer: css({ display: "flex", justifyContent: "center" }),
+};
 
 export const Dashboard: HvFlowNodeFC<NodeGroups> = (props) => {
   const { id: idProp } = props;
@@ -63,12 +68,20 @@ export const Dashboard: HvFlowNodeFC<NodeGroups> = (props) => {
         },
       ]}
       previewItems={previewItems}
+      classes={{
+        footerContainer: classes.footer,
+      }}
+      footer={
+        <HvButton
+          size="sm"
+          variant="secondarySubtle"
+          onClick={() => setOpen(true)}
+        >
+          Preview Dashboard
+        </HvButton>
+      }
       {...props}
-    >
-      <HvButton variant="secondarySubtle" onClick={() => setOpen(true)}>
-        Preview Dashboard
-      </HvButton>
-    </HvDashboardNode>
+    />
   );
 };
 

--- a/packages/lab/src/Flow/stories/Usage.stories.mdx
+++ b/packages/lab/src/Flow/stories/Usage.stories.mdx
@@ -195,33 +195,49 @@ that are not in a group. This default group is customizable via the `defaultGrou
 
 ## Inputs and outputs <a id="inputs-and-outputs" />
 
-Nodes need inputs and/or outputs to connect to other nodes. Inputs and outputs can be defined as properties of the component and they
-follow specific types as shown below.
+Nodes need inputs and/or outputs to connect to other nodes and they can be defined as properties of the component.
+Below are the specifications for a single input and output.
 
 ```typescript
-type HvFlowNodeInput = {
-  label: string;
+interface HvFlowNodeInput {
+  id?: string;
+  label: React.ReactNode;
   isMandatory?: boolean;
   accepts?: string[];
   maxConnections?: number;
-};
+}
 
-type HvFlowNodeOutput = {
-  label: string;
+interface HvFlowNodeOutput {
+  id?: string;
+  label: React.ReactNode;
   isMandatory?: boolean;
   provides?: string;
   maxConnections?: number;
-};
+}
 ```
 
-You'll notice that input nodes have an `accepts` property and the output nodes have a `provides` property. These are used to limit
-how nodes connect to other nodes and as a descriptor of what a node provides or accepts. Thus, for example, if a node
-provides `"config"`, only nodes that accept this string will allow a connection from that node. While inputs can accept an array of strings,
+You'll notice that an input have an `accepts` property and an output have a `provides` property. These are used to limit
+how nodes connect to other nodes and as a descriptor of what a node provides or accepts. Thus, for example, if an output of a node
+provides `"config"`, only nodes with inputs that accept this string will allow a connection from that output. While inputs can accept an array of strings,
 an output only provides one. If, instead, you want a node input to accept outputs from any other node without restrictions,
 you only need to set the `accepts` property to an empty array or, alternatively, not setting the `accepts` at all.
 
 Furthermore, it's also possible to define the maximum number of connections allowed for a particular input and output. This enables you to limit
 the number of connections an input accepts as well as the number of connections an output can establish.
+
+Nodes can also accept groups of inputs and outputs. These groups are defined by the types below.
+
+```typescript
+interface HvFlowNodeInputGroup {
+  label: React.ReactNode;
+  inputs: HvFlowNodeInput[];
+}
+
+interface HvFlowNodeOutputGroup {
+  label: React.ReactNode;
+  outputs: HvFlowNodeOutput[];
+}
+```
 
 ## Parameters <a id="parameters" />
 

--- a/packages/lab/src/Flow/types/flow.ts
+++ b/packages/lab/src/Flow/types/flow.ts
@@ -63,25 +63,35 @@ export type HvFlowNodeTypeMeta<
 
 export interface HvFlowNodeMeta {
   label: string;
-  inputs?: HvFlowNodeInput[];
-  outputs?: HvFlowNodeOutput[];
+  inputs?: (HvFlowNodeInput | HvFlowNodeInputGroup)[];
+  outputs?: (HvFlowNodeOutput | HvFlowNodeOutputGroup)[];
 }
 
-export type HvFlowNodeInput = {
+export interface HvFlowNodeInput {
   id?: string;
-  label: string;
+  label: React.ReactNode;
   isMandatory?: boolean;
   accepts?: string[];
   maxConnections?: number;
-};
+}
 
-export type HvFlowNodeOutput = {
+export interface HvFlowNodeInputGroup {
+  label: React.ReactNode;
+  inputs: HvFlowNodeInput[];
+}
+
+export interface HvFlowNodeOutput {
   id?: string;
-  label: string;
+  label: React.ReactNode;
   isMandatory?: boolean;
   provides?: string;
   maxConnections?: number;
-};
+}
+
+export interface HvFlowNodeOutputGroup {
+  label: React.ReactNode;
+  outputs: HvFlowNodeOutput[];
+}
 
 export interface HvFlowNodeSharedParam {
   id: string;


### PR DESCRIPTION
- Nodes accept groups of inputs and outputs
- Inputs and outputs labels are now `React.ReactNode` instead of `string`
- Docs updated
- Node data type added to `useFlowNodeUtils` 
- Fix: It was not possible to override the parents' nodes (`HvFlowNode` and `HvFlowBaseNode`) `classes` for `HvDashboardNode` and `HvFlowNode`
- The actions were moved to the footer for samples using `HvDashboardNode`
   - Since the actions are in the footer now, I removed the unnecessary class that was wrapping `children` for this component

![Screenshot 2024-01-18 at 16 46 31](https://github.com/lumada-design/hv-uikit-react/assets/43220251/1cd0661a-4aad-4ae0-bdb9-51b7cb8a0442)
