### PR TITLE
fix: disabled button inside tooltip

### DIFF
--- a/packages/core/src/Button/Button.stories.tsx
+++ b/packages/core/src/Button/Button.stories.tsx
@@ -1,4 +1,4 @@
-import { StoryFn, StoryObj } from "@storybook/react";
+import { StoryObj } from "@storybook/react";
 import { css } from "@emotion/css";
 import {
   Delete,
@@ -40,8 +40,21 @@ export const Main: StoryObj<HvButtonProps> = {
   },
 };
 
-export const Variants: StoryFn<HvButtonProps> = () => {
-  return (
+export const Variants: StoryObj<HvButtonProps> = {
+  decorators: [
+    (Story) => (
+      <HvBox
+        sx={{
+          display: "grid",
+          gap: 20,
+          gridTemplateColumns: "repeat(3, 140px)",
+        }}
+      >
+        {Story()}
+      </HvBox>
+    ),
+  ],
+  render: () => (
     <>
       <HvButton variant="primary">Primary</HvButton>
       <HvButton variant="primarySubtle">Primary Subtle</HvButton>
@@ -59,25 +72,72 @@ export const Variants: StoryFn<HvButtonProps> = () => {
         Disabled Ghost
       </HvButton>
     </>
-  );
+  ),
 };
 
-Variants.decorators = [
-  (Story) => (
-    <HvBox
-      sx={{
-        display: "grid",
-        gap: 20,
-        gridTemplateColumns: "repeat(3, 140px)",
-      }}
-    >
-      {Story()}
-    </HvBox>
+export const FocusableWhenDisabled: StoryObj<HvButtonProps> = {
+  decorators: [
+    (Story) => (
+      <HvBox
+        sx={{
+          display: "grid",
+          gap: 20,
+          gridTemplateColumns: "repeat(3, 140px)",
+        }}
+      >
+        {Story()}
+      </HvBox>
+    ),
+  ],
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "If you still need the button to be focusable when disabled for accessibility purposes, you can set the `focusableWhenDisabled` property to `true`. When using this property, the buttons will continue be read by screen readers when disabled.",
+      },
+    },
+  },
+  render: () => (
+    <>
+      <HvButton variant="primary" disabled focusableWhenDisabled>
+        Primary
+      </HvButton>
+      <HvButton variant="primarySubtle" disabled focusableWhenDisabled>
+        Primary Subtle
+      </HvButton>
+      <HvButton variant="primaryGhost" disabled focusableWhenDisabled>
+        Primary Ghost
+      </HvButton>
+      <div />
+      <HvButton variant="secondarySubtle" disabled focusableWhenDisabled>
+        Secondary Subtle
+      </HvButton>
+      <HvButton variant="secondaryGhost" disabled focusableWhenDisabled>
+        Secondary Ghost
+      </HvButton>
+    </>
   ),
-];
+};
 
