### PR TITLE
feat(ListItem): improve reusability with external focus management

### DIFF
--- a/packages/core/src/ListContainer/ListContainer.stories.tsx
+++ b/packages/core/src/ListContainer/ListContainer.stories.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, MouseEvent } from "react";
+import { useState, useEffect } from "react";
 import { Meta, StoryObj } from "@storybook/react";
 import {
   HvListItem,
@@ -37,15 +37,7 @@ export const Main: StoryObj<HvListContainerProps> = {
   },
   render: ({ interactive, condensed, disableGutters }) => {
     return (
-      <div
-        style={{
-          backgroundColor: theme.colors.atmo1,
-          padding: 20,
-          overflow: "auto",
-          position: "relative",
-          maxWidth: 220,
-        }}
-      >
+      <HvPanel style={{ padding: 20, maxWidth: 220 }}>
         <HvListContainer
           interactive={interactive}
           condensed={condensed}
@@ -60,7 +52,7 @@ export const Main: StoryObj<HvListContainerProps> = {
           <HvListItem>98002, Store Manager</HvListItem>
           <HvListItem>98003, Store Manager</HvListItem>
         </HvListContainer>
-      </div>
+      </HvPanel>
     );
   },
 };
@@ -70,15 +62,7 @@ export const SingleSelection: StoryObj<HvListContainerProps> = {
     const [selectedItem, setSelectedItem] = useState(-1);
 
     return (
-      <div
-        style={{
-          backgroundColor: theme.colors.atmo1,
-          padding: 20,
-          overflow: "auto",
-          position: "relative",
-          maxWidth: 220,
-        }}
-      >
+      <HvPanel style={{ padding: 20, maxWidth: 220 }}>
         <HvListContainer interactive condensed aria-label="Stores">
           <HvListItem
             onClick={() => setSelectedItem(0)}
@@ -124,7 +108,7 @@ export const SingleSelection: StoryObj<HvListContainerProps> = {
             98003, Store Manager
           </HvListItem>
         </HvListContainer>
-      </div>
+      </HvPanel>
     );
   },
 };
@@ -140,26 +124,17 @@ export const MultiSelection: StoryObj<HvListContainerProps> = {
     });
 
     const handleListItemClick = (
-      _evt: MouseEvent,
+      event: React.MouseEvent,
       index: keyof typeof selectedItems
     ) => {
-      setSelectedItems((previousSelection) => {
-        return {
-          ...previousSelection,
-          [index]: !previousSelection[index],
-        };
-      });
+      setSelectedItems((previousSelection) => ({
+        ...previousSelection,
+        [index]: !previousSelection[index],
+      }));
     };
+
     return (
-      <div
-        style={{
-          backgroundColor: theme.colors.atmo1,
-          padding: 20,
-          overflow: "auto",
-          position: "relative",
-          maxWidth: 220,
-        }}
-      >
+      <HvPanel style={{ padding: 20, maxWidth: 220 }}>
         <HvListContainer interactive condensed aria-label="Stores">
           <HvListItem
             onClick={(event) => handleListItemClick(event, 0)}
@@ -192,7 +167,7 @@ export const MultiSelection: StoryObj<HvListContainerProps> = {
             98005, Store Manager
           </HvListItem>
         </HvListContainer>
-      </div>
+      </HvPanel>
     );
   },
 };
