### PR TITLE
feat(GlobalActions): align with new DS styles

### DIFF
--- a/packages/core/src/GlobalActions/GlobalActions.stories.tsx
+++ b/packages/core/src/GlobalActions/GlobalActions.stories.tsx
@@ -208,7 +208,6 @@ export const CustomContent: StoryObj<HvGlobalActionsProps> = {
       wrapper: css({
         display: "flex",
         justifyContent: "space-between",
-        padding: theme.spacing(0, "xs"),
         height: 48,
       }),
       actions: css({ marginLeft: "unset" }),

--- a/packages/core/src/GlobalActions/GlobalActions.styles.tsx
+++ b/packages/core/src/GlobalActions/GlobalActions.styles.tsx
@@ -1,3 +1,4 @@
+import { CSSInterpolation } from "@emotion/serialize";
 import { theme } from "@hitachivantara/uikit-styles";
 
 import { createClasses } from "../utils/classes";
@@ -29,40 +30,62 @@ export const { staticClasses, useClasses } = createClasses("HvGlobalActions", {
       background: theme.colors.atmo2,
       opacity: "75%",
     },
+
+    "& $wrapper": {
+      top: 0,
+      left: 0,
+      backgroundColor: theme.colors.atmo1,
+      width: "100%",
+      borderWidth: 1,
+      borderRadius: theme.radii.round,
+    },
+  },
+  section: {
+    "& $wrapper": {
+      borderTopWidth: 1,
+      paddingLeft: 0,
+    },
   },
   wrapper: {
-    padding: theme.space.sm,
+    padding: theme.space.xs,
+    position: "relative",
     display: "flex",
     justifyContent: "flex-start",
     alignItems: "center",
-    border: `1px solid ${theme.colors.atmo4}`,
-    borderRadius: theme.radii.round,
-  },
-  globalWrapperComplement: {
-    position: "relative",
-    top: 0,
-    left: 0,
-    background: theme.colors.atmo1,
-    width: "100%",
-  },
-  globalSectionArea: {
-    backgroundColor: theme.colors.atmo1,
-    borderTop: `1px solid ${theme.colors.atmo4}`,
+    gap: theme.space.xs,
+    borderColor: theme.colors.atmo4,
     paddingLeft: theme.space.sm,
   },
-  backButton: {
-    marginRight: theme.space.xs,
-  },
+
+  /** @deprecated use classes.global $wrapper */
+  globalSectionArea: {},
+  /** @deprecated use classes.section $wrapper */
+  globalWrapperComplement: {},
+  backButton: {},
   name: {
     flexGrow: 1,
   },
-  sectionName: {
-    ...theme.typography.title4,
-  },
+  /** @deprecated use classes.name */
+  sectionName: {},
   actions: {
     display: "flex",
     alignItems: "center",
-    marginLeft: "auto",
     gap: theme.space.xs,
+    // TODO: remove in v6 in favour of consistently setting `flexGrow: 1` in a title "wrapper"
+    marginLeft: "auto",
   },
 });
+
+export const getBreakpointStyles = (
+  isUpMd: boolean,
+  isSmDown: boolean
+): CSSInterpolation => {
+  const unit = isUpMd ? 4 : isSmDown ? 2 : 0;
+  if (!unit) return {};
+
+  return {
+    width: `calc(100% - 2 * ${theme.spacing(unit)})`,
+    marginLeft: theme.spacing(unit),
+    marginRight: theme.spacing(unit),
+  };
+};

--- a/packages/core/src/GlobalActions/GlobalActions.tsx
+++ b/packages/core/src/GlobalActions/GlobalActions.tsx
@@ -1,14 +1,16 @@
 import { useTheme as useMuiTheme } from "@mui/material/styles";
 import useMediaQuery from "@mui/material/useMediaQuery";
-import isString from "lodash/isString";
-import { theme } from "@hitachivantara/uikit-styles";
 
 import { useDefaultProps } from "../hooks/useDefaultProps";
 import { HvBaseProps } from "../types/generic";
 import { HvTypography } from "../Typography";
 import { ExtractNames } from "../utils/classes";
 
