### PR TITLE
refactor(BaseDropdown): break component into reusable pieces

### DIFF
--- a/packages/core/src/BaseDropdown/BaseDropdown.styles.tsx
+++ b/packages/core/src/BaseDropdown/BaseDropdown.styles.tsx
@@ -1,6 +1,5 @@
 import { theme } from "@hitachivantara/uikit-styles";
 
-import { outlineStyles } from "../utils/focusUtils";
 import { createClasses } from "../utils/classes";
 
 export const { useClasses, staticClasses } = createClasses("HvBaseDropdown", {
@@ -13,108 +12,25 @@ export const { useClasses, staticClasses } = createClasses("HvBaseDropdown", {
   },
   anchor: { display: "inline-block", width: "100%" },
   container: { zIndex: theme.zIndices.popover, width: "auto" },
-  header: {
-    cursor: "pointer",
-    userSelect: "none",
-    position: "relative",
-    background: theme.colors.atmo1,
-    boxSizing: "border-box",
-    border: `1px solid ${theme.colors.secondary}`,
-    borderRadius: theme.radii.base,
-    "&:hover": {
-      border: `1px solid ${theme.colors.primary}`,
-    },
-    "&:focus": {
-      outline: "none",
-    },
-    "&:focus-visible": {
-      ...outlineStyles,
-      border: `1px solid ${theme.colors.primary}`,
-    },
-  },
-  headerOpen: {
-    border: `1px solid ${theme.colors.secondary}`,
-
-    "&:hover": {
-      border: `1px solid ${theme.colors.secondary}`,
-    },
-  },
-  headerOpenUp: {
-    borderRadius: `0px 0px ${theme.radii.base} ${theme.radii.base}`,
-  },
-  headerOpenDown: {
-    borderRadius: `${theme.radii.base} ${theme.radii.base} 0px 0px`,
-  },
-  headerDisabled: {
-    cursor: "not-allowed",
-    pointerEvents: "none",
-    border: `1px solid ${theme.colors.secondary_60}`,
-    background: theme.colors.atmo2,
-    "&:hover": {
-      border: `1px solid ${theme.colors.secondary_60}`,
-    },
-  },
-  headerReadOnly: {
-    cursor: "not-allowed",
-    pointerEvents: "none",
-    border: `1px solid ${theme.colors.secondary_60}`,
-    background: theme.colors.atmo2,
-    userSelect: "text",
-    "&:focus-visible": {
-      outline: "none",
-      border: `1px solid ${theme.colors.secondary_60}`,
-    },
-  },
-  arrowContainer: {
-    position: "absolute",
-    pointerEvents: "none",
-    top: -1,
-    right: -1,
-  },
+  header: {},
+  headerOpen: {},
+  headerOpenUp: {},
+  headerOpenDown: {},
+  headerDisabled: {},
+  headerReadOnly: {},
+  arrowContainer: {},
   arrow: {},
-  selection: {
-    display: "flex",
-    alignItems: "center",
-    height: "30px",
-    boxSizing: "border-box",
-    paddingLeft: theme.space.xs,
-    paddingRight: theme.sizes.sm,
-  },
-  placeholder: {
-    display: "block",
-    overflow: "hidden",
-    textOverflow: "ellipsis",
-    whiteSpace: "nowrap",
-    ...theme.typography.body,
-    color: theme.colors.secondary_80,
-  },
-  selectionDisabled: { color: theme.colors.secondary_60 },
+  selection: {},
+  placeholder: {},
   panel: {
-    position: "relative",
-
-    backgroundColor: theme.colors.atmo1,
-    border: `1px solid ${theme.colors.secondary}`,
+    // unset HvPanel's padding as children are already setting it
+    padding: 0,
   },
-  panelOpenedUp: {
-    top: 1,
-    borderRadius: `${theme.radii.base} ${theme.radii.base} 0 0`,
-  },
-  panelOpenedDown: {
-    top: -1,
-    borderRadius: `0 0 ${theme.radii.base} ${theme.radii.base}`,
-  },
-  inputExtensionOpen: {
-    height: "0px",
-    backgroundColor: theme.colors.atmo1,
-    borderTop: "none",
-    borderBottom: "none",
-    borderRight: `1px solid ${theme.colors.secondary}`,
-    borderLeft: `1px solid ${theme.colors.secondary}`,
-  },
-  inputExtensionLeftPosition: { marginLeft: "auto" },
-  inputExtensionOpenShadow: {
-    boxShadow: `0px 8px 0px ${theme.colors.atmo1}, 0px 0px 9px 0px rgba(65,65,65,.12)`,
-  },
-  inputExtensionFloatRight: { float: "right" },
-  inputExtensionFloatLeft: { float: "left" },
+  panelOpenedUp: {},
+  panelOpenedDown: {},
+  inputExtensionOpen: {},
+  inputExtensionLeftPosition: {},
+  inputExtensionOpenShadow: {},
+  inputExtensionFloatRight: {},
+  inputExtensionFloatLeft: {},
 });

--- a/packages/core/src/BaseDropdown/DropdownButton.tsx
+++ b/packages/core/src/BaseDropdown/DropdownButton.tsx
@@ -1,0 +1,157 @@
+import { forwardRef } from "react";
+import type { Placement } from "@popperjs/core";
+import { DropDownXS } from "@hitachivantara/uikit-react-icons";
+import { theme } from "@hitachivantara/uikit-styles";
+
+import { useDefaultProps } from "../hooks/useDefaultProps";
+import { ExtractNames, createClasses } from "../utils/classes";
+import { outlineStyles } from "../utils/focusUtils";
+
+export const { staticClasses, useClasses } = createClasses("HvDropdownButton", {
+  root: {
+    cursor: "pointer",
+    userSelect: "none",
+    position: "relative",
+    background: theme.colors.atmo1,
+    boxSizing: "border-box",
+    border: `1px solid ${theme.colors.secondary}`,
+    borderRadius: theme.radii.base,
+    "&:hover": {
+      border: `1px solid ${theme.colors.primary}`,
+    },
+    "&:focus": {
+      outline: "none",
+    },
+    "&:focus-visible": {
+      ...outlineStyles,
+      border: `1px solid ${theme.colors.primary}`,
+    },
+  },
+  open: {
+    border: `1px solid ${theme.colors.secondary}`,
+
+    "&:hover": {
+      border: `1px solid ${theme.colors.secondary}`,
+    },
+  },
+  openUp: {
+    borderRadius: `0px 0px ${theme.radii.base} ${theme.radii.base}`,
+  },
+  openDown: {
+    borderRadius: `${theme.radii.base} ${theme.radii.base} 0px 0px`,
+  },
+  disabled: {
+    cursor: "not-allowed",
+    pointerEvents: "none",
+    color: theme.colors.secondary_60,
+    border: `1px solid ${theme.colors.secondary_60}`,
+    background: theme.colors.atmo2,
+    "&:hover": {
+      border: `1px solid ${theme.colors.secondary_60}`,
+    },
+  },
+  readOnly: {
+    cursor: "not-allowed",
+    pointerEvents: "none",
+    border: `1px solid ${theme.colors.secondary_60}`,
+    background: theme.colors.atmo2,
+    userSelect: "text",
+    "&:focus-visible": {
+      outline: "none",
+      border: `1px solid ${theme.colors.secondary_60}`,
+    },
+  },
+
+  selection: {
+    display: "flex",
+    alignItems: "center",
+    height: "30px",
+    boxSizing: "border-box",
+    paddingLeft: theme.space.xs,
+    paddingRight: theme.sizes.sm,
+  },
+  placeholder: {
+    display: "block",
+    overflow: "hidden",
+    textOverflow: "ellipsis",
+    whiteSpace: "nowrap",
+    ...theme.typography.body,
+    color: theme.colors.secondary_80,
+  },
+
+  arrowContainer: {
+    position: "absolute",
+    pointerEvents: "none",
+    top: -1,
+    right: -1,
+  },
+  arrow: {
+    transition: "rotate 0.2s ease",
+  },
+});
+
+export type HvDropdownButtonClasses = ExtractNames<typeof useClasses>;
+
+export interface HvDropdownButtonProps
+  extends React.HTMLAttributes<HTMLDivElement> {
+  readOnly?: boolean;
+  open?: boolean;
+  disabled?: boolean;
+  placement?: Placement;
+  adornment?: React.ReactNode;
+  classes?: HvDropdownButtonClasses;
+}
+
+/**
+ * HvBaseDropdown internal header button component
+ *
+ * TODO: migrate to use HvButton with `endIcon` & align with DS specs
+ */
+export const HvDropdownButton = forwardRef<
+  HTMLDivElement,
+  HvDropdownButtonProps
+>((props, ref) => {
+  const {
+    classes: classesProp,
+    className,
+    open,
+    placement = "bottom",
+    disabled,
+    readOnly,
+    children,
+    adornment,
+    ...others
+  } = useDefaultProps("HvDropdownButton", props);
+  const { classes, cx } = useClasses(classesProp);
+
+  return (
+    <div
+      ref={ref}
+      className={cx(classes.root, className, {
+        [classes.open]: open,
+        [classes.openUp]: open && placement.includes("top"),
+        [classes.openDown]: open && placement.includes("bottom"),
+        [classes.disabled]: disabled,
+        [classes.readOnly]: readOnly,
+      })}
+      {...others}
+    >
+      <div className={classes.selection}>
+        {children && typeof children === "string" ? (
+          <div className={cx(classes.placeholder)}>{children}</div>
+        ) : (
+          children
+        )}
+      </div>
+      <div className={classes.arrowContainer}>
+        {adornment || (
+          <DropDownXS
+            iconSize="XS"
+            className={classes.arrow}
+            style={{ rotate: open ? "180deg" : undefined }}
+          />
+        )}
+      </div>
+    </div>
+  );
+});

--- a/packages/core/src/BaseDropdown/DropdownButton.tsx
+++ b/packages/core/src/BaseDropdown/DropdownButton.tsx
@@ -84,6 +84,10 @@ export const { staticClasses, useClasses } = createClasses("HvDropdownButton", {
     pointerEvents: "none",
     top: -1,
     right: -1,
+    // TODO: make this the default for icons in v6
+    "& svg .color0": {
+      fill: "currentcolor",
+    },
   },
   arrow: {
     transition: "rotate 0.2s ease",

--- a/packages/core/src/BaseDropdown/DropdownContainer.tsx
+++ b/packages/core/src/BaseDropdown/DropdownContainer.tsx
@@ -1,0 +1,49 @@
+import { forwardRef } from "react";
+import {
+  ClickAwayListener,
+  ClickAwayListenerProps,
+} from "@mui/base/ClickAwayListener";
+import { Portal } from "@mui/base/Portal";
+
+import { useTheme } from "../hooks/useTheme";
+import { getContainerElement } from "../utils/document";
+
+export interface HvDropdownContainerProps
+  extends React.HTMLAttributes<HTMLDivElement> {
+  disablePortal?: boolean;
+  onClickAway: ClickAwayListenerProps["onClickAway"];
+  onContainerKeyDown?: React.KeyboardEventHandler<HTMLDivElement>;
+}
+
+/**
+ * HvBaseDropdown internal popper container component
+ *
+ * TODO: migrate MuiPopper/MuiPopup to simplify code
+ */
+export const HvDropdownContainer = forwardRef<
+  HTMLDivElement,
+  HvDropdownContainerProps
+>((props, ref) => {
+  const {
+    children,
+    disablePortal,
+    onClickAway,
+    onContainerKeyDown,
+    ...others
+  } = props;
+  const { rootId } = useTheme();
+
+  return (
+    <Portal
+      disablePortal={disablePortal}
+      container={getContainerElement(rootId)}
+    >
+      <div ref={ref} {...others}>
+        <ClickAwayListener onClickAway={onClickAway}>
+          {/* eslint-disable-next-line jsx-a11y/no-static-element-interactions */}
+          <div onKeyDown={onContainerKeyDown}>{children}</div>
+        </ClickAwayListener>
+      </div>
+    </Portal>
+  );
+});

--- a/packages/core/src/BaseDropdown/DropdownPanel.tsx
+++ b/packages/core/src/BaseDropdown/DropdownPanel.tsx
@@ -1,0 +1,89 @@
+import { forwardRef } from "react";
+import { theme } from "@hitachivantara/uikit-styles";
+
+import { HvPanel, HvPanelProps } from "../Panel";
+import { createClasses, ExtractNames } from "../utils/classes";
+
+export const { staticClasses, useClasses } = createClasses("HvDropdownPanel", {
+  panel: {
+    border: `1px solid ${theme.colors.secondary}`,
+    // borderRadius: 0,
+    marginTop: -1,
+    marginBottom: -1,
+  },
+  panelOpenedUp: {
+    borderRadius: `${theme.radii.base} ${theme.radii.base} 0 0`,
+  },
+  panelOpenedDown: {
+    borderRadius: `0 0 ${theme.radii.base} ${theme.radii.base}`,
+  },
+  extensionOpen: {
+    height: 0,
+    backgroundColor: theme.colors.atmo1,
+    borderTop: "none",
+    borderBottom: "none",
+    borderRight: `1px solid ${theme.colors.secondary}`,
+    borderLeft: `1px solid ${theme.colors.secondary}`,
+    boxShadow: `0px 8px 0px ${theme.colors.atmo1}, 0px 0px 9px 0px rgba(65,65,65,.12)`,
+  },
+  extensionLeftPosition: { marginLeft: "auto" },
+  extensionFloatRight: { float: "right" },
+  extensionFloatLeft: { float: "left" },
+});
+
+export type HvDropdownPanelClasses = ExtractNames<typeof useClasses>;
+
+export interface HvDropdownPanelProps extends Omit<HvPanelProps, "classes"> {
+  classes?: HvDropdownPanelClasses;
+  placement?: string;
+}
+
+/**
+ * HvBaseDropdown container HvPanel that includes DS3 "extensions"
+ *
+ * TODO:
+ * - make default HvBaseDropdown inherit `HvPanel`'s padding
+ * - refactor extensions into ::before and ::after to remove DS3-only DOM elements
+ */
+export const HvDropdownPanel = forwardRef<HTMLDivElement, HvDropdownPanelProps>(
+  (props, ref) => {
+    const {
+      classes: classesProp,
+      className,
+      children,
+      placement = "bottom-start",
+      ...others
+    } = props;
+    const { classes, cx } = useClasses(classesProp);
+
+    return (
+      <>
+        {placement.includes("bottom") && (
+          <div
+            className={cx(classes.extensionOpen, {
+              [classes.extensionLeftPosition]: placement.includes("end"),
+            })}
+          />
+        )}
+        <HvPanel
+          ref={ref}
+          className={cx(classes.panel, className, {
+            [classes.panelOpenedUp]: placement.includes("top"),
+            [classes.panelOpenedDown]: placement.includes("bottom"),
+          })}
+          {...others}
+        >
+          {children}
+        </HvPanel>
+        {placement.includes("top") && (
+          <div
+            className={cx(classes.extensionOpen, {
+              [classes.extensionFloatRight]: placement.includes("end"),
+              [classes.extensionFloatLeft]: placement.includes("start"),
+            })}
+          />
+        )}
+      </>
+    );
+  }
+);

--- a/packages/core/src/Button/Button.styles.ts
+++ b/packages/core/src/Button/Button.styles.ts
@@ -117,6 +117,7 @@ export const getSizeStyles = (size: HvButtonSize): CSSInterpolation => ({
 });
 
 export const getOverrideColors = (): CSSInterpolation => ({
+  // TODO: make this the default for icons in v6
   "& svg .color0": {
     fill: "currentcolor",
   },

--- a/packages/core/src/ColorPicker/ColorPicker.styles.tsx
+++ b/packages/core/src/ColorPicker/ColorPicker.styles.tsx
@@ -1,3 +1,5 @@
+import { theme } from "@hitachivantara/uikit-styles";
+
 import { createClasses } from "../utils/classes";
 
 export const { staticClasses, useClasses } = createClasses("HvColorPicker", {
@@ -16,17 +18,18 @@ export const { staticClasses, useClasses } = createClasses("HvColorPicker", {
     textTransform: "uppercase",
   },
   headerColorIcon: {
-    width: 24,
-    "& svg": {
-      marginLeft: 0,
-    },
+    width: 16,
+    height: 16,
+    margin: theme.space.xs,
+    marginLeft: 0,
   },
   panel: {
     width: "100%",
     minWidth: "266px",
     display: "flex",
+    flexDirection: "column",
     justifyContent: "center",
-    padding: "16px",
+    padding: theme.space.sm,
   },
   colorPicker: {
     width: "232px",
@@ -41,6 +44,10 @@ export const { staticClasses, useClasses } = createClasses("HvColorPicker", {
     width: 32,
     height: 32,
   },
-  headerColorIconOnly: {},
+  headerColorIconOnly: {
+    width: 16,
+    height: 16,
+    margin: theme.space.xs,
+  },
   pickerFields: { paddingBottom: 20 },
 });

--- a/packages/core/src/ColorPicker/ColorPicker.tsx
+++ b/packages/core/src/ColorPicker/ColorPicker.tsx
@@ -2,7 +2,7 @@ import { forwardRef } from "react";
 
 import { ColorState } from "react-color";
 
-import { Checkbox, ColorPicker } from "@hitachivantara/uikit-react-icons";
+import { ColorPicker } from "@hitachivantara/uikit-react-icons";
 
 import { useDefaultProps } from "../hooks/useDefaultProps";
 import { useControlled } from "../hooks/useControlled";
@@ -262,9 +262,9 @@ export const HvColorPicker = forwardRef<HTMLDivElement, HvColorPickerProps>(
           }}
           adornment={
             iconOnly && color ? (
-              <Checkbox
+              <div
                 className={classes.headerColorIconOnly}
-                color={[color, "transparent"]}
+                style={{ backgroundColor: color }}
               />
             ) : dropdownIcon === "colorPicker" ? (
               <ColorPicker className={classes.colorPickerIcon} />
@@ -273,9 +273,9 @@ export const HvColorPicker = forwardRef<HTMLDivElement, HvColorPickerProps>(
           placeholder={
             iconOnly ? undefined : color ? (
               <>
-                <Checkbox
+                <div
                   className={classes.headerColorIcon}
-                  color={[color, "transparent"]}
+                  style={{ backgroundColor: color }}
                 />
                 <HvTypography
                   className={classes.headerColorValue}

--- a/packages/core/src/DatePicker/DatePicker.tsx
+++ b/packages/core/src/DatePicker/DatePicker.tsx
@@ -497,12 +497,7 @@ export const HvDatePicker = forwardRef<HTMLDivElement, HvDatePickerProps>(
           onClickOutside={handleCalendarClose}
           onContainerCreation={focusOnContainer}
           placeholder={renderInput(getDateLabel(dateValue, rangeMode, locale))}
-          adornment={
-            <Calendar
-              className={classes.icon}
-              color={disabled ? "secondary_80" : undefined}
-            />
-          }
+          adornment={<Calendar className={classes.icon} />}
           popperProps={{
             modifiers: [
               { name: "preventOverflow", enabled: escapeWithReference },

--- a/packages/core/src/DropDownMenu/DropDownMenu.tsx
+++ b/packages/core/src/DropDownMenu/DropDownMenu.tsx
@@ -138,12 +138,7 @@ export const HvDropDownMenu = (props: HvDropDownMenuProps) => {
           aria-label="Dropdown menu"
           aria-haspopup="menu"
         >
-          {icon || (
-            <MoreOptionsVertical
-              aria-hidden
-              color={disabled ? "secondary_60" : undefined}
-            />
-          )}
+          {icon || <MoreOptionsVertical aria-hidden />}
         </HvButton>
       }
       placement={placement}

--- a/packages/core/src/TimePicker/TimePicker.tsx
+++ b/packages/core/src/TimePicker/TimePicker.tsx
@@ -273,7 +273,6 @@ export const HvTimePicker = forwardRef<HTMLDivElement, HvTimePickerProps>(
         <HvBaseDropdown
           ref={dropdownForkedRef}
           role="combobox"
-          variableWidth
           disabled={disabled}
           readOnly={readOnly}
           placeholder={
@@ -300,12 +299,7 @@ export const HvTimePicker = forwardRef<HTMLDivElement, HvTimePickerProps>(
             headerOpen: classes.dropdownHeaderOpen,
           }}
           placement="right"
-          adornment={
-            <TimeIcon
-              color={disabled ? "secondary_60" : undefined}
-              className={classes.icon}
-            />
-          }
+          adornment={<TimeIcon className={classes.icon} />}
           expanded={open}
           onToggle={(evt, newOpen) => {
             if (disableExpand) return;


### PR DESCRIPTION
Break into the components:
- `DropdownButton`
  - the default button
  - ~refactored to use `HvButton`~ reverted (address this in DS button update?)
- `DropdownContainer`
- `DropdownPanel`
  - `HvPanel` container with DS3 extensions

Improve the DropdownButton to:
- animate the arrow icon
- inherit the icon colors from the text
  - similarly to what `HvButton` does