### PR TITLE
fix(Table): dropdown renderer crashing & cut-off

### DIFF
--- a/packages/core/src/Table/renderers/DropdownColumnCell/DropdownColumnCell.tsx
+++ b/packages/core/src/Table/renderers/DropdownColumnCell/DropdownColumnCell.tsx
@@ -29,7 +29,6 @@ export const HvDropdownColumnCell = ({
       placeholder={placeholder}
       disabled={disabled}
       values={values}
-      disablePortal
       {...dropdownProps}
     />
   );

--- a/packages/core/src/Table/renderers/DropdownColumnCell/DropdownColumnCell.tsx
+++ b/packages/core/src/Table/renderers/DropdownColumnCell/DropdownColumnCell.tsx
@@ -3,11 +3,11 @@ import { HvListValue } from "../../../List";
 
 export interface HvDropdownColumnCellProp {
   /** Values to render in the dropdown. */
-  values: HvListValue[];
+  values?: HvListValue[];
   /** Placeholder text for when the dropdown is empty. */
-  placeholder: string;
-  /** The whether the dropdown is disabled. */
-  disabled: boolean;
+  placeholder?: string;
+  /** Whether the dropdown is disabled. */
+  disabled?: boolean;
   /** Function called when there is change on the dropdown. */
   onChange?: (value: HvListValue) => void;
   /** Extra props to be passed onto the dropdown. */

--- a/packages/core/src/Table/renderers/renderers.tsx
+++ b/packages/core/src/Table/renderers/renderers.tsx
@@ -223,13 +223,14 @@ export function hvDropdownColumn<
   return {
     Cell: (cellProps: HvCellProps<D, H>) => {
       const { value, row, column } = cellProps;
-      const dsbld = value.length < 1;
+      const disabled =
+        !Array.isArray(value) || (Array.isArray(value) && value.length < 1);
       return (
         <HvDropdownColumnCell
           values={value}
-          placeholder={dsbld ? disabledPlaceholder : placeholder}
+          placeholder={disabled ? disabledPlaceholder : placeholder}
           onChange={(val) => onChange?.(row.id, val)}
-          disabled={dsbld}
+          disabled={disabled}
           dropdownProps={{
             "aria-labelledby": setId(id, column.id) || column.id || id, // TODO - to be reviewed because it doesn't make much sense
           }}

--- a/packages/core/src/Table/stories/TableRenderers/DropDownColumnRenderer.test.tsx
+++ b/packages/core/src/Table/stories/TableRenderers/DropDownColumnRenderer.test.tsx
@@ -1,0 +1,163 @@
+import React, { useMemo, useState } from "react";
+
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import {
+  HvTable,
+  HvTableBody,
+  HvTableCell,
+  HvTableContainer,
+  HvTableHead,
+  HvTableHeader,
+  HvTableRow,
+  useHvData,
+  useHvPagination,
+  HvRowInstance,
+  HvCellProps,
+  hvDropdownColumn,
+} from "@hitachivantara/uikit-react-core";
+
+import { makeRenderersData, NewRendererEntry } from "../storiesUtils";
+
+const consoleMock = vi.spyOn(console, "error").mockImplementation(() => ({}));
+
+const DropdownColumnRenderer = () => {
+  const initialData = useMemo(() => makeRenderersData(3), []);
+
+  const [data, setData] = useState(initialData);
+
+  initialData[0].severity = undefined;
+
+  const columns = useMemo(() => {
+    return [
+      hvDropdownColumn<NewRendererEntry, string>(
+        { Header: "Severity", accessor: "severity", id: "severity-header" },
+        undefined,
+        "Select severity...",
+        "Select severity...",
+        (id, value) => {
+          let newData = [...data];
+          newData = newData.map((val, index) => {
+            const newVal = { ...val };
+            if (index.toString() === id) {
+              if (newVal.severity) {
+                newVal.severity = newVal.severity.map((sev) => {
+                  const newSev = { ...sev };
+                  newSev.selected = false;
+                  if (newSev.id === value.id) newSev.selected = value.selected;
+                  return newSev;
+                });
+              }
+            }
+            return newVal;
+          });
+          setData(newData);
+        }
+      ),
+    ];
+  }, [data]);
+
+  const { getTableProps, getTableBodyProps, prepareRow, headers, page } =
+    useHvData<NewRendererEntry, string>(
+      {
+        columns,
+        data,
+        defaultColumn: {
+          Cell: ({ value }: HvCellProps<NewRendererEntry, string>) =>
+            value ?? "—",
+        },
+      },
+      useHvPagination
+    );
+
+  const rowRenderer = (pages: HvRowInstance<NewRendererEntry, string>[]) => {
+    return pages.map((row, index) => {
+      prepareRow(row);
+
+      return (
+        <React.Fragment key={row.id}>
+          <HvTableRow
+            {...row.getRowProps({
+              "aria-rowindex": index + 1,
+            })}
+          >
+            {row.cells.map((cell) => (
+              <HvTableCell {...cell.getCellProps()}>
+                {cell.render("Cell")}
+              </HvTableCell>
+            ))}
+          </HvTableRow>
+        </React.Fragment>
+      );
+    });
+  };
+
+  return (
+    <HvTableContainer>
+      <HvTable
+        {...getTableProps({
+          "aria-rowcount": data.length,
+        })}
+        style={{
+          width: 230,
+        }}
+      >
+        <HvTableHead>
+          <HvTableRow>
+            {headers.map((col) => (
+              <HvTableHeader
+                {...col.getHeaderProps()}
+                key={col.Header}
+                id={col.id}
+              >
+                {col.render("Header")}
+              </HvTableHeader>
+            ))}
+          </HvTableRow>
+        </HvTableHead>
+        <HvTableBody {...getTableBodyProps()}>{rowRenderer(page)}</HvTableBody>
+      </HvTable>
+    </HvTableContainer>
+  );
+};
+
+describe("DropDownColumnRenderer", () => {
+  beforeEach(() => {
+    consoleMock.mockReset();
+    render(<DropdownColumnRenderer />);
+  });
+
+  it("table should render with no erros when one row has no values defined", async () => {
+    expect(consoleMock).not.toHaveBeenCalled();
+    expect(screen.getAllByText("Select severity...")).toHaveLength(1);
+  });
+
+  /* Test can be uncommented after https://hv-eng.atlassian.net/browse/HVUIKIT-7017 is fixed
+  it("should be possible to unselect an element without errors", async () => {
+    await userEvent.click(screen.getByText("Major"));
+
+    await userEvent.selectOptions(
+      screen.getByRole("listbox"),
+      screen.getByRole("option", { name: "Major" })
+    );
+
+    expect(consoleMock).not.toHaveBeenCalled();
+    expect(screen.getAllByText("Select severity...")).toHaveLength(1);
+  }); */
+
+  it("should allow to change value", async () => {
+    expect(screen.getAllByText("Average")).toHaveLength(1);
+    expect(screen.queryAllByText("Minor")).toHaveLength(0);
+
+    await userEvent.click(screen.getByText("Average"));
+    await userEvent.selectOptions(
+      screen.getByRole("listbox"),
+      screen.getByRole("option", { name: "Minor" })
+    );
+
+    expect(screen.queryAllByText("Average")).toHaveLength(0);
+    expect(screen.getAllByText("Minor")).toHaveLength(1);
+  });
+});

--- a/packages/core/src/Table/stories/TableRenderers/TableRenderers.tsx
+++ b/packages/core/src/Table/stories/TableRenderers/TableRenderers.tsx
@@ -27,6 +27,7 @@ import {
   hvProgressColumn,
   theme,
 } from "@hitachivantara/uikit-react-core";
+import { fireEvent, screen, waitFor, within } from "@storybook/testing-library";
 
 import { makeRenderersData, NewRendererEntry } from "../storiesUtils";
 
@@ -1881,6 +1882,8 @@ const DropdownColumnRenderer = () => {
 
   const [data, setData] = useState(initialData);
 
+  // initialData[0].severity = undefined;
+
   const columns = useMemo(() => {
     return [
       hvDropdownColumn<NewRendererEntry, string>(
@@ -1893,12 +1896,14 @@ const DropdownColumnRenderer = () => {
           newData = newData.map((val, index) => {
             const newVal = { ...val };
             if (index.toString() === id) {
-              newVal.severity = newVal.severity.map((sev) => {
-                const newSev = { ...sev };
-                newSev.selected = false;
-                if (newSev.id === value.id) newSev.selected = !!value.selected;
-                return newSev;
-              });
+              if (newVal.severity) {
+                newVal.severity = newVal.severity.map((sev) => {
+                  const newSev = { ...sev };
+                  newSev.selected = false;
+                  if (newSev.id === value.id) newSev.selected = value.selected;
+                  return newSev;
+                });
+              }
             }
             return newVal;
           });
@@ -1985,6 +1990,23 @@ const DropdownColumnRenderer = () => {
 
 export const DropdownColumnRendererStory: StoryObj = {
   parameters: {
+    eyes: {
+      include: true,
+      runBefore() {
+        // reduce the number of visible rows
+        fireEvent.click(
+          screen.getByRole("combobox", { name: "Select how many to display" })
+        );
+        fireEvent.click(screen.getByRole("option", { name: "5" }));
+
+        const tableElement = screen.getByRole("table", {
+          name: "Severity",
+        });
+        fireEvent.click(within(tableElement).getByText("Major"));
+
+        return waitFor(() => screen.getByRole("listbox"));
+      },
+    },
     docs: {
       source: {
         code: `

--- a/packages/core/src/Table/stories/TableRenderers/TableRenderers.tsx
+++ b/packages/core/src/Table/stories/TableRenderers/TableRenderers.tsx
@@ -27,7 +27,7 @@ import {
   hvProgressColumn,
   theme,
 } from "@hitachivantara/uikit-react-core";
-import { fireEvent, screen, waitFor, within } from "@storybook/testing-library";
+import { fireEvent, screen, waitFor } from "@storybook/testing-library";
 
 import { makeRenderersData, NewRendererEntry } from "../storiesUtils";
 
@@ -1882,8 +1882,6 @@ const DropdownColumnRenderer = () => {
 
   const [data, setData] = useState(initialData);
 
-  // initialData[0].severity = undefined;
-
   const columns = useMemo(() => {
     return [
       hvDropdownColumn<NewRendererEntry, string>(
@@ -1922,6 +1920,7 @@ const DropdownColumnRenderer = () => {
     getHvPaginationProps,
   } = useHvData<NewRendererEntry, string>(
     {
+      initialState: { pageSize: 5 },
       columns,
       data,
       defaultColumn: {
@@ -1993,16 +1992,7 @@ export const DropdownColumnRendererStory: StoryObj = {
     eyes: {
       include: true,
       runBefore() {
-        // reduce the number of visible rows
-        fireEvent.click(
-          screen.getByRole("combobox", { name: "Select how many to display" })
-        );
-        fireEvent.click(screen.getByRole("option", { name: "5" }));
-
-        const tableElement = screen.getByRole("table", {
-          name: "Severity",
-        });
-        fireEvent.click(within(tableElement).getByText("Major"));
+        fireEvent.click(screen.getByText("Major"));
 
         return waitFor(() => screen.getByRole("listbox"));
       },

--- a/packages/core/src/Table/stories/storiesUtils.tsx
+++ b/packages/core/src/Table/stories/storiesUtils.tsx
@@ -16,7 +16,7 @@ export interface NewRendererEntry {
     status_color?: string;
     status_text_color?: string;
   };
-  severity: {
+  severity?: {
     id?: string;
     label?: string;
     selected?: boolean;


### PR DESCRIPTION
Addresses https://github.com/lumada-design/hv-uikit-react/issues/3975

- The table was crashing when the dropdown renderer didn't have any values for the dropdown
- The dropdown list was cut-off when there wasn't many rows in the table: `disablePortal` was removed to fix this. 
   - Let me know if you think there's any problem removing `disablePortal` and it should be opt-out instead for backward compatibility purposes 

After:

https://github.com/lumada-design/hv-uikit-react/assets/43220251/7bd65816-21e3-4014-9335-0a34a604db42


