### PR TITLE
refactor(app): move to routes object & lazy route loading

### DIFF
--- a/apps/app/src/lib/routes.tsx
+++ b/apps/app/src/lib/routes.tsx
@@ -1,23 +1,8 @@
 import { lazy } from "react";
-import {
-  Route,
-  Navigate,
-  createRoutesFromElements,
-  createBrowserRouter,
-} from "react-router-dom";
+import { Navigate, createBrowserRouter, RouteObject } from "react-router-dom";
 
-const RootLayout = lazy(() => import("~/pages/layout/root"));
-const NavigationLayout = lazy(() => import("~/pages/layout/navigation"));
-
-const Root = lazy(() => import("~/pages/Root"));
-const Components = lazy(() => import("~/pages/Components"));
-const Instructions = lazy(() => import("~/pages/Instructions"));
-const Flow = lazy(() => import("~/pages/Flow"));
-const DashboardPreview = lazy(() => import("~/pages/Flow/DashboardPreview"));
-const NotFound = lazy(() => import("~/pages/NotFound"));
-
-// Templates
 /* eslint-disable import/no-relative-packages */
+// Templates
 const AssetInventory = lazy(
   () => import("../../../../templates/AssetInventory")
 );
@@ -27,28 +12,34 @@ const DetailsView = lazy(() => import("../../../../templates/DetailsView"));
 const Dashboard = lazy(() => import("../../../../templates/Dashboard"));
 const Welcome = lazy(() => import("../../../../templates/Welcome"));
 
-const routes = createRoutesFromElements(
-  <Route element={<RootLayout />}>
-    <Route element={<NavigationLayout />}>
-      <Route path="/" element={<Root />} />
-      <Route path="/components" element={<Components />} />
-      <Route path="/home" element={<Instructions />} />
-      <Route path="/flow" element={<Flow />} />
-      <Route
-        path="/templates"
-        element={<Navigate to="/templates/welcome" replace />}
-      />
-      <Route path="/templates/welcome" element={<Welcome />} />
-      <Route path="/templates/dashboard" element={<Dashboard />} />
-      <Route path="/templates/asset-inventory" element={<AssetInventory />} />
-      <Route path="/templates/list-view" element={<ListView />} />
-      <Route path="/templates/form" element={<Form />} />
-      <Route path="/templates/details-view" element={<DetailsView />} />
-      <Route path="/*" element={<NotFound />} />
-    </Route>
-    <Route path="/dashboard-preview" element={<DashboardPreview />} />
-  </Route>
-);
+const routes: RouteObject[] = [
+  {
+    lazy: () => import("~/pages/layout/navigation"),
+    children: [
+      { path: "/", lazy: () => import("~/pages/Root") },
+      { path: "/components", lazy: () => import("~/pages/Components") },
+      { path: "/home", lazy: () => import("~/pages/Instructions") },
+      { path: "/flow", lazy: () => import("~/pages/Flow") },
+      {
+        path: "/templates",
+        children: [
+          { index: true, element: <Navigate to="welcome" replace /> },
+          { path: "welcome", element: <Welcome /> },
+          { path: "dashboard", element: <Dashboard /> },
+          { path: "asset-inventory", element: <AssetInventory /> },
+          { path: "list-view", element: <ListView /> },
+          { path: "form", element: <Form /> },
+          { path: "details-view", element: <DetailsView /> },
+        ],
+      },
+      { path: "/*", lazy: () => import("~/pages/NotFound") },
+    ],
+  },
+  {
+    path: "/dashboard-preview",
+    lazy: () => import("~/pages/Flow/DashboardPreview"),
+  },
+];
 
 export const router = createBrowserRouter(routes, {
   basename: import.meta.env.BASE_URL,

--- a/apps/app/src/pages/Components/Components.tsx
+++ b/apps/app/src/pages/Components/Components.tsx
@@ -316,4 +316,4 @@ const Components = () => {
   );
 };
 
-export default Components;
+export { Components as Component };

--- a/apps/app/src/pages/Components/index.ts
+++ b/apps/app/src/pages/Components/index.ts
@@ -1,1 +1,1 @@
-export { default } from "./Components";
+export * from "./Components";

--- a/apps/app/src/pages/Flow/DashboardPreview/DashboardPreview.tsx
+++ b/apps/app/src/pages/Flow/DashboardPreview/DashboardPreview.tsx
@@ -113,7 +113,7 @@ const DashboardPreview = () => {
   );
 };
 
