### PR TITLE
fix(DropdownMenu): add variant prop to be inline with other components

### DIFF
--- a/packages/core/src/DropDownMenu/DropDownMenu.stories.tsx
+++ b/packages/core/src/DropDownMenu/DropDownMenu.stories.tsx
@@ -35,7 +35,7 @@ export const Main: StoryObj<HvDropDownMenuProps> = {
     disabled: false,
     expanded: true,
     defaultExpanded: false,
-    category: "secondaryGhost",
+    variant: "secondaryGhost",
   },
   argTypes: {
     classes: { control: { disable: true } },

--- a/packages/core/src/DropDownMenu/DropDownMenu.tsx
+++ b/packages/core/src/DropDownMenu/DropDownMenu.tsx
@@ -55,8 +55,13 @@ export interface HvDropDownMenuProps
   expanded?: boolean;
   /** When uncontrolled, defines the initial expanded state. */
   defaultExpanded?: boolean;
-  /** The variant to be used in the header. */
+  /**
+   * The variant to be used in the header.
+   * @deprecated Use `variant` instead
+   */
   category?: HvButtonVariant;
+  /** The variant to be used in the header. */
+  variant?: HvButtonVariant;
   /** A Jss Object used to override or extend the styles applied to the component. */
   classes?: HvDropDownMenuClasses;
 }
@@ -80,6 +85,7 @@ export const HvDropDownMenu = (props: HvDropDownMenuProps) => {
     expanded,
     defaultExpanded = false,
     category = "secondaryGhost",
+    variant = "secondaryGhost",
     ...others
   } = useDefaultProps("HvDropDownMenu", props);
 
@@ -133,7 +139,7 @@ export const HvDropDownMenu = (props: HvDropDownMenuProps) => {
       component={
         <HvButton
           icon
-          variant={category}
+          variant={variant ?? category}
           id={setId(id, "icon-button")}
           className={cx(classes.icon, { [classes.iconSelected]: open })}
           aria-expanded={open}

--- a/packages/core/src/DropDownMenu/DropDownMenu.tsx
+++ b/packages/core/src/DropDownMenu/DropDownMenu.tsx
@@ -85,7 +85,7 @@ export const HvDropDownMenu = (props: HvDropDownMenuProps) => {
     expanded,
     defaultExpanded = false,
     category = "secondaryGhost",
-    variant = "secondaryGhost",
+    variant,
     ...others
   } = useDefaultProps("HvDropDownMenu", props);
 


### PR DESCRIPTION
It doesn't make much sense that this component has a prop categories while others have variants and the values are the same.

category was marked as deprecated and not remove to not cause breaking changes