### PR TITLE
docs: review DropDownMenu & Panel

### DIFF
--- a/packages/core/src/DropDownMenu/DropDownMenu.stories.tsx
+++ b/packages/core/src/DropDownMenu/DropDownMenu.stories.tsx
@@ -1,26 +1,20 @@
 import { useState } from "react";
 import { Calendar, Plane, User } from "@hitachivantara/uikit-react-icons";
 import { Meta, StoryObj } from "@storybook/react";
+import { fireEvent, screen, waitFor } from "@storybook/testing-library";
 import {
   HvButton,
   HvDropDownMenu,
   HvDropDownMenuProps,
-  HvListValue,
 } from "@hitachivantara/uikit-react-core";
 
 const meta: Meta<typeof HvDropDownMenu> = {
   title: "Components/Dropdown Menu",
   component: HvDropDownMenu,
   decorators: [
-    (storyFn) => (
-      <div
-        style={{
-          display: "flex",
-          justifyContent: "center",
-          height: 175,
-        }}
-      >
-        {storyFn()}
+    (Story) => (
+      <div style={{ display: "flex", justifyContent: "center", height: 175 }}>
+        {Story()}
       </div>
     ),
   ],
@@ -33,8 +27,8 @@ export const Main: StoryObj<HvDropDownMenuProps> = {
     placement: "left",
     keepOpened: false,
     disabled: false,
-    expanded: true,
-    defaultExpanded: false,
+    expanded: undefined,
+    defaultExpanded: true,
     category: "secondaryGhost",
   },
   argTypes: {
@@ -42,65 +36,39 @@ export const Main: StoryObj<HvDropDownMenuProps> = {
     onToggle: { control: { disable: true } },
     onClick: { control: { disable: true } },
   },
-  render: ({ expanded, onToggle, ...rest }) => {
-    const [open, setOpen] = useState<boolean>(!!expanded);
-
-    return (
-      <HvDropDownMenu
-        expanded={open}
-        onToggle={() => setOpen((o) => !o)}
-        {...rest}
-      />
-    );
+  render: (args) => {
+    return <HvDropDownMenu {...args} />;
   },
 };
 
-export const WithIconsAndActions: StoryObj<HvDropDownMenuProps> = {
+/** wrapper needed for Storybook not to crash */
+const renderIcon = (Icon: React.ElementType) => () => <Icon />;
+
+export const WithIcons: StoryObj<HvDropDownMenuProps> = {
   parameters: {
     docs: {
       description: {
-        story:
-          "DropDownMenu with Icons and Actions. Icons should be colored accordingly when selected.",
+        story: "DropDownMenu with icons and disabled actions",
+      },
+    },
+    parameters: {
+      eyes: {
+        runBefore() {
+          fireEvent.click(screen.getByRole("button"));
+          return waitFor(() => screen.getByRole("menuitem"));
+        },
       },
     },
   },
   render: () => {
-    const iconSelectedColor =
-      (Icon: React.ElementType): HvListValue["icon"] =>
-      ({ isSelected }) =>
-        <Icon color={isSelected ? "atmo1" : undefined} />;
-
     return (
       <HvDropDownMenu
-        expanded
         placement="right"
         onClick={(e, item) => console.log(item.label)}
         dataList={[
-          { label: "Label 1", icon: iconSelectedColor(User) },
-          { label: "Label 2", icon: iconSelectedColor(Calendar) },
-          { label: "Label 3", icon: iconSelectedColor(Plane) },
-        ]}
-      />
-    );
-  },
-};
-
-export const DisabledItems: StoryObj<HvDropDownMenuProps> = {
-  parameters: {
-    docs: {
-      description: {
-        story: "DropDownMenu with disabled items.",
-      },
-    },
-  },
-  render: () => {
-    return (
-      <HvDropDownMenu
-        expanded
-        dataList={[
-          { label: "Label 1" },
-          { label: "Label 2", disabled: true },
-          { label: "Label 3" },
+          { label: "Label 1", icon: renderIcon(User) },
+          { label: "Label 2", icon: renderIcon(Calendar), disabled: true },
+          { label: "Label 3", icon: renderIcon(Plane) },
         ]}
       />
     );
@@ -117,19 +85,12 @@ export const Controlled: StoryObj<HvDropDownMenuProps> = {
     eyes: { include: false },
   },
   render: () => {
-    const [open, setOpen] = useState(true);
+    const [open, setOpen] = useState(false);
 
     return (
       <>
-        <HvButton
-          variant="secondaryGhost"
-          onClick={() => {
-            setOpen(!open);
-          }}
-          style={{ width: 125 }}
-        >
-          Click to&nbsp;
-          {!open ? "Open" : "Close"}
+        <HvButton variant="secondaryGhost" onClick={() => setOpen(!open)}>
+          {`Click to ${!open ? "Open" : "Close"}`}
         </HvButton>
         <HvDropDownMenu
           expanded={open}

--- a/packages/core/src/ListContainer/ListContainer.stories.tsx
+++ b/packages/core/src/ListContainer/ListContainer.stories.tsx
@@ -37,7 +37,7 @@ export const Main: StoryObj<HvListContainerProps> = {
   },
   render: ({ interactive, condensed, disableGutters }) => {
     return (
-      <HvPanel style={{ padding: 20, maxWidth: 220 }}>
+      <HvPanel style={{ maxWidth: 220 }}>
         <HvListContainer
           interactive={interactive}
           condensed={condensed}
@@ -62,7 +62,7 @@ export const SingleSelection: StoryObj<HvListContainerProps> = {
     const [selectedItem, setSelectedItem] = useState(-1);
 
     return (
-      <HvPanel style={{ padding: 20, maxWidth: 220 }}>
+      <HvPanel style={{ maxWidth: 220 }}>
         <HvListContainer interactive condensed aria-label="Stores">
           <HvListItem
             onClick={() => setSelectedItem(0)}
@@ -134,7 +134,7 @@ export const MultiSelection: StoryObj<HvListContainerProps> = {
     };
 
     return (
-      <HvPanel style={{ padding: 20, maxWidth: 220 }}>
+      <HvPanel style={{ maxWidth: 220 }}>
         <HvListContainer interactive condensed aria-label="Stores">
           <HvListItem
             onClick={(event) => handleListItemClick(event, 0)}
@@ -175,7 +175,7 @@ export const MultiSelection: StoryObj<HvListContainerProps> = {
 export const WithIcons: StoryObj<HvListContainerProps> = {
   render: () => {
     return (
-      <HvPanel style={{ padding: 20, maxWidth: 220 }}>
+      <HvPanel style={{ maxWidth: 220 }}>
         <HvListContainer
           interactive
           aria-label="Single Selection List with Left Icons Title"
@@ -430,7 +430,7 @@ export const MultiSelectWithShift: StoryObj<HvListContainerProps> = {
       const { selectedItems, handleListItemClick } = useKeyboardSelection();
 
       return (
-        <HvPanel style={{ padding: 20, maxWidth: 220 }}>
+        <HvPanel style={{ maxWidth: 220 }}>
           <HvListContainer
             interactive
             condensed

--- a/packages/core/src/Panel/Panel.stories.tsx
+++ b/packages/core/src/Panel/Panel.stories.tsx
@@ -5,6 +5,7 @@ import {
   HvButton,
   HvPanel,
   HvPanelProps,
+  HvTooltip,
   HvTypography,
   theme,
 } from "@hitachivantara/uikit-react-core";
@@ -31,21 +32,17 @@ export const Main: StoryObj<HvPanelProps> = {
 export const WithScroll: StoryObj<HvPanelProps> = {
   render: () => {
     return (
-      <HvPanel style={{ width: "400px", height: "400px" }}>
-        <div style={{ height: 600, backgroundColor: theme.colors.atmo4 }}>
-          &nbsp;
-        </div>
+      <HvPanel style={{ width: 400, height: 400 }}>
+        <div style={{ height: 600, backgroundColor: theme.colors.atmo4 }} />
       </HvPanel>
     );
   },
 };
 
-const StyledButton = styled(HvButton)({
+const CornerButton = styled(HvButton)({
   position: "absolute",
   top: theme.space.sm,
   right: theme.space.sm,
-  width: "32px",
-  height: "32px",
 });
 
 export const FullWidth: StoryObj<HvPanelProps> = {
@@ -53,21 +50,15 @@ export const FullWidth: StoryObj<HvPanelProps> = {
     return (
       <HvPanel style={{ width: "100%", height: "200px" }}>
         <HvTypography>Panel Content</HvTypography>
-        <StyledButton icon aria-label="Edit" variant="secondaryGhost">
-          <Edit />
-        </StyledButton>
+        <HvTooltip title="Edit">
+          <CornerButton icon>
+            <Edit />
+          </CornerButton>
+        </HvTooltip>
       </HvPanel>
     );
   },
 };
-
-const CloseButton = styled(HvButton)({
-  position: "absolute",
-  top: theme.space.sm,
-  right: theme.space.sm,
-  width: "32px",
-  height: "32px",
-});
 
 const Overlay = styled("div")({
   backgroundColor: theme.colors.atmo3,
@@ -88,9 +79,11 @@ export const Modal: StoryObj<HvPanelProps> = {
           }}
         >
           <HvTypography>Panel Content</HvTypography>
-          <CloseButton icon aria-label="Close" variant="secondaryGhost">
-            <Close />
-          </CloseButton>
+          <HvTooltip title="Close">
+            <CornerButton icon>
+              <Close />
+            </CornerButton>
+          </HvTooltip>
         </HvPanel>
       </Overlay>
     );


### PR DESCRIPTION
- review opened/redudant DropDownMenu samples
  - `iconSelectedColor` made no sense as there's no selection state, but something similar is needed for SB not to enter an infinite-loop 😞 
  - merge disabled & icons samples
    - they don't add much separately, and this way we visually test disabled icons
- review Panel samples
  - use DS's padding instead of `20` override (Applitools changes are expected)