### PR TITLE
feat(FlowNode): outputs and inputs actions

### DIFF
--- a/packages/core/src/ActionsGeneric/ActionsGeneric.test.tsx
+++ b/packages/core/src/ActionsGeneric/ActionsGeneric.test.tsx
@@ -43,12 +43,13 @@ describe("ActionsGeneric", () => {
     expect(menuItems).toHaveLength(2);
   });
 
-  it("should call actionsCallback on action click", async () => {
+  it("should call actionsCallback and onAction on action click", async () => {
     const user = userEvent.setup();
     const callbackSpy = vi.fn();
     render(
       <HvActionsGeneric
         actions={actions}
+        onAction={callbackSpy}
         actionsCallback={callbackSpy}
         maxVisibleActions={2}
       />
@@ -57,7 +58,7 @@ describe("ActionsGeneric", () => {
     const previewBtn = screen.getByRole("button", { name: "Preview" });
 
     await user.click(previewBtn);
-    expect(callbackSpy).toHaveBeenCalledOnce();
+    expect(callbackSpy).toHaveBeenCalledTimes(2);
 
     const dropdownBtn = screen.getByRole("button", { name: "Dropdown menu" });
     await user.click(dropdownBtn);
@@ -65,16 +66,17 @@ describe("ActionsGeneric", () => {
     const deleteItem = screen.getByText("Delete");
     await user.click(deleteItem);
 
-    expect(callbackSpy).toHaveBeenCalledTimes(2);
+    expect(callbackSpy).toHaveBeenCalledTimes(4);
   });
 
-  it("should not call actionsCallback if the action is disabled", async () => {
+  it("should not call actionsCallback and onAction if the action is disabled", async () => {
     const user = userEvent.setup();
     const callbackSpy = vi.fn();
     render(
       <HvActionsGeneric
         actions={actions}
         actionsCallback={callbackSpy}
+        onAction={callbackSpy}
         maxVisibleActions={2}
       />
     );

--- a/packages/core/src/ActionsGeneric/ActionsGeneric.tsx
+++ b/packages/core/src/ActionsGeneric/ActionsGeneric.tsx
@@ -2,41 +2,55 @@ import React, { isValidElement } from "react";
 import { MoreOptionsVertical } from "@hitachivantara/uikit-react-icons";
 
 import { useDefaultProps } from "../hooks/useDefaultProps";
-import { HvButton, HvButtonVariant } from "../Button";
+import { HvButton, HvButtonProps, HvButtonVariant } from "../Button";
 import { HvDropDownMenu } from "../DropDownMenu";
 import { setId } from "../utils/setId";
 import { ExtractNames } from "../utils/classes";
 import { HvBaseProps } from "../types/generic";
-
 import { staticClasses, useClasses } from "./ActionsGeneric.styles";
+import { IconButton } from "../utils/IconButton";
 
 export { staticClasses as actionsGenericClasses };
 
 export type HvActionsGenericClasses = ExtractNames<typeof useClasses>;
 
 export interface HvActionGeneric {
+  /** Action id. */
   id: string;
+  /** Action label. */
   label: string;
+  /** Action icon. */
   icon?:
     | React.ReactNode
     | ((params: { isDisabled?: boolean }) => React.ReactNode);
+  /** Whether the action is disabled or not. */
   disabled?: boolean;
+  /** When set to `true`, the button will have the icon has its content and a tooltip with the label will appear when the button is visible and hovered. */
+  iconOnly?: boolean;
 }
 
 export interface HvActionsGenericProps extends HvBaseProps {
-  /** Button category. */
+  /**
+   * The button category for all actions.
+   *
+   * @deprecated Use `variant` instead.
+   */
   category?: HvButtonVariant;
-  /**  Whether actions should be all disabled */
+  /** The button variant for all actions. */
+  variant?: HvButtonVariant;
+  /** Whether the actions should be all disabled. */
   disabled?: boolean;
-  /** The renderable content inside the actions slot of the footer, or an Array of actions `{id, label, icon, disabled}` */
+  /** Whether the actions should be all icon buttons when visible. */
+  iconOnly?: boolean;
+  /** The renderable content inside the actions slot of the footer, or an array of actions. */
   actions: React.ReactNode | HvActionGeneric[];
-  /**  The callback function ran when an action is triggered, receiving `action` as param */
+  /** The callback function called when an action is triggered, receiving the `action` as parameter. */
   actionsCallback?: (
     event: React.SyntheticEvent,
     id: string,
     action: HvActionGeneric
   ) => void;
-  /**  The number of maximum visible actions before they're collapsed into a `DropDownMenu`. */
+  /** The maximum number of visible actions before they're collapsed into a dropdown menu. */
   maxVisibleActions?: number;
   /** A Jss Object used to override or extend the styles applied to the component. */
   classes?: HvActionsGenericClasses;
@@ -47,37 +61,60 @@ export const HvActionsGeneric = (props: HvActionsGenericProps) => {
     id,
     classes: classesProp,
     className,
-    category = "secondaryGhost",
+    category = "secondaryGhost", // TODO - remove and update variant default in v6
+    variant: variantProp,
     disabled = false,
     actions = [],
     actionsCallback,
     maxVisibleActions = Infinity,
+    iconOnly: iconOnlyProp,
     ...others
   } = useDefaultProps("HvActionsGeneric", props);
+
+  const variant = variantProp || category;
 
   const { classes, cx } = useClasses(classesProp);
 
   if (!Array.isArray(actions)) return isValidElement(actions) ? actions : null;
 
   const renderButton = (action: HvActionGeneric, idx: number) => {
-    const { disabled: actDisabled, id: actId, icon, label, ...other } = action;
+    const {
+      disabled: actDisabled,
+      id: actId,
+      icon,
+      label,
+      iconOnly,
+      ...other
+    } = action;
     const actionId = setId(id, idx, "action", action.id);
 
     const renderedIcon = isValidElement(icon)
       ? icon
       : (icon as Function)?.({ isDisabled: disabled });
 
+    const commonButtonProps: HvButtonProps = {
+      id: actionId,
+      variant,
+      className: classes.button,
+      disabled: actDisabled ?? disabled,
+      onClick: (event) => actionsCallback?.(event, id || "", action),
+      ...other,
+    };
+
+    const key = actionId || idx;
+
+    const isIcon = iconOnly ?? iconOnlyProp;
+
+    if (isIcon) {
+      return (
+        <IconButton {...commonButtonProps} key={key} title={label}>
+          {renderedIcon}
+        </IconButton>
+      );
+    }
+
     return (
-      <HvButton
-        id={actionId}
-        key={actionId || idx}
-        variant={category}
-        className={classes.button}
-        disabled={actDisabled ?? disabled}
-        onClick={(event) => actionsCallback?.(event, id || "", action)}
-        startIcon={renderedIcon}
-        {...other}
-      >
+      <HvButton {...commonButtonProps} key={key} startIcon={renderedIcon}>
         {label}
       </HvButton>
     );
@@ -87,7 +124,7 @@ export const HvActionsGeneric = (props: HvActionsGenericProps) => {
     const actsVisible = actions.slice(0, maxVisibleActions);
     const actsDropdown = actions.slice(maxVisibleActions);
 
-    const semantic = category === "semantic";
+    const semantic = variant === "semantic";
     const iconColor =
       (disabled && "secondary_60") || (semantic && "base_dark") || undefined;
 
@@ -97,7 +134,7 @@ export const HvActionsGeneric = (props: HvActionsGenericProps) => {
         <HvDropDownMenu
           id={setId(id, "menu")}
           disabled={disabled}
-          category={category}
+          variant={variant}
           classes={{
             root: classes.dropDownMenu,
             icon: classes.dropDownMenuButton,

--- a/packages/core/src/ActionsGeneric/ActionsGeneric.tsx
+++ b/packages/core/src/ActionsGeneric/ActionsGeneric.tsx
@@ -44,12 +44,18 @@ export interface HvActionsGenericProps extends HvBaseProps {
   iconOnly?: boolean;
   /** The renderable content inside the actions slot of the footer, or an array of actions. */
   actions: React.ReactNode | HvActionGeneric[];
-  /** The callback function called when an action is triggered, receiving the `action` as parameter. */
+  /**
+   * The callback function called when an action is triggered, receiving the `action` as parameter.
+   *
+   * @deprecated Use `onAction` instead.
+   * */
   actionsCallback?: (
     event: React.SyntheticEvent,
     id: string,
     action: HvActionGeneric
   ) => void;
+  /** The callback function called when an action is triggered, receiving the `action` as parameter. */
+  onAction?: (event: React.SyntheticEvent, action: HvActionGeneric) => void;
   /** The maximum number of visible actions before they're collapsed into a dropdown menu. */
   maxVisibleActions?: number;
   /** A Jss Object used to override or extend the styles applied to the component. */
@@ -58,14 +64,15 @@ export interface HvActionsGenericProps extends HvBaseProps {
 
 export const HvActionsGeneric = (props: HvActionsGenericProps) => {
   const {
-    id,
+    id: idProp,
     classes: classesProp,
     className,
     category = "secondaryGhost", // TODO - remove and update variant default in v6
     variant: variantProp,
     disabled = false,
     actions = [],
-    actionsCallback,
+    actionsCallback, // TODO - remove in v6
+    onAction,
     maxVisibleActions = Infinity,
     iconOnly: iconOnlyProp,
     ...others
@@ -74,6 +81,15 @@ export const HvActionsGeneric = (props: HvActionsGenericProps) => {
   const variant = variantProp || category;
 
   const { classes, cx } = useClasses(classesProp);
+
+  const handleCallback: HvActionsGenericProps["actionsCallback"] = (
+    event,
+    id,
+    action
+  ) => {
+    actionsCallback?.(event, id, action);
+    onAction?.(event, action);
+  };
 
   if (!Array.isArray(actions)) return isValidElement(actions) ? actions : null;
 
@@ -86,7 +102,7 @@ export const HvActionsGeneric = (props: HvActionsGenericProps) => {
       iconOnly,
       ...other
     } = action;
-    const actionId = setId(id, idx, "action", action.id);
+    const actionId = setId(idProp, idx, "action", action.id);
 
     const renderedIcon = isValidElement(icon)
       ? icon
@@ -97,7 +113,7 @@ export const HvActionsGeneric = (props: HvActionsGenericProps) => {
       variant,
       className: classes.button,
       disabled: actDisabled ?? disabled,
-      onClick: (event) => actionsCallback?.(event, id || "", action),
+      onClick: (event) => handleCallback(event, idProp || "", action),
       ...other,
     };
 
@@ -132,7 +148,7 @@ export const HvActionsGeneric = (props: HvActionsGenericProps) => {
       <>
         {actsVisible.map((action, idx) => renderButton(action, idx))}
         <HvDropDownMenu
-          id={setId(id, "menu")}
+          id={setId(idProp, "menu")}
           disabled={disabled}
           variant={variant}
           classes={{
@@ -143,7 +159,7 @@ export const HvActionsGeneric = (props: HvActionsGenericProps) => {
           icon={<MoreOptionsVertical color={iconColor} />}
           placement="left"
           onClick={(event, action) =>
-            actionsCallback?.(event, id || "", action as HvActionGeneric)
+            handleCallback(event, idProp || "", action as HvActionGeneric)
           }
           dataList={actsDropdown}
           keepOpened={false}

--- a/packages/core/src/Banner/BannerContent/ActionContainer/ActionContainer.tsx
+++ b/packages/core/src/Banner/BannerContent/ActionContainer/ActionContainer.tsx
@@ -53,7 +53,7 @@ export const HvActionContainer = (props: HvActionContainerProps) => {
         <div className={classes.actionsInnerContainer}>
           <HvActionsGeneric
             id={id}
-            category="semantic"
+            variant="semantic"
             actions={action}
             actionsCallback={actionCallback}
           />

--- a/packages/core/src/Banner/BannerContent/MessageContainer/MessageContainer.tsx
+++ b/packages/core/src/Banner/BannerContent/MessageContainer/MessageContainer.tsx
@@ -50,7 +50,7 @@ export const HvMessageContainer = ({
         >
           <HvActionsGeneric
             id={id}
-            category="semantic"
+            variant="semantic"
             actions={actionsOnMessage}
             actionsCallback={actionsOnMessageCallback}
           />

--- a/packages/core/src/BulkActions/BulkActions.tsx
+++ b/packages/core/src/BulkActions/BulkActions.tsx
@@ -179,7 +179,7 @@ export const HvBulkActions = (props: HvBulkActionsProps) => {
       <HvActionsGeneric
         id={setId(id, "actions")}
         classes={{ root: classes.actions }}
-        category={
+        variant={
           isSemantic
             ? (activeTheme?.bulkActions.actionButtonVariant as HvButtonVariant)
             : "secondaryGhost"

--- a/packages/core/src/Card/Card.stories.tsx
+++ b/packages/core/src/Card/Card.stories.tsx
@@ -224,9 +224,7 @@ export const AllComponents: StoryObj<HvCardProps> = {
           <HvActionsGeneric
             actions={myActions}
             maxVisibleActions={1}
-            actionsCallback={(e, id, a) =>
-              alert(`You have pressed ${a.label}.`)
-            }
+            onAction={(e, a) => alert(`You have pressed ${a.label}.`)}
           />
         </HvActionBar>
       </HvCard>

--- a/packages/core/src/DropDownMenu/DropDownMenu.tsx
+++ b/packages/core/src/DropDownMenu/DropDownMenu.tsx
@@ -13,7 +13,6 @@ import { HvBaseDropdown, HvBaseDropdownProps } from "../BaseDropdown";
 import { HvButton, HvButtonVariant } from "../Button";
 import { HvList, HvListProps, HvListValue } from "../List";
 import { HvPanel } from "../Panel";
-
 import { staticClasses, useClasses } from "./DropDownMenu.styles";
 
 export { staticClasses as dropDownMenuClasses };
@@ -82,7 +81,7 @@ export const HvDropDownMenu = (props: HvDropDownMenuProps) => {
     disabled = false,
     expanded,
     defaultExpanded = false,
-    category = "secondaryGhost",
+    category = "secondaryGhost", // TODO - remove and update variant default in v6
     variant,
     ...others
   } = useDefaultProps("HvDropDownMenu", props);

--- a/packages/core/src/Section/Section.stories.tsx
+++ b/packages/core/src/Section/Section.stories.tsx
@@ -110,7 +110,7 @@ export const WithActions: StoryObj<HvSectionProps> = {
               label: "Action 3",
             },
           ]}
-          actionsCallback={(_, __, action) => {
+          onAction={(event, action) => {
             console.log(action.label);
           }}
           maxVisibleActions={1}

--- a/packages/core/src/Snackbar/SnackbarContent/SnackbarContent.tsx
+++ b/packages/core/src/Snackbar/SnackbarContent/SnackbarContent.tsx
@@ -82,7 +82,7 @@ export const HvSnackbarContent = forwardRef<
             <div id={setId(id, "action")} className={classes.action}>
               <HvActionsGeneric
                 id={id}
-                category={
+                variant={
                   activeTheme?.snackbar.actionButtonVariant as HvButtonVariant
                 }
                 actions={innerAction}

--- a/packages/core/src/Table/stories/TableComplete/TableComplete.tsx
+++ b/packages/core/src/Table/stories/TableComplete/TableComplete.tsx
@@ -163,7 +163,7 @@ export const TableComplete = <T extends object>(props: TableProps<T>) => {
           actions={actions}
           disabled={actions.every((a) => a.disabled)}
           maxVisibleActions={0}
-          actionsCallback={(evt, id, action) => onAction?.(evt, action, row)}
+          onAction={(evt, action) => onAction?.(evt, action, row)}
         />
       ),
     };

--- a/packages/core/src/Table/stories/TableSection/PropsTableSection.tsx
+++ b/packages/core/src/Table/stories/TableSection/PropsTableSection.tsx
@@ -57,7 +57,7 @@ export const PropsTableSection = () => {
             label: "Action 3",
           },
         ]}
-        actionsCallback={(_, __, action) => {
+        onAction={(event, action) => {
           console.log(action.label);
         }}
         maxVisibleActions={1}

--- a/packages/lab/src/Flow/Node/BaseNode.styles.tsx
+++ b/packages/lab/src/Flow/Node/BaseNode.styles.tsx
@@ -127,4 +127,9 @@ export const { staticClasses, useClasses } = createClasses("HvFlowBaseNode", {
     padding: theme.space.sm,
     borderTop: `1px solid ${theme.colors.atmo3}`,
   },
+  handleLabelContainer: {
+    display: "flex",
+    alignItems: "center",
+    gap: theme.space.xs,
+  },
 });

--- a/packages/lab/src/Flow/Node/BaseNode.tsx
+++ b/packages/lab/src/Flow/Node/BaseNode.tsx
@@ -188,7 +188,7 @@ export const HvFlowBaseNode = ({
       const {
         actions,
         actionsButtonVariant,
-        actionsCallback,
+        onAction,
         actionsIconOnly,
         maxVisibleActions,
       } = result;
@@ -197,7 +197,7 @@ export const HvFlowBaseNode = ({
         <HvActionsGeneric
           actions={actions}
           maxVisibleActions={maxVisibleActions}
-          actionsCallback={(e, i, a) => actionsCallback?.(e, i, a, item)}
+          onAction={(e, a) => onAction?.(e, a, item)}
           iconOnly={actionsIconOnly}
           variant={actionsButtonVariant}
         />

--- a/packages/lab/src/Flow/Node/Node.styles.tsx
+++ b/packages/lab/src/Flow/Node/Node.styles.tsx
@@ -20,9 +20,11 @@ export const { staticClasses, useClasses } = createClasses("HvFlowNode", {
     justifyContent: "space-between",
     alignItems: "center",
   },
-  actions: {
-    display: "flex",
-    alignItems: "center",
+  actions: {},
+  actionsButton: {
+    "&:not(:last-child)": {
+      marginRight: 0,
+    },
   },
   paramsContainer: {
     borderTop: `1px solid ${theme.colors.atmo4}`,

--- a/packages/lab/src/Flow/Node/Node.tsx
+++ b/packages/lab/src/Flow/Node/Node.tsx
@@ -1,11 +1,10 @@
-import React, { isValidElement, useState } from "react";
+import React, { useState } from "react";
 import {
   ExtractNames,
-  HvActionGeneric,
+  HvActionsGeneric,
   HvActionsGenericProps,
   HvButton,
   HvButtonProps,
-  HvDropDownMenu,
   HvTooltip,
   HvTypography,
   useLabels,
@@ -38,11 +37,13 @@ export interface HvFlowNodeProps<T = any> extends HvFlowBaseNodeProps<T> {
   /** Node description */
   description?: string;
   /** Node actions */
-  actions?: HvActionGeneric[];
+  actions?: HvActionsGenericProps["actions"];
   /** Node action callback */
   actionCallback?: HvActionsGenericProps["actionsCallback"];
+  /** Whether the actions should be all icon buttons when visible. @default true */
+  actionsIconOnly?: HvActionsGenericProps["iconOnly"];
   /** Node maximum number of actions visible */
-  maxVisibleActions?: number;
+  maxVisibleActions?: HvActionsGenericProps["maxVisibleActions"];
   /** Node expanded */
   expanded?: boolean;
   /** Node parameters */
@@ -57,9 +58,6 @@ export interface HvFlowNodeProps<T = any> extends HvFlowBaseNodeProps<T> {
   classes?: HvFlowNodeClasses;
 }
 
-const renderedIcon = (actionIcon: HvActionGeneric["icon"]) =>
-  isValidElement(actionIcon) ? actionIcon : (actionIcon as Function)?.();
-
 export const HvFlowNode = ({
   id,
   type,
@@ -69,6 +67,7 @@ export const HvFlowNode = ({
   actionCallback,
   maxVisibleActions = 1,
   expanded = false,
+  actionsIconOnly = true,
   params,
   nodeDefaults,
   classes: classesProp,
@@ -94,9 +93,6 @@ export const HvFlowNode = ({
   const groupLabel = group?.label || nodeDefaults?.title;
   const icon = group?.icon || nodeDefaults?.icon;
   const color = group?.color || nodeDefaults?.color;
-
-  const actsVisible = actions?.slice(0, maxVisibleActions);
-  const actsDropdown = actions?.slice(maxVisibleActions);
 
   const hasParams = !!(params && params.length > 0);
 
@@ -141,44 +137,23 @@ export const HvFlowNode = ({
       labels={labels as HvFlowNodeProps["labels"]}
       {...props}
     >
-      {(subtitle || actsVisible?.length || actsDropdown?.length) && (
+      {(subtitle || actions) && (
         <div className={classes.subtitleContainer}>
           {subtitle && (
             <div>
               <HvTypography>{subtitle}</HvTypography>
             </div>
           )}
-          <div className={classes.actions}>
-            {actions?.length && actions?.length > 0 && (
-              <>
-                {actsVisible?.map((action) => (
-                  <HvTooltip key={action.id} title={action.label}>
-                    <HvButton
-                      icon
-                      onClick={(event) => {
-                        actionCallback?.(event, id, action);
-                      }}
-                      aria-label={action.label}
-                    >
-                      {renderedIcon(action.icon)}
-                    </HvButton>
-                  </HvTooltip>
-                ))}
-                {actsDropdown && actsDropdown.length > 0 && (
-                  <HvDropDownMenu
-                    keepOpened={false}
-                    dataList={actsDropdown?.map((action) => ({
-                      id: action.id,
-                      label: action.label,
-                    }))}
-                    onClick={(event, action) => {
-                      actionCallback?.(event, id, action as HvActionGeneric);
-                    }}
-                  />
-                )}
-              </>
-            )}
-          </div>
+          {actions && (
+            <HvActionsGeneric
+              className={classes.actions}
+              classes={{ button: classes.actionsButton }}
+              actions={actions}
+              actionsCallback={actionCallback}
+              maxVisibleActions={maxVisibleActions}
+              iconOnly={actionsIconOnly}
+            />
+          )}
         </div>
       )}
       {children}

--- a/packages/lab/src/Flow/Node/Node.tsx
+++ b/packages/lab/src/Flow/Node/Node.tsx
@@ -33,17 +33,22 @@ const DEFAULT_LABELS = {
   expandLabel: "Expand",
 };
 
-export interface HvFlowNodeProps<T = any> extends HvFlowBaseNodeProps<T> {
+export interface HvFlowNodeProps<T = any>
+  extends HvFlowBaseNodeProps<T>,
+    Pick<
+      Partial<HvActionsGenericProps>,
+      "actions" | "maxVisibleActions" | "onAction"
+    > {
   /** Node description */
   description?: string;
-  /** Node actions */
-  actions?: HvActionsGenericProps["actions"];
-  /** Node action callback */
-  actionCallback?: HvActionsGenericProps["actionsCallback"]; // TODO - v6 rename to actionsCallback
+  /**
+   * Node action callback
+   *
+   * @deprecated Use `onAction` instead.
+   * */
+  actionCallback?: HvActionsGenericProps["actionsCallback"]; // TODO - remove in v6
   /** Whether the actions should be all icon buttons when visible. @default true */
   actionsIconOnly?: HvActionsGenericProps["iconOnly"];
-  /** Node maximum number of actions visible */
-  maxVisibleActions?: HvActionsGenericProps["maxVisibleActions"];
   /** Node expanded */
   expanded?: boolean;
   /** Node parameters */
@@ -64,7 +69,8 @@ export const HvFlowNode = ({
   headerItems,
   description,
   actions,
-  actionCallback,
+  actionCallback, // TODO - remove in v6
+  onAction,
   maxVisibleActions = 1,
   expanded = false,
   actionsIconOnly = true,
@@ -149,7 +155,11 @@ export const HvFlowNode = ({
               className={classes.actions}
               classes={{ button: classes.actionsButton }}
               actions={actions}
-              actionsCallback={actionCallback}
+              // TODO - use onAction in v6
+              actionsCallback={(event, acId, action) => {
+                actionCallback?.(event, acId, action);
+                onAction?.(event, action);
+              }}
               maxVisibleActions={maxVisibleActions}
               iconOnly={actionsIconOnly}
             />

--- a/packages/lab/src/Flow/Node/Node.tsx
+++ b/packages/lab/src/Flow/Node/Node.tsx
@@ -39,7 +39,7 @@ export interface HvFlowNodeProps<T = any> extends HvFlowBaseNodeProps<T> {
   /** Node actions */
   actions?: HvActionsGenericProps["actions"];
   /** Node action callback */
-  actionCallback?: HvActionsGenericProps["actionsCallback"];
+  actionCallback?: HvActionsGenericProps["actionsCallback"]; // TODO - v6 rename to actionsCallback
   /** Whether the actions should be all icon buttons when visible. @default true */
   actionsIconOnly?: HvActionsGenericProps["iconOnly"];
   /** Node maximum number of actions visible */

--- a/packages/lab/src/Flow/Node/utils.ts
+++ b/packages/lab/src/Flow/Node/utils.ts
@@ -5,9 +5,39 @@ import { HvActionGeneric } from "@hitachivantara/uikit-react-core";
 import {
   HvFlowNodeInput,
   HvFlowNodeInputGroup,
+  HvFlowNodeLabelActions,
   HvFlowNodeOutput,
   HvFlowNodeOutputGroup,
 } from "../types";
+
+export const returnActions = (
+  handleProps:
+    | HvFlowNodeInput
+    | HvFlowNodeInputGroup
+    | HvFlowNodeOutput
+    | HvFlowNodeOutputGroup,
+  defaultActions?: HvFlowNodeLabelActions
+): HvFlowNodeLabelActions | undefined => {
+  const {
+    actions,
+    actionsButtonVariant,
+    actionsCallback,
+    actionsIconOnly,
+    actionsPlacement,
+    maxVisibleActions,
+  } = handleProps;
+
+  return actions
+    ? {
+        actions,
+        actionsButtonVariant,
+        actionsCallback,
+        actionsIconOnly,
+        actionsPlacement,
+        maxVisibleActions,
+      }
+    : defaultActions;
+};
 
 export const isInputGroup = (
   input: HvFlowNodeInput | HvFlowNodeInputGroup

--- a/packages/lab/src/Flow/Node/utils.ts
+++ b/packages/lab/src/Flow/Node/utils.ts
@@ -5,39 +5,9 @@ import { HvActionGeneric } from "@hitachivantara/uikit-react-core";
 import {
   HvFlowNodeInput,
   HvFlowNodeInputGroup,
-  HvFlowNodeLabelActions,
   HvFlowNodeOutput,
   HvFlowNodeOutputGroup,
 } from "../types";
-
-export const returnActions = (
-  handleProps:
-    | HvFlowNodeInput
-    | HvFlowNodeInputGroup
-    | HvFlowNodeOutput
-    | HvFlowNodeOutputGroup,
-  defaultActions?: HvFlowNodeLabelActions
-): HvFlowNodeLabelActions | undefined => {
-  const {
-    actions,
-    actionsButtonVariant,
-    onAction,
-    actionsIconOnly,
-    actionsPlacement,
-    maxVisibleActions,
-  } = handleProps;
-
-  return actions
-    ? {
-        actions,
-        actionsButtonVariant,
-        onAction,
-        actionsIconOnly,
-        actionsPlacement,
-        maxVisibleActions,
-      }
-    : defaultActions;
-};
 
 export const isInputGroup = (
   input: HvFlowNodeInput | HvFlowNodeInputGroup

--- a/packages/lab/src/Flow/Node/utils.ts
+++ b/packages/lab/src/Flow/Node/utils.ts
@@ -21,7 +21,7 @@ export const returnActions = (
   const {
     actions,
     actionsButtonVariant,
-    actionsCallback,
+    onAction,
     actionsIconOnly,
     actionsPlacement,
     maxVisibleActions,
@@ -31,7 +31,7 @@ export const returnActions = (
     ? {
         actions,
         actionsButtonVariant,
-        actionsCallback,
+        onAction,
         actionsIconOnly,
         actionsPlacement,
         maxVisibleActions,

--- a/packages/lab/src/Flow/stories/Base/Asset.tsx
+++ b/packages/lab/src/Flow/stories/Base/Asset.tsx
@@ -18,6 +18,7 @@ import {
   HvFlowNode,
   HvFlowNodeFC,
   HvFlowNodeOutput,
+  HvFlowNodeProps,
   HvFlowNodeTypeMeta,
   useFlowNode,
 } from "@hitachivantara/uikit-react-lab";
@@ -42,7 +43,7 @@ export const Asset: HvFlowNodeFC<NodeGroup, AssetData> = (props) => {
   const [details, setDetails] = useState<Node>();
   const node = useFlowNode();
 
-  const handleAction = (event: any, nodeId: string, action: any) => {
+  const handleAction: HvFlowNodeProps["onAction"] = (event, action) => {
     if (!node) return;
 
     switch (action.id) {
@@ -56,9 +57,8 @@ export const Asset: HvFlowNodeFC<NodeGroup, AssetData> = (props) => {
     }
   };
 
-  const handleActionCallback: HvFlowNodeOutput["actionsCallback"] = (
+  const handleActionCallback: HvFlowNodeOutput["onAction"] = (
     event,
-    id,
     action,
     item
   ) => {
@@ -105,7 +105,7 @@ export const Asset: HvFlowNodeFC<NodeGroup, AssetData> = (props) => {
             icon: <Flag />,
           },
         ]}
-        actionCallback={handleAction}
+        onAction={handleAction}
         params={[
           {
             id: "asset",
@@ -128,7 +128,7 @@ export const Asset: HvFlowNodeFC<NodeGroup, AssetData> = (props) => {
                 label: "Configure",
               },
             ],
-            actionsCallback: handleActionCallback,
+            onAction: handleActionCallback,
             actionsButtonVariant: "primarySubtle",
             actionsPlacement: "right",
             // Actions shared by all outputs in the group
@@ -140,7 +140,7 @@ export const Asset: HvFlowNodeFC<NodeGroup, AssetData> = (props) => {
                   icon: <Edit />,
                 },
               ],
-              actionsCallback: handleActionCallback,
+              onAction: handleActionCallback,
               actionsButtonVariant: "primaryGhost",
               actionsIconOnly: true,
             },

--- a/packages/lab/src/Flow/stories/Base/Asset.tsx
+++ b/packages/lab/src/Flow/stories/Base/Asset.tsx
@@ -17,8 +17,8 @@ import {
   HvFlowInstance,
   HvFlowNode,
   HvFlowNodeFC,
-  HvFlowNodeOutput,
   HvFlowNodeProps,
+  HvFlowNodeLabelAction,
   HvFlowNodeTypeMeta,
   useFlowNode,
 } from "@hitachivantara/uikit-react-lab";
@@ -57,12 +57,12 @@ export const Asset: HvFlowNodeFC<NodeGroup, AssetData> = (props) => {
     }
   };
 
-  const handleActionCallback: HvFlowNodeOutput["onAction"] = (
+  const handleActionCallback: HvFlowNodeLabelAction["onClick"] = (
     event,
-    action,
+    id,
     item
   ) => {
-    console.log("Action called:", action.id, item);
+    console.log("Action called:", id, item);
   };
 
   return (
@@ -122,27 +122,19 @@ export const Asset: HvFlowNodeFC<NodeGroup, AssetData> = (props) => {
           {
             id: "sensors",
             label: "Sensors",
-            actions: [
-              {
-                id: "config",
-                label: "Configure",
-              },
-            ],
-            onAction: handleActionCallback,
-            actionsButtonVariant: "primarySubtle",
-            actionsPlacement: "right",
+            labelAction: {
+              id: "config",
+              label: "Configure",
+              onClick: handleActionCallback,
+            },
             // Actions shared by all outputs in the group
-            defaultOutputsActions: {
-              actions: [
-                {
-                  id: "edit",
-                  label: "Edit",
-                  icon: <Edit />,
-                },
-              ],
-              onAction: handleActionCallback,
-              actionsButtonVariant: "primaryGhost",
-              actionsIconOnly: true,
+            defaultOutputsLabelAction: {
+              id: "edit",
+              label: "Edit",
+              icon: <Edit />,
+              iconOnly: true,
+              variant: "primaryGhost",
+              onClick: handleActionCallback,
             },
             outputs: [
               {

--- a/packages/lab/src/Flow/stories/Base/Asset.tsx
+++ b/packages/lab/src/Flow/stories/Base/Asset.tsx
@@ -17,6 +17,7 @@ import {
   HvFlowInstance,
   HvFlowNode,
   HvFlowNodeFC,
+  HvFlowNodeOutput,
   HvFlowNodeTypeMeta,
   useFlowNode,
 } from "@hitachivantara/uikit-react-lab";
@@ -29,22 +30,17 @@ interface AssetData {
   asset?: string;
 }
 
+const classes = {
+  container: css({
+    width: "40%",
+    minHeight: 200,
+  }),
+};
+
 export const Asset: HvFlowNodeFC<NodeGroup, AssetData> = (props) => {
   const [showDialog, setShowDialog] = useState(false);
   const [details, setDetails] = useState<Node>();
   const node = useFlowNode();
-
-  const classes = {
-    container: css({
-      width: "40%",
-      minHeight: 200,
-    }),
-    outputLabel: css({
-      display: "flex",
-      alignItems: "center",
-      gap: 2,
-    }),
-  };
 
   const handleAction = (event: any, nodeId: string, action: any) => {
     if (!node) return;
@@ -58,6 +54,15 @@ export const Asset: HvFlowNodeFC<NodeGroup, AssetData> = (props) => {
       default:
         break;
     }
+  };
+
+  const handleActionCallback: HvFlowNodeOutput["actionsCallback"] = (
+    event,
+    id,
+    action,
+    item
+  ) => {
+    console.log("Action called:", action.id, item);
   };
 
   return (
@@ -89,7 +94,6 @@ export const Asset: HvFlowNodeFC<NodeGroup, AssetData> = (props) => {
             label: "View Details",
             icon: <Search />,
           },
-
           {
             id: "favorite",
             label: "Add Favorite",
@@ -116,36 +120,40 @@ export const Asset: HvFlowNodeFC<NodeGroup, AssetData> = (props) => {
         ]}
         outputs={[
           {
-            label: (
-              <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
-                Sensors
-                <HvButton size="sm" variant="primarySubtle">
-                  Configure
-                </HvButton>
-              </div>
-            ),
+            id: "sensors",
+            label: "Sensors",
+            actions: [
+              {
+                id: "config",
+                label: "Configure",
+              },
+            ],
+            actionsCallback: handleActionCallback,
+            actionsButtonVariant: "primarySubtle",
+            actionsPlacement: "right",
+            // Actions shared by all outputs in the group
+            defaultOutputsActions: {
+              actions: [
+                {
+                  id: "edit",
+                  label: "Edit",
+                  icon: <Edit />,
+                },
+              ],
+              actionsCallback: handleActionCallback,
+              actionsButtonVariant: "primaryGhost",
+              actionsIconOnly: true,
+            },
             outputs: [
               {
-                label: (
-                  <div className={classes.outputLabel}>
-                    <HvButton icon variant="primaryGhost" aria-label="Edit">
-                      <Edit />
-                    </HvButton>
-                    Sensor Group 1
-                  </div>
-                ),
+                id: "sensor1",
+                label: "Sensor Group 1",
                 isMandatory: true,
                 provides: "sensorData",
               },
               {
-                label: (
-                  <div className={classes.outputLabel}>
-                    <HvButton icon variant="primaryGhost" aria-label="Edit">
-                      <Edit />
-                    </HvButton>
-                    Sensor Group 2
-                  </div>
-                ),
+                id: "sensor2",
+                label: "Sensor Group 2",
                 isMandatory: true,
                 provides: "sensorData",
               },

--- a/packages/lab/src/Flow/stories/InitialState/index.tsx
+++ b/packages/lab/src/Flow/stories/InitialState/index.tsx
@@ -150,14 +150,14 @@ const initialState = {
   edges: [
     {
       source: "1caf2381eaf",
-      sourceHandle: "0",
+      sourceHandle: "sensor1",
       target: "caf2381eaf3",
       targetHandle: "0",
       id: "reactflow__edge-1caf2381eaf0-caf2381eaf30",
     },
     {
       source: "1caf2381eaf",
-      sourceHandle: "1",
+      sourceHandle: "sensor2",
       target: "af2381eaf37",
       targetHandle: "0",
       id: "reactflow__edge-1caf2381eaf1-af2381eaf370",

--- a/packages/lab/src/Flow/stories/NoGroups/Asset.tsx
+++ b/packages/lab/src/Flow/stories/NoGroups/Asset.tsx
@@ -9,7 +9,6 @@ export const Asset: HvFlowNodeFC = (props) => {
     <HvFlowNode
       description="Asset description"
       expanded
-      maxVisibleActions={1}
       params={[
         {
           id: "asset",

--- a/packages/lab/src/Flow/stories/Usage.mdx
+++ b/packages/lab/src/Flow/stories/Usage.mdx
@@ -207,20 +207,22 @@ Nodes need inputs and/or outputs to connect to other nodes and they can be defin
 Below are the specifications for a single input and output.
 
 ```typescript
-interface HvFlowNodeInput extends HvFlowNodeLabelActions {
+interface HvFlowNodeInput {
   id?: string;
   label: React.ReactNode;
   isMandatory?: boolean;
   accepts?: string[];
   maxConnections?: number;
+  labelAction?: HvFlowNodeLabelAction;
 }
 
-interface HvFlowNodeOutput extends HvFlowNodeLabelActions {
+interface HvFlowNodeOutput {
   id?: string;
   label: React.ReactNode;
   isMandatory?: boolean;
   provides?: string;
   maxConnections?: number;
+  labelAction?: HvFlowNodeLabelAction;
 }
 ```
 
@@ -236,86 +238,49 @@ the number of connections an input accepts as well as the number of connections 
 Nodes can also accept groups of inputs and outputs. These groups are defined by the types below.
 
 ```typescript
-interface HvFlowNodeInputGroup extends HvFlowNodeLabelActions {
+interface HvFlowNodeInputGroup {
   id?: string;
   label: React.ReactNode;
   inputs: HvFlowNodeInput[];
-  defaultInputsActions?: HvFlowNodeLabelActions;
+  defaultInputsLabelAction?: HvFlowNodeLabelAction;
+  labelAction?: HvFlowNodeLabelAction;
 }
 
-interface HvFlowNodeOutputGroup extends HvFlowNodeLabelActions {
+interface HvFlowNodeOutputGroup {
   id?: string;
   label: React.ReactNode;
   outputs: HvFlowNodeOutput[];
-  defaultOutputsActions?: HvFlowNodeLabelActions;
+  defaultOutputsLabelAction?: HvFlowNodeLabelAction;
+  labelAction?: HvFlowNodeLabelAction;
 }
 ```
 
-You might have noticed that all the types mentioned above in this section extend `HvFlowNodeLabelActions`. This type has the following properties:
+You might have noticed that all the types mentioned above have the `labelAction` property which is defined by the `HvFlowNodeLabelAction` type.
+This type has the following properties:
 
 ```typescript
-interface HvFlowNodeLabelActions {
-  actions?: HvActionsGeneric[];
-  onAction?: (
-    event: React.SyntheticEvent,
-    action: HvActionGeneric,
+interface HvFlowNodeLabelAction {
+  id: string;
+  label: string;
+  icon?: React.ReactNode;
+  iconOnly?: boolean;
+  variant?: HvButtonVariant;
+  onClick?: (
+    event: React.MouseEvent<HTMLButtonElement, MouseEvent>,
+    id: string,
     item:
       | HvFlowNodeInput
       | HvFlowNodeInputGroup
       | HvFlowNodeOutput
       | HvFlowNodeOutputGroup
   ) => void;
-  actionsIconOnly?: boolean;
-  maxVisibleActions?: number;
-  actionsPlacement?: "left" | "right";
-  actionsButtonVariant?: HvButtonVariant;
 }
 ```
 
-These properties enable you to easily position actions to the left or right of the label. However, if you need more flexibility or to implement
-a more complex design, you should opt to customise the label since you can provide a `React.ReactNode`.
+The `labelAction` property enables you to define an action that will be positioned near the label.
+Actions for an input or output group will be positioned on the right of the label whereas for an input and output they will be positioned on the left.
+However, if you need more flexibility or to implement a more complex design, you can customise the label by providing a `React.ReactNode`.
 
-Please find an example below on how to use actions on the labels.
-
-```typescript
-<HvFlowNode
-  (...)
-  outputs={[
-    {
-      id: "sensors",
-      label: "Sensors",
-      actions: [
-        {
-          id: "config",
-          label: "Configure",
-        },
-      ],
-      actionsButtonVariant: "primarySubtle",
-      actionsPlacement: "right",
-      outputs: [
-        {
-          id: "sensor1"
-          label: "Sensor 1",
-          actions: [
-            {
-              id: "edit",
-              label: "Edit",
-              icon: <Edit />,
-            },
-          ],
-          actionsButtonVariant: "primaryGhost",
-          actionsIconOnly: true,
-          provides: "sensorData",
-        },
-      ],
-    },
-  ]}
-/>
-```
-
-Sometimes inputs/outputs inside a group have the same actions. Instead of repeating the same properties for all the inputs/outputs, the
-`defaultInputsActions` and `defaultOutputsActions` properties are provided.
-These default actions will be used in case none are defined at the input/output level.
 Please find an example below.
 
 ```typescript
@@ -325,26 +290,53 @@ Please find an example below.
     {
       id: "sensors",
       label: "Sensors",
-      actions: [
+      labelAction: {
+        id: "config",
+        label: "Configure",
+      },
+      outputs: [
         {
-          id: "config",
-          label: "Configure",
-        },
-      ],
-      actionsButtonVariant: "primarySubtle",
-      actionsPlacement: "right",
-      // Actions shared by all outputs in the group
-      defaultOutputsActions: {
-        actions: [
-          {
+          id: "sensor1"
+          label: "Sensor 1",
+          labelAction: {
             id: "edit",
             label: "Edit",
             icon: <Edit />,
+            iconOnly: true,
+            variant: "primaryGhost",
           },
-        ],
-        actionsButtonVariant: "primaryGhost",
-        actionsIconOnly: true,
+          provides: "sensorData",
+        },
+      ],
+    },
+  ]}
+/>
+```
+
+Sometimes inputs and outputs inside a group have the same action. Instead of repeating code, the `defaultInputsLabelAction` and
+`defaultOutputsLabelAction` properties are provided. This default action will be used in case none are defined at the input/output level.
+
+Please find an example below.
+
+```typescript
+<HvFlowNode
+  (...)
+  outputs={[
+    {
+      id: "sensors",
+      label: "Sensors",
+      labelAction: {
+        id: "config",
+        label: "Configure",
       },
+      // Actions shared by all outputs in the group
+      defaultOutputsLabelAction: {
+        id: "edit",
+        label: "Edit",
+        icon: <Edit />,
+        iconOnly: true,
+        variant: "primaryGhost",
+      ,
       outputs: [
         {
           id: "sensor1",

--- a/packages/lab/src/Flow/stories/Usage.mdx
+++ b/packages/lab/src/Flow/stories/Usage.mdx
@@ -207,7 +207,7 @@ Nodes need inputs and/or outputs to connect to other nodes and they can be defin
 Below are the specifications for a single input and output.
 
 ```typescript
-interface HvFlowNodeInput {
+interface HvFlowNodeInput extends HvFlowNodeLabelActions {
   id?: string;
   label: React.ReactNode;
   isMandatory?: boolean;
@@ -215,7 +215,7 @@ interface HvFlowNodeInput {
   maxConnections?: number;
 }
 
-interface HvFlowNodeOutput {
+interface HvFlowNodeOutput extends HvFlowNodeLabelActions {
   id?: string;
   label: React.ReactNode;
   isMandatory?: boolean;
@@ -236,15 +236,131 @@ the number of connections an input accepts as well as the number of connections 
 Nodes can also accept groups of inputs and outputs. These groups are defined by the types below.
 
 ```typescript
-interface HvFlowNodeInputGroup {
+interface HvFlowNodeInputGroup extends HvFlowNodeLabelActions {
+  id?: string;
   label: React.ReactNode;
   inputs: HvFlowNodeInput[];
+  defaultInputsActions?: HvFlowNodeLabelActions;
 }
 
-interface HvFlowNodeOutputGroup {
+interface HvFlowNodeOutputGroup extends HvFlowNodeLabelActions {
+  id?: string;
   label: React.ReactNode;
   outputs: HvFlowNodeOutput[];
+  defaultOutputsActions?: HvFlowNodeLabelActions;
 }
+```
+
+You might have noticed that all the types mentioned above in this section extend `HvFlowNodeLabelActions`. This type has the following properties:
+
+```typescript
+interface HvFlowNodeLabelActions {
+  actions?: HvActionsGeneric[];
+  actionsCallback?: (
+    event: React.SyntheticEvent,
+    id: string,
+    action: HvActionGeneric,
+    item:
+      | HvFlowNodeInput
+      | HvFlowNodeInputGroup
+      | HvFlowNodeOutput
+      | HvFlowNodeOutputGroup
+  ) => void;
+  actionsIconOnly?: boolean;
+  maxVisibleActions?: number;
+  actionsPlacement?: "left" | "right";
+  actionsButtonVariant?: HvButtonVariant;
+}
+```
+
+These properties enable you to easily position actions to the left or right of the label. However, if you need more flexibility or to implement
+a more complex design, you should opt to customise the label since you can provide a `React.ReactNode`.
+
+Please find an example below on how to use actions on the labels.
+
+```typescript
+<HvFlowNode
+  (...)
+  outputs={[
+    {
+      id: "sensors",
+      label: "Sensors",
+      actions: [
+        {
+          id: "config",
+          label: "Configure",
+        },
+      ],
+      actionsButtonVariant: "primarySubtle",
+      actionsPlacement: "right",
+      outputs: [
+        {
+          id: "sensor1"
+          label: "Sensor 1",
+          actions: [
+            {
+              id: "edit",
+              label: "Edit",
+              icon: <Edit />,
+            },
+          ],
+          actionsButtonVariant: "primaryGhost",
+          actionsIconOnly: true,
+          provides: "sensorData",
+        },
+      ],
+    },
+  ]}
+/>
+```
+
+Sometimes inputs/outputs inside a group have the same actions. Instead of repeating the same properties for all the inputs/outputs, the
+`defaultInputsActions` and `defaultOutputsActions` properties are provided.
+These default actions will be used in case none are defined at the input/output level.
+Please find an example below.
+
+```typescript
+<HvFlowNode
+  (...)
+  outputs={[
+    {
+      id: "sensors",
+      label: "Sensors",
+      actions: [
+        {
+          id: "config",
+          label: "Configure",
+        },
+      ],
+      actionsButtonVariant: "primarySubtle",
+      actionsPlacement: "right",
+      // Actions shared by all outputs in the group
+      defaultOutputsActions: {
+        actions: [
+          {
+            id: "edit",
+            label: "Edit",
+            icon: <Edit />,
+          },
+        ],
+        actionsButtonVariant: "primaryGhost",
+        actionsIconOnly: true,
+      },
+      outputs: [
+        {
+          id: "sensor1",
+          label: "Sensor Group 1",
+          provides: "sensorData",
+        },
+        {
+          id: "sensor2",
+          label: "Sensor Group 2",
+          provides: "sensorData",
+        },
+      ],
+    },
+  ]}
+/>
 ```
 
 ## Parameters <a id="parameters" />
@@ -328,7 +444,7 @@ At the node level you can specify other actions. To achieve this you'll have to 
 - A set of actions (`actions`);
 - A callback to handle these actions (`actionCallback`);
 - A maximum number of visible actions (`maxVisibleActions`). All the other actions will be placed in a dropdown menu. By default, only one action is visible;
-- And whether the actions should be all icon buttons when visible (`actionsIconButton`). By default, this is set to `true`.
+- And whether the actions should be all icon buttons when visible (`actionsIconOnly`). By default, this is set to `true`.
 
 ```tsx
 const handleAction = (event: any, id: string, action: any) => {

--- a/packages/lab/src/Flow/stories/Usage.mdx
+++ b/packages/lab/src/Flow/stories/Usage.mdx
@@ -256,9 +256,8 @@ You might have noticed that all the types mentioned above in this section extend
 ```typescript
 interface HvFlowNodeLabelActions {
   actions?: HvActionsGeneric[];
-  actionsCallback?: (
+  onAction?: (
     event: React.SyntheticEvent,
-    id: string,
     action: HvActionGeneric,
     item:
       | HvFlowNodeInput
@@ -442,12 +441,12 @@ The `id` property will be typed to be one of the allowed default actions.
 At the node level you can specify other actions. To achieve this you'll have to define:
 
 - A set of actions (`actions`);
-- A callback to handle these actions (`actionCallback`);
+- A callback to handle these actions (`onAction`);
 - A maximum number of visible actions (`maxVisibleActions`). All the other actions will be placed in a dropdown menu. By default, only one action is visible;
 - And whether the actions should be all icon buttons when visible (`actionsIconOnly`). By default, this is set to `true`.
 
 ```tsx
-const handleAction = (event: any, id: string, action: any) => {
+const handleAction = (event: React.SyntheticEvent, action: HvActionGeneric) => {
   const node: Node | undefined = reactFlowInstance.getNode(id);
   if (!node) return;
 
@@ -480,7 +479,7 @@ const handleAction = (event: any, id: string, action: any) => {
       icon: <Favorite />,
     },
   ]}
-  actionCallback={handleAction}
+  onAction={handleAction}
   {...props}
 />;
 ```
@@ -599,7 +598,10 @@ export const Asset: HvFlowNodeFC = (props) => {
 
   const node = useFlowNode();
 
-  const handleAction = (event: any, nodeId: string, action: any) => {
+  const handleAction = (
+    event: React.SyntheticEvent,
+    action: HvActionGeneric
+  ) => {
     if (!node) return;
 
     switch (action.id) {
@@ -655,7 +657,7 @@ export const Asset: HvFlowNodeFC = (props) => {
             icon: <Flag />,
           },
         ]}
-        actionCallback={handleAction}
+        onAction={handleAction}
         params={[
           {
             id: "asset",

--- a/packages/lab/src/Flow/stories/Usage.mdx
+++ b/packages/lab/src/Flow/stories/Usage.mdx
@@ -325,9 +325,10 @@ The `id` property will be typed to be one of the allowed default actions.
 
 At the node level you can specify other actions. To achieve this you'll have to define:
 
-- A set of actions;
-- A callback to handle these actions;
-- Optionally, a maximum number of visible actions and the others will be placed in a dropdown menu.
+- A set of actions (`actions`);
+- A callback to handle these actions (`actionCallback`);
+- A maximum number of visible actions (`maxVisibleActions`). All the other actions will be placed in a dropdown menu. By default, only one action is visible;
+- And whether the actions should be all icon buttons when visible (`actionsIconButton`). By default, this is set to `true`.
 
 ```tsx
 const handleAction = (event: any, id: string, action: any) => {
@@ -357,7 +358,6 @@ const handleAction = (event: any, id: string, action: any) => {
       label: "View Details",
       icon: <Search />,
     },
-
     {
       id: "favorite",
       label: "Add Favorite",
@@ -470,18 +470,18 @@ If you need to export your data at any point you can use the `toObject` function
 Below you can find a full example of a custom Node that exercises the topics approached in this page.
 
 ```tsx
+const classes = {
+  container: css({
+    width: "40%",
+    minHeight: 200,
+  }),
+};
+
 export const Asset: HvFlowNodeFC = (props) => {
   const [showDialog, setShowDialog] = useState(false);
   const [details, setDetails] = useState<Node | undefined>();
 
   const node = useFlowNode();
-
-  const classes = {
-    container: css({
-      width: "40%",
-      minHeight: 200,
-    }),
-  };
 
   const handleAction = (event: any, nodeId: string, action: any) => {
     if (!node) return;

--- a/packages/lab/src/Flow/types/flow.ts
+++ b/packages/lab/src/Flow/types/flow.ts
@@ -2,7 +2,7 @@ import React, { ComponentClass, FC } from "react";
 import { Node, NodeProps, ReactFlowInstance } from "reactflow";
 import {
   HvActionGeneric,
-  HvActionsGenericProps,
+  HvButtonVariant,
   HvSliderProps,
 } from "@hitachivantara/uikit-react-core";
 import { HvColorAny } from "@hitachivantara/uikit-styles";
@@ -66,21 +66,17 @@ export interface HvFlowNodeMeta {
   outputs?: (HvFlowNodeOutput | HvFlowNodeOutputGroup)[];
 }
 
-export interface HvFlowNodeLabelActions
-  extends Pick<
-    Partial<HvActionsGenericProps>,
-    "actions" | "maxVisibleActions"
-  > {
-  /** Where to place the actions relatively to the label. @default left */
-  actionsPlacement?: "left" | "right";
-  /** The button variant for all actions. @default secondaryGhost */
-  actionsButtonVariant?: HvActionsGenericProps["variant"];
-  /** Whether the actions should be all icon buttons when visible. */
-  actionsIconOnly?: boolean;
-  /** The callback called when an action is triggered. */
-  onAction?: (
-    event: React.SyntheticEvent,
-    action: HvActionGeneric,
+export interface HvFlowNodeLabelAction {
+  id: string;
+  label: string;
+  icon?: React.ReactNode;
+  /** @default false */
+  iconOnly?: boolean;
+  /** @default primarySubtle */
+  variant?: HvButtonVariant;
+  onClick?: (
+    event: React.MouseEvent<HTMLButtonElement, MouseEvent>,
+    id: string,
     item:
       | HvFlowNodeInput
       | HvFlowNodeInputGroup
@@ -89,34 +85,38 @@ export interface HvFlowNodeLabelActions
   ) => void;
 }
 
-export interface HvFlowNodeInput extends HvFlowNodeLabelActions {
+export interface HvFlowNodeInput {
   id?: string;
   label: React.ReactNode;
   isMandatory?: boolean;
   accepts?: string[];
   maxConnections?: number;
+  labelAction?: HvFlowNodeLabelAction;
 }
 
-export interface HvFlowNodeInputGroup extends HvFlowNodeLabelActions {
+export interface HvFlowNodeInputGroup {
   id?: string;
   label: React.ReactNode;
   inputs: HvFlowNodeInput[];
-  defaultInputsActions?: HvFlowNodeLabelActions;
+  labelAction?: HvFlowNodeLabelAction;
+  defaultInputsLabelAction?: HvFlowNodeLabelAction;
 }
 
-export interface HvFlowNodeOutput extends HvFlowNodeLabelActions {
+export interface HvFlowNodeOutput {
   id?: string;
   label: React.ReactNode;
   isMandatory?: boolean;
   provides?: string;
   maxConnections?: number;
+  labelAction?: HvFlowNodeLabelAction;
 }
 
-export interface HvFlowNodeOutputGroup extends HvFlowNodeLabelActions {
+export interface HvFlowNodeOutputGroup {
   id?: string;
   label: React.ReactNode;
   outputs: HvFlowNodeOutput[];
-  defaultOutputsActions?: HvFlowNodeLabelActions;
+  labelAction?: HvFlowNodeLabelAction;
+  defaultOutputsLabelAction?: HvFlowNodeLabelAction;
 }
 
 export interface HvFlowNodeSharedParam {
@@ -131,7 +131,7 @@ export interface HvFlowNodeTextParam extends HvFlowNodeSharedParam {
 export interface HvFlowNodeSelectParam extends HvFlowNodeSharedParam {
   type: "select";
   multiple?: boolean;
-  options?: string[] | { id: string; label: string }[]; // v6 - only allow objects
+  options?: string[] | { id: string; label: string }[]; // TODO - only allow objects in v6
 }
 
 export interface HvFlowNodeSliderParam

--- a/packages/lab/src/Flow/types/flow.ts
+++ b/packages/lab/src/Flow/types/flow.ts
@@ -78,9 +78,8 @@ export interface HvFlowNodeLabelActions
   /** Whether the actions should be all icon buttons when visible. */
   actionsIconOnly?: boolean;
   /** The callback called when an action is triggered. */
-  actionsCallback?: (
+  onAction?: (
     event: React.SyntheticEvent,
-    id: string,
     action: HvActionGeneric,
     item:
       | HvFlowNodeInput

--- a/packages/lab/src/Flow/types/flow.ts
+++ b/packages/lab/src/Flow/types/flow.ts
@@ -1,7 +1,8 @@
-import { ComponentClass, FC } from "react";
+import React, { ComponentClass, FC } from "react";
 import { Node, NodeProps, ReactFlowInstance } from "reactflow";
 import {
   HvActionGeneric,
+  HvActionsGenericProps,
   HvSliderProps,
 } from "@hitachivantara/uikit-react-core";
 import { HvColorAny } from "@hitachivantara/uikit-styles";
@@ -65,7 +66,31 @@ export interface HvFlowNodeMeta {
   outputs?: (HvFlowNodeOutput | HvFlowNodeOutputGroup)[];
 }
 
-export interface HvFlowNodeInput {
+export interface HvFlowNodeLabelActions
+  extends Pick<
+    Partial<HvActionsGenericProps>,
+    "actions" | "maxVisibleActions"
+  > {
+  /** Where to place the actions relatively to the label. @default left */
+  actionsPlacement?: "left" | "right";
+  /** The button variant for all actions. @default secondaryGhost */
+  actionsButtonVariant?: HvActionsGenericProps["variant"];
+  /** Whether the actions should be all icon buttons when visible. */
+  actionsIconOnly?: boolean;
+  /** The callback called when an action is triggered. */
+  actionsCallback?: (
+    event: React.SyntheticEvent,
+    id: string,
+    action: HvActionGeneric,
+    item:
+      | HvFlowNodeInput
+      | HvFlowNodeInputGroup
+      | HvFlowNodeOutput
+      | HvFlowNodeOutputGroup
+  ) => void;
+}
+
+export interface HvFlowNodeInput extends HvFlowNodeLabelActions {
   id?: string;
   label: React.ReactNode;
   isMandatory?: boolean;
@@ -73,12 +98,14 @@ export interface HvFlowNodeInput {
   maxConnections?: number;
 }
 
-export interface HvFlowNodeInputGroup {
+export interface HvFlowNodeInputGroup extends HvFlowNodeLabelActions {
+  id?: string;
   label: React.ReactNode;
   inputs: HvFlowNodeInput[];
+  defaultInputsActions?: HvFlowNodeLabelActions;
 }
 
-export interface HvFlowNodeOutput {
+export interface HvFlowNodeOutput extends HvFlowNodeLabelActions {
   id?: string;
   label: React.ReactNode;
   isMandatory?: boolean;
@@ -86,9 +113,11 @@ export interface HvFlowNodeOutput {
   maxConnections?: number;
 }
 
-export interface HvFlowNodeOutputGroup {
+export interface HvFlowNodeOutputGroup extends HvFlowNodeLabelActions {
+  id?: string;
   label: React.ReactNode;
   outputs: HvFlowNodeOutput[];
+  defaultOutputsActions?: HvFlowNodeLabelActions;
 }
 
 export interface HvFlowNodeSharedParam {
@@ -117,7 +146,7 @@ export type HvFlowNodeParam =
   | HvFlowNodeTextParam
   | HvFlowNodeSliderParam;
 
-export interface HvFlowNodeAction extends HvActionGeneric {
+export interface HvFlowNodeAction extends Omit<HvActionGeneric, "iconOnly"> {
   callback?: (node: Node) => void;
 }
 


### PR DESCRIPTION
- `HvActionsGeneric` updated:
   - Added the possibility to have icon buttons by adding the `iconOnly` property to `HvActionGeneric` and `HvActionsGenericProps`
   - `category` prop deprecated in favor of `variant` to standardise with other components
   - `actionsCallback` prop deprecated in favor of `onAction` (the deprecation will be spread out to other components in another PR)
   - Tests updated 
-  `HvFlowNode` updated:
   - Leverages `HvActionsGeneric` to dedupe code
   -  `actionsIconOnly` property added to `HvFlowNodeProps` and defaults to `true` to keep the previous behaviour since all actions buttons should be icon buttons by default
- `HvFlowBaseNode` updated:
   - ~~`HvActionsGeneric` leveraged to add actions near the inputs/outputs labels~~ Added the possibility to add an action near the labels
   - Docs updated: sample and usage page

Feel free to propose other property names