### PR TITLE
chore(Flow): useReactFlow export, small refactor, and docs updates

### DIFF
--- a/apps/app/src/pages/Flow/Flow.tsx
+++ b/apps/app/src/pages/Flow/Flow.tsx
@@ -1,5 +1,4 @@
 import { Suspense, useEffect, useMemo, useState } from "react";
-import { Edge, ReactFlowInstance, Node } from "reactflow";
 import {
   HvButton,
   HvGlobalActions,
@@ -13,6 +12,7 @@ import {
   HvFlow,
   HvFlowControls,
   HvFlowEmpty,
+  HvFlowInstance,
   HvFlowProps,
   HvFlowSidebar,
 } from "@hitachivantara/uikit-react-lab";
@@ -23,7 +23,6 @@ import {
   DashboardsStorage,
   LAYOUT_COLS,
 } from "./types";
-
 import { buildLayout, createDataset, useDatasets } from "./utils";
 import { baseNodeTypes, edges, nodeGroups, nodes } from "./config";
 
@@ -37,11 +36,13 @@ const layout = [
   { w: 12, h: 4, x: 0, y: 4, i: "7" },
 ] satisfies HvDashboardProps["layout"];
 
+type Node = NonNullable<ReturnType<HvFlowInstance["getNode"]>>;
+type Edge = NonNullable<ReturnType<HvFlowInstance["getEdge"]>>;
+
 const Content = () => {
   const { data } = useDatasets();
 
-  const [reactFlowInstance, setReactFlowInstance] =
-    useState<ReactFlowInstance>();
+  const [reactFlowInstance, setReactFlowInstance] = useState<HvFlowInstance>();
   const [open, setOpen] = useState(false);
 
   const persistDashboards = (

--- a/apps/app/src/pages/Flow/Nodes/BarChart.tsx
+++ b/apps/app/src/pages/Flow/Nodes/BarChart.tsx
@@ -9,10 +9,8 @@ import {
 
 import { NodeData, NodeGroup } from "../types";
 
-export const BarChart: HvFlowNodeFC = (props) => {
-  const { id } = props;
-
-  const inputNodes = useFlowInputNodes<NodeData>(id);
+export const BarChart: HvFlowNodeFC<NodeGroup> = (props) => {
+  const inputNodes = useFlowInputNodes<NodeData>();
 
   const params: HvFlowNodeProps["params"] = useMemo(() => {
     const columns = inputNodes[0]?.data.columns;

--- a/apps/app/src/pages/Flow/Nodes/Dashboard.tsx
+++ b/apps/app/src/pages/Flow/Nodes/Dashboard.tsx
@@ -53,7 +53,7 @@ const classes = {
   }),
 };
 
-export const Dashboard: HvFlowNodeFC = (props) => {
+export const Dashboard: HvFlowNodeFC<NodeGroup> = (props) => {
   const { id } = props;
 
   const { nodeTypes } = useFlowContext();

--- a/apps/app/src/pages/Flow/Nodes/DonutChart.tsx
+++ b/apps/app/src/pages/Flow/Nodes/DonutChart.tsx
@@ -9,10 +9,8 @@ import {
 
 import { NodeData, NodeGroup } from "../types";
 
-export const DonutChart: HvFlowNodeFC = (props) => {
-  const { id } = props;
-
-  const inputNodes = useFlowInputNodes<NodeData>(id);
+export const DonutChart: HvFlowNodeFC<NodeGroup> = (props) => {
+  const inputNodes = useFlowInputNodes<NodeData>();
 
   const params: HvFlowNodeProps["params"] = useMemo(() => {
     const columns = inputNodes[0]?.data.columns;

--- a/apps/app/src/pages/Flow/Nodes/Kpi.tsx
+++ b/apps/app/src/pages/Flow/Nodes/Kpi.tsx
@@ -9,10 +9,8 @@ import {
 
 import { NodeData, NodeGroup } from "../types";
 
-export const Kpi: HvFlowNodeFC = (props) => {
-  const { id } = props;
-
-  const inputNodes = useFlowInputNodes<NodeData>(id);
+export const Kpi: HvFlowNodeFC<NodeGroup> = (props) => {
+  const inputNodes = useFlowInputNodes<NodeData>();
 
   const params: HvFlowNodeProps["params"] = useMemo(() => {
     const columns = inputNodes[0]?.data.columns;

--- a/apps/app/src/pages/Flow/Nodes/LineChart.tsx
+++ b/apps/app/src/pages/Flow/Nodes/LineChart.tsx
@@ -9,10 +9,8 @@ import {
 
 import { NodeData, NodeGroup } from "../types";
 
-export const LineChart: HvFlowNodeFC = (props) => {
-  const { id } = props;
-
-  const inputNodes = useFlowInputNodes<NodeData>(id);
+export const LineChart: HvFlowNodeFC<NodeGroup> = (props) => {
+  const inputNodes = useFlowInputNodes<NodeData>();
 
   const params: HvFlowNodeProps["params"] = useMemo(() => {
     const columns = inputNodes[0]?.data.columns;

--- a/apps/app/src/pages/Flow/Nodes/Table.tsx
+++ b/apps/app/src/pages/Flow/Nodes/Table.tsx
@@ -8,7 +8,7 @@ import {
 
 import { NodeGroup } from "../types";
 
-export const Table: HvFlowNodeFC = (props) => {
+export const Table: HvFlowNodeFC<NodeGroup> = (props) => {
   const params: HvFlowNodeProps["params"] = useMemo(() => {
     return [
       { label: "Title", id: "title", type: "text" },

--- a/apps/app/src/pages/Flow/types.ts
+++ b/apps/app/src/pages/Flow/types.ts
@@ -1,5 +1,7 @@
-import { Node } from "reactflow";
-import { HvDashboardProps } from "@hitachivantara/uikit-react-lab";
+import {
+  HvDashboardProps,
+  HvFlowInstance,
+} from "@hitachivantara/uikit-react-lab";
 
 export type NodeGroup = "dashboard" | "visualization" | "dataset";
 
@@ -8,9 +10,11 @@ export const DASHBOARDS_STORAGE_KEY = "dashboards";
 
 export const LAYOUT_COLS = 12;
 
+type Node = NonNullable<ReturnType<HvFlowInstance<NodeData>["getNode"]>>;
+
 export interface DashboardSpecs
   extends Pick<HvDashboardProps, "layout" | "cols"> {
-  items: Node<NodeData>[];
+  items: Node[];
 }
 
 export type DashboardsStorage = Record<string, DashboardSpecs | undefined>;

--- a/packages/core/src/VerticalNavigation/VerticalNavigation.stories.tsx
+++ b/packages/core/src/VerticalNavigation/VerticalNavigation.stories.tsx
@@ -105,7 +105,6 @@ export const Main: StoryObj<HvVerticalNavigationProps> = {
             aria-label="Example 1 navigation"
             selected={value}
             onChange={(event, data) => {
-              console.log(data);
               if (data.id === "02-01-01") {
                 event.preventDefault();
                 event.stopPropagation();
@@ -196,10 +195,7 @@ export const TreeViewMode: StoryObj<HvVerticalNavigationProps> = {
             defaultExpanded
             aria-label="Example 3 navigation"
             selected={value}
-            onChange={(event, data) => {
-              console.log(data);
-              setValue(data.id);
-            }}
+            onChange={(event, data) => setValue(data.id)}
             data={navigationData}
           />
           <HvVerticalNavigationActions>
@@ -379,10 +375,7 @@ export const Collapsible: StoryObj<HvVerticalNavigationProps> = {
             defaultExpanded
             aria-label="Example 3 navigation"
             selected={value}
-            onChange={(event, data) => {
-              console.log(data);
-              setValue(data.id);
-            }}
+            onChange={(event, data) => setValue(data.id)}
             data={navigationDataState}
           />
           <HvVerticalNavigationActions>
@@ -515,10 +508,7 @@ export const CollapsibleIcons: StoryObj<HvVerticalNavigationProps> = {
             defaultExpanded
             aria-label="Example 3 navigation"
             selected={value}
-            onChange={(event, data) => {
-              console.log(data);
-              setValue(data.id);
-            }}
+            onChange={(event, data) => setValue(data.id)}
             data={navigationDataState}
           />
           <HvVerticalNavigationActions>
@@ -592,10 +582,7 @@ export const CollapsibleIconsWithoutSubItems: StoryObj<HvVerticalNavigationProps
               defaultExpanded
               aria-label="Example 3 navigation"
               selected={value}
-              onChange={(event, data) => {
-                console.log(data);
-                setValue(data.id);
-              }}
+              onChange={(event, data) => setValue(data.id)}
               data={navigationDataState}
             />
             <HvVerticalNavigationActions>
@@ -737,10 +724,7 @@ export const CollapsibleIconsWithCustomPopupStyles: StoryObj<HvVerticalNavigatio
               defaultExpanded
               aria-label="Example 3 navigation"
               selected={value}
-              onChange={(event, data) => {
-                console.log(data);
-                setValue(data.id);
-              }}
+              onChange={(event, data) => setValue(data.id)}
               data={navigationDataState}
               classes={{ navigationPopup: popupStyles }}
             />
@@ -849,10 +833,7 @@ export const SliderMode: StoryObj<HvVerticalNavigationProps> = {
               defaultExpanded
               aria-label="Example 4 Slider Mode"
               selected={value}
-              onChange={(event, data) => {
-                console.log(data);
-                setValue(data.id);
-              }}
+              onChange={(event, data) => setValue(data.id)}
               data={navigationDataState}
             />
           </HvVerticalNavigation>
@@ -977,10 +958,7 @@ export const MobileNavigation: StoryObj<HvVerticalNavigationProps> = {
               defaultExpanded
               aria-label="Example 4 navigation slider"
               selected={value}
-              onChange={(event, data) => {
-                console.log(data);
-                setValue(data.id);
-              }}
+              onChange={(event, data) => setValue(data.id)}
               data={navigationDataState}
             />
             <HvVerticalNavigationActions>

--- a/packages/lab/src/Flow/Controls/Controls.tsx
+++ b/packages/lab/src/Flow/Controls/Controls.tsx
@@ -3,13 +3,10 @@ import {
   Panel,
   PanelPosition,
   ReactFlowState,
-  useReactFlow,
   useStore,
   useStoreApi,
 } from "reactflow";
-
 import { shallow } from "zustand/shallow";
-
 import {
   HvButton,
   HvMultiButton,
@@ -22,6 +19,8 @@ import {
   ZoomIn,
   ZoomOut,
 } from "@hitachivantara/uikit-react-icons";
+
+import { useFlowInstance } from "../hooks";
 
 export type HvFlowControlsPosition = PanelPosition;
 
@@ -83,7 +82,7 @@ export const HvFlowControls = ({
     shallow
   );
   const store = useStoreApi();
-  const { zoomIn, zoomOut, fitView } = useReactFlow();
+  const { zoomIn, zoomOut, fitView } = useFlowInstance();
 
   const labels = useLabels(DEFAULT_LABELS, labelsProps);
 

--- a/packages/lab/src/Flow/DroppableFlow.tsx
+++ b/packages/lab/src/Flow/DroppableFlow.tsx
@@ -7,7 +7,6 @@ import ReactFlow, {
   addEdge,
   applyEdgeChanges,
   applyNodeChanges,
-  useReactFlow,
   MarkerType,
   Edge,
   Node,
@@ -23,7 +22,7 @@ import {
   HvFlowNodeOutputGroup,
 } from "./types";
 import { staticClasses, useClasses } from "./Flow.styles";
-import { useFlowContext } from "./hooks";
+import { useFlowContext, useFlowInstance } from "./hooks";
 import { flowStyles } from "./base";
 import { useNodeMetaRegistry } from "./FlowContext/NodeMetaContext";
 
@@ -146,7 +145,7 @@ export const HvDroppableFlow = ({
 
   const elementId = useUniqueId(id, "hvFlow");
 
-  const reactFlowInstance = useReactFlow();
+  const reactFlowInstance = useFlowInstance();
 
   const { nodeTypes } = useFlowContext();
 

--- a/packages/lab/src/Flow/Flow.styles.tsx
+++ b/packages/lab/src/Flow/Flow.styles.tsx
@@ -5,12 +5,6 @@ import { flowBaseNodeClasses } from "./Node";
 export const { staticClasses, useClasses } = createClasses("HvFlow", {
   root: {
     height: "100%",
-    "& .react-flow__handle-connecting": {
-      backgroundColor: theme.colors.negative_20,
-    },
-    "& .react-flow__handle-valid": {
-      backgroundColor: theme.colors.positive_20,
-    },
     [`& .selected > .${flowBaseNodeClasses.root}`]: {
       border: `1px solid ${theme.colors.secondary_60}`,
       borderRadius: theme.radii.round,

--- a/packages/lab/src/Flow/Node/BaseNode.styles.tsx
+++ b/packages/lab/src/Flow/Node/BaseNode.styles.tsx
@@ -92,6 +92,12 @@ export const { staticClasses, useClasses } = createClasses("HvFlowBaseNode", {
     "&.react-flow__handle-right": {
       right: -21,
     },
+    "&.react-flow__handle-connecting": {
+      backgroundColor: theme.colors.negative_20,
+    },
+    "&.react-flow__handle-valid": {
+      backgroundColor: theme.colors.positive_20,
+    },
     "::before": {
       fontSize: 14,
       color: theme.colors.secondary_60,
@@ -104,6 +110,11 @@ export const { staticClasses, useClasses } = createClasses("HvFlowBaseNode", {
     backgroundColor: theme.colors.secondary_60,
     width: 8,
     height: 8,
+
+    "::before": {
+      fontSize: 11,
+      marginTop: -8,
+    },
   },
   mandatory: {
     width: 10,

--- a/packages/lab/src/Flow/Node/BaseNode.tsx
+++ b/packages/lab/src/Flow/Node/BaseNode.tsx
@@ -132,9 +132,9 @@ export const HvFlowBaseNode = ({
 
   const { classes, cx, css } = useClasses(classesProp);
 
-  const node = useFlowNode(id);
-  const inputEdges = useFlowNodeInputEdges(id);
-  const outputEdges = useFlowNodeOutputEdges(id);
+  const node = useFlowNode();
+  const inputEdges = useFlowNodeInputEdges();
+  const outputEdges = useFlowNodeOutputEdges();
 
   const handleDefaultAction = useCallback(
     (action: HvFlowNodeAction) => {

--- a/packages/lab/src/Flow/Node/BaseNode.tsx
+++ b/packages/lab/src/Flow/Node/BaseNode.tsx
@@ -5,13 +5,7 @@ import React, {
   useMemo,
   useState,
 } from "react";
-import {
-  Handle,
-  NodeProps,
-  NodeToolbar,
-  Position,
-  useReactFlow,
-} from "reactflow";
+import { Handle, NodeProps, NodeToolbar, Position } from "reactflow";
 import { uid } from "uid";
 import {
   ExtractNames,
@@ -45,6 +39,7 @@ import {
   isOutputGroup,
   renderedIcon,
 } from "./utils";
+import { useFlowInstance } from "../hooks";
 
 export { staticClasses as flowBaseNodeClasses };
 
@@ -128,7 +123,7 @@ export const HvFlowBaseNode = ({
   }, [id, title, inputs, outputs, registerNode, unregisterNode]);
 
   const [showActions, setShowActions] = useState(false);
-  const reactFlowInstance = useReactFlow();
+  const reactFlowInstance = useFlowInstance();
 
   const { classes, cx, css } = useClasses(classesProp);
 

--- a/packages/lab/src/Flow/Node/BaseNode.tsx
+++ b/packages/lab/src/Flow/Node/BaseNode.tsx
@@ -181,10 +181,9 @@ export const HvFlowBaseNode = ({
           isConnectableEnd={false}
           id={output.id}
           position={Position.Right}
-          className={cx(
-            classes.handle,
-            edgeConnected && classes.handleConnected
-          )}
+          className={cx(classes.handle, {
+            [classes.handleConnected]: edgeConnected,
+          })}
         />
         {output.isMandatory && !edgeConnected && (
           <div className={classes.mandatory} />
@@ -204,10 +203,9 @@ export const HvFlowBaseNode = ({
           isConnectableStart={false}
           id={input.id}
           position={Position.Left}
-          className={cx(
-            classes.handle,
-            edgeConnected && classes.handleConnected
-          )}
+          className={cx(classes.handle, {
+            [classes.handleConnected]: edgeConnected,
+          })}
         />
         <HvTypography component="div">{input.label}</HvTypography>
         {input.isMandatory && !edgeConnected && (

--- a/packages/lab/src/Flow/Node/Node.tsx
+++ b/packages/lab/src/Flow/Node/Node.tsx
@@ -83,7 +83,7 @@ export const HvFlowNode = ({
 
   const [showParams, setShowParams] = useState(expanded);
 
-  const node = useFlowNode(id);
+  const node = useFlowNode();
 
   const { nodeGroups, nodeTypes, defaultActions } = useFlowContext();
 

--- a/packages/lab/src/Flow/hooks/index.ts
+++ b/packages/lab/src/Flow/hooks/index.ts
@@ -1,3 +1,4 @@
 export * from "./useFlowNode";
 export * from "./useFlowContext";
 export * from "./useFlowNodeMeta";
+export * from "./useFlowInstance";

--- a/packages/lab/src/Flow/hooks/useFlowInstance.ts
+++ b/packages/lab/src/Flow/hooks/useFlowInstance.ts
@@ -1,0 +1,11 @@
+import { useReactFlow } from "reactflow";
+
+import { HvFlowInstance } from "../types";
+
+/** Retrieves the React Flow instance */
+export function useFlowInstance<
+  NodeData = any,
+  EdgeData = any
+>(): HvFlowInstance<NodeData, EdgeData> {
+  return useReactFlow<NodeData, EdgeData>();
+}

--- a/packages/lab/src/Flow/hooks/useFlowNode.ts
+++ b/packages/lab/src/Flow/hooks/useFlowNode.ts
@@ -7,45 +7,63 @@ import {
   useNodes,
   useEdges,
   useReactFlow,
-  useNodeId,
 } from "reactflow";
 import { shallow } from "zustand/shallow";
 
-export function useFlowNode<T extends Node = Node>(id: string) {
+import { useNodeId } from "./useNodeId";
+
+/** Retrieves the node instance */
+export function useFlowNode<T extends Node = Node>(id?: string) {
+  const nodeId = useNodeId(id);
+
   const nodeSelector = useCallback(
     (state: ReactFlowState) =>
-      state.getNodes().find((n: Node): n is T => n.id === id),
-    [id]
+      state.getNodes().find((n: Node): n is T => n.id === nodeId),
+    [nodeId]
   );
   return useStore<T | undefined>(nodeSelector, shallow);
 }
 
-export function useFlowNodeInputEdges(id: string) {
+/** Provides the input edges connected to the node */
+export function useFlowNodeInputEdges(id?: string) {
+  const nodeId = useNodeId(id);
+
   const inputEdgesSelector = useCallback(
-    (state: ReactFlowState) => state.edges.filter((e: Edge) => e.target === id),
-    [id]
+    (state: ReactFlowState) =>
+      state.edges.filter((e: Edge) => e.target === nodeId),
+    [nodeId]
   );
   return useStore(inputEdgesSelector, shallow);
 }
 
-export function useFlowNodeOutputEdges(id: string) {
+/** Gives the output edges connected from the node */
+export function useFlowNodeOutputEdges(id?: string) {
+  const nodeId = useNodeId(id);
+
   const outputEdgesSelector = useCallback(
-    (state: ReactFlowState) => state.edges.filter((e: Edge) => e.source === id),
-    [id]
+    (state: ReactFlowState) =>
+      state.edges.filter((e: Edge) => e.source === nodeId),
+    [nodeId]
   );
   return useStore(outputEdgesSelector, shallow);
 }
 
-export function useFlowNodeEdges(id: string) {
+/** Offers both input and output edges of the node */
+export function useFlowNodeEdges(id?: string) {
+  const nodeId = useNodeId(id);
+
   const edgesSelector = useCallback(
     (state: ReactFlowState) =>
-      state.edges.filter((e: Edge) => e.source === id || e.target === id),
-    [id]
+      state.edges.filter(
+        (e: Edge) => e.source === nodeId || e.target === nodeId
+      ),
+    [nodeId]
   );
   return useStore(edgesSelector, shallow);
 }
 
-export function useFlowNodeParents(id: string) {
+/** Gets the parent nodes of a specified node (nodes that have an output connected to one of the inputs of the node) */
+export function useFlowNodeParents(id?: string) {
   const inputEdges = useFlowNodeInputEdges(id);
   const parentNodesSelector = useCallback(
     (state: ReactFlowState) => {
@@ -58,33 +76,37 @@ export function useFlowNodeParents(id: string) {
   return useStore(parentNodesSelector, shallow);
 }
 
-export function useFlowInputNodes<T = any>(id: string) {
+/** Retrieves the nodes connected to the inputs of the node */
+export function useFlowInputNodes<T = any>(id?: string) {
+  const nodeId = useNodeId(id);
   const nodes = useNodes();
   const edges = useEdges();
 
   return useMemo(() => {
     return edges
-      .filter((e) => e.target === id)
+      .filter((e) => e.target === nodeId)
       .map((e) => nodes.find((n) => n.id === e.source))
       .filter((n): n is Node<T> => n !== null);
-  }, [edges, id, nodes]);
+  }, [edges, nodeId, nodes]);
 }
 
-export function useFlowOutputNodes<T = any>(id: string) {
+/** Retrieves the nodes connected to the outputs of the node */
+export function useFlowOutputNodes<T = any>(id?: string) {
+  const nodeId = useNodeId(id);
   const nodes = useNodes();
   const edges = useEdges();
 
   return useMemo(() => {
     return edges
-      .filter((e) => e.source === id)
+      .filter((e) => e.source === nodeId)
       .map((e) => nodes.find((n) => n.id === e.target))
       .filter((n): n is Node<T> => n !== null);
-  }, [edges, id, nodes]);
+  }, [edges, nodeId, nodes]);
 }
 
 /** Utilities to manipulate a node in the flow */
-export function useFlowNodeUtils<NodeData = any>() {
-  const nodeId = useNodeId();
+export function useFlowNodeUtils<NodeData = any>(id?: string) {
+  const nodeId = useNodeId(id);
   const reactFlowInstance = useReactFlow<NodeData>();
 
   /** Mutate the node's `.data` object */

--- a/packages/lab/src/Flow/hooks/useFlowNode.ts
+++ b/packages/lab/src/Flow/hooks/useFlowNode.ts
@@ -6,10 +6,10 @@ import {
   useStore,
   useNodes,
   useEdges,
-  useReactFlow,
 } from "reactflow";
 import { shallow } from "zustand/shallow";
 
+import { useFlowInstance } from "./useFlowInstance";
 import { useNodeId } from "./useNodeId";
 
 /** Retrieves the node instance */
@@ -107,7 +107,7 @@ export function useFlowOutputNodes<T = any>(id?: string) {
 /** Utilities to manipulate a node in the flow */
 export function useFlowNodeUtils<NodeData = any>(id?: string) {
   const nodeId = useNodeId(id);
-  const reactFlowInstance = useReactFlow<NodeData>();
+  const reactFlowInstance = useFlowInstance<NodeData>();
 
   /** Mutate the node's `.data` object */
   const setNodeData = useCallback(

--- a/packages/lab/src/Flow/hooks/useFlowNodeMeta.ts
+++ b/packages/lab/src/Flow/hooks/useFlowNodeMeta.ts
@@ -1,7 +1,11 @@
 import { useNodeMetaRegistry } from "../FlowContext/NodeMetaContext";
+import { useNodeId } from "./useNodeId";
 
-export function useFlowNodeMeta(id: string) {
+export function useFlowNodeMeta(id?: string) {
+  const nodeId = useNodeId(id);
   const { registry } = useNodeMetaRegistry();
 
-  return registry[id];
+  if (nodeId) {
+    return registry[nodeId];
+  }
 }

--- a/packages/lab/src/Flow/hooks/useNodeId.ts
+++ b/packages/lab/src/Flow/hooks/useNodeId.ts
@@ -1,0 +1,7 @@
+import { useNodeId as useReactNodeId } from "reactflow";
+
+/** Retrieves the node id. INTERNAL USE ONLY */
+export function useNodeId(id?: string) {
+  const currentNodeId = useReactNodeId();
+  return id ?? currentNodeId;
+}

--- a/packages/lab/src/Flow/stories/Base/Asset.tsx
+++ b/packages/lab/src/Flow/stories/Base/Asset.tsx
@@ -14,18 +14,20 @@ import {
   Search,
 } from "@hitachivantara/uikit-react-icons";
 import {
+  HvFlowInstance,
   HvFlowNode,
   HvFlowNodeFC,
   HvFlowNodeTypeMeta,
   useFlowNode,
 } from "@hitachivantara/uikit-react-lab";
-import { Node } from "reactflow";
 
 import type { NodeGroup } from ".";
 
+type Node = ReturnType<HvFlowInstance["getNode"]>;
+
 export const Asset: HvFlowNodeFC<NodeGroup> = (props) => {
   const [showDialog, setShowDialog] = useState(false);
-  const [details, setDetails] = useState<Node | undefined>();
+  const [details, setDetails] = useState<Node>();
   const node = useFlowNode();
 
   const classes = {
@@ -73,7 +75,6 @@ export const Asset: HvFlowNodeFC<NodeGroup> = (props) => {
           </HvButton>
         </HvDialogActions>
       </HvDialog>
-
       <HvFlowNode
         description="Asset description"
         expanded

--- a/packages/lab/src/Flow/stories/Base/Asset.tsx
+++ b/packages/lab/src/Flow/stories/Base/Asset.tsx
@@ -16,17 +16,17 @@ import {
 import {
   HvFlowNode,
   HvFlowNodeFC,
+  HvFlowNodeTypeMeta,
   useFlowNode,
 } from "@hitachivantara/uikit-react-lab";
 import { Node } from "reactflow";
 
-import type { NodeGroups } from ".";
+import type { NodeGroup } from ".";
 
-export const Asset: HvFlowNodeFC<NodeGroups> = (props) => {
-  const { id } = props;
+export const Asset: HvFlowNodeFC<NodeGroup> = (props) => {
   const [showDialog, setShowDialog] = useState(false);
   const [details, setDetails] = useState<Node | undefined>();
-  const node = useFlowNode(id);
+  const node = useFlowNode();
 
   const classes = {
     container: css({
@@ -156,4 +156,4 @@ export const Asset: HvFlowNodeFC<NodeGroups> = (props) => {
 Asset.meta = {
   label: "My Asset",
   groupId: "assets",
-};
+} satisfies HvFlowNodeTypeMeta<NodeGroup>;

--- a/packages/lab/src/Flow/stories/Base/Dashboard.tsx
+++ b/packages/lab/src/Flow/stories/Base/Dashboard.tsx
@@ -10,19 +10,19 @@ import {
   HvFlowNodeFC,
   HvDashboardNode,
   useFlowInputNodes,
+  HvFlowNodeTypeMeta,
 } from "@hitachivantara/uikit-react-lab";
 
-import type { NodeGroups } from ".";
+import type { NodeGroup } from ".";
 
 const classes = {
   footer: css({ display: "flex", justifyContent: "center" }),
 };
 
-export const Dashboard: HvFlowNodeFC<NodeGroups> = (props) => {
-  const { id: idProp } = props;
+export const Dashboard: HvFlowNodeFC<NodeGroup> = (props) => {
   const [open, setOpen] = useState(false);
 
-  const inputNodes = useFlowInputNodes(idProp);
+  const inputNodes = useFlowInputNodes();
 
   const nodeLayout = inputNodes.map<Layout>((node, i) => {
     const { type, data } = node;
@@ -92,4 +92,4 @@ export const Dashboard: HvFlowNodeFC<NodeGroups> = (props) => {
 Dashboard.meta = {
   label: "Dashboard",
   groupId: "dashboard",
-};
+} satisfies HvFlowNodeTypeMeta<NodeGroup>;

--- a/packages/lab/src/Flow/stories/Base/KPI.tsx
+++ b/packages/lab/src/Flow/stories/Base/KPI.tsx
@@ -1,8 +1,12 @@
-import { HvFlowNode, HvFlowNodeFC } from "@hitachivantara/uikit-react-lab";
+import {
+  HvFlowNode,
+  HvFlowNodeFC,
+  HvFlowNodeTypeMeta,
+} from "@hitachivantara/uikit-react-lab";
 
-import type { NodeGroups } from ".";
+import type { NodeGroup } from ".";
 
-export const KPI: HvFlowNodeFC<NodeGroups> = (props) => {
+export const KPI: HvFlowNodeFC<NodeGroup> = (props) => {
   return (
     <HvFlowNode
       description="KPI description"
@@ -28,4 +32,4 @@ export const KPI: HvFlowNodeFC<NodeGroups> = (props) => {
 KPI.meta = {
   label: "KPI",
   groupId: "insights",
-};
+} satisfies HvFlowNodeTypeMeta<NodeGroup>;

--- a/packages/lab/src/Flow/stories/Base/LineChart.tsx
+++ b/packages/lab/src/Flow/stories/Base/LineChart.tsx
@@ -1,8 +1,12 @@
-import { HvFlowNode, HvFlowNodeFC } from "@hitachivantara/uikit-react-lab";
+import {
+  HvFlowNode,
+  HvFlowNodeFC,
+  HvFlowNodeTypeMeta,
+} from "@hitachivantara/uikit-react-lab";
 
-import type { NodeGroups } from ".";
+import type { NodeGroup } from ".";
 
-export const LineChart: HvFlowNodeFC<NodeGroups> = (props) => {
+export const LineChart: HvFlowNodeFC<NodeGroup> = (props) => {
   return (
     <HvFlowNode
       description="LineChart description"
@@ -28,4 +32,4 @@ export const LineChart: HvFlowNodeFC<NodeGroups> = (props) => {
 LineChart.meta = {
   label: "LineChart",
   groupId: "insights",
-};
+} satisfies HvFlowNodeTypeMeta<NodeGroup>;

--- a/packages/lab/src/Flow/stories/Base/MLModelDetection.tsx
+++ b/packages/lab/src/Flow/stories/Base/MLModelDetection.tsx
@@ -1,8 +1,12 @@
-import { HvFlowNode, HvFlowNodeFC } from "@hitachivantara/uikit-react-lab";
+import {
+  HvFlowNode,
+  HvFlowNodeFC,
+  HvFlowNodeTypeMeta,
+} from "@hitachivantara/uikit-react-lab";
 
-import type { NodeGroups } from ".";
+import type { NodeGroup } from ".";
 
-export const MLModelDetection: HvFlowNodeFC<NodeGroups> = (props) => {
+export const MLModelDetection: HvFlowNodeFC<NodeGroup> = (props) => {
   return (
     <HvFlowNode
       description="Anomaly detection description"
@@ -28,4 +32,4 @@ export const MLModelDetection: HvFlowNodeFC<NodeGroups> = (props) => {
 MLModelDetection.meta = {
   label: "ML Model Detection",
   groupId: "models",
-};
+} satisfies HvFlowNodeTypeMeta<NodeGroup>;

--- a/packages/lab/src/Flow/stories/Base/MLModelPrediction.tsx
+++ b/packages/lab/src/Flow/stories/Base/MLModelPrediction.tsx
@@ -1,8 +1,12 @@
-import { HvFlowNode, HvFlowNodeFC } from "@hitachivantara/uikit-react-lab";
+import {
+  HvFlowNode,
+  HvFlowNodeFC,
+  HvFlowNodeTypeMeta,
+} from "@hitachivantara/uikit-react-lab";
 
-import type { NodeGroups } from ".";
+import type { NodeGroup } from ".";
 
-export const MLModelPrediction: HvFlowNodeFC<NodeGroups> = (props) => {
+export const MLModelPrediction: HvFlowNodeFC<NodeGroup> = (props) => {
   return (
     <HvFlowNode
       description="Anomaly Prediction description"
@@ -28,4 +32,4 @@ export const MLModelPrediction: HvFlowNodeFC<NodeGroups> = (props) => {
 MLModelPrediction.meta = {
   label: "ML Model Prediction",
   groupId: "models",
-};
+} satisfies HvFlowNodeTypeMeta<NodeGroup>;

--- a/packages/lab/src/Flow/stories/Base/NoGroup/Asset.tsx
+++ b/packages/lab/src/Flow/stories/Base/NoGroup/Asset.tsx
@@ -1,4 +1,8 @@
-import { HvFlowNode, HvFlowNodeFC } from "@hitachivantara/uikit-react-lab";
+import {
+  HvFlowNode,
+  HvFlowNodeFC,
+  HvFlowNodeTypeMeta,
+} from "@hitachivantara/uikit-react-lab";
 
 export const Asset: HvFlowNodeFC = (props) => {
   return (
@@ -41,4 +45,4 @@ export const Asset: HvFlowNodeFC = (props) => {
 
 Asset.meta = {
   label: "My Asset",
-};
+} satisfies HvFlowNodeTypeMeta;

--- a/packages/lab/src/Flow/stories/Base/NoGroup/LineChart.tsx
+++ b/packages/lab/src/Flow/stories/Base/NoGroup/LineChart.tsx
@@ -1,4 +1,8 @@
-import { HvFlowNode, HvFlowNodeFC } from "@hitachivantara/uikit-react-lab";
+import {
+  HvFlowNode,
+  HvFlowNodeFC,
+  HvFlowNodeTypeMeta,
+} from "@hitachivantara/uikit-react-lab";
 
 export const LineChart: HvFlowNodeFC = (props) => {
   return (
@@ -23,4 +27,4 @@ export const LineChart: HvFlowNodeFC = (props) => {
 
 LineChart.meta = {
   label: "LineChart",
-};
+} satisfies HvFlowNodeTypeMeta;

--- a/packages/lab/src/Flow/stories/Base/NoGroup/MLModelPrediction.tsx
+++ b/packages/lab/src/Flow/stories/Base/NoGroup/MLModelPrediction.tsx
@@ -1,4 +1,8 @@
-import { HvFlowNode, HvFlowNodeFC } from "@hitachivantara/uikit-react-lab";
+import {
+  HvFlowNode,
+  HvFlowNodeFC,
+  HvFlowNodeTypeMeta,
+} from "@hitachivantara/uikit-react-lab";
 
 export const MLModelPrediction: HvFlowNodeFC = (props) => {
   return (
@@ -30,4 +34,4 @@ export const MLModelPrediction: HvFlowNodeFC = (props) => {
 
 MLModelPrediction.meta = {
   label: "ML Model Prediction",
-};
+} satisfies HvFlowNodeTypeMeta;

--- a/packages/lab/src/Flow/stories/Base/Table.tsx
+++ b/packages/lab/src/Flow/stories/Base/Table.tsx
@@ -1,8 +1,12 @@
-import { HvFlowNode, HvFlowNodeFC } from "@hitachivantara/uikit-react-lab";
+import {
+  HvFlowNode,
+  HvFlowNodeFC,
+  HvFlowNodeTypeMeta,
+} from "@hitachivantara/uikit-react-lab";
 
-import type { NodeGroups } from ".";
+import type { NodeGroup } from ".";
 
-export const Table: HvFlowNodeFC<NodeGroups> = (props) => {
+export const Table: HvFlowNodeFC<NodeGroup> = (props) => {
   return (
     <HvFlowNode
       description="Table description"
@@ -28,4 +32,4 @@ export const Table: HvFlowNodeFC<NodeGroups> = (props) => {
 Table.meta = {
   label: "Table",
   groupId: "insights",
-};
+} satisfies HvFlowNodeTypeMeta<NodeGroup>;

--- a/packages/lab/src/Flow/stories/Base/index.tsx
+++ b/packages/lab/src/Flow/stories/Base/index.tsx
@@ -44,7 +44,7 @@ export const nodeGroups = {
   },
 } satisfies HvFlowProps["nodeGroups"];
 
-export type NodeGroups = keyof typeof nodeGroups;
+export type NodeGroup = keyof typeof nodeGroups;
 
 // Node types
 export const nodeTypes = {

--- a/packages/lab/src/Flow/stories/CustomDrop/BarChart.tsx
+++ b/packages/lab/src/Flow/stories/CustomDrop/BarChart.tsx
@@ -2,16 +2,16 @@ import { css } from "@emotion/css";
 import {
   HvFlowNode,
   HvFlowNodeFC,
+  HvFlowNodeTypeMeta,
   useFlowInputNodes,
 } from "@hitachivantara/uikit-react-lab";
 import { HvBarChart } from "@hitachivantara/uikit-react-viz";
 
 import { NodeData, data } from "./data";
-import type { NodeGroups } from ".";
+import type { NodeGroup } from ".";
 
-export const BarChart: HvFlowNodeFC<NodeGroups> = (props) => {
-  const { id } = props;
-  const inputNodes = useFlowInputNodes<NodeData>(id);
+export const BarChart: HvFlowNodeFC<NodeGroup> = (props) => {
+  const inputNodes = useFlowInputNodes<NodeData>();
   const country = inputNodes[0]?.data.country;
 
   return (
@@ -53,4 +53,4 @@ export const BarChart: HvFlowNodeFC<NodeGroups> = (props) => {
 BarChart.meta = {
   label: "Bar Chart",
   groupId: "visualizations",
-};
+} satisfies HvFlowNodeTypeMeta<NodeGroup>;

--- a/packages/lab/src/Flow/stories/CustomDrop/LineChart.tsx
+++ b/packages/lab/src/Flow/stories/CustomDrop/LineChart.tsx
@@ -2,16 +2,16 @@ import { css } from "@emotion/css";
 import {
   HvFlowNode,
   HvFlowNodeFC,
+  HvFlowNodeTypeMeta,
   useFlowInputNodes,
 } from "@hitachivantara/uikit-react-lab";
 import { HvLineChart } from "@hitachivantara/uikit-react-viz";
 
 import { NodeData, data } from "./data";
-import type { NodeGroups } from ".";
+import type { NodeGroup } from ".";
 
-export const LineChart: HvFlowNodeFC<NodeGroups> = (props) => {
-  const { id } = props;
-  const inputNodes = useFlowInputNodes<NodeData>(id);
+export const LineChart: HvFlowNodeFC<NodeGroup> = (props) => {
+  const inputNodes = useFlowInputNodes<NodeData>();
   const country = inputNodes[0]?.data.country;
 
   return (
@@ -53,4 +53,4 @@ export const LineChart: HvFlowNodeFC<NodeGroups> = (props) => {
 LineChart.meta = {
   label: "Line Chart",
   groupId: "visualizations",
-};
+} satisfies HvFlowNodeTypeMeta<NodeGroup>;

--- a/packages/lab/src/Flow/stories/CustomDrop/Precipitation.tsx
+++ b/packages/lab/src/Flow/stories/CustomDrop/Precipitation.tsx
@@ -1,9 +1,13 @@
-import { HvFlowNode, HvFlowNodeFC } from "@hitachivantara/uikit-react-lab";
+import {
+  HvFlowNode,
+  HvFlowNodeFC,
+  HvFlowNodeTypeMeta,
+} from "@hitachivantara/uikit-react-lab";
 
 import { data } from "./data";
-import type { NodeGroups } from ".";
+import type { NodeGroup } from ".";
 
-export const Precipitation: HvFlowNodeFC<NodeGroups> = (props) => {
+export const Precipitation: HvFlowNodeFC<NodeGroup> = (props) => {
   return (
     <HvFlowNode
       description="Precipitation data"
@@ -34,4 +38,4 @@ export const Precipitation: HvFlowNodeFC<NodeGroups> = (props) => {
 Precipitation.meta = {
   label: "Precipitation",
   groupId: "sources",
-};
+} satisfies HvFlowNodeTypeMeta<NodeGroup>;

--- a/packages/lab/src/Flow/stories/CustomDrop/index.tsx
+++ b/packages/lab/src/Flow/stories/CustomDrop/index.tsx
@@ -51,7 +51,7 @@ export const nodeGroups = {
   },
 } satisfies HvFlowProps["nodeGroups"];
 
-export type NodeGroups = keyof typeof nodeGroups;
+export type NodeGroup = keyof typeof nodeGroups;
 
 // Node types
 export const nodeTypes = {
@@ -63,8 +63,8 @@ export const nodeTypes = {
 export type NodeType = keyof typeof nodeTypes;
 
 // Flow
-const nodes: HvFlowProps<NodeGroups, NodeType>["nodes"] = [];
-const edges: HvFlowProps<NodeGroups, NodeType>["edges"] = [];
+const nodes: HvFlowProps<NodeGroup, NodeType>["nodes"] = [];
+const edges: HvFlowProps<NodeGroup, NodeType>["edges"] = [];
 
 // Classes
 const classes = {

--- a/packages/lab/src/Flow/stories/CustomDrop/index.tsx
+++ b/packages/lab/src/Flow/stories/CustomDrop/index.tsx
@@ -23,8 +23,8 @@ import {
   HvFlow,
   HvFlowProps,
   HvFlowControls,
+  HvFlowInstance,
 } from "@hitachivantara/uikit-react-lab";
-import { Node, ReactFlowInstance } from "reactflow";
 import { restrictToWindowEdges } from "@dnd-kit/modifiers";
 
 // The code for these components and values are available here: https://github.com/lumada-design/hv-uikit-react/tree/master/packages/lab/src/components/Flow/stories/CustomDrop
@@ -75,11 +75,12 @@ const classes = {
   }),
 };
 
+type Node = ReturnType<HvFlowInstance["getNode"]>;
+
 export const CustomDrop = () => {
   const { rootId } = useTheme();
 
-  const [reactFlowInstance, setReactFlowInstance] =
-    useState<ReactFlowInstance>();
+  const [reactFlowInstance, setReactFlowInstance] = useState<HvFlowInstance>();
 
   const [open, setOpen] = useState(false);
   const [precipitationConfig, setPrecipitationConfig] = useState<Node>();

--- a/packages/lab/src/Flow/stories/Dynamic/index.tsx
+++ b/packages/lab/src/Flow/stories/Dynamic/index.tsx
@@ -30,14 +30,14 @@ const nodeGroups = {
   },
 } satisfies HvFlowProps["nodeGroups"];
 
-type NodeGroups = keyof typeof nodeGroups;
+type NodeGroup = keyof typeof nodeGroups;
 
 /** Create a generic node programmatically */
 const createNode = (
   nodeProps: Partial<HvFlowNodeProps>,
-  nodeMeta: HvFlowNodeFC<NodeGroups>["meta"]
+  nodeMeta: HvFlowNodeFC<NodeGroup>["meta"]
 ) => {
-  const Asset: HvFlowNodeFC<NodeGroups> = (props) => (
+  const Asset: HvFlowNodeFC<NodeGroup> = (props) => (
     <HvFlowNode {...nodeProps} {...props} />
   );
 

--- a/packages/lab/src/Flow/stories/DynamicHandles/Asset.tsx
+++ b/packages/lab/src/Flow/stories/DynamicHandles/Asset.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useMemo, useRef } from "react";
-import { useReactFlow } from "reactflow";
 import {
   HvFlowNodeFC,
   HvFlowNodeInput,
@@ -7,6 +6,7 @@ import {
   HvFlowNode,
   HvFlowNodeTypeMeta,
   useFlowNodeUtils,
+  useFlowInstance,
 } from "@hitachivantara/uikit-react-lab";
 
 import type { NodeGroup } from ".";
@@ -63,7 +63,7 @@ export const Asset: HvFlowNodeFC<NodeGroup, NodeData> = (props) => {
 
   const curType = useRef(data.type);
 
-  const reactFlowInstance = useReactFlow();
+  const reactFlowInstance = useFlowInstance();
 
   const { setNodeData } = useFlowNodeUtils();
 

--- a/packages/lab/src/Flow/stories/DynamicHandles/Asset.tsx
+++ b/packages/lab/src/Flow/stories/DynamicHandles/Asset.tsx
@@ -6,6 +6,7 @@ import {
   HvFlowNodeOutput,
   HvFlowNode,
   HvFlowNodeTypeMeta,
+  useFlowNodeUtils,
 } from "@hitachivantara/uikit-react-lab";
 
 // Inputs and outputs info
@@ -62,30 +63,22 @@ export const Asset: HvFlowNodeFC<string, NodeData> = (props) => {
 
   const reactFlowInstance = useReactFlow();
 
+  const { setNodeData } = useFlowNodeUtils();
+
   useEffect(() => {
     if (data.type !== curType.current) {
       // Update type
       curType.current = data.type;
 
       // Update inputs and outputs for the node
-      reactFlowInstance?.setNodes((nds) =>
-        nds.map((nd) => {
-          if (nd.id === id) {
-            nd.data = {
-              ...nd.data,
-              ...types[nd.data.type],
-            };
-          }
-          return nd;
-        })
-      );
+      setNodeData((prev) => ({ ...prev, ...types[prev.type] }));
 
       // Clean up the edges for this node since the inputs and outputs changed
       reactFlowInstance?.setEdges((eds) =>
         eds.filter((ed) => ed.source !== id && ed.target !== id)
       );
     }
-  }, [data.type, id, reactFlowInstance]);
+  }, [data.type, id, reactFlowInstance, setNodeData]);
 
   const inputs = useMemo(() => data.inputs, [data.inputs]);
 

--- a/packages/lab/src/Flow/stories/DynamicHandles/Asset.tsx
+++ b/packages/lab/src/Flow/stories/DynamicHandles/Asset.tsx
@@ -9,6 +9,8 @@ import {
   useFlowNodeUtils,
 } from "@hitachivantara/uikit-react-lab";
 
+import type { NodeGroup } from ".";
+
 // Inputs and outputs info
 export const types = {
   type1: {
@@ -56,7 +58,7 @@ export interface NodeData {
   outputs?: HvFlowNodeOutput[];
 }
 
-export const Asset: HvFlowNodeFC<string, NodeData> = (props) => {
+export const Asset: HvFlowNodeFC<NodeGroup, NodeData> = (props) => {
   const { data, id } = props;
 
   const curType = useRef(data.type);
@@ -108,4 +110,4 @@ export const Asset: HvFlowNodeFC<string, NodeData> = (props) => {
 Asset.meta = {
   label: "Asset",
   groupId: "assets",
-} satisfies HvFlowNodeTypeMeta;
+} satisfies HvFlowNodeTypeMeta<NodeGroup>;

--- a/packages/lab/src/Flow/stories/DynamicHandles/index.tsx
+++ b/packages/lab/src/Flow/stories/DynamicHandles/index.tsx
@@ -1,7 +1,6 @@
 import { useMemo, useState } from "react";
 import { css } from "@emotion/css";
 import { restrictToWindowEdges } from "@dnd-kit/modifiers";
-import { Node, ReactFlowInstance } from "reactflow";
 import {
   HvButton,
   HvDialog,
@@ -20,6 +19,7 @@ import {
   HvFlowProps,
   HvFlowSidebar,
   HvFlowControls,
+  HvFlowInstance,
 } from "@hitachivantara/uikit-react-lab";
 
 // The code for these utils are available here: https://github.com/lumada-design/hv-uikit-react/tree/master/packages/lab/src/components/Flow/stories/Base
@@ -93,14 +93,15 @@ const edges: HvFlowProps["edges"] = [
   },
 ];
 
+type Node = ReturnType<HvFlowInstance<NodeData>["getNode"]>;
+
 export const DynamicHandles = () => {
   const { rootId } = useTheme();
 
-  const [reactFlowInstance, setReactFlowInstance] =
-    useState<ReactFlowInstance>();
+  const [reactFlowInstance, setReactFlowInstance] = useState<HvFlowInstance>();
 
   const [open, setOpen] = useState(false);
-  const [nodeConfig, setNodeConfig] = useState<Node<NodeData>>();
+  const [nodeConfig, setNodeConfig] = useState<Node>();
 
   const options = useMemo(
     () =>

--- a/packages/lab/src/Flow/stories/DynamicHandles/index.tsx
+++ b/packages/lab/src/Flow/stories/DynamicHandles/index.tsx
@@ -46,6 +46,8 @@ export const nodeGroups = {
   },
 } satisfies HvFlowProps["nodeGroups"];
 
+export type NodeGroup = keyof typeof nodeGroups;
+
 // Node types
 export const nodeTypes = {
   asset: Asset,

--- a/packages/lab/src/Flow/stories/Main/index.tsx
+++ b/packages/lab/src/Flow/stories/Main/index.tsx
@@ -19,7 +19,7 @@ import { restrictToWindowEdges } from "@dnd-kit/modifiers";
 
 // The code for these values are available here: https://github.com/lumada-design/hv-uikit-react/tree/master/packages/lab/src/components/Flow/stories/Base/index.tsx
 import {
-  NodeGroups,
+  NodeGroup,
   NodeType,
   nodeGroups,
   nodeTypes,
@@ -27,8 +27,8 @@ import {
 } from "../Base";
 
 // Flow
-const nodes: HvFlowProps<NodeGroups, NodeType>["nodes"] = [];
-const edges: HvFlowProps<NodeGroups, NodeType>["edges"] = [];
+const nodes: HvFlowProps<NodeGroup, NodeType>["nodes"] = [];
+const edges: HvFlowProps<NodeGroup, NodeType>["edges"] = [];
 
 // Classes
 export const classes = {

--- a/packages/lab/src/Flow/stories/Usage.stories.mdx
+++ b/packages/lab/src/Flow/stories/Usage.stories.mdx
@@ -332,11 +332,9 @@ const handleAction = (event: any, id: string, action: any) => {
 
   switch (action.id) {
     case "details": {
-      console.log("These are the details");
       break;
     }
     case "favorite": {
-      console.log("Add as favorite");
       break;
     }
     default:

--- a/packages/lab/src/Flow/stories/Usage.stories.mdx
+++ b/packages/lab/src/Flow/stories/Usage.stories.mdx
@@ -58,7 +58,7 @@ Example:
 
 ```typescript
 // Node groups
-type NodeGroups = "assets" | "models";
+type NodeGroup = "assets" | "models";
 
 const nodeGroups = {
   assets: {
@@ -73,7 +73,7 @@ const nodeGroups = {
     description: "Find here all the available models.",
     icon: <Favorite />,
   },
-} satisfies HvFlowProps<NodeGroups>["nodeGroups"];
+} satisfies HvFlowProps<NodeGroup>["nodeGroups"];
 ```
 
 You can then create the sidebar by using the `HvFlowSidebar` component as a prop of the `HvFlow` component:
@@ -132,9 +132,13 @@ The parameters and the list of inputs and outputs are passed as a property of th
 Find an example of a custom node below.
 
 ```tsx
-import { HvFlowNode } from "@hitachivantara/uikit-react-lab";
+import {
+  HvFlowNode,
+  HvFlowNodeFC,
+  HvFlowNodeTypeMeta,
+} from "@hitachivantara/uikit-react-lab";
 
-export const CustomNode = (props) => {
+export const CustomNode: HvFlowNodeFC = (props) => {
   return (
     <HvFlowNode
       description="CustomNode description"
@@ -175,7 +179,7 @@ export const CustomNode = (props) => {
 CustomNode.meta = {
   label: "CustomNode",
   groupId: "someNodeGroup",
-};
+} satisfies HvFlowNodeTypeMeta;
 ```
 
 If you don't set a group id for any given node, then it will be added to a `Default` group that will serve as a repository to all nodes
@@ -395,50 +399,57 @@ like knowing the parents of the node.
 
 To facilitate this, we provide a set of specialized hooks:
 
-- `useFlowNode(id: string)`: Retrieves the node instance based on the given ID.
-- `useFlowNodeParents(id: string)`: Gets the parent nodes of a specified node (nodes that have an output connected to one of the inputs of the node).
-- `useFlowNodeInputEdges(id: string)`: Provides the input edges connected to the node.
-- `useFlowNodeOutputEdges(id: string)`: Gives the output edges connected from the node.
-- `useFlowNodeEdges(id: string)`: Offers both input and output edges of the node.
+- `useFlowNode(id?: string)`: Retrieves the node instance.
+- `useFlowNodeParents(id?: string)`: Gets the parent nodes of a specified node (nodes that have an output connected to one of the inputs of the node).
+- `useFlowNodeInputEdges(id?: string)`: Provides the input edges connected to the node.
+- `useFlowNodeOutputEdges(id?: string)`: Gives the output edges connected from the node.
+- `useFlowNodeEdges(id?: string)`: Offers both input and output edges of the node.
+- `useFlowInputNodes(id?: string)`: Retrieves the nodes connected to the inputs of the node.
+- `useFlowOutputNodes(id?: string)`: Gets the nodes connected to the outputs of the node.
+- `useFlowNodeUtils(id?: string)`: Offers utilities to manipulate the node in the flow.
+
+A node id can be passed to the hooks mentioned above to retrieve the data for a particular node.
+If no id is provided, the hooks will automatically assume the id of the node it is used inside to avoid manually passing down the id as a prop.
 
 Find below an example usage in a custom node component.
 
 ```tsx
-export const Asset = (props) => {
-  const { id } = props;
-  const node = useFlowNode(id);
-  const parentNodes = useFlowNodeParents(id);
+export const Asset: HvFlowNodeFC = (props) => {
+  // The hooks automatically assume the id (props.id) of the Asset node
+  const node = useFlowNode();
+  const parentNodes = useFlowNodeParents();
 
   // ...
 };
 ```
 
-For more advanced operations, consider using the `reactflow` instance directly:
+We also offer a hook that retrieves the `reactflow` instance directly:
 
 ```tsx
-const instance = useReactFlow();
+const instance = useFlowInstance();
 ```
 
-Alternatively you can directly access the underlying store that `reactflow` uses to access specific parts of the state using the
-`useStore` hook.
+For more advanced operations, you can directly access the underlying store that `reactflow` uses to access specific parts of the state using the
+`useStore` hook provided by the React Flow library.
 
-To access specific parts of the React Flow state with minimal impact on performance, use the `useStore` hook. This hook is re-exported from the Zustand state management library and allows for creating finely-tuned selectors:
+To access specific parts of the React Flow state with minimal impact on performance, use the `useStore` hook.
+This hook is re-exported from the Zustand state management library and allows for creating finely-tuned selectors:
 
 ```tsx
 const selectedNodesSelector = (state) => {
   return state.nodes.filter((node) => node.selected);
 };
 
-export const Asset = (props) => {
-  const { id } = props;
-
+export const Asset: HvFlowNodeFC = (props) => {
   const selectedNodes = useStore(selectedNodesSelector);
 
   // ...
 };
 ```
 
-Other hooks are also available depending on your needs, like the `useNodes` and `useEdges` hooks. However, it's important to note that components using `useNodes` and `useEdges` will re-render whenever any node or edge changes. This includes selections and movements of nodes, which can affect performance in complex flows.
+Other hooks, provided by the React Flow, are also available depending on your needs, like the `useNodes` and `useEdges` hooks.
+However, it's important to note that components using `useNodes` and `useEdges` will re-render whenever any node or edge changes.
+This includes selections and movements of nodes, which can affect performance in complex flows.
 
 Prefer using `useStore` with specific selectors to reduce the number of re-renders, ensuring that components only update when necessary.
 
@@ -449,7 +460,8 @@ specially on the hooks section.
 
 Like mentioned in the [Parameters](#parameters) section, data is saved in the `data` property of the node object in the `reactflow` instance.
 If you need to have more complex use cases for your nodes and need to store data, you should follow the same logic and use the `data` property.
-The `reactflow`instance provides the `setNodes` function to save and update the nodes list.
+The `reactflow` instance provides the `setNodes` function to save and update the nodes list. Alternatively, the `useFlowNodeUtils` hook provides
+an utility function called `setNodeData` to update the data of the node the hook was used on.
 
 If you need to export your data at any point you can use the `toObject` function on the `instance` object.
 
@@ -458,11 +470,11 @@ If you need to export your data at any point you can use the `toObject` function
 Below you can find a full example of a custom Node that exercises the topics approached in this page.
 
 ```tsx
-export const Asset = (props) => {
-  const { id } = props;
+export const Asset: HvFlowNodeFC = (props) => {
   const [showDialog, setShowDialog] = useState(false);
   const [details, setDetails] = useState<Node | undefined>();
-  const node = useFlowNode(id);
+
+  const node = useFlowNode();
 
   const classes = {
     container: css({
@@ -568,7 +580,7 @@ export const Asset = (props) => {
 Asset.meta = {
   label: "Asset",
   groupId: "someNodeGroup",
-};
+} satisfies HvFlowNodeTypeMeta;
 ```
 
 Other examples of custom nodes can be found on

--- a/packages/lab/src/Flow/stories/Visualizations/BarChart.tsx
+++ b/packages/lab/src/Flow/stories/Visualizations/BarChart.tsx
@@ -2,16 +2,16 @@ import { css } from "@emotion/css";
 import {
   HvFlowNode,
   HvFlowNodeFC,
+  HvFlowNodeTypeMeta,
   useFlowInputNodes,
 } from "@hitachivantara/uikit-react-lab";
 import { HvBarChart } from "@hitachivantara/uikit-react-viz";
 
 import type { NodeData } from "./data";
-import type { NodeGroups } from ".";
+import type { NodeGroup } from ".";
 
-export const BarChart: HvFlowNodeFC<NodeGroups> = (props) => {
-  const { id } = props;
-  const inputNodes = useFlowInputNodes<NodeData>(id);
+export const BarChart: HvFlowNodeFC<NodeGroup> = (props) => {
+  const inputNodes = useFlowInputNodes<NodeData>();
   const jsonData = inputNodes[0]?.data.jsonData;
 
   return (
@@ -51,4 +51,4 @@ export const BarChart: HvFlowNodeFC<NodeGroups> = (props) => {
 BarChart.meta = {
   label: "Bar Chart",
   groupId: "visualizations",
-};
+} satisfies HvFlowNodeTypeMeta<NodeGroup>;

--- a/packages/lab/src/Flow/stories/Visualizations/Filter.tsx
+++ b/packages/lab/src/Flow/stories/Visualizations/Filter.tsx
@@ -8,21 +8,23 @@ import {
 import {
   HvFlowNode,
   HvFlowNodeFC,
+  HvFlowNodeTypeMeta,
   useFlowInputNodes,
   useFlowNodeUtils,
 } from "@hitachivantara/uikit-react-lab";
 
 import { NodeData } from "./data";
+import type { NodeGroup } from ".";
 
 function filterDataByCountries(data, countriesToFilter: string[]) {
   return data.filter((item) => countriesToFilter.includes(item.country));
 }
 
-export const Filter: HvFlowNodeFC = (props) => {
-  const { data, id } = props;
+export const Filter: HvFlowNodeFC<NodeGroup> = (props) => {
+  const { data } = props;
   const { setNodeData } = useFlowNodeUtils();
 
-  const inputNodes = useFlowInputNodes<NodeData>(id);
+  const inputNodes = useFlowInputNodes<NodeData>();
   const jsonData = inputNodes[0]?.data.jsonData;
 
   const options = useMemo(() => {
@@ -77,4 +79,4 @@ export const Filter: HvFlowNodeFC = (props) => {
 Filter.meta = {
   label: "Filter",
   groupId: "transformations",
-};
+} satisfies HvFlowNodeTypeMeta<NodeGroup>;

--- a/packages/lab/src/Flow/stories/Visualizations/JsonInput.tsx
+++ b/packages/lab/src/Flow/stories/Visualizations/JsonInput.tsx
@@ -1,8 +1,13 @@
-import { HvFlowNode, HvFlowNodeFC } from "@hitachivantara/uikit-react-lab";
+import {
+  HvFlowNode,
+  HvFlowNodeFC,
+  HvFlowNodeTypeMeta,
+} from "@hitachivantara/uikit-react-lab";
 
 import { data } from "./data";
+import type { NodeGroup } from ".";
 
-export const JsonInput: HvFlowNodeFC = (props) => {
+export const JsonInput: HvFlowNodeFC<NodeGroup> = (props) => {
   return (
     <HvFlowNode
       description="Population Datakky7"
@@ -24,4 +29,4 @@ JsonInput.meta = {
   data: {
     jsonData: data,
   },
-};
+} satisfies HvFlowNodeTypeMeta<NodeGroup>;

--- a/packages/lab/src/Flow/stories/Visualizations/LineChart.tsx
+++ b/packages/lab/src/Flow/stories/Visualizations/LineChart.tsx
@@ -2,15 +2,16 @@ import { css } from "@emotion/css";
 import {
   HvFlowNode,
   HvFlowNodeFC,
+  HvFlowNodeTypeMeta,
   useFlowInputNodes,
 } from "@hitachivantara/uikit-react-lab";
 import { HvLineChart } from "@hitachivantara/uikit-react-viz";
 
 import { NodeData } from "./data";
+import type { NodeGroup } from ".";
 
-export const LineChart: HvFlowNodeFC = (props) => {
-  const { id } = props;
-  const inputNodes = useFlowInputNodes<NodeData>(id);
+export const LineChart: HvFlowNodeFC<NodeGroup> = (props) => {
+  const inputNodes = useFlowInputNodes<NodeData>();
   const jsonData = inputNodes[0]?.data.jsonData;
 
   return (
@@ -50,4 +51,4 @@ export const LineChart: HvFlowNodeFC = (props) => {
 LineChart.meta = {
   label: "Line Chart",
   groupId: "visualizations",
-};
+} satisfies HvFlowNodeTypeMeta<NodeGroup>;

--- a/packages/lab/src/Flow/stories/Visualizations/index.tsx
+++ b/packages/lab/src/Flow/stories/Visualizations/index.tsx
@@ -62,7 +62,7 @@ const nodeGroups = {
   },
 } satisfies HvFlowProps["nodeGroups"];
 
-export type NodeGroups = keyof typeof nodeGroups;
+export type NodeGroup = keyof typeof nodeGroups;
 
 // Flow
 const nodes = [
@@ -103,7 +103,7 @@ const nodes = [
     position: { x: 980, y: 600 },
     data: {},
   },
-] satisfies HvFlowProps<NodeGroups, NodeType>["nodes"];
+] satisfies HvFlowProps<NodeGroup, NodeType>["nodes"];
 
 const edges = [
   {
@@ -134,7 +134,7 @@ const edges = [
     target: "barChartFiltered",
     targetHandle: "0",
   },
-] satisfies HvFlowProps<NodeGroups, NodeType>["edges"];
+] satisfies HvFlowProps<NodeGroup, NodeType>["edges"];
 
 // Classes
 export const classes = {

--- a/packages/lab/src/Flow/types/flow.ts
+++ b/packages/lab/src/Flow/types/flow.ts
@@ -1,7 +1,5 @@
 import { ComponentClass, FC } from "react";
-
-import { Node, NodeProps } from "reactflow";
-
+import { Node, NodeProps, ReactFlowInstance } from "reactflow";
 import {
   HvActionGeneric,
   HvSliderProps,
@@ -130,3 +128,8 @@ export type HvFlowBuiltInActions = Omit<HvFlowNodeAction, "id" | "callback"> & {
 };
 
 export type HvFlowNodeMetaRegistry = Record<string, HvFlowNodeMeta>;
+
+export type HvFlowInstance<NodeData = any, EdgeData = any> = ReactFlowInstance<
+  NodeData,
+  EdgeData
+>;

--- a/packages/lab/src/Wizard/Wizard.stories.tsx
+++ b/packages/lab/src/Wizard/Wizard.stories.tsx
@@ -117,8 +117,7 @@ export const Main: StoryObj<HvWizardProps> = {
       previous: "Go Back",
       next: "Go Forward",
     };
-    const mockSubmit = useCallback((context) => {
-      console.log("MainStory::mockSubmit", { context });
+    const mockSubmit = useCallback(() => {
       setLoading(true);
       setTimeout(() => {
         setLoading(false);
@@ -178,8 +177,7 @@ export const Skippable = () => {
     previous: "Previous Step",
     next: "Next Step",
   };
-  const mockSubmit = useCallback((context) => {
-    console.log("MainStory::mockSubmit", { context });
+  const mockSubmit = useCallback(() => {
     setLoading(true);
     setTimeout(() => {
       setLoading(false);
@@ -242,8 +240,7 @@ export const ComponentBreakDown = () => {
     }
   }, []);
 
-  const handleSubmit = useCallback((newContext) => {
-    console.log(newContext);
+  const handleSubmit = useCallback(() => {
     setOpen(false);
   }, []);
 

--- a/packages/viz/src/LineChart/LineChart.stories.tsx
+++ b/packages/viz/src/LineChart/LineChart.stories.tsx
@@ -800,7 +800,6 @@ export const CustomEchartsOptions: StoryObj<HvLineChartProps> = {
         groupBy="Month"
         measures="Sales Target"
         onOptionChange={(option) => {
-          console.log(option);
           if (Array.isArray(option.yAxis) && option.yAxis.length === 1) {
             option.yAxis = [{ ...option.yAxis[0], splitNumber: 8 }];
           }

--- a/templates/AssetInventory/CardView/CardView.tsx
+++ b/templates/AssetInventory/CardView/CardView.tsx
@@ -20,7 +20,6 @@ interface CarViewProps {
 }
 
 export const CardView = ({ id, instance }: CarViewProps) => {
-  console.log(instance);
   const selectedCardsIds = instance.selectedFlatRows.map((r) => r.id);
   return (
     <HvSimpleGrid


### PR DESCRIPTION
- Docs updated to leverage `useFlowNodeUtils` (only missing in one story)
- Clean-up: unnecessary console logs removed
- The nodes' hooks were standardised since some hooks required the node `id` as prop but not `useFlowNodeUtils`. The node `id` is now optional for all hooks. If not passed, the hooks will use React Flow's `useNodeId` to get the `id` of the node the hook is being used in. 
- The `useReactFlow` hook was re-exported as `useFlowInstance` to avoid installing `reactflow` only to use this hook. I also added the `HvFlowInstance` type. In this sense, I removed all imports from `reactflow` in our samples.
- Usage docs updated
- The node handle style was fixed when already connected:

https://github.com/lumada-design/hv-uikit-react/assets/43220251/7077eb14-5bd0-4c6d-960f-ac85b96dcd01