-export const Icons: StoryFn<HvButtonProps> = () => {
-  return (
+export const Icons: StoryObj<HvButtonProps> = {
+  decorators: [
+    (Story) => (
+      <div
+        className={css({
+          display: "flex",
+          flexFlow: "column",
+          gap: 10,
+          "& > div": {
+            display: "flex",
+            gap: 20,
+          },
+        })}
+      >
+        {Story()}
+      </div>
+    ),
+  ],
+  render: () => (
     <>
       <div>
         <HvButton icon aria-label="Play" variant="primaryGhost">
@@ -131,37 +191,26 @@ export const Icons: StoryFn<HvButtonProps> = () => {
         </HvButton>
       </div>
     </>
-  );
+  ),
 };
 
-Icons.decorators = [
-  (Story) => (
-    <div
-      className={css({
-        display: "flex",
-        flexFlow: "column",
-        gap: 10,
-        "& > div": {
+export const Semantic: StoryObj<HvButtonProps> = {
+  decorators: [
+    (Story) => (
+      <HvBox
+        sx={{
           display: "flex",
           gap: 20,
-        },
-      })}
-    >
-      {Story()}
-    </div>
-  ),
-];
-
-export const Semantic = () => {
-  return (
-    <HvBox
-      sx={{
-        display: "flex",
-        gap: 20,
-        backgroundColor: theme.colors.neutral_20,
-        padding: 20,
-      }}
-    >
+          backgroundColor: theme.colors.neutral_20,
+          padding: 20,
+        }}
+      >
+        {Story()}
+      </HvBox>
+    ),
+  ],
+  render: () => (
+    <>
       <HvButton
         variant="semantic"
         aria-label="Favorite"
@@ -178,8 +227,8 @@ export const Semantic = () => {
       <HvButton variant="semantic" icon aria-label="More options">
         <MoreOptionsVertical />
       </HvButton>
-    </HvBox>
-  );
+    </>
+  ),
 };
 
 interface CustomLinkProps extends HvButtonProps<"a"> {
@@ -192,9 +241,22 @@ const CustomLink = ({ to, children, ...others }: CustomLinkProps) => (
   </a>
 );
 
-export const CustomRootComponent = () => {
-  return (
-    <HvBox sx={{ display: "flex", gap: 20, padding: 20 }}>
+export const CustomRootComponent: StoryObj<HvButtonProps> = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "If necessary the button's root component can be changed by setting the `component` property.",
+      },
+    },
+  },
+  decorators: [
+    (Story) => (
+      <HvBox sx={{ display: "flex", gap: 20, padding: 20 }}>{Story()}</HvBox>
+    ),
+  ],
+  render: () => (
+    <>
       <HvButton startIcon={<Point />}>Button</HvButton>
       <HvButton
         variant="secondaryGhost"
@@ -212,15 +274,6 @@ export const CustomRootComponent = () => {
       >
         Custom link
       </HvButton>
-    </HvBox>
-  );
-};
-
-CustomRootComponent.parameters = {
-  docs: {
-    description: {
-      story:
-        "If necessary the button's root component can be changed by setting the `component` property.",
-    },
-  },
+    </>
+  ),
 };

--- a/packages/core/src/Button/Button.styles.ts
+++ b/packages/core/src/Button/Button.styles.ts
@@ -1,10 +1,8 @@
 import { CSSInterpolation } from "@emotion/serialize";
-
 import { theme } from "@hitachivantara/uikit-styles";
 
 import { outlineStyles } from "../utils/focusUtils";
 import { createClasses } from "../utils/classes";
-
 import { HvButtonRadius, HvButtonSize } from "./types";
 
 export const { staticClasses, useClasses } = createClasses("HvButton", {
@@ -15,18 +13,21 @@ export const { staticClasses, useClasses } = createClasses("HvButton", {
     textTransform: "none",
     cursor: "pointer",
     minWidth: "70px",
-
     whiteSpace: "nowrap",
 
-    "&:hover": {
-      backgroundColor: theme.colors.containerBackgroundHover,
-    },
-    "&:focus-visible": {
-      ...outlineStyles,
+    "&:hover:not($disabled)": {
       backgroundColor: theme.colors.containerBackgroundHover,
     },
 
-    // default button - no size specified
+    "&:focus-visible": {
+      ...outlineStyles,
+
+      "&:not($disabled)": {
+        backgroundColor: theme.colors.containerBackgroundHover,
+      },
+    },
+
+    // Default button - no size specified
     fontFamily: theme.fontFamily.body,
     fontSize: theme.fontSizes.base,
     fontWeight: theme.fontWeights.semibold,
@@ -43,27 +44,25 @@ export const { staticClasses, useClasses } = createClasses("HvButton", {
     marginRight: `calc(-1 * ${theme.space.xs})`,
   },
   focusVisible: {},
-
   disabled: {
     color: theme.colors.secondary_60,
     borderColor: theme.colors.atmo4,
     backgroundColor: theme.colors.atmo3,
     cursor: "not-allowed",
-    pointerEvents: "none",
   },
-
   icon: {
     margin: 0,
     padding: 0,
     height: "fit-content",
     minWidth: "unset",
   },
-
   primary: {
     color: theme.colors.atmo1,
     backgroundColor: theme.colors.primary,
-    "&:hover, &:focus-visible": {
-      backgroundColor: theme.colors.primary_80,
+    "&:not($disabled)": {
+      "&:hover, &:focus-visible": {
+        backgroundColor: theme.colors.primary_80,
+      },
     },
   },
   primarySubtle: {
@@ -74,7 +73,7 @@ export const { staticClasses, useClasses } = createClasses("HvButton", {
   primaryGhost: {
     color: theme.colors.primary,
     backgroundColor: "transparent",
-    "&:disabled": {
+    "&$disabled": {
       backgroundColor: "transparent",
     },
   },
@@ -86,17 +85,19 @@ export const { staticClasses, useClasses } = createClasses("HvButton", {
   secondaryGhost: {
     color: theme.colors.secondary,
     backgroundColor: "transparent",
-    "&:disabled": {
+    "&$disabled": {
       backgroundColor: "transparent",
     },
   },
   semantic: {
     color: theme.colors.base_dark,
     backgroundColor: "transparent",
-    "&:hover, &:focus-visible": {
-      backgroundColor: "rgba(251, 252, 252, 0.3)",
+    "&:not($disabled)": {
+      "&:hover, &:focus-visible": {
+        backgroundColor: "rgba(251, 252, 252, 0.3)",
+      },
     },
-    "&:disabled": {
+    "&$disabled": {
       backgroundColor: "rgba(251, 252, 252, 0.1)",
     },
   },

--- a/packages/core/src/Button/Button.test.tsx
+++ b/packages/core/src/Button/Button.test.tsx
@@ -1,10 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Alert } from "@hitachivantara/uikit-react-icons";
 
 import { HvLoading } from "../Loading";
-
 import { HvButton } from "./Button";
 import { buttonVariant } from "./types";
 
@@ -33,6 +32,7 @@ describe("Button", () => {
   });
 
   it("calls onClick when clicked", async () => {
+    const user = userEvent.setup();
     const clickMock = vi.fn();
     render(<HvButton onClick={clickMock}>content</HvButton>);
 
@@ -40,13 +40,15 @@ describe("Button", () => {
 
     expect(button).toBeInTheDocument();
     expect(clickMock).not.toHaveBeenCalled();
-    await userEvent.click(button);
+
+    await user.click(button);
     expect(clickMock).toHaveBeenCalledTimes(1);
-    await userEvent.click(button);
+
+    await user.click(button);
     expect(clickMock).toHaveBeenCalledTimes(2);
   });
 
-  it("disables for all variants", () => {
+  it("disabled for all variants", () => {
     render(
       <div>
         {buttonVariant.map((variant) => (
@@ -74,67 +76,69 @@ describe("Button", () => {
   });
 
   it(`submits form when type="submit"`, async () => {
+    const user = userEvent.setup();
     const submitFn = vi.fn();
     render(
       <form onSubmit={submitFn}>
         <HvButton type="submit">Button</HvButton>
       </form>
     );
+
     const button = screen.getByRole("button", { name: "Button" });
     expect(button).toHaveAttribute("type", "submit");
 
-    await userEvent.click(button);
+    await user.click(button);
     expect(submitFn).toHaveBeenCalled();
   });
 
   describe("interactions", () => {
-    it("executes passed function on a click", () => {
+    it("executes passed function on a click", async () => {
+      const user = userEvent.setup();
       const buttonSpy = vi.fn();
       const buttonText = "click me";
-      const { getByRole } = render(
-        <HvButton onClick={buttonSpy}>{buttonText}</HvButton>
-      );
+      render(<HvButton onClick={buttonSpy}>{buttonText}</HvButton>);
 
-      const buttonToTest = getByRole("button", { name: buttonText });
+      const buttonToTest = screen.getByRole("button", { name: buttonText });
       expect(buttonToTest).toBeInTheDocument();
-      fireEvent.click(buttonToTest);
+
+      await user.click(buttonToTest);
       expect(buttonSpy).toHaveBeenCalled();
     });
 
     it("executes the passed function on keydown", async () => {
+      const user = userEvent.setup();
       const buttonSpy = vi.fn();
       const buttonText = "click me";
-      const { getByRole } = render(
-        <HvButton onClick={buttonSpy}>{buttonText}</HvButton>
-      );
+      render(<HvButton onClick={buttonSpy}>{buttonText}</HvButton>);
 
-      const buttonToTest = getByRole("button", { name: buttonText });
+      const buttonToTest = screen.getByRole("button", { name: buttonText });
       expect(buttonToTest).toBeInTheDocument();
 
       buttonToTest.focus();
 
-      userEvent.keyboard("{enter}");
-      await waitFor(() => {
-        expect(buttonSpy).toHaveBeenCalledOnce();
-      });
+      await user.keyboard("{enter}");
+      expect(buttonSpy).toHaveBeenCalledOnce();
     });
 
-    it("does not executes the passed function on click", () => {
+    it("does not executes the passed function on click", async () => {
+      const user = userEvent.setup();
       const buttonSpy = vi.fn();
       const buttonText = "click me";
-      const { getByRole } = render(
+      render(
         <HvButton disabled onClick={buttonSpy}>
           {buttonText}
         </HvButton>
       );
 
-      const buttonToTest = getByRole("button", { name: buttonText });
+      const buttonToTest = screen.getByRole("button", { name: buttonText });
       expect(buttonToTest).toBeInTheDocument();
-      fireEvent.click(buttonToTest);
+
+      await user.click(buttonToTest);
       expect(buttonSpy).not.toHaveBeenCalled();
     });
 
     it("focus the button", async () => {
+      const user = userEvent.setup();
       const buttonSpy = vi.fn();
       const buttonSpyDismiss = vi.fn();
       const buttonDismissText = "don't focus me";
@@ -148,6 +152,7 @@ describe("Button", () => {
 
       const div = screen.getByTestId("outer-div");
       expect(div).toBeInTheDocument();
+
       const buttonToDismissTest = screen.getByRole("button", {
         name: buttonDismissText,
       });
@@ -157,23 +162,26 @@ describe("Button", () => {
       expect(buttonToTest).toBeInTheDocument();
       expect(buttonToDismissTest).toBeInTheDocument();
 
-      userEvent.keyboard("{tab}");
-      userEvent.keyboard("{tab}");
-      userEvent.keyboard("{enter}");
-      await waitFor(() => {
-        expect(buttonSpy).toHaveBeenCalledOnce();
-        expect(buttonSpyDismiss).toBeCalledTimes(0);
-      });
+      await user.keyboard("{tab}");
+      await user.keyboard("{tab}");
+      await user.keyboard("{enter}");
+      expect(buttonSpy).toHaveBeenCalledOnce();
+      expect(buttonSpyDismiss).toBeCalledTimes(0);
     });
 
     it("does not focus the button", async () => {
+      const user = userEvent.setup();
       const buttonSpy = vi.fn();
       const buttonSpyDismiss = vi.fn();
       const buttonDismissText = "don't focus me";
       const buttonText = "focus me";
       render(
         <div data-testid="outer-div">
-          <HvButton onClick={buttonSpyDismiss} onKeyDown={buttonSpyDismiss}>
+          <HvButton
+            disabled
+            onClick={buttonSpyDismiss}
+            onKeyDown={buttonSpyDismiss}
+          >
             {buttonDismissText}
           </HvButton>
           <HvButton disabled onClick={buttonSpy} onKeyDown={buttonSpy}>
@@ -184,6 +192,7 @@ describe("Button", () => {
 
       const div = screen.getByTestId("outer-div");
       expect(div).toBeInTheDocument();
+
       const buttonToDismissTest = screen.getByRole("button", {
         name: buttonDismissText,
       });
@@ -193,13 +202,12 @@ describe("Button", () => {
       expect(buttonToTest).toBeInTheDocument();
       expect(buttonToDismissTest).toBeInTheDocument();
 
-      userEvent.keyboard("{tab}");
-      userEvent.keyboard("{tab}");
-      userEvent.keyboard("{enter}");
-      await waitFor(() => {
-        expect(buttonSpy).toBeCalledTimes(0);
-        expect(buttonSpyDismiss).toBeCalledTimes(0);
-      });
+      await user.keyboard("{tab}");
+      await user.keyboard("{enter}");
+      await user.keyboard("{tab}");
+      await user.keyboard("{enter}");
+      expect(buttonSpy).toBeCalledTimes(0);
+      expect(buttonSpyDismiss).toBeCalledTimes(0);
     });
   });
 
@@ -210,54 +218,71 @@ describe("Button", () => {
       </a>
     );
 
-    it("has href", () => {
-      const { getByRole } = render(
-        <HvButton component="a" href="/path/to">
+    it("has href", async () => {
+      const user = userEvent.setup();
+      const buttonSpy = vi.fn();
+      render(
+        <HvButton component="a" href="/path/to" onClick={buttonSpy}>
           Link
         </HvButton>
       );
 
-      const button = getByRole("link", { name: "Link" });
-
+      const button = screen.getByRole("link", { name: "Link" });
       expect(button).toBeInTheDocument();
       expect(button).toHaveAttribute("href", "/path/to");
-    });
 
-    it("disabled link", () => {
-      const { getByRole } = render(
-        <HvButton component="a" href="/path/to" disabled>
-          Link
-        </HvButton>
-      );
-
-      const button = getByRole("link", { name: "Link" });
-
-      expect(button).toHaveAttribute("aria-disabled", "true");
+      await user.click(button);
+      expect(buttonSpy).toHaveBeenCalledOnce();
     });
 
     it("custom link", () => {
-      const { getByRole } = render(
+      render(
         <HvButton component={CustomLink} to="/path/to">
           Link
         </HvButton>
       );
 
-      const button = getByRole("link", { name: "Link" });
-
+      const button = screen.getByRole("link", { name: "Link" });
       expect(button).toBeInTheDocument();
       expect(button).toHaveAttribute("href", "/path/to");
     });
+  });
 
-    it("disabled custom link", () => {
-      const { getByRole } = render(
-        <HvButton component={CustomLink} to="/path/to" disabled>
-          Link
-        </HvButton>
+  describe("focusableWhenDisabled", () => {
+    it("not disabled, aria-disabled, focusable, and not clickable on click and key down for all variants", () => {
+      const user = userEvent.setup();
+      const buttonSpy = vi.fn();
+      render(
+        <div>
+          {buttonVariant.map((variant) => (
+            <HvButton
+              onClick={buttonSpy}
+              key={variant}
+              variant={variant}
+              focusableWhenDisabled
+              disabled
+            >
+              {variant}
+            </HvButton>
+          ))}
+        </div>
       );
 
-      const button = getByRole("link", { name: "Link" });
+      buttonVariant.forEach(async (variant) => {
+        const button = screen.getByRole("button", { name: variant });
 
-      expect(button).toHaveAttribute("aria-disabled", "true");
+        expect(button).not.toBeDisabled();
+        expect(button).toHaveAttribute("aria-disabled", "true");
+
+        await user.click(button);
+        expect(buttonSpy).not.toHaveBeenCalled();
+
+        await user.keyboard("{tab}");
+        expect(button).toHaveFocus();
+
+        await user.keyboard("{enter}");
+        expect(buttonSpy).not.toHaveBeenCalled();
+      });
     });
   });
 });

--- a/packages/core/src/Button/Button.tsx
+++ b/packages/core/src/Button/Button.tsx
@@ -24,11 +24,11 @@ export type HvButtonProps<C extends React.ElementType = "button"> =
   PolymorphicComponentRef<
     C,
     {
-      /** Use the variant prop to change the visual style of the Button. */
+      /** Use the variant prop to change the visual style of the button. */
       variant?: HvButtonVariant;
-      /** Whether the Button is an icon-only button. */
+      /** Whether the button is an icon-only button. */
       icon?: boolean;
-      /** Whether the Button is disabled or not. */
+      /** Whether the button is disabled or not. */
       disabled?: boolean;
       /** Class names to be applied. */
       className?: string;
@@ -44,8 +44,14 @@ export type HvButtonProps<C extends React.ElementType = "button"> =
       overrideIconColors?: boolean;
       /** A Jss Object used to override or extend the styles applied. */
       classes?: HvButtonClasses;
-      /** Whether the Button is selected or not. */
+      /** Whether the button is selected or not. */
       selected?: boolean;
+      /**
+       * Whether the button is focusable when disabled.
+       * Without this property, the accessibility of the button decreases when disabled since it's not read by screen readers.
+       * Set this property to `true` when you need the button to still be focusable when disabled for accessibility purposes.
+       */
+      focusableWhenDisabled?: boolean;
     }
   >;
 
@@ -96,6 +102,9 @@ export const HvButton = fixedForwardRef(function HvButton<
     radius,
     overrideIconColors = true,
     component: Component = "button",
+    focusableWhenDisabled,
+    onClick: onClickProp,
+    onMouseDown: onMouseDownProp,
     ...others
   } = useDefaultProps("HvButton", props);
   const { classes, css, cx } = useClasses(classesProp);
@@ -104,6 +113,16 @@ export const HvButton = fixedForwardRef(function HvButton<
     variantProp ?? (icon ? "secondaryGhost" : "primary"),
     activeTheme?.name
   );
+
+  const handleClick: HvButtonProps["onClick"] = (e) => {
+    if (disabled) return;
+    onClickProp?.(e);
+  };
+
+  const handleMouseDown: HvButtonProps["onMouseDown"] = (e) => {
+    if (disabled) return;
+    onMouseDownProp?.(e);
+  };
 
   return (
     <Component
@@ -120,10 +139,12 @@ export const HvButton = fixedForwardRef(function HvButton<
         },
         className
       )}
+      onClick={handleClick}
+      onMouseDown={handleMouseDown}
       {...(Component === "button" && { type: "button" })}
       {...(disabled && {
-        disabled: true,
-        tabIndex: -1,
+        disabled: !focusableWhenDisabled,
+        tabIndex: focusableWhenDisabled ? 0 : -1,
         "aria-disabled": true,
       })}
       {...others}

--- a/packages/core/src/Pagination/Pagination.test.tsx
+++ b/packages/core/src/Pagination/Pagination.test.tsx
@@ -1,8 +1,10 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 
 import { HvPagination } from "./Pagination";
 
+// toHaveAttribute("aria-disabled", "true") is used instead of toBeDisabled() since the buttons (IconButton) are still focusable when disabled
 describe("Pagination", () => {
   it("renders default page size and page", () => {
     render(<HvPagination />);
@@ -13,14 +15,14 @@ describe("Pagination", () => {
       screen.getAllByRole("button");
 
     expect(firstButton).toHaveAttribute("aria-label", "First Page");
-    expect(firstButton).toBeDisabled();
+    expect(firstButton).toHaveAttribute("aria-disabled", "true");
     expect(prevButton).toHaveAttribute("aria-label", "Previous Page");
-    expect(prevButton).toBeDisabled();
+    expect(prevButton).toHaveAttribute("aria-disabled", "true");
 
     expect(nextButton).toHaveAccessibleName("Next Page");
-    expect(nextButton).toBeDisabled();
+    expect(nextButton).toHaveAttribute("aria-disabled", "true");
     expect(lastButton).toHaveAccessibleName("Last Page");
-    expect(lastButton).toBeDisabled();
+    expect(lastButton).toHaveAttribute("aria-disabled", "true");
   });
 
   it("renders page size and page", () => {
@@ -37,7 +39,8 @@ describe("Pagination", () => {
     expect(screen.queryByText("100")).toBeNull();
   });
 
-  it("renders correctly on first page", () => {
+  it("renders correctly on first page", async () => {
+    const user = userEvent.setup();
     const changeMock = vi.fn();
     render(
       <HvPagination canNext page={0} pages={100} onPageChange={changeMock} />
@@ -47,23 +50,25 @@ describe("Pagination", () => {
       screen.getAllByRole("button");
 
     expect(firstButton).toHaveAttribute("aria-label", "First Page");
-    expect(firstButton).toBeDisabled();
+    expect(firstButton).toHaveAttribute("aria-disabled", "true");
     expect(prevButton).toHaveAttribute("aria-label", "Previous Page");
-    expect(prevButton).toBeDisabled();
+    expect(prevButton).toHaveAttribute("aria-disabled", "true");
 
     expect(nextButton).toHaveAccessibleName("Next Page");
     expect(nextButton).toBeEnabled();
     expect(lastButton).toHaveAccessibleName("Last Page");
     expect(lastButton).toBeEnabled();
 
-    fireEvent.click(firstButton);
-    expect(changeMock).not.toHaveBeenCalled();
-    fireEvent.click(prevButton);
+    await user.click(firstButton);
     expect(changeMock).not.toHaveBeenCalled();
 
-    fireEvent.click(nextButton);
+    await user.click(prevButton);
+    expect(changeMock).not.toHaveBeenCalled();
+
+    await user.click(nextButton);
     expect(changeMock).toHaveBeenCalledWith(1);
-    fireEvent.click(lastButton);
+
+    await user.click(lastButton);
     expect(changeMock).toHaveBeenCalledWith(99);
   });
 });

--- a/packages/core/src/QueryBuilder/QueryBuilder.test.tsx
+++ b/packages/core/src/QueryBuilder/QueryBuilder.test.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from "react";
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { vi } from "vitest";
 
 import {
   HvQueryBuilder,
@@ -306,11 +307,20 @@ describe("QueryBuilder", () => {
   });
 
   describe("read only", () => {
-    it("should not be interactable", () => {
-      render(<QueryBuilder readOnly />);
+    it("should not be interactable", async () => {
+      const querySpy = vi.fn();
+      render(<QueryBuilder onChange={querySpy} readOnly />);
 
       const buttons = screen.getAllByRole("button");
-      buttons.map((b) => expect(b).toBeDisabled());
+
+      // toHaveAttribute("aria-disabled", "true") is used instead of toBeDisabled() since some buttons (IconButton) are still focusable when disabled
+      const assertButton = async (b: HTMLElement) => {
+        fireEvent.click(b);
+        expect(querySpy).not.toHaveBeenCalled();
+        expect(b).toHaveAttribute("aria-disabled", "true");
+      };
+
+      await Promise.all(buttons.map(assertButton));
     });
   });
 

--- a/packages/core/src/QueryBuilder/RuleGroup/RuleGroup.tsx
+++ b/packages/core/src/QueryBuilder/RuleGroup/RuleGroup.tsx
@@ -97,6 +97,7 @@ export const RuleGroup = ({
       <HvMultiButton
         className={cx(classes.combinator, classes.topCombinator)}
         disabled={readOnly}
+        aria-disabled={readOnly}
       >
         {combinators?.map((item) => (
           <HvButton
@@ -199,6 +200,7 @@ export const RuleGroup = ({
                 }}
                 className={classes.createConditionButton}
                 disabled={readOnly}
+                aria-disabled={readOnly}
               >
                 {`${labels.empty?.createCondition}`}
               </HvTypography>
@@ -213,6 +215,7 @@ export const RuleGroup = ({
                     }}
                     className={classes.createGroupButton}
                     disabled={readOnly}
+                    aria-disabled={readOnly}
                   >
                     {`${labels.empty?.createGroup}`}
                   </HvTypography>

--- a/packages/core/src/utils/IconButton/IconButton.test.tsx
+++ b/packages/core/src/utils/IconButton/IconButton.test.tsx
@@ -1,0 +1,53 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { vi } from "vitest";
+
+import { IconButton } from "./IconButton";
+
+const title = "My tooltip button";
+
+const assertTooltipWhenHovered = async () => {
+  const user = userEvent.setup();
+  const button = screen.getByRole("button", { name: title });
+  expect(button).toBeInTheDocument();
+
+  await user.hover(button);
+  await waitFor(() => {
+    const tooltip = screen.getByRole("tooltip");
+    expect(tooltip).toBeInTheDocument();
+  });
+};
+
+describe("IconButton", () => {
+  it("button should be clickable and tooltip should appear when button is hovered", async () => {
+    const user = userEvent.setup();
+    const buttonSpy = vi.fn();
+    render(<IconButton title={title} onClick={buttonSpy} />);
+
+    const button = screen.getByRole("button", { name: title });
+
+    await user.click(button);
+    expect(buttonSpy).toHaveBeenCalledTimes(1);
+
+    await user.keyboard("{enter}");
+    expect(buttonSpy).toHaveBeenCalledTimes(2);
+
+    assertTooltipWhenHovered();
+  });
+
+  it("disabled button should not be clickable and tooltip should appear when button is hovered", async () => {
+    const user = userEvent.setup();
+    const buttonSpy = vi.fn();
+    render(<IconButton disabled title={title} onClick={buttonSpy} />);
+
+    const button = screen.getByRole("button", { name: title });
+
+    await user.click(button);
+    expect(buttonSpy).not.toHaveBeenCalled();
+
+    await user.keyboard("{enter}");
+    expect(buttonSpy).not.toHaveBeenCalled();
+
+    assertTooltipWhenHovered();
+  });
+});

--- a/packages/core/src/utils/IconButton/IconButton.tsx
+++ b/packages/core/src/utils/IconButton/IconButton.tsx
@@ -1,7 +1,8 @@
-import { HvButton, HvButtonProps } from "../Button";
-import { HvTooltip, HvTooltipProps } from "../Tooltip";
+import { HvButton, HvButtonProps } from "../../Button";
+import { HvTooltip, HvTooltipProps } from "../../Tooltip";
 
-export interface IconButtonProps extends Omit<HvButtonProps, "icon" | "title"> {
+export interface IconButtonProps
+  extends Omit<HvButtonProps, "icon" | "title" | "component"> {
   title: React.ReactNode;
   placement?: HvTooltipProps["placement"];
   onClick?: HvButtonProps["onClick"];
@@ -14,6 +15,6 @@ export const IconButton = ({
   ...others
 }: IconButtonProps) => (
   <HvTooltip enterDelay={500} title={title} placement={placement}>
-    <HvButton icon {...others} />
+    <HvButton focusableWhenDisabled icon {...others} />
   </HvTooltip>
 );

--- a/packages/core/src/utils/IconButton/index.ts
+++ b/packages/core/src/utils/IconButton/index.ts
@@ -1,0 +1,1 @@
+export * from "./IconButton";


### PR DESCRIPTION
Addresses https://github.com/lumada-design/hv-uikit-react/issues/4013

- We have an internal component called `IconButton` which uses a tooltip around a button. When the button is disabled, the error shown above is thrown. To solve this, a new [`focusableWhenDisabled`](https://mui.com/base-ui/react-button/#focus-on-disabled-buttons) property was added to the `HvButton` as proposed in the thread below. When using this property, the button is disabled only through  `aria-disabled` and not through `disabled` in order to be accessible by screen readers and the tooltip to show on hover. 
- Tests updated and new tests created