### PR TITLE
ci: bump actions versions

### DIFF
--- a/.github/actions/build-artifacts/action.yml
+++ b/.github/actions/build-artifacts/action.yml
@@ -5,7 +5,7 @@ runs:
   using: "composite"
   steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Install Dependencies
       uses: ./.github/actions/install-dependencies
@@ -17,7 +17,7 @@ runs:
       shell: bash
 
     - name: Archive Documentation
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: documentation
         path: ${{ github.workspace }}/dist
@@ -28,7 +28,7 @@ runs:
       shell: bash
 
     - name: Archive App
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: app
         path: ${{ github.workspace }}/apps/app/dist
@@ -40,7 +40,7 @@ runs:
       shell: bash
 
     - name: Archive Nextra Docs
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: nextra-docs
         path: ${{ github.workspace }}/apps/docs/out

--- a/.github/actions/deploy-artifacts/action.yml
+++ b/.github/actions/deploy-artifacts/action.yml
@@ -14,7 +14,7 @@ runs:
         fi
 
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Start Deployment
       uses: bobheadxi/deployments@v1
@@ -27,7 +27,7 @@ runs:
         desc: ${{ env.PUBLISH_MESSAGE }}
 
     - name: Checkout Artifacts Repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         repository: ${{ env.PUBLISH_REPO }}
         ref: master
@@ -40,7 +40,7 @@ runs:
       shell: bash
 
     - name: Fetch Artifact
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: ${{ env.ARTIFACT }}
         path: ${{ github.workspace }}/gh-docs/${{env.PUBLISH_FOLDER}}

--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -5,10 +5,10 @@ runs:
   using: "composite"
   steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Install Node.js
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: 18
 

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Build Artifacts
         uses: ./.github/actions/build-artifacts
@@ -45,7 +45,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Deploy Artifacts
         uses: ./.github/actions/deploy-artifacts

--- a/.github/workflows/pr-close.yml
+++ b/.github/workflows/pr-close.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: ${{ env.PUBLISH_REPO }}
           ref: ${{ env.PUBLISH_BRANCH }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,14 +20,14 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           # Pulls all commits (needed for semantic release to correctly version)
           # See https://github.com/semantic-release/semantic-release/issues/1526
           fetch-depth: "0"
 
       - name: Install Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 16
 
@@ -89,7 +89,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Get Releases Commit Message
         uses: actions/github-script@v3

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Run Dependency Check Scans
         uses: dependency-check/Dependency-Check_Action@1.1.0
@@ -42,10 +42,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Java
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           java-version: "11"
           distribution: "adopt"

--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install Dependencies
         uses: ./.github/actions/install-dependencies
@@ -50,7 +50,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install Dependencies
         uses: ./.github/actions/install-dependencies
@@ -73,7 +73,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install Dependencies
         uses: ./.github/actions/install-dependencies

--- a/.github/workflows/tests-a11y.yml
+++ b/.github/workflows/tests-a11y.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install Dependencies
         uses: ./.github/actions/install-dependencies
@@ -42,7 +42,7 @@ jobs:
 
       - name: Archive a11y report
         if: success() || failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: a11y-report
           path: ${{ github.workspace }}/a11y-report

--- a/.github/workflows/tests-applitools.yml
+++ b/.github/workflows/tests-applitools.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install Dependencies
         uses: ./.github/actions/install-dependencies


### PR DESCRIPTION
Bump common actions to `@v4` to fix the extensive warnings we're getting

![image](https://github.com/lumada-design/hv-uikit-react/assets/638946/386b6e08-0c51-4b8e-9439-c1ff4a34d1e8)
