### PR TITLE
docs: update custom echarts options sample

### DIFF
--- a/.storybook/decorators/withThemeProvider.tsx
+++ b/.storybook/decorators/withThemeProvider.tsx
@@ -27,7 +27,7 @@ const useDarkClass = <T extends HTMLElement = HTMLDivElement>(mode: string) => {
   return ref;
 };
 
-const ThemeDecorator: Decorator = (story) => {
+const ThemeDecorator: Decorator = (Story) => {
   const initialTheme = getLocalTheme();
 
   const [selectedTheme, setSelectedTheme] = useState(initialTheme);
@@ -68,7 +68,7 @@ const ThemeDecorator: Decorator = (story) => {
             className="hv-story-sample"
             style={{ padding: 20 }}
           >
-            {story()}
+            <Story />
           </div>
         </HvVizProvider>
       </HvProvider>

--- a/packages/viz/src/BarChart/BarChart.tsx
+++ b/packages/viz/src/BarChart/BarChart.tsx
@@ -9,6 +9,7 @@ import {
   LegendComponent,
   DataZoomSliderComponent,
   DataZoomInsideComponent,
+  MarkLineComponent,
 } from "echarts/components";
 import ReactECharts from "echarts-for-react/lib/core";
 
@@ -41,6 +42,7 @@ echarts.use([
   LegendComponent,
   DataZoomSliderComponent,
   DataZoomInsideComponent,
+  MarkLineComponent,
 ]);
 
 export interface HvBarChartClasses extends HvChartTooltipClasses {}

--- a/packages/viz/src/LineChart/LineChart.stories.tsx
+++ b/packages/viz/src/LineChart/LineChart.stories.tsx
@@ -6,6 +6,7 @@ import {
   HvTypography,
   HvCheckBox,
   Random,
+  useTheme,
 } from "@hitachivantara/uikit-react-core";
 import { css } from "@emotion/css";
 import { Meta, StoryObj } from "@storybook/react";
@@ -773,6 +774,7 @@ export const CustomEchartsOptions: StoryObj<HvLineChartProps> = {
     },
   },
   render: () => {
+    const { colors } = useTheme();
     return (
       <HvLineChart
         data={{
@@ -806,16 +808,21 @@ export const CustomEchartsOptions: StoryObj<HvLineChartProps> = {
             data: [{ yAxis: 3000, name: "Average" }],
             symbol: "none",
             itemStyle: {
-              color: "#F27C27",
+              color: colors?.secondary,
+            },
+            label: {
+              color: colors?.secondary,
             },
           };
           option.series[0].smooth = true;
           option.series[0].lineStyle = {
-            color: "#999999",
+            color: colors?.secondary_60,
           };
           option.series[0].itemStyle = {
             color(params) {
-              return params.data[1] > 3000 ? "#00CC00" : "#CC0000";
+              return params.data[1] > 3000
+                ? colors?.positive
+                : colors?.negative;
             },
           };
 

--- a/packages/viz/src/LineChart/LineChart.stories.tsx
+++ b/packages/viz/src/LineChart/LineChart.stories.tsx
@@ -798,9 +798,28 @@ export const CustomEchartsOptions: StoryObj<HvLineChartProps> = {
         groupBy="Month"
         measures="Sales Target"
         onOptionChange={(option) => {
+          console.log(option);
           if (Array.isArray(option.yAxis) && option.yAxis.length === 1) {
             option.yAxis = [{ ...option.yAxis[0], splitNumber: 8 }];
           }
+          option.series[0].markLine = {
+            data: [{ yAxis: 3000, name: "Average" }],
+            symbol: "none",
+            itemStyle: {
+              color: "#F27C27",
+            },
+          };
+          option.series[0].smooth = true;
+          option.series[0].lineStyle = {
+            color: "#999999",
+          };
+          option.series[0].itemStyle = {
+            color(params) {
+              return params.data[1] > 3000 ? "#00CC00" : "#CC0000";
+            },
+          };
+
+          option.series[0].symbolSize = 8;
 
           return option;
         }}

--- a/packages/viz/src/LineChart/LineChart.tsx
+++ b/packages/viz/src/LineChart/LineChart.tsx
@@ -9,6 +9,7 @@ import {
   LegendComponent,
   DataZoomSliderComponent,
   DataZoomInsideComponent,
+  MarkLineComponent,
 } from "echarts/components";
 import ReactECharts from "echarts-for-react/lib/core";
 
@@ -41,6 +42,7 @@ echarts.use([
   LegendComponent,
   DataZoomSliderComponent,
   DataZoomInsideComponent,
+  MarkLineComponent,
 ]);
 
 export interface HvLineChartClasses extends HvChartTooltipClasses {}

--- a/packages/viz/src/hooks/useSeries.tsx
+++ b/packages/viz/src/hooks/useSeries.tsx
@@ -174,15 +174,15 @@ export const useSeries = ({
   }, [
     data,
     groupByKey,
-    area,
-    stack,
-    nameFormatter,
-    emptyCellMode,
-    areaOpacity,
     measures,
     type,
-    horizontal,
+    nameFormatter,
     radius,
+    stack,
+    horizontal,
+    emptyCellMode,
+    area,
+    areaOpacity,
   ]);
 
   return option;


### PR DESCRIPTION
- Allow the use of `MarkLineComponent` on the `LineChart` and `BarChart` components
- Update the custom echart options sample for the `LineChart` component