-export default () => (
+export const Component = () => (
   <Suspense fallback={<HvLoading />}>
     <HvContainer component="main" maxWidth="xl" className="w-full">
       <DashboardPreview />

--- a/apps/app/src/pages/Flow/DashboardPreview/index.ts
+++ b/apps/app/src/pages/Flow/DashboardPreview/index.ts
@@ -1,1 +1,1 @@
-export { default } from "./DashboardPreview";
+export * from "./DashboardPreview";

--- a/apps/app/src/pages/Flow/Flow.tsx
+++ b/apps/app/src/pages/Flow/Flow.tsx
@@ -216,10 +216,8 @@ const Content = () => {
   );
 };
 
-const Flow = () => (
+export const Component = () => (
   <Suspense fallback={<HvLoading />}>
     <Content />
   </Suspense>
 );
-
-export default Flow;

--- a/apps/app/src/pages/Flow/index.ts
+++ b/apps/app/src/pages/Flow/index.ts
@@ -1,1 +1,1 @@
-export { default } from "./Flow";
+export * from "./Flow";

--- a/apps/app/src/pages/Instructions/Instructions.tsx
+++ b/apps/app/src/pages/Instructions/Instructions.tsx
@@ -42,7 +42,7 @@ const Entry = ({
   </div>
 );
 
-const Instructions = () => {
+export const Component = () => {
   const { setTutorialOpen } = useGeneratorContext();
 
   return (
@@ -140,5 +140,3 @@ const Instructions = () => {
     </HvContainer>
   );
 };
-
-export default Instructions;

--- a/apps/app/src/pages/Instructions/index.ts
+++ b/apps/app/src/pages/Instructions/index.ts
@@ -1,1 +1,1 @@
-export { default } from "./Instructions";
+export * from "./Instructions";

--- a/apps/app/src/pages/NotFound/NotFound.tsx
+++ b/apps/app/src/pages/NotFound/NotFound.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from "react-i18next";
 import { HvButton, HvEmptyState } from "@hitachivantara/uikit-react-core";
 import { Info } from "@hitachivantara/uikit-react-icons";
 
-const NotFound = () => {
+export const Component = () => {
   const { t } = useTranslation("common");
 
   return (
@@ -23,5 +23,3 @@ const NotFound = () => {
     />
   );
 };
-
-export default NotFound;

--- a/apps/app/src/pages/NotFound/index.ts
+++ b/apps/app/src/pages/NotFound/index.ts
@@ -1,1 +1,1 @@
-export { default } from "./NotFound";
+export * from "./NotFound";

--- a/apps/app/src/pages/Root/Root.tsx
+++ b/apps/app/src/pages/Root/Root.tsx
@@ -1,6 +1,6 @@
 import { Navigate, useSearchParams } from "react-router-dom";
 
-const Root = () => {
+export const Component = () => {
   const [searchParams] = useSearchParams();
 
   if (searchParams.get("dashboard") != null) {
@@ -14,5 +14,3 @@ const Root = () => {
 
   return <Navigate to="/home" replace />;
 };
-
-export default Root;

--- a/apps/app/src/pages/Root/index.ts
+++ b/apps/app/src/pages/Root/index.ts
@@ -1,1 +1,1 @@
-export { default } from "./Root";
+export * from "./Root";

--- a/apps/app/src/pages/layout/navigation.tsx
+++ b/apps/app/src/pages/layout/navigation.tsx
@@ -56,7 +56,7 @@ const Navigation = () => {
 };
 
 /** Navigation + Theme Generator layout & providers */
-export default () => (
+export const Component = () => (
   <div className="flex flex-row rounded-circle">
     <GeneratorProvider>
       <div className="flex-1 overflow-y-auto">

--- a/apps/app/src/pages/layout/root.tsx
+++ b/apps/app/src/pages/layout/root.tsx
@@ -1,7 +1,0 @@
-import { Outlet } from "react-router-dom";
-
-export const Component = () => {
-  return <Outlet />;
-};
-
-export default Component;


### PR DESCRIPTION
Update the app router routes to better align with the latest & default react-router recommendations
- Leverage nested routing for templates
- use lazy route import
- use object (the default) instead of JSX definition

The goal of this change is to make it easier to compare with the App Shell's config spec