-import { staticClasses, useClasses } from "./GlobalActions.styles";
+import {
+  getBreakpointStyles,
+  staticClasses,
+  useClasses,
+} from "./GlobalActions.styles";
 
 export { staticClasses as globalActionsClasses };
 export type HvGlobalActionsClasses = ExtractNames<typeof useClasses>;
@@ -29,27 +31,12 @@ export interface HvGlobalActionsProps
   headingLevel?: HvGlobalActionsHeadingLevel;
   /**
    * Position of the Global Actions.
-   * Defaults to `sticky` when it is a global title and `relative` when it's a section title.
+   * @default variant === "global" ? "sticky" : "relative"
    */
   position?: HvGlobalActionsPosition;
   /** A Jss Object used to override or extend the styles applied to the component. */
   classes?: HvGlobalActionsClasses;
 }
-
-const getBreakpointStyles = (isUpMd: boolean, isSmDown: boolean) =>
-  isUpMd
-    ? {
-        width: `calc(100% - 2 * ${theme.spacing(4)})`,
-        marginLeft: `${theme.spacing(4)}`,
-        marginRight: `${theme.spacing(4)}`,
-      }
-    : isSmDown
-    ? {
-        width: `calc(100% - 2 * ${theme.spacing(2)})`,
-        marginLeft: `${theme.spacing(2)}`,
-        marginRight: `${theme.spacing(2)}`,
-      }
-    : {};
 
 /**
  * Global Actions are actions that affect the entire page they live in.
@@ -72,9 +59,6 @@ export const HvGlobalActions = (props: HvGlobalActionsProps) => {
   const isSmDown = useMediaQuery(muiTheme.breakpoints.down("sm"));
   const isUpMd = useMediaQuery(muiTheme.breakpoints.up("md"));
 
-  const fixedPositionCss =
-    positionProp === "fixed" && getBreakpointStyles(isUpMd, isSmDown);
-
   const headingLevelToApply = headingLevel || (variant === "global" ? 1 : 2);
 
   const position =
@@ -88,8 +72,9 @@ export const HvGlobalActions = (props: HvGlobalActionsProps) => {
           [classes.positionSticky]: position === "sticky",
           [classes.positionFixed]: position === "fixed",
           [classes.global]: variant === "global",
+          [classes.section]: variant === "section",
         },
-        css(fixedPositionCss),
+        position === "fixed" && css(getBreakpointStyles(isUpMd, isSmDown)),
         className
       )}
       {...others}
@@ -103,11 +88,11 @@ export const HvGlobalActions = (props: HvGlobalActionsProps) => {
         {variant === "global" && backButton && (
           <div className={classes.backButton}>{backButton}</div>
         )}
-        {!isString(title) ? (
+        {typeof title !== "string" ? (
           title
         ) : (
           <HvTypography
-            variant="title3"
+            variant={variant === "global" ? "title3" : "title4"}
             component={`h${headingLevelToApply}`}
             className={cx(classes.name, {
               [classes.sectionName]: variant !== "global",

--- a/packages/styles/src/themes/ds3.ts
+++ b/packages/styles/src/themes/ds3.ts
@@ -825,14 +825,18 @@ const ds3 = makeTheme((theme) => ({
     },
     HvGlobalActions: {
       classes: {
-        wrapper: {
-          padding: theme.space.xs,
-          border: "transparent",
-          borderRadius: theme.radii.none,
+        section: {
+          "& .HvGlobalActions-wrapper": {
+            backgroundColor: "transparent",
+            paddingLeft: "0px",
+          },
         },
-        globalSectionArea: {
-          backgroundColor: "transparent",
-          paddingLeft: "0px",
+        wrapper: {
+          "&&": {
+            padding: theme.space.xs,
+            borderWidth: 0,
+            borderRadius: 0,
+          },
         },
         sectionName: {
           ...theme.typography.sectionTitle,


### PR DESCRIPTION
Align `GlobalActions` DS 5.9 specs:

- update padding
- `"section"` variant has only border-top and no background
- remove `lodash` usage
- deprecate `globalSectionArea`/`globalWrapperComplement`/`sectionName` classes in favour of selector classes, following our component guidelines