### PR TITLE
feat(Select): add `HvSelect` component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37711,7 +37711,7 @@
         "@hitachivantara/uikit-react-shared": "^5.1.28",
         "@hitachivantara/uikit-styles": "^5.19.0",
         "@internationalized/date": "^3.2.0",
-        "@mui/base": "^5.0.0-beta.4",
+        "@mui/base": "^5.0.0-beta.34",
         "@popperjs/core": "^2.11.8",
         "@react-aria/datepicker": "^3.9.0",
         "@react-stately/datepicker": "^3.9.0",
@@ -37749,6 +37749,37 @@
         "@mui/material": "^5.12.2",
         "react": "^17.0.0 || ^18.0.0",
         "react-dom": "^17.0.0 || ^18.0.0"
+      }
+    },
+    "packages/core/node_modules/@mui/base": {
+      "version": "5.0.0-beta.34",
+      "resolved": "https://registry.npmjs.org/@mui/base/-/base-5.0.0-beta.34.tgz",
+      "integrity": "sha512-e2mbTGTtReD/y5RFwnhkl1Tgl3XwgJhY040IlfkTVaU9f5LWrVhEnpRsYXu3B1CtLrwiWs4cu7aMHV9yRd4jpw==",
+      "dependencies": {
+        "@babel/runtime": "^7.23.9",
+        "@floating-ui/react-dom": "^2.0.8",
+        "@mui/types": "^7.2.13",
+        "@mui/utils": "^5.15.7",
+        "@popperjs/core": "^2.11.8",
+        "clsx": "^2.1.0",
+        "prop-types": "^15.8.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@types/react": "^17.0.0 || ^18.0.0",
+        "react": "^17.0.0 || ^18.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "packages/icons": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -48,7 +48,7 @@
     "@hitachivantara/uikit-react-shared": "^5.1.28",
     "@hitachivantara/uikit-styles": "^5.19.0",
     "@internationalized/date": "^3.2.0",
-    "@mui/base": "^5.0.0-beta.4",
+    "@mui/base": "^5.0.0-beta.34",
     "@popperjs/core": "^2.11.8",
     "@react-aria/datepicker": "^3.9.0",
     "@react-stately/datepicker": "^3.9.0",

--- a/packages/core/src/Select/Option.tsx
+++ b/packages/core/src/Select/Option.tsx
@@ -1,0 +1,72 @@
+import { useRef } from "react";
+import { useOption } from "@mui/base/useOption";
+import { OptionOwnProps } from "@mui/base/Option";
+import { useForkRef } from "@mui/material/utils";
+
+import { HvListItem, HvListItemProps } from "../ListContainer";
+import { useDefaultProps } from "../hooks/useDefaultProps";
+import { fixedForwardRef } from "../types/generic";
+import { ExtractNames, createClasses } from "../utils/classes";
+import { outlineStyles } from "../utils/focusUtils";
+
+const { staticClasses, useClasses } = createClasses("HvOption", {
+  root: {},
+  highlighted: {
+    ...outlineStyles,
+  },
+});
+
+export { staticClasses as optionClasses };
+
+export type HvOptionClasses = ExtractNames<typeof useClasses>;
+
+export interface HvOptionProps<OptionValue extends {}>
+  extends Omit<HvListItemProps, "value" | "disabled">,
+    Pick<OptionOwnProps<OptionValue>, "disabled" | "label" | "value"> {
+  classes?: HvOptionClasses;
+}
+
+export const HvOption = fixedForwardRef(function HvOption<
+  OptionValue extends {}
+>(props: HvOptionProps<OptionValue>, ref: React.Ref<HTMLLIElement>) {
+  const {
+    classes: classesProp,
+    className,
+    disabled = false,
+    label,
+    value,
+    children,
+    ...others
+  } = useDefaultProps("HvOption", props);
+  const { classes, cx } = useClasses(classesProp);
+
+  const optionRef = useRef<HTMLElement>(null);
+  const rootRef = useForkRef(optionRef, ref);
+
+  const computedLabel =
+    label ??
+    (typeof children === "string"
+      ? children
+      : optionRef.current?.textContent?.trim());
+
+  const { getRootProps, selected, highlighted } = useOption({
+    disabled,
+    label: computedLabel,
+    rootRef,
+    value,
+  });
+
+  return (
+    <HvListItem
+      ref={ref}
+      selected={selected}
+      className={cx(classes.root, className, {
+        [classes.highlighted]: highlighted,
+      })}
+      {...getRootProps()}
+      {...others}
+    >
+      {children}
+    </HvListItem>
+  );
+});

--- a/packages/core/src/Select/OptionGroup.tsx
+++ b/packages/core/src/Select/OptionGroup.tsx
@@ -1,0 +1,40 @@
+import { forwardRef } from "react";
+import { OptionGroup, OptionGroupProps } from "@mui/base/OptionGroup";
+import { theme } from "@hitachivantara/uikit-styles";
+
+import { ExtractNames, createClasses } from "../utils/classes";
+import { useDefaultProps } from "../hooks/useDefaultProps";
+
+const { staticClasses, useClasses } = createClasses("HvOptionGroup", {
+  root: {
+    listStyle: "none",
+    ...theme.typography.label,
+  },
+});
+
+export { staticClasses as optionGroupClasses };
+
+export type HvOptionGroupClasses = ExtractNames<typeof useClasses>;
+
+export interface HvOptionGroupProps extends OptionGroupProps {
+  classes?: HvOptionGroupClasses;
+}
+
+export const HvOptionGroup = forwardRef<HTMLLIElement, HvOptionGroupProps>(
+  (props, ref) => {
+    const {
+      className,
+      classes: classesProp,
+      ...others
+    } = useDefaultProps("HvOptionGroup", props);
+    const { classes, cx } = useClasses(classesProp);
+
+    return (
+      <OptionGroup
+        ref={ref}
+        className={cx(classes.root, className)}
+        {...others}
+      />
+    );
+  }
+);

--- a/packages/core/src/Select/Select.stories.tsx
+++ b/packages/core/src/Select/Select.stories.tsx
@@ -1,0 +1,123 @@
+import { Decorator, Meta, StoryObj } from "@storybook/react";
+import {
+  HvSelect,
+  HvSelectProps,
+  HvOption,
+  HvOptionGroup,
+} from "@hitachivantara/uikit-react-core";
+
+import FormStory from "./stories/Form";
+import FormStoryRaw from "./stories/Form?raw";
+import ControlledStory from "./stories/Controlled";
+import ControlledStoryRaw from "./stories/Controlled?raw";
+
+const decorator: Decorator = (Story) => (
+  <div className="w-[300px] min-h-[300px]">{Story()}</div>
+);
+
+export default {
+  title: "Components/Select",
+  component: HvSelect,
+  // @ts-expect-error https://github.com/storybookjs/storybook/issues/20782
+  subcomponents: { HvOption, HvOptionGroup },
+} satisfies Meta<typeof HvSelect>;
+
+export const Main: StoryObj<HvSelectProps<{}, false>> = {
+  args: {
+    multiple: false,
+  },
+  argTypes: {},
+  decorators: [decorator],
+  render: (args) => {
+    return (
+      <HvSelect
+        required
+        name="country"
+        label="Country"
+        description="Select your favorite country"
+        placeholder="Select country"
+        onChange={(evt, val) => console.log(val)}
+        {...args}
+      >
+        <HvOptionGroup label="America">
+          <HvOption value="ar">Argentina</HvOption>
+          <HvOption value="us">United States</HvOption>
+        </HvOptionGroup>
+        <HvOptionGroup label="Europe">
+          <HvOption value="bg">Belgium</HvOption>
+          <HvOption value="pt">Portugal</HvOption>
+          <HvOption value="pl">Poland</HvOption>
+          <HvOption value="sp">Spain</HvOption>
+        </HvOptionGroup>
+      </HvSelect>
+    );
+  },
+};
+
+export const Variants: StoryObj<HvSelectProps<{}, false>> = {
+  parameters: {
+    docs: {
+      description: {
+        story: "Selects in their various form state variants.",
+      },
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div className="flex flex-wrap gap-sm [&>*]:w-[200px]">{Story()}</div>
+    ),
+  ],
+  render: () => {
+    return (
+      <>
+        <HvSelect required label="Required">
+          <HvOption value="op">Option</HvOption>
+        </HvSelect>
+        <HvSelect disabled label="Disabled">
+          <HvOption value="op">Option</HvOption>
+        </HvSelect>
+        <HvSelect readOnly label="Read-only">
+          <HvOption value="op">Option</HvOption>
+        </HvSelect>
+        <HvSelect
+          status="invalid"
+          label="Invalid"
+          statusMessage="This is always invalid"
+        >
+          <HvOption value="op">Option</HvOption>
+        </HvSelect>
+      </>
+    );
+  },
+};
+
+export const Form: StoryObj<HvSelectProps<{}, false>> = {
+  parameters: {
+    docs: {
+      source: { code: FormStoryRaw },
+      description: {
+        story:
+          "To integrate `HvSelect` in a form, make sure you're giving it a `name`. <br />\
+          The value result will be the selected option's `value`, or a JSON of the selected values when multi-select is enabled. The value can be customized via the `getSerializedValue` prop.",
+      },
+    },
+  },
+  decorators: [decorator],
+  render: () => <FormStory />,
+};
+
+export const Controlled: StoryObj<HvSelectProps<{}, false>> = {
+  parameters: {
+    docs: {
+      source: { code: ControlledStoryRaw },
+      description: {
+        story:
+          "The value and open states of `HvSelect` can be controlled by using the `value`/`onChange` and `open`/`onOpenChange` props respectively.",
+      },
+    },
+  },
+  decorators: [
+    (Story) => <div className="flex gap-sm min-h-[300px]">{Story()}</div>,
+  ],
+  render: () => <ControlledStory />,
+};

--- a/packages/core/src/Select/Select.styles.ts
+++ b/packages/core/src/Select/Select.styles.ts
@@ -1,0 +1,42 @@
+import { theme } from "@hitachivantara/uikit-styles";
+
+import { createClasses } from "../utils/classes";
+
+export const { staticClasses, useClasses } = createClasses("HvSelect", {
+  root: {
+    position: "relative",
+    "&$disabled,&$readOnly": {
+      pointerEvents: "none",
+    },
+  },
+  disabled: {},
+  readOnly: {},
+  invalid: {
+    border: `1px solid ${theme.colors.negative}`,
+  },
+  labelContainer: {
+    display: "flex",
+    alignItems: "flex-start",
+  },
+  label: {
+    display: "block",
+    paddingBottom: 6,
+  },
+  description: {},
+  select: {},
+  popper: {
+    zIndex: theme.zIndices.popover,
+  },
+  panel: {
+    border: `1px solid ${theme.colors.secondary}`,
+    marginTop: -1,
+    marginBottom: -1,
+  },
+  panelOpenedUp: {
+    borderRadius: `${theme.radii.base} ${theme.radii.base} 0 0`,
+  },
+  panelOpenedDown: {
+    borderRadius: `0 0 ${theme.radii.base} ${theme.radii.base}`,
+  },
+  error: {},
+});

--- a/packages/core/src/Select/Select.test.tsx
+++ b/packages/core/src/Select/Select.test.tsx
@@ -1,0 +1,90 @@
+import { render, screen } from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { HvSelect, HvSelectProps } from "./Select";
+import { HvOption } from "./Option";
+import { HvOptionGroup } from "./OptionGroup";
+
+const name = "MySelect";
+
+const getSelect = () => screen.getByRole("combobox", { name });
+
+const setup = (props?: HvSelectProps<string, false>) =>
+  render(
+    <HvSelect name="options" label={name} {...props}>
+      <HvOption value="opt1">Option1</HvOption>
+      <HvOption value="opt2">Option2</HvOption>
+      <HvOption value="opt3">Option3</HvOption>
+    </HvSelect>
+  );
+
+describe("Select", () => {
+  it("renders the select element", () => {
+    setup();
+
+    expect(getSelect()).toBeInTheDocument();
+  });
+
+  it("shows the options on open", async () => {
+    const mockOpen = vi.fn();
+    setup({ onOpenChange: mockOpen });
+
+    await userEvent.click(getSelect());
+
+    expect(screen.getByRole("listbox")).toBeInTheDocument();
+    expect(screen.getAllByRole("option").length).toBe(3);
+    expect(mockOpen).toHaveBeenCalledTimes(1);
+  });
+
+  it("selects the option", async () => {
+    const mockChange = vi.fn();
+    setup({ onChange: mockChange });
+
+    await userEvent.click(getSelect());
+    await userEvent.click(screen.getByRole("option", { name: "Option2" }));
+
+    expect(mockChange).toHaveBeenCalledWith(expect.anything(), "opt2");
+    expect(getSelect()).toHaveTextContent("Option2");
+  });
+
+  it("renders pre-selected values", () => {
+    render(
+      <HvSelect label={name} multiple defaultValue={["opt1", "opt2"]}>
+        <HvOption value="opt1">Option1</HvOption>
+        <HvOption value="opt2">Option2</HvOption>
+        <HvOption value="opt3">Option3</HvOption>
+      </HvSelect>
+    );
+
+    expect(getSelect()).toHaveTextContent("Option1, Option2");
+  });
+
+  it("renders correctly with groups and multiple section", async () => {
+    render(
+      <HvSelect multiple label={name}>
+        <HvOptionGroup label="Group1">
+          <HvOption value="opt1">Option1</HvOption>
+          <HvOption value="opt2">Option2</HvOption>
+          <HvOption value="opt3">Option3</HvOption>
+        </HvOptionGroup>
+        <HvOptionGroup label="Group2">
+          <HvOption value="opt4">Option4</HvOption>
+          <HvOption value="opt5">Option5</HvOption>
+        </HvOptionGroup>
+      </HvSelect>
+    );
+
+    await userEvent.click(getSelect());
+    const listbox = screen.getByRole("listbox");
+    expect(listbox).toBeInTheDocument();
+    expect(listbox).toHaveAttribute("aria-multiselectable", "true");
+    expect(screen.getAllByRole("list").length).toBe(2);
+    expect(screen.getAllByRole("option").length).toBe(5);
+
+    await userEvent.click(screen.getByRole("option", { name: "Option2" }));
+    await userEvent.click(screen.getByRole("option", { name: "Option4" }));
+
+    expect(getSelect()).toHaveTextContent("Option2, Option4");
+  });
+});

--- a/packages/core/src/Select/Select.tsx
+++ b/packages/core/src/Select/Select.tsx
@@ -1,0 +1,302 @@
+/* eslint-disable @typescript-eslint/no-use-before-define */
+import React, { useRef, useState } from "react";
+import type { Placement } from "@popperjs/core";
+import clsx from "clsx";
+
+import {
+  SelectProvider,
+  UseSelectParameters,
+  useSelect,
+} from "@mui/base/useSelect";
+import { useControlled, useForkRef } from "@mui/material/utils";
+import { Popper } from "@mui/base/Popper";
+import { SelectOption } from "@mui/base/useOption";
+
+import {
+  HvFormElement,
+  HvFormElementProps,
+  HvFormStatus,
+  HvInfoMessage,
+  HvLabel,
+  HvWarningText,
+} from "../Forms";
+import { ExtractNames } from "../utils/classes";
+import { fixedForwardRef } from "../types/generic";
+import { useDefaultProps } from "../hooks/useDefaultProps";
+import { staticClasses, useClasses } from "./Select.styles";
+import { setId } from "../utils/setId";
+import { useUniqueId } from "../hooks/useUniqueId";
+import { HvPanel } from "../Panel";
+import { HvListContainer } from "../ListContainer";
+import { HvSelectButton } from "./SelectButton";
+
+function defaultRenderValue<Value>(
+  options: SelectOption<Value> | SelectOption<Value>[] | null
+) {
+  if (Array.isArray(options)) {
+    if (options.length === 0) return null;
+    return <>{options.map((o) => o.label).join(", ")}</>;
+  }
+
+  return options?.label ?? null;
+}
+
+const mergeIds = (...ids: clsx.ClassValue[]) => clsx(ids) || undefined;
+
+export { staticClasses as selectClasses };
+
+export type HvSelectClasses = ExtractNames<typeof useClasses>;
+
+export interface HvSelectProps<
+  OptionValue extends {},
+  Multiple extends boolean = false
+> extends Omit<HvFormElementProps, "value" | "defaultValue" | "onChange">,
+    Pick<
+      UseSelectParameters<OptionValue, Multiple>,
+      | "name"
+      | "required"
+      | "disabled"
+      | "multiple"
+      | "open"
+      | "defaultOpen"
+      | "value"
+      | "defaultValue"
+      | "buttonRef"
+      | "options"
+      | "getSerializedValue"
+      | "onChange"
+      | "onOpenChange"
+    > {
+  classes?: HvSelectClasses;
+  placeholder?: React.ReactNode;
+  autoComplete?: string;
+  /** Whether the width of the select panel can vary independently. */
+  variableWidth?: boolean;
+}
+
+/**
+ * The `HvSelect` component is a form control element that allows selection from a list of options.
+ *
+ * It aims to be aligned with the native HTML `<select>` and `<option>` APIs and be easily integrated with forms.
+ *
+ * @example
+ * <HvSelect name="pets">
+ *   <HvOption value="dog">Dog</HvOption>
+ *   <HvOption value="cat">Cat</HvOption>
+ * </HvSelect>
+ * */
+export const HvSelect = fixedForwardRef(function HvSelect<
+  OptionValue extends {},
+  Multiple extends boolean
+>(
+  props: HvSelectProps<OptionValue, Multiple>,
+  ref: React.Ref<HTMLButtonElement>
+) {
+  const {
+    children,
+    classes: classesProp,
+    className,
+    id: idProp,
+    name,
+    required,
+    disabled: disabledProp,
+    readOnly,
+    label,
+    open: openProp,
+    defaultOpen,
+    multiple,
+    autoComplete,
+    options: optionsProp,
+    variableWidth,
+    value: valueProp,
+    defaultValue,
+    placeholder,
+    "aria-label": ariaLabel,
+    "aria-labelledby": ariaLabelledBy,
+    description,
+    "aria-describedby": ariaDescribedBy,
+    status,
+    statusMessage,
+    "aria-errormessage": ariaErrorMessage,
+    getSerializedValue,
+    onClick,
+    onChange,
+    onOpenChange,
+    ...others
+  } = useDefaultProps("HvSelect", props);
+  const { classes, cx } = useClasses(classesProp);
+
+  const [placement, setPlacement] = useState<Placement>("bottom-start");
+
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const handleButtonRef = useForkRef(ref, buttonRef);
+
+  const {
+    contextValue,
+    disabled,
+    getButtonProps,
+    getListboxProps,
+    getHiddenInputProps,
+    getOptionMetadata,
+    value,
+    open,
+  } = useSelect<OptionValue, Multiple>({
+    componentName: "HvSelect",
+    name,
+    required,
+    disabled: disabledProp,
+    multiple,
+    open: openProp,
+    defaultOpen,
+    value: valueProp,
+    defaultValue,
+    options: optionsProp,
+    buttonRef: handleButtonRef,
+    getSerializedValue,
+    onChange,
+    onOpenChange: handleOpenChange,
+  });
+
+  const id = useUniqueId(idProp);
+  const labelId = useUniqueId(setId(idProp, "label"));
+  const descriptionId = useUniqueId(setId(idProp, "description"));
+  const errorMessageId = useUniqueId(setId(idProp, "error"));
+
+  const [validationMessage] = useControlled({
+    name: "HvSelect.statusMessage",
+    controlled: statusMessage,
+    default: "Required",
+  });
+  const [validationState, setValidationState] = useControlled<HvFormStatus>({
+    name: "HvSelect.status",
+    controlled: status,
+    default: "standBy",
+  });
+
+  function handleOpenChange(newOpen: boolean) {
+    if (!newOpen) {
+      const hasValue = multiple ? (value as OptionValue[]).length > 0 : !!value;
+      setValidationState(required && !hasValue ? "invalid" : "valid");
+    }
+    onOpenChange?.(newOpen);
+  }
+
+  // the error message area will only be created if:
+  // - an external element that provides an error message isn't identified via aria-errormessage AND
+  //   - both status and statusMessage properties are being controlled OR
+  //   - status is uncontrolled and required is true
+  const canShowError =
+    ariaErrorMessage == null &&
+    ((status !== undefined && statusMessage !== undefined) ||
+      (status === undefined && required));
+
+  const isInvalid = validationState === "invalid";
+
+  const actualValue = multiple
+    ? (value as OptionValue[])
+        .map((v) => getOptionMetadata(v))
+        .filter((v): v is SelectOption<OptionValue> => v !== undefined)
+    : getOptionMetadata(value as OptionValue) ?? null;
+
+  const isOpen = open && !!children;
+
+  return (
+    <HvFormElement
+      name={name}
+      required={required}
+      disabled={disabled}
+      readOnly={readOnly}
+      status={validationState}
+      className={cx(classes.root, className, {
+        [classes.disabled]: disabled,
+        [classes.readOnly]: readOnly,
+      })}
+      {...others}
+    >
+      {(label || description) && (
+        <div className={classes.labelContainer}>
+          {label && (
+            <HvLabel
+              id={labelId}
+              htmlFor={id}
+              label={label}
+              className={classes.label}
+            />
+          )}
+          {description && (
+            <HvInfoMessage id={descriptionId} className={classes.description}>
+              {description}
+            </HvInfoMessage>
+          )}
+        </div>
+      )}
+
+      <HvSelectButton
+        id={id}
+        open={isOpen}
+        disabled={disabled}
+        readOnly={readOnly}
+        className={cx(classes.select, {
+          [classes.invalid]: validationState === "invalid",
+        })}
+        placement={placement}
+        aria-label={ariaLabel}
+        aria-labelledby={mergeIds(label && labelId, ariaLabelledBy)}
+        aria-invalid={isInvalid ? true : undefined}
+        aria-errormessage={errorMessageId}
+        aria-describedby={mergeIds(
+          description && descriptionId,
+          ariaDescribedBy
+        )}
+        {...getButtonProps()}
+      >
+        {defaultRenderValue(actualValue) ?? placeholder}
+      </HvSelectButton>
+      <Popper
+        open={isOpen}
+        keepMounted
+        disablePortal
+        anchorEl={buttonRef.current}
+        className={classes.popper}
+        placement={placement}
+        modifiers={[
+          {
+            enabled: true,
+            phase: "main",
+            fn: ({ state }) => setPlacement(state.placement),
+          },
+        ]}
+      >
+        <HvPanel
+          style={{
+            width: variableWidth
+              ? "auto"
+              : (buttonRef.current?.clientWidth || 0) + 2,
+          }}
+          className={cx(classes.panel, className, {
+            [classes.panelOpenedUp]: placement.includes("top"),
+            [classes.panelOpenedDown]: placement.includes("bottom"),
+          })}
+        >
+          <SelectProvider value={contextValue}>
+            <HvListContainer condensed selectable {...getListboxProps()}>
+              {children}
+            </HvListContainer>
+          </SelectProvider>
+        </HvPanel>
+      </Popper>
+
+      <input {...getHiddenInputProps()} autoComplete={autoComplete} />
+
+      {canShowError && (
+        <HvWarningText
+          id={errorMessageId}
+          disableBorder
+          className={classes.error}
+        >
+          {validationMessage}
+        </HvWarningText>
+      )}
+    </HvFormElement>
+  );
+});

--- a/packages/core/src/Select/SelectButton.tsx
+++ b/packages/core/src/Select/SelectButton.tsx
@@ -1,0 +1,117 @@
+import { forwardRef } from "react";
+import type { Placement } from "@popperjs/core";
+import { DropDownXS } from "@hitachivantara/uikit-react-icons";
+import { theme } from "@hitachivantara/uikit-styles";
+
+import { useDefaultProps } from "../hooks/useDefaultProps";
+import { ExtractNames, createClasses } from "../utils/classes";
+import { HvButton } from "../Button";
+
+export const { staticClasses, useClasses } = createClasses("HvSelectButton", {
+  root: {
+    width: "100%",
+    minWidth: "unset",
+    userSelect: "none",
+    position: "relative",
+    paddingLeft: theme.space.xs,
+    justifyContent: "flex-start",
+  },
+  disabled: {},
+  readOnly: {
+    userSelect: "text",
+    backgroundColor: theme.colors.atmo2,
+  },
+  open: {
+    backgroundColor: theme.colors.atmo1,
+  },
+  openUp: {
+    borderRadius: `0px 0px ${theme.radii.base} ${theme.radii.base}`,
+  },
+  openDown: {
+    borderRadius: `${theme.radii.base} ${theme.radii.base} 0px 0px`,
+  },
+
+  selection: {
+    color: "inherit",
+    flex: 1,
+    textAlign: "start",
+
+    overflow: "clip visible",
+    textOverflow: "ellipsis",
+    whiteSpace: "nowrap",
+  },
+  placeholder: {},
+  arrowContainer: {
+    marginRight: theme.spacing(-2),
+  },
+  arrow: {
+    transition: "rotate 0.2s ease",
+  },
+});
+
+export type HvSelectButtonClasses = ExtractNames<typeof useClasses>;
+
+export interface HvSelectButtonProps
+  extends React.HTMLAttributes<HTMLButtonElement> {
+  readOnly?: boolean;
+  open?: boolean;
+  disabled?: boolean;
+  placement?: Placement;
+  adornment?: React.ReactNode;
+  classes?: HvSelectButtonClasses;
+}
+
+/**
+ * HvSelect internal header button component
+ */
+export const HvSelectButton = forwardRef<
+  HTMLButtonElement,
+  HvSelectButtonProps
+>((props, ref) => {
+  const {
+    classes: classesProp,
+    className,
+    open,
+    placement = "bottom",
+    disabled,
+    readOnly,
+    children,
+    adornment,
+    ...others
+  } = useDefaultProps("HvSelectButton", props);
+  const { classes, cx } = useClasses(classesProp);
+
+  const endIcon = adornment ?? (
+    <DropDownXS
+      iconSize="XS"
+      style={{ rotate: open ? "180deg" : undefined }}
+      className={classes.arrow}
+    />
+  );
+
+  return (
+    <HvButton
+      ref={ref}
+      variant="secondarySubtle"
+      disabled={disabled || readOnly}
+      className={cx(classes.root, className, {
+        [classes.open]: open,
+        [classes.openUp]: open && placement.includes("top"),
+        [classes.openDown]: open && placement.includes("bottom"),
+        [classes.disabled]: disabled,
+        [classes.readOnly]: readOnly,
+      })}
+      classes={{ endIcon: classes.arrowContainer }}
+      endIcon={endIcon}
+      {...others}
+    >
+      <div className={classes.selection}>
+        {children && typeof children === "string" ? (
+          <div className={classes.placeholder}>{children}</div>
+        ) : (
+          children
+        )}
+      </div>
+    </HvButton>
+  );
+});

--- a/packages/core/src/Select/index.ts
+++ b/packages/core/src/Select/index.ts
@@ -1,0 +1,3 @@
+export * from "./Select";
+export * from "./Option";
+export * from "./OptionGroup";

--- a/packages/core/src/Select/stories/Controlled.tsx
+++ b/packages/core/src/Select/stories/Controlled.tsx
@@ -1,0 +1,50 @@
+import { useState } from "react";
+import { HvButton, HvOption, HvSelect } from "@hitachivantara/uikit-react-core";
+
+const options = [
+  { value: "ar", label: "Argentina", flag: "🇦🇷" },
+  { value: "bg", label: "Belgium", flag: "🇧🇪" },
+  { value: "pt", label: "Portugal", flag: "🇵🇹" },
+  { value: "pl", label: "Poland", flag: "🇵🇱" },
+  { value: "sp", label: "Spain", flag: "🇪🇸" },
+  { value: "us", label: "United States", flag: "🇺🇸" },
+];
+
+export default () => {
+  const [selection, setSelection] = useState<string[]>([]);
+  const [open, setOpen] = useState(false);
+
+  const anySelected = selection.length > 0;
+
+  return (
+    <>
+      <HvSelect
+        multiple
+        required
+        open={open}
+        name="countries"
+        aria-label="Country"
+        placeholder="Select countries"
+        value={selection}
+        style={{ width: 300 }}
+        onChange={(evt, val) => setSelection(val)}
+        onOpenChange={setOpen}
+      >
+        {options.map(({ value, label, flag }) => (
+          <HvOption key={value} value={value} label={label}>
+            {`${flag} ${label}`}
+          </HvOption>
+        ))}
+      </HvSelect>
+      <HvButton
+        style={{ width: 120 }}
+        variant="secondarySubtle"
+        onClick={() => {
+          setSelection(anySelected ? [] : options.map((o) => o.value));
+        }}
+      >
+        {anySelected ? "Deselect all" : "Select all"}
+      </HvButton>
+    </>
+  );
+};

--- a/packages/core/src/Select/stories/Form.tsx
+++ b/packages/core/src/Select/stories/Form.tsx
@@ -1,0 +1,40 @@
+import { HvButton, HvOption, HvSelect } from "@hitachivantara/uikit-react-core";
+
+const options = [
+  { value: "ar", label: "Argentina", flag: "🇦🇷" },
+  { value: "bg", label: "Belgium", flag: "🇧🇪" },
+  { value: "pt", label: "Portugal", flag: "🇵🇹" },
+  { value: "pl", label: "Poland", flag: "🇵🇱" },
+  { value: "sp", label: "Spain", flag: "🇪🇸" },
+  { value: "us", label: "United States", flag: "🇺🇸" },
+];
+
+export default () => (
+  <form
+    onSubmit={(evt) => {
+      evt.preventDefault();
+      const formData = new FormData(evt.currentTarget);
+      alert(JSON.stringify(Object.fromEntries(formData)));
+    }}
+  >
+    <HvSelect
+      multiple
+      required
+      name="countries"
+      label="Country"
+      description="Select your favorite countries"
+      placeholder="Select countries"
+      getSerializedValue={(values) => values.map((v) => v.value).join(",")}
+    >
+      {options.map(({ value, label, flag }) => (
+        <HvOption key={value} value={value} label={label}>
+          {`${flag} ${label}`}
+        </HvOption>
+      ))}
+    </HvSelect>
+    <br />
+    <HvButton type="submit" variant="secondarySubtle">
+      Submit
+    </HvButton>
+  </form>
+);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -29,6 +29,7 @@ export * from "./Forms/FormElement";
 export * from "./Forms/Label";
 export * from "./Forms/InfoMessage";
 export * from "./Forms/WarningText";
+export * from "./Select";
 export * from "./SelectionList";
 export * from "./Forms/Suggestions";
 export * from "./BaseInput";

--- a/packages/styles/src/themes/ds3.ts
+++ b/packages/styles/src/themes/ds3.ts
@@ -930,6 +930,18 @@ const ds3 = makeTheme((theme) => ({
         },
       },
     },
+    HvSelect: {
+      classes: {
+        select: {
+          ".HvButton-endIcon": {
+            marginRight: theme.spacing(-1),
+          },
+        },
+        panel: {
+          borderColor: theme.colors.atmo4,
+        },
+      },
+    },
     HvVerticalScrollListItem: {
       classes: {
         notSelected: {


### PR DESCRIPTION
Add `HvSelect` component (and `HvOption`/`HvOptionGroup`)
- uses MUI's `useSelect` behind the scenes (handles multi-select/focus/navigation/search)
- uses `HvButton` for the "header component"

