### PR TITLE
feat(List): add visually selectable prop

### DIFF
--- a/packages/core/src/ListContainer/ListContainer.stories.tsx
+++ b/packages/core/src/ListContainer/ListContainer.stories.tsx
@@ -35,14 +35,10 @@ export const Main: StoryObj<HvListContainerProps> = {
   argTypes: {
     classes: { control: { disable: true } },
   },
-  render: ({ interactive, condensed, disableGutters }) => {
+  render: (args) => {
     return (
       <HvPanel style={{ maxWidth: 220 }}>
-        <HvListContainer
-          interactive={interactive}
-          condensed={condensed}
-          disableGutters={disableGutters}
-        >
+        <HvListContainer {...args}>
           <HvListItem>98001, Store Manager</HvListItem>
           <HvListItem>98002, Store Manager</HvListItem>
           <HvListItem>98003, Store Manager</HvListItem>

--- a/packages/core/src/ListContainer/ListContext/ListContext.ts
+++ b/packages/core/src/ListContainer/ListContext/ListContext.ts
@@ -4,6 +4,7 @@ const ListContext = React.createContext<{
   interactive?: boolean;
   nesting?: number;
   condensed?: boolean;
+  selectable?: boolean;
   disableGutters?: boolean;
   topContainerRef?: React.MutableRefObject<HTMLUListElement | null>;
 }>({});

--- a/packages/core/src/ListContainer/ListItem/ListItem.tsx
+++ b/packages/core/src/ListContainer/ListItem/ListItem.tsx
@@ -15,6 +15,8 @@ export type HvListItemClasses = ExtractNames<typeof useClasses>;
 export interface HvListItemProps extends HvBaseProps<HTMLLIElement> {
   /** Indicates if the list item is selected. */
   selected?: boolean;
+  /** Indicated if the list item is _visually_ selectable */
+  selectable?: boolean;
   /** If true, the list item will be disabled. */
   disabled?: boolean;
   /**
@@ -91,6 +93,7 @@ export const HvListItem = forwardRef<any, HvListItemProps>((props, ref) => {
     value,
     selected,
     disabled,
+    selectable: selectableProp,
     interactive: interactiveProp,
     condensed: condensedProp,
     disableGutters: disableGuttersProp,
@@ -109,11 +112,13 @@ export const HvListItem = forwardRef<any, HvListItemProps>((props, ref) => {
     condensed: condensedContext,
     disableGutters: disableGuttersContext,
     interactive: interactiveContext,
+    selectable: selectableContext,
   } = useContext(HvListContext);
 
   const condensed = condensedProp ?? condensedContext;
   const disableGutters = disableGuttersProp ?? disableGuttersContext;
   const interactive = interactiveProp ?? interactiveContext;
+  const selectable = selectableProp ?? selectableContext;
 
   const handleClick = useCallback<React.MouseEventHandler<HTMLLIElement>>(
     (evt) => {
@@ -183,7 +188,7 @@ export const HvListItem = forwardRef<any, HvListItemProps>((props, ref) => {
         {
           [classes.gutters]: !disableGutters,
           [classes.condensed]: condensed,
-          [classes.interactive]: interactive,
+          [classes.interactive]: interactive || selectable,
           [classes.selected]: selected || props["aria-selected"],
           [classes.disabled]: disabled || props["aria-disabled"],
           [classes.withStartAdornment]: startAdornment != null,


### PR DESCRIPTION
Adds `selectable` prop (feel free to suggest a better name) to `HvListContainer` and `HvListItem` to enable visual selection. This is needed for when we can't use `interactive` because selection is managed externally.