### PR TITLE
refactor: fix `forwardRef` type inference

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -23,6 +23,7 @@
   "ignorePatterns": ["*.d.ts", "dist", "node_modules", "playwright.config.ts"],
   "rules": {
     "arrow-body-style": "off",
+    "prefer-arrow-callback": "off",
     "react/prop-types": "off",
     "react/no-unused-prop-types": "off",
     "react/require-default-props": "off",

--- a/packages/core/src/Button/Button.stories.tsx
+++ b/packages/core/src/Button/Button.stories.tsx
@@ -18,8 +18,6 @@ import {
   theme,
 } from "@hitachivantara/uikit-react-core";
 
-import { buttonRadius, buttonSize, buttonVariant } from "./types";
-
 export default { title: "Components/Button", component: HvButton };
 
 export const Main: StoryObj<HvButtonProps> = {
@@ -34,98 +32,11 @@ export const Main: StoryObj<HvButtonProps> = {
     onClick: () => console.log("clicked"),
   },
   argTypes: {
-    children: {
-      description: "Button children.",
-      table: {
-        type: { summary: "React.ReactNode" },
-      },
-    },
-    selected: {
-      description: "Whether the Button is selected or not.",
-      table: {
-        type: { summary: "boolean" },
-      },
-    },
-    variant: {
-      description:
-        "Use the variant prop to change the visual style of the Button.",
-      options: buttonVariant,
-      control: { type: "select" },
-      table: {
-        defaultValue: { summary: "primary" },
-        type: { summary: "HvButtonVariant" },
-      },
-    },
-    disabled: {
-      description: "Whether the Button is disabled or not.",
-      table: {
-        defaultValue: { summary: "false" },
-        type: { summary: "boolean" },
-      },
-    },
-    size: {
-      description: "Button size.",
-      options: buttonSize,
-      control: { type: "select" },
-      table: {
-        type: { summary: "HvButtonSize" },
-      },
-    },
-    radius: {
-      description: "Button border radius.",
-      options: buttonRadius,
-      control: { type: "select" },
-      table: {
-        defaultValue: { summary: "base" },
-        type: { summary: "HvButtonRadius" },
-      },
-    },
-    overrideIconColors: {
-      description:
-        "Defines the default colors of the button are forced into the icon.",
-      table: {
-        defaultValue: { summary: "true" },
-        type: { summary: "boolean" },
-      },
-    },
-    classes: {
-      description:
-        "A Jss Object used to override or extend the styles applied.",
-      table: {
-        type: { summary: "HvButtonClasses" },
-      },
-      control: { disable: true },
-    },
-    icon: {
-      description: "Whether the Button is an icon-only button.",
-      table: {
-        defaultValue: { summary: "false" },
-        type: { summary: "boolean" },
-      },
-      control: { disable: true },
-    },
-    startIcon: {
-      description: "Element placed before the children.",
-      table: {
-        type: { summary: "React.ReactElement" },
-      },
-      control: { disable: true },
-    },
-    endIcon: {
-      description: "Element placed after the children.",
-      table: {
-        type: { summary: "React.ReactElement" },
-      },
-      control: { disable: true },
-    },
-    component: {
-      description: "Element to use for the root node. Defaults to `button`.",
-      table: {
-        defaultValue: { summary: "button" },
-        type: { summary: "React.ElementType" },
-      },
-      control: { disable: true },
-    },
+    classes: { control: { disable: true } },
+    component: { control: { disable: true } },
+    ref: { control: { disable: true } },
+    size: { control: { type: "select" } },
+    radius: { control: { type: "select" } },
   },
 };
 

--- a/packages/core/src/Button/Button.tsx
+++ b/packages/core/src/Button/Button.tsx
@@ -1,8 +1,10 @@
-import React, { forwardRef } from "react";
-
 import { useTheme } from "../hooks/useTheme";
 import { useDefaultProps } from "../hooks/useDefaultProps";
-import { PolymorphicComponentRef, PolymorphicRef } from "../types/generic";
+import {
+  fixedForwardRef,
+  PolymorphicComponentRef,
+  PolymorphicRef,
+} from "../types/generic";
 import { ExtractNames } from "../utils/classes";
 
 import {
@@ -78,62 +80,57 @@ const mapVariant = (
 /**
  * Button component is used to trigger an action or event.
  */
-export const HvButton: <C extends React.ElementType = "button">(
-  props: HvButtonProps<C>
-) => React.ReactElement | null = forwardRef(
-  <C extends React.ElementType = "button">(
-    props: HvButtonProps<C>,
-    ref: PolymorphicRef<C>
-  ) => {
-    const {
-      classes: classesProp,
-      children,
-      variant: variantProp,
-      disabled = false,
-      className,
-      startIcon,
-      endIcon,
-      icon = false,
-      size,
-      radius,
-      overrideIconColors = true,
-      component: Component = "button",
-      ...others
-    } = useDefaultProps("HvButton", props);
-    const { classes, css, cx } = useClasses(classesProp);
-    const { activeTheme } = useTheme();
-    const variant = mapVariant(
-      variantProp ?? (icon ? "secondaryGhost" : "primary"),
-      activeTheme?.name
-    );
+export const HvButton = fixedForwardRef(function HvButton<
+  C extends React.ElementType = "button"
+>(props: HvButtonProps<C>, ref: PolymorphicRef<C>) {
+  const {
+    classes: classesProp,
+    children,
+    variant: variantProp,
+    disabled = false,
+    className,
+    startIcon,
+    endIcon,
+    icon = false,
+    size,
+    radius,
+    overrideIconColors = true,
+    component: Component = "button",
+    ...others
+  } = useDefaultProps("HvButton", props);
+  const { classes, css, cx } = useClasses(classesProp);
+  const { activeTheme } = useTheme();
+  const variant = mapVariant(
+    variantProp ?? (icon ? "secondaryGhost" : "primary"),
+    activeTheme?.name
+  );
 
-    return (
-      <Component
-        ref={ref}
-        className={cx(
-          classes.root,
-          classes[variant],
-          size && css(getSizeStyles(size)),
-          radius && css(getRadiusStyles(radius)),
-          overrideIconColors && css(getOverrideColors()),
-          {
-            [classes.icon]: icon,
-            [classes.disabled]: disabled,
-          },
-          className
-        )}
-        {...(Component === "button" && { type: "button" })}
-        {...(disabled && {
-          disabled: true,
-          tabIndex: -1,
-          "aria-disabled": true,
-        })}
-        {...others}
-      >
-        {startIcon && <span className={classes.startIcon}>{startIcon}</span>}
-        {children}
-        {endIcon && <span className={classes.endIcon}>{endIcon}</span>}
-      </Component>
-    );
-  }
-);
+  return (
+    <Component
+      ref={ref}
+      className={cx(
+        classes.root,
+        classes[variant],
+        size && css(getSizeStyles(size)),
+        radius && css(getRadiusStyles(radius)),
+        overrideIconColors && css(getOverrideColors()),
+        {
+          [classes.icon]: icon,
+          [classes.disabled]: disabled,
+        },
+        className
+      )}
+      {...(Component === "button" && { type: "button" })}
+      {...(disabled && {
+        disabled: true,
+        tabIndex: -1,
+        "aria-disabled": true,
+      })}
+      {...others}
+    >
+      {startIcon && <span className={classes.startIcon}>{startIcon}</span>}
+      {children}
+      {endIcon && <span className={classes.endIcon}>{endIcon}</span>}
+    </Component>
+  );
+});

--- a/packages/core/src/TimeAgo/TimeAgo.stories.tsx
+++ b/packages/core/src/TimeAgo/TimeAgo.stories.tsx
@@ -51,71 +51,9 @@ export const Main: StoryObj<HvTimeAgoProps> = {
     justText: false,
   },
   argTypes: {
-    timestamp: {
-      description:
-        "The timestamp to format, in seconds or milliseconds. Defaults to `emptyElement` if value is null or 0.",
-      table: {
-        type: { summary: "number" },
-      },
-    },
-    locale: {
-      description:
-        "The locale to be used. Should be on of the dayjs supported locales and explicitly imported. See https://day.js.org/docs/en/i18n/i18n.",
-      control: "select",
-      options: ["en", "fr", "de", "pt"],
-      table: {
-        defaultValue: { summary: "en" },
-        type: { summary: "string" },
-      },
-    },
-    disableRefresh: {
-      description: "Disables periodic date refreshes.",
-      table: {
-        defaultValue: { summary: "false" },
-        type: { summary: "boolean" },
-      },
-    },
-    showSeconds: {
-      description: "Whether to show seconds in the rendered time.",
-      table: {
-        defaultValue: { summary: "false" },
-        type: { summary: "boolean" },
-      },
-    },
-    justText: {
-      description:
-        "Whether the component should render just the string. Consider using `useTimeAgo` instead.",
-      table: {
-        defaultValue: { summary: "false" },
-        type: { summary: "boolean" },
-      },
-    },
-    classes: {
-      description:
-        "A Jss Object used to override or extend the styles applied to the component.",
-      table: {
-        type: { summary: "HvTimeAgoClasses" },
-      },
-      control: { disable: true },
-    },
-    component: {
-      description:
-        "Element to use for the root node. Defaults to `HvTypography`.",
-      table: {
-        defaultValue: { summary: "HvTypography" },
-        type: { summary: "React.ElementType" },
-      },
-      control: { disable: true },
-    },
-    emptyElement: {
-      description:
-        "The element to render when the timestamp is null or 0. Defaults to `—` (Em Dash).",
-      control: { disable: true },
-      table: {
-        defaultValue: { summary: "-" },
-        type: { summary: "string" },
-      },
-    },
+    classes: { control: { disable: true } },
+    component: { control: { disable: true } },
+    ref: { control: { disable: true } },
   },
   render: (args) => {
     return <HvTimeAgo {...args} />;

--- a/packages/core/src/TimeAgo/TimeAgo.tsx
+++ b/packages/core/src/TimeAgo/TimeAgo.tsx
@@ -1,11 +1,11 @@
-import { forwardRef } from "react";
-
-import isEmpty from "lodash/isEmpty";
-
 import { useDefaultProps } from "../hooks/useDefaultProps";
 import { ExtractNames } from "../utils/classes";
 import { HvTypography } from "../Typography";
-import { PolymorphicComponentRef, PolymorphicRef } from "../types/generic";
+import {
+  fixedForwardRef,
+  PolymorphicComponentRef,
+  PolymorphicRef,
+} from "../types/generic";
 
 import { staticClasses, useClasses } from "./TimeAgo.styles";
 import useTimeAgo from "./useTimeAgo";
@@ -50,41 +50,36 @@ export type HvTimeAgoProps<C extends React.ElementType = "p"> =
 /**
  * The HvTimeAgo component implements the Design System relative time format guidelines.
  */
-export const HvTimeAgo: <C extends React.ElementType = "p">(
-  props: HvTimeAgoProps<C>
-) => React.ReactElement | null = forwardRef(
-  <C extends React.ElementType = "p">(
-    props: HvTimeAgoProps<C>,
-    ref: PolymorphicRef<C>
-  ) => {
-    const {
-      classes: classesProp,
-      className,
-      timestamp,
-      locale: localeProp = "en",
-      component: Component = HvTypography,
-      emptyElement = "—",
-      disableRefresh = false,
-      showSeconds = false,
-      justText = false,
-      ...others
-    } = useDefaultProps("HvTimeAgo", props);
+export const HvTimeAgo = fixedForwardRef(function HvTimeAgo<
+  C extends React.ElementType = "p"
+>(props: HvTimeAgoProps<C>, ref: PolymorphicRef<C>) {
+  const {
+    classes: classesProp,
+    className,
+    timestamp,
+    locale: localeProp = "en",
+    component: Component = HvTypography,
+    emptyElement = "—",
+    disableRefresh = false,
+    showSeconds = false,
+    justText = false,
+    ...others
+  } = useDefaultProps("HvTimeAgo", props);
 
-    const { classes, cx } = useClasses(classesProp);
-    const locale = isEmpty(localeProp) ? "en" : localeProp;
-    const timeAgo = useTimeAgo(timestamp, {
-      locale,
-      disableRefresh,
-      showSeconds,
-    });
+  const { classes, cx } = useClasses(classesProp);
+  const locale = localeProp || "en";
+  const timeAgo = useTimeAgo(timestamp, {
+    locale,
+    disableRefresh,
+    showSeconds,
+  });
 
-    // eslint-disable-next-line react/jsx-no-useless-fragment
-    if (justText && timestamp) return <>{timeAgo}</>;
+  // eslint-disable-next-line react/jsx-no-useless-fragment
+  if (justText && timestamp) return <>{timeAgo}</>;
 
-    return (
-      <Component ref={ref} className={cx(classes.root, className)} {...others}>
-        {!timestamp ? emptyElement : timeAgo}
-      </Component>
-    );
-  }
-);
+  return (
+    <Component ref={ref} className={cx(classes.root, className)} {...others}>
+      {!timestamp ? emptyElement : timeAgo}
+    </Component>
+  );
+});

--- a/packages/core/src/TreeView/TreeView.stories.tsx
+++ b/packages/core/src/TreeView/TreeView.stories.tsx
@@ -19,55 +19,8 @@ import VerticalNavigationStoryRaw from "./stories/VerticalNavigation?raw";
 
 export default {
   title: "Components/Tree View",
-  subtitle: "Blah",
-  // @ts-expect-error
-  component: "HvTreeView",
-  argTypes: {
-    children: {
-      description: "HvTreeView content. Typically `HvTreeItem` elements.",
-      table: {
-        type: { summary: "ReactNode", disable: true },
-      },
-    },
-    classes: {
-      description:
-        "A Jss Object used to override or extend the styles applied.",
-      table: {
-        type: { summary: "HvTreeViewClasses" },
-      },
-      control: { disable: true },
-    },
-    multiSelect: {
-      description: "Whether the tree view allows multiple selection.",
-      defaultValue: { summary: false },
-      table: {
-        type: { summary: "boolean" },
-      },
-    },
-    expanded: {
-      description: "Expanded node ids, when expansion is controlled.",
-    },
-    defaultExpanded: {
-      description: "Expanded node ids, when expansion is uncontrolled.",
-    },
-    selected: {
-      description:
-        "Selected node ids when controlled. Array of ids when multiSelect, else just the id string",
-    },
-    defaultSelected: {
-      description:
-        "Selected node ids when uncontrolled. Array of ids when multiSelect, else just the id string",
-    },
-    onNodeSelect: {
-      description: "Callback fired when tree items are selected/unselected.",
-    },
-    onNodeToggle: {
-      description: "Callback fired when tree items are expanded/collapsed.",
-    },
-    onNodeFocus: {
-      description: "Callback fired when tree items are focused.",
-    },
-  },
+  component: HvTreeView,
+  argTypes: {},
   // @ts-expect-error
   subcomponents: { HvTreeItem },
 } satisfies Meta<typeof HvTreeView>;

--- a/packages/core/src/TreeView/TreeView.tsx
+++ b/packages/core/src/TreeView/TreeView.tsx
@@ -1,8 +1,7 @@
-import { ReactNode, Ref, forwardRef } from "react";
 import { useSlotProps } from "@mui/base/utils";
 import { DropDownXS, DropRightXS } from "@hitachivantara/uikit-react-icons";
 
-import { HvBaseProps } from "../types/generic";
+import { HvBaseProps, fixedForwardRef } from "../types/generic";
 import { ExtractNames } from "../utils/classes";
 import { useDefaultProps } from "../hooks/useDefaultProps";
 
@@ -24,14 +23,9 @@ export interface HvTreeViewProps<Multiple extends boolean | undefined>
   /** A Jss Object used to override or extend the styles applied. */
   classes?: HvTreeViewClasses;
   /** Tree View children. Usually a `HvTreeItem` instance, or a custom variation of it */
-  children?: ReactNode;
+  children?: React.ReactNode;
 }
 
-type HvTreeViewComponent = <Multiple extends boolean | undefined = undefined>(
-  props: HvTreeViewProps<Multiple>
-) => React.JSX.Element;
-
-/* eslint-disable prefer-arrow-callback */
 /**
  * A Tree View displays hierarchical structures.
  * It also facilitates the exploration of categorical levels and their content.
@@ -48,9 +42,9 @@ type HvTreeViewComponent = <Multiple extends boolean | undefined = undefined>(
  * </HvTreeView>
  * ```
  */
-const HvTreeView = forwardRef(function HvTreeView<
+export const HvTreeView = fixedForwardRef(function HvTreeView<
   Multiple extends boolean | undefined
->(props: HvTreeViewProps<Multiple>, ref: Ref<HTMLUListElement>) {
+>(props: HvTreeViewProps<Multiple>, ref: React.Ref<HTMLUListElement>) {
   const {
     id,
     children,
@@ -111,6 +105,4 @@ const HvTreeView = forwardRef(function HvTreeView<
       </ul>
     </TreeViewProvider>
   );
-}) as HvTreeViewComponent;
-
-export { HvTreeView };
+});

--- a/packages/core/src/TreeView/stories/VerticalNavigation.tsx
+++ b/packages/core/src/TreeView/stories/VerticalNavigation.tsx
@@ -108,6 +108,7 @@ export const VerticalNavigation = () => {
   return (
     <HvPanel style={{ width: 300 }}>
       <HvTreeView
+        multiSelect={false}
         aria-label="site navigation"
         selected={selected}
         onNodeSelect={(evt, nodeId) => setSelected(nodeId)}

--- a/packages/core/src/Typography/Typography.stories.tsx
+++ b/packages/core/src/Typography/Typography.stories.tsx
@@ -18,53 +18,9 @@ export const Main: StoryObj<HvTypographyProps> = {
     paragraph: false,
   },
   argTypes: {
-    variant: {
-      description:
-        "Use the variant prop to change the visual style of the Typography.",
-      table: {
-        defaultValue: { summary: "body" },
-        type: { summary: "HvTypographyVariants | HvTypographyLegacyVariants" },
-      },
-      options: typographyVariants,
-    },
-    link: {
-      description: "If `true` the typography will display the look of a link.",
-      table: {
-        defaultValue: { summary: "false" },
-        type: { summary: "boolean" },
-      },
-    },
-    disabled: {
-      description:
-        "If `true` the typography will display the look of a disabled state.",
-      table: {
-        defaultValue: { summary: "false" },
-        type: { summary: "boolean" },
-      },
-    },
-    noWrap: {
-      description:
-        "If `true`, the text will not wrap, but instead will truncate with a text overflow ellipsis. Note that text overflow can only happen with block or inline-block level elements (the element needs to have a width in order to overflow).",
-      table: {
-        defaultValue: { summary: "false" },
-        type: { summary: "boolean" },
-      },
-    },
-    component: {
-      description: "Element to use for the root node.",
-      table: {
-        type: { summary: "React.ElementType" },
-      },
-      control: { disable: true },
-    },
-    classes: {
-      description:
-        "A Jss Object used to override or extend the styles applied to the component.",
-      table: {
-        type: { summary: "HvTypographyClasses" },
-      },
-      control: { disable: true },
-    },
+    classes: { control: { disable: true } },
+    component: { control: { disable: true } },
+    ref: { control: { disable: true } },
   },
   decorators: [(Story) => <div style={{ width: 400 }}>{Story()}</div>],
   render: (args) => (

--- a/packages/core/src/Typography/Typography.tsx
+++ b/packages/core/src/Typography/Typography.tsx
@@ -1,6 +1,8 @@
-import { ElementType, forwardRef } from "react";
-
-import { PolymorphicComponentRef, PolymorphicRef } from "../types/generic";
+import {
+  fixedForwardRef,
+  PolymorphicComponentRef,
+  PolymorphicRef,
+} from "../types/generic";
 import { ExtractNames } from "../utils/classes";
 import { useTheme } from "../hooks/useTheme";
 import { useDefaultProps } from "../hooks/useDefaultProps";
@@ -48,7 +50,7 @@ const HvTypographyMap = {
   xsInlineLink: "p",
 } satisfies Record<
   HvTypographyVariants | HvTypographyLegacyVariants,
-  ElementType
+  React.ElementType
 >;
 
 export type HvTypographyProps<C extends React.ElementType = "p"> =
@@ -81,48 +83,43 @@ export type HvTypographyProps<C extends React.ElementType = "p"> =
 /**
  * Typography component is used to render text and paragraphs within an interface.
  */
-export const HvTypography: <C extends React.ElementType = "p">(
-  props: HvTypographyProps<C>
-) => React.ReactElement | null = forwardRef(
-  <C extends React.ElementType = "p">(
-    props: HvTypographyProps<C>,
-    ref: PolymorphicRef<C>
-  ) => {
-    const {
-      className,
-      component: ComponentProp,
-      classes: classesProp,
-      variant: variantProp = "body",
-      link = false,
-      noWrap = false,
-      paragraph = false,
-      disabled = false,
-      ...others
-    } = useDefaultProps("HvTypography", props);
-    const { classes, cx } = useClasses(classesProp);
-    const { activeTheme } = useTheme();
+export const HvTypography = fixedForwardRef(function HvTypography<
+  C extends React.ElementType = "p"
+>(props: HvTypographyProps<C>, ref: PolymorphicRef<C>) {
+  const {
+    className,
+    component: ComponentProp,
+    classes: classesProp,
+    variant: variantProp = "body",
+    link = false,
+    noWrap = false,
+    paragraph = false,
+    disabled = false,
+    ...others
+  } = useDefaultProps("HvTypography", props);
+  const { classes, cx } = useClasses(classesProp);
+  const { activeTheme } = useTheme();
 
-    const variant = mapVariant(variantProp, activeTheme?.name);
+  const variant = mapVariant(variantProp, activeTheme?.name);
 
-    const Component =
-      ComponentProp || (paragraph && "p") || HvTypographyMap[variant] || "span";
+  const Component =
+    ComponentProp || (paragraph && "p") || HvTypographyMap[variant] || "span";
 
-    return (
-      <Component
-        ref={ref}
-        className={cx(
-          classes.root,
-          classes[variant],
-          {
-            [classes.isLink]: link,
-            [classes.noWrap]: noWrap,
-            [classes.disabled]: disabled,
-          },
-          className
-        )}
-        disabled={disabled}
-        {...others}
-      />
-    );
-  }
-);
+  return (
+    <Component
+      ref={ref}
+      className={cx(
+        classes.root,
+        classes[variant],
+        {
+          [classes.isLink]: link,
+          [classes.noWrap]: noWrap,
+          [classes.disabled]: disabled,
+        },
+        className
+      )}
+      disabled={disabled}
+      {...others}
+    />
+  );
+});

--- a/packages/core/src/types/generic.ts
+++ b/packages/core/src/types/generic.ts
@@ -1,4 +1,4 @@
-import { HTMLAttributes } from "react";
+import { forwardRef } from "react";
 
 import type {
   HvExtraProps,
@@ -8,6 +8,7 @@ import type {
 export type { HvExtraProps, HvExtraDeepProps };
 
 type AsProp<C extends React.ElementType> = {
+  /** Custom element type to override the root component */
   component?: C;
 };
 
@@ -33,11 +34,11 @@ export type PolymorphicComponentRef<
   Props = {}
 > = PolymorphicComponent<C, Props> & { ref?: PolymorphicRef<C> };
 
-/** HV Base Props. Extends `HTMLAttributes` of an element `E`, and filters `K` keys. */
+/** HV Base Props. Extends `React.HTMLAttributes` of an element `E`, and filters `K` keys. */
 export type HvBaseProps<
   E extends HTMLElement = HTMLDivElement,
-  K extends keyof HTMLAttributes<E> = never
-> = Omit<HTMLAttributes<E>, K>;
+  K extends keyof React.HTMLAttributes<E> = never
+> = Omit<React.HTMLAttributes<E>, K>;
 
 /** This type allows to do a deep partial by applying the Partial type to each key recursively */
 export type DeepPartial<T> = T extends Object
@@ -53,3 +54,11 @@ export type HvExtraDeepPartialProps<T> = Partial<{
   HvExtraProps;
 
 export type Arrayable<T> = T | T[];
+
+/** React.forwardRef with fixed type declarations */
+export function fixedForwardRef<T, P = {}>(
+  // TODO: change `React.ReactElement | null` to `React.ReactNode` in typescript@5
+  render: (props: P, ref: React.Ref<T>) => React.ReactElement | null
+): (props: P & React.RefAttributes<T>) => React.ReactElement | null {
+  return forwardRef(render) as any;
+}


### PR DESCRIPTION
- fix `forwardRef` issues in our `forwardRef` + polymorphic/generic components that make us lose TSDoc definitions
  - add `fixedForwardRef` to fix generics (fix based on [this article](https://www.totaltypescript.com/forwardref-with-generic-components#the-problem-with-forwardref))