### PR TITLE
build(table): fix useHvTable pluginName side-effects

### DIFF
--- a/packages/core/src/Table/hooks/useFilters.ts
+++ b/packages/core/src/Table/hooks/useFilters.ts
@@ -1,4 +1,4 @@
-import { useFilters as useHvFilters, Hooks } from "react-table";
+import { useFilters, Hooks } from "react-table";
 
 export type UseFiltersProps = (<D extends object = Record<string, unknown>>(
   hooks: Hooks<D>
@@ -6,6 +6,7 @@ export type UseFiltersProps = (<D extends object = Record<string, unknown>>(
 
 // #endregion ##### TYPES #####
 
+const useHvFilters = useFilters.bind({});
 (useHvFilters.pluginName as string) = "useHvFilters";
 
 export default useHvFilters as UseFiltersProps;

--- a/packages/core/src/Table/hooks/useGlobalFilter.ts
+++ b/packages/core/src/Table/hooks/useGlobalFilter.ts
@@ -1,4 +1,4 @@
-import { useGlobalFilter as useHvGlobalFilter, Hooks } from "react-table";
+import { useGlobalFilter, Hooks } from "react-table";
 
 export type UseGlobalFilterProps = (<
   D extends object = Record<string, unknown>
@@ -8,6 +8,7 @@ export type UseGlobalFilterProps = (<
 
 // #endregion ##### TYPES #####
 
+const useHvGlobalFilter = useGlobalFilter.bind({});
 (useHvGlobalFilter.pluginName as string) = "useHvGlobalFilter";
 
 export default useHvGlobalFilter as UseGlobalFilterProps;


### PR DESCRIPTION
- fixes `useFilters` and `useGlobalFilter`'s side-effects by cloning the hooks, instead of re-exporting & mutating `react-table`'s

https://www.unpkg.com/browse/@hitachivantara/uikit-react-core@5.44.8/dist/esm/index.js (lines 35-36)