@@ -200,15 +175,7 @@ export const MultiSelection: StoryObj<HvListContainerProps> = {
 export const WithIcons: StoryObj<HvListContainerProps> = {
   render: () => {
     return (
-      <div
-        style={{
-          backgroundColor: theme.colors.atmo1,
-          padding: 20,
-          overflow: "auto",
-          position: "relative",
-          maxWidth: 220,
-        }}
-      >
+      <HvPanel style={{ padding: 20, maxWidth: 220 }}>
         <HvListContainer
           interactive
           aria-label="Single Selection List with Left Icons Title"
@@ -229,7 +196,7 @@ export const WithIcons: StoryObj<HvListContainerProps> = {
             Advanced server DS555
           </HvListItem>
         </HvListContainer>
-      </div>
+      </HvPanel>
     );
   },
 };
@@ -463,15 +430,7 @@ export const MultiSelectWithShift: StoryObj<HvListContainerProps> = {
       const { selectedItems, handleListItemClick } = useKeyboardSelection();
 
       return (
-        <div
-          style={{
-            backgroundColor: theme.colors.atmo1,
-            padding: 20,
-            overflow: "auto",
-            position: "relative",
-            maxWidth: 220,
-          }}
-        >
+        <HvPanel style={{ padding: 20, maxWidth: 220 }}>
           <HvListContainer
             interactive
             condensed
@@ -519,7 +478,7 @@ export const MultiSelectWithShift: StoryObj<HvListContainerProps> = {
               98005, Store Manager
             </HvListItem>
           </HvListContainer>
-        </div>
+        </HvPanel>
       );
     };
 

--- a/packages/core/src/ListContainer/ListItem/ListItem.tsx
+++ b/packages/core/src/ListContainer/ListItem/ListItem.tsx
@@ -56,32 +56,28 @@ export interface HvListItemProps extends HvBaseProps<HTMLLIElement> {
 }
 
 const applyClassNameAndStateToElement = (
-  element,
-  selected,
-  disabled,
-  onClick,
-  className
+  element: any,
+  selected: boolean | undefined,
+  disabled: boolean | undefined,
+  onClick: React.MouseEventHandler<HTMLLIElement>,
+  className?: string
 ) => {
-  if (element != null) {
-    return React.cloneElement(element, {
-      className,
-      checked: !!selected,
-      disabled,
-      onChange: (evt) => onClick?.(evt),
-    });
-  }
+  if (element == null) return null;
 
-  return null;
+  return React.cloneElement(element, {
+    className,
+    checked: !!selected,
+    disabled,
+    onChange: onClick,
+  });
 };
 
-const applyClassNameToElement = (element, className) => {
-  if (element != null) {
-    return React.cloneElement(element, {
-      className,
-    });
-  }
+const applyClassNameToElement = (element, className?: string) => {
+  if (element == null) return null;
 
-  return null;
+  return React.cloneElement(element, {
+    className,
+  });
 };
 
 /**
@@ -89,7 +85,6 @@ const applyClassNameToElement = (element, className) => {
  */
 export const HvListItem = forwardRef<any, HvListItemProps>((props, ref) => {
   const {
-    id,
     classes: classesProp,
     className,
     role,
@@ -116,17 +111,14 @@ export const HvListItem = forwardRef<any, HvListItemProps>((props, ref) => {
     interactive: interactiveContext,
   } = useContext(HvListContext);
 
-  const condensed = condensedProp != null ? condensedProp : condensedContext;
-  const disableGutters =
-    disableGuttersProp != null ? disableGuttersProp : disableGuttersContext;
-  const interactive =
-    interactiveProp != null ? interactiveProp : interactiveContext;
+  const condensed = condensedProp ?? condensedContext;
+  const disableGutters = disableGuttersProp ?? disableGuttersContext;
+  const interactive = interactiveProp ?? interactiveContext;
 
-  const handleOnClick = useCallback(
+  const handleClick = useCallback<React.MouseEventHandler<HTMLLIElement>>(
     (evt) => {
-      if (!disabled) {
-        onClick?.(evt);
-      }
+      if (disabled) return;
+      onClick?.(evt);
     },
     [disabled, onClick]
   );
@@ -137,7 +129,7 @@ export const HvListItem = forwardRef<any, HvListItemProps>((props, ref) => {
         startAdornment,
         selected,
         disabled,
-        handleOnClick,
+        handleClick,
         cx(
           classes.startAdornment,
           { [classes.disabled]: disabled },
@@ -151,7 +143,7 @@ export const HvListItem = forwardRef<any, HvListItemProps>((props, ref) => {
       classes?.startAdornment,
       classes?.disabled,
       disabled,
-      handleOnClick,
+      handleClick,
       selected,
       startAdornment,
     ]
@@ -181,9 +173,8 @@ export const HvListItem = forwardRef<any, HvListItemProps>((props, ref) => {
 
   const listItem = (
     // For later: this should only have an onClick event if interactive and has the appropriate role.
-    // eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions
+    // eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions, jsx-a11y/click-events-have-key-events
     <li
-      id={id}
       ref={ref}
       role={role}
       value={value}
@@ -193,15 +184,15 @@ export const HvListItem = forwardRef<any, HvListItemProps>((props, ref) => {
           [classes.gutters]: !disableGutters,
           [classes.condensed]: condensed,
           [classes.interactive]: interactive,
-          [classes.selected]: !!selected,
-          [classes.disabled]: !!disabled,
+          [classes.selected]: selected || props["aria-selected"],
+          [classes.disabled]: disabled || props["aria-disabled"],
           [classes.withStartAdornment]: startAdornment != null,
           [classes.withEndAdornment]: endAdornment != null,
         },
         className
       )}
-      onClick={handleOnClick}
-      onKeyDown={() => {}} // Needed because of jsx-a11yclick-events-have-key-events
+      tabIndex={interactive ? undefined : tabIndex}
+      onClick={handleClick}
       {...roleOptionAriaProps}
       {...others}
     >

--- a/packages/core/src/Panel/Panel.tsx
+++ b/packages/core/src/Panel/Panel.tsx
@@ -1,3 +1,5 @@
+import { forwardRef } from "react";
+
 import { useDefaultProps } from "../hooks/useDefaultProps";
 
 import { HvBaseProps } from "../types/generic";
@@ -20,19 +22,20 @@ export interface HvPanelProps extends HvBaseProps {
  * It can be horizontal or vertical and its size is defined by its content and how it relates to surrounding patterns.
  * Regardless of its content, a panel look and feel should be consistent.
  */
-export const HvPanel = (props: HvPanelProps) => {
-  const {
-    id,
-    className,
-    classes: classesProp,
-    children,
-    ...others
-  } = useDefaultProps("HvPanel", props);
-  const { classes, cx } = useClasses(classesProp);
+export const HvPanel = forwardRef<HTMLDivElement, HvPanelProps>(
+  (props, ref) => {
+    const {
+      className,
+      classes: classesProp,
+      children,
+      ...others
+    } = useDefaultProps("HvPanel", props);
+    const { classes, cx } = useClasses(classesProp);
 
-  return (
-    <div id={id} className={cx(classes.root, className)} {...others}>
-      {children}
-    </div>
-  );
-};
+    return (
+      <div ref={ref} className={cx(classes.root, className)} {...others}>
+        {children}
+      </div>
+    );
+  }
+);


### PR DESCRIPTION
changes related to reusing these components in `HvSelect`:

- forwardRef `HvPanel`
- use `HvPanel` in List stories
- improve `HvListItem` reusability with external focus management
  - allow `tabIndex` to be used
  - allow `aria-disabled` & `aria-selected` to dictate disable/selection state