### PR TITLE
feat(SplitButton): add split button variant to `MultiButton` component

### DIFF
--- a/docs/overview/status/data.json
+++ b/docs/overview/status/data.json
@@ -69,8 +69,8 @@
     {
       "name": "Dropdown",
       "features": "Split",
-      "status": "Not Planned",
-      "notes": ""
+      "status": "Supported",
+      "notes": "Use the MultiButton component"
     },
     {
       "name": "Empty State",
@@ -183,7 +183,7 @@
     {
       "name": "Tag",
       "features": "Actions",
-      "status": "Planned",
+      "status": "✅",
       "notes": ""
     },
     {

--- a/packages/core/src/Button/Button.stories.tsx
+++ b/packages/core/src/Button/Button.stories.tsx
@@ -190,6 +190,38 @@ export const Icons: StoryObj<HvButtonProps> = {
           Stop
         </HvButton>
       </div>
+      <div>
+        <HvButton icon aria-label="Play" variant="primarySubtle">
+          <Play />
+        </HvButton>
+        <HvButton aria-label="Play" variant="primarySubtle">
+          Play
+        </HvButton>
+        <HvButton icon aria-label="Pause" variant="primarySubtle" size="xs">
+          <Pause iconSize="XS" />
+        </HvButton>
+        <HvButton aria-label="Play" variant="primarySubtle" size="xs">
+          XS
+        </HvButton>
+        <HvButton icon aria-label="Stop" variant="primarySubtle" size="md">
+          <Stop />
+        </HvButton>
+        <HvButton aria-label="Play" variant="primarySubtle" size="md">
+          MD
+        </HvButton>
+        <HvButton icon aria-label="Stop" variant="primarySubtle" size="lg">
+          <Stop />
+        </HvButton>
+        <HvButton aria-label="Play" variant="primarySubtle" size="lg">
+          LG
+        </HvButton>
+        <HvButton icon aria-label="Stop" variant="primarySubtle" size="xl">
+          <Stop />
+        </HvButton>
+        <HvButton aria-label="Play" variant="primarySubtle" size="xl">
+          XL
+        </HvButton>
+      </div>
     </>
   ),
 };

--- a/packages/core/src/Button/Button.stories.tsx
+++ b/packages/core/src/Button/Button.stories.tsx
@@ -190,38 +190,6 @@ export const Icons: StoryObj<HvButtonProps> = {
           Stop
         </HvButton>
       </div>
-      <div>
-        <HvButton icon aria-label="Play" variant="primarySubtle">
-          <Play />
-        </HvButton>
-        <HvButton aria-label="Play" variant="primarySubtle">
-          Play
-        </HvButton>
-        <HvButton icon aria-label="Pause" variant="primarySubtle" size="xs">
-          <Pause iconSize="XS" />
-        </HvButton>
-        <HvButton aria-label="Play" variant="primarySubtle" size="xs">
-          XS
-        </HvButton>
-        <HvButton icon aria-label="Stop" variant="primarySubtle" size="md">
-          <Stop />
-        </HvButton>
-        <HvButton aria-label="Play" variant="primarySubtle" size="md">
-          MD
-        </HvButton>
-        <HvButton icon aria-label="Stop" variant="primarySubtle" size="lg">
-          <Stop />
-        </HvButton>
-        <HvButton aria-label="Play" variant="primarySubtle" size="lg">
-          LG
-        </HvButton>
-        <HvButton icon aria-label="Stop" variant="primarySubtle" size="xl">
-          <Stop />
-        </HvButton>
-        <HvButton aria-label="Play" variant="primarySubtle" size="xl">
-          XL
-        </HvButton>
-      </div>
     </>
   ),
 };

--- a/packages/core/src/Button/Button.styles.ts
+++ b/packages/core/src/Button/Button.styles.ts
@@ -117,6 +117,11 @@ export const getSizeStyles = (size: HvButtonSize): CSSInterpolation => ({
   fontSize: theme.fontSizes[size],
 });
 
+export const getIconSizeStyles = (size: HvButtonSize): CSSInterpolation => ({
+  height: theme.sizes[size],
+  width: theme.sizes[size],
+});
+
 export const getOverrideColors = (): CSSInterpolation => ({
   "& svg .color0": {
     fill: "currentcolor",

--- a/packages/core/src/Button/Button.tsx
+++ b/packages/core/src/Button/Button.tsx
@@ -106,6 +106,7 @@ export const HvButton = fixedForwardRef(function HvButton<
     focusableWhenDisabled,
     onClick: onClickProp,
     onMouseDown: onMouseDownProp,
+    selected,
     ...others
   } = useDefaultProps("HvButton", props);
   const { classes, css, cx } = useClasses(classesProp);
@@ -149,6 +150,7 @@ export const HvButton = fixedForwardRef(function HvButton<
         tabIndex: focusableWhenDisabled ? 0 : -1,
         "aria-disabled": true,
       })}
+      {...(selected && { "aria-pressed": selected })}
       {...others}
     >
       {startIcon && <span className={classes.startIcon}>{startIcon}</span>}

--- a/packages/core/src/Button/Button.tsx
+++ b/packages/core/src/Button/Button.tsx
@@ -12,6 +12,7 @@ import {
   getOverrideColors,
   getRadiusStyles,
   getSizeStyles,
+  getIconSizeStyles,
   useClasses,
 } from "./Button.styles";
 import { HvButtonRadius, HvButtonSize, HvButtonVariant } from "./types";
@@ -130,13 +131,14 @@ export const HvButton = fixedForwardRef(function HvButton<
       className={cx(
         classes.root,
         classes[variant],
-        size && css(getSizeStyles(size)),
+        size && !icon && css(getSizeStyles(size)),
         radius && css(getRadiusStyles(radius)),
         overrideIconColors && css(getOverrideColors()),
         {
           [classes.icon]: icon,
           [classes.disabled]: disabled,
         },
+        size && icon && css(getIconSizeStyles(size)),
         className
       )}
       onClick={handleClick}

--- a/packages/core/src/DropDownMenu/DropDownMenu.tsx
+++ b/packages/core/src/DropDownMenu/DropDownMenu.tsx
@@ -10,11 +10,12 @@ import { setId } from "../utils/setId";
 import { getPrevNextFocus } from "../utils/focusableElementFinder";
 import { ExtractNames } from "../utils/classes";
 import { HvBaseDropdown, HvBaseDropdownProps } from "../BaseDropdown";
-import { HvButton, HvButtonVariant } from "../Button";
+import { HvButton, HvButtonSize, HvButtonVariant } from "../Button";
 import { HvList, HvListProps, HvListValue } from "../List";
 import { HvPanel } from "../Panel";
 
 import { staticClasses, useClasses } from "./DropDownMenu.styles";
+import { getIconSizeStyles } from "../Button/Button.styles";
 
 export { staticClasses as dropDownMenuClasses };
 
@@ -60,6 +61,8 @@ export interface HvDropDownMenuProps
   category?: HvButtonVariant;
   /** The variant to be used in the header. */
   variant?: HvButtonVariant;
+  /** Button size. */
+  size?: HvButtonSize;
   /** A Jss Object used to override or extend the styles applied to the component. */
   classes?: HvDropDownMenuClasses;
 }
@@ -84,10 +87,11 @@ export const HvDropDownMenu = (props: HvDropDownMenuProps) => {
     defaultExpanded = false,
     category = "secondaryGhost",
     variant,
+    size,
     ...others
   } = useDefaultProps("HvDropDownMenu", props);
 
-  const { classes, cx } = useClasses(classesProp);
+  const { classes, cx, css } = useClasses(classesProp);
   const [open, setOpen] = useControlled(expanded, Boolean(defaultExpanded));
   const id = useUniqueId(idProp, "dropdown-menu");
   const focusNodes = getPrevNextFocus(setId(id, "icon-button"));
@@ -132,9 +136,14 @@ export const HvDropDownMenu = (props: HvDropDownMenuProps) => {
           icon
           variant={variant ?? category}
           id={setId(id, "icon-button")}
-          className={cx(classes.icon, { [classes.iconSelected]: open })}
+          className={cx(
+            classes.icon,
+            { [classes.iconSelected]: open },
+            size && icon && css(getIconSizeStyles(size))
+          )}
           aria-expanded={open}
           disabled={disabled}
+          size={size}
           aria-label="Dropdown menu"
           aria-haspopup="menu"
         >

--- a/packages/core/src/MultiButton/MultiButton.stories.tsx
+++ b/packages/core/src/MultiButton/MultiButton.stories.tsx
@@ -440,6 +440,7 @@ export const SplitButton: StoryObj<HvMultiButtonProps> = {
         <HvMultiButton variant="primary" style={{ width: "232px" }} split>
           <HvButton>{selectedOption.label}</HvButton>
           <HvDropDownMenu
+            keepOpened={false}
             dataList={options}
             icon={<DropDownXS />}
             onClick={(e, item) =>
@@ -452,6 +453,7 @@ export const SplitButton: StoryObj<HvMultiButtonProps> = {
         <HvMultiButton variant="primarySubtle" style={{ width: "232px" }} split>
           <HvButton>{selectedOption.label}</HvButton>
           <HvDropDownMenu
+            keepOpened={false}
             dataList={options}
             icon={<DropDownXS />}
             onClick={(e, item) =>
@@ -468,6 +470,7 @@ export const SplitButton: StoryObj<HvMultiButtonProps> = {
         >
           <HvButton>{selectedOption.label}</HvButton>
           <HvDropDownMenu
+            keepOpened={false}
             dataList={options}
             icon={<DropDownXS />}
             onClick={(e, item) =>
@@ -484,6 +487,7 @@ export const SplitButton: StoryObj<HvMultiButtonProps> = {
           size="xs"
         >
           <HvDropDownMenu
+            keepOpened={false}
             dataList={options}
             icon={<DropDownXS />}
             onClick={(e, item) =>
@@ -501,6 +505,7 @@ export const SplitButton: StoryObj<HvMultiButtonProps> = {
           size="xs"
         >
           <HvDropDownMenu
+            keepOpened={false}
             dataList={options}
             icon={<DropDownXS />}
             onClick={(e, item) =>
@@ -518,6 +523,7 @@ export const SplitButton: StoryObj<HvMultiButtonProps> = {
           size="xs"
         >
           <HvDropDownMenu
+            keepOpened={false}
             dataList={options}
             icon={<DropDownXS />}
             onClick={(e, item) =>
@@ -536,6 +542,7 @@ export const SplitButton: StoryObj<HvMultiButtonProps> = {
         >
           <HvButton>{selectedOption.label}</HvButton>
           <HvDropDownMenu
+            keepOpened={false}
             dataList={options}
             icon={<DropDownXS />}
             onClick={(e, item) =>
@@ -553,6 +560,7 @@ export const SplitButton: StoryObj<HvMultiButtonProps> = {
         >
           <HvButton>{selectedOption.label}</HvButton>
           <HvDropDownMenu
+            keepOpened={false}
             dataList={options}
             icon={<DropDownXS />}
             onClick={(e, item) =>
@@ -570,6 +578,7 @@ export const SplitButton: StoryObj<HvMultiButtonProps> = {
         >
           <HvButton>{selectedOption.label}</HvButton>
           <HvDropDownMenu
+            keepOpened={false}
             dataList={options}
             icon={<DropDownXS />}
             onClick={(e, item) =>
@@ -588,6 +597,7 @@ export const SplitButton: StoryObj<HvMultiButtonProps> = {
         >
           <HvButton>{selectedOption.label}</HvButton>
           <HvDropDownMenu
+            keepOpened={false}
             dataList={options}
             icon={<DropDownXS />}
             onClick={(e, item) =>
@@ -606,6 +616,7 @@ export const SplitButton: StoryObj<HvMultiButtonProps> = {
         >
           <HvButton>{selectedOption.label}</HvButton>
           <HvDropDownMenu
+            keepOpened={false}
             dataList={options}
             icon={<DropDownXS />}
             onClick={(e, item) =>
@@ -624,6 +635,7 @@ export const SplitButton: StoryObj<HvMultiButtonProps> = {
         >
           <HvButton>{selectedOption.label}</HvButton>
           <HvDropDownMenu
+            keepOpened={false}
             dataList={options}
             icon={<DropDownXS />}
             onClick={(e, item) =>

--- a/packages/core/src/MultiButton/MultiButton.stories.tsx
+++ b/packages/core/src/MultiButton/MultiButton.stories.tsx
@@ -1,11 +1,17 @@
 import { MouseEvent, useState } from "react";
 import range from "lodash/range";
 import { Meta, StoryObj } from "@storybook/react";
-import { LocationPin, Map } from "@hitachivantara/uikit-react-icons";
+import {
+  DropDownXS,
+  LocationPin,
+  Map,
+} from "@hitachivantara/uikit-react-icons";
 import {
   HvButton,
+  HvDropDownMenu,
   HvMultiButton,
   HvMultiButtonProps,
+  HvSimpleGrid,
 } from "@hitachivantara/uikit-react-core";
 
 const meta: Meta<typeof HvMultiButton> = {
@@ -19,11 +25,13 @@ export const Main: StoryObj<HvMultiButtonProps> = {
     disabled: false,
     vertical: false,
     variant: "secondarySubtle",
+    size: undefined,
   },
   argTypes: {
     classes: { control: { disable: true } },
+    size: { control: { type: "select" } },
   },
-  render: ({ vertical, disabled, variant }) => {
+  render: ({ vertical, disabled, variant, size }) => {
     const [val, setVal] = useState(-1);
 
     return (
@@ -32,6 +40,7 @@ export const Main: StoryObj<HvMultiButtonProps> = {
         vertical={vertical}
         disabled={disabled}
         variant={variant}
+        size={size}
       >
         <HvButton
           key="1"
@@ -405,6 +414,226 @@ export const VerticalOrientation: StoryObj<HvMultiButtonProps> = {
           ))}
         </HvMultiButton>
       </div>
+    );
+  },
+};
+
+export const SplitButton: StoryObj<HvMultiButtonProps> = {
+  parameters: {
+    docs: {
+      description: {
+        story: "MultiButton component used to create a **Split Button**.",
+      },
+    },
+  },
+  render: () => {
+    const options = [
+      { label: "Create merge commit" },
+      { label: "Squash and merge" },
+      { label: "Rebase and merge" },
+    ];
+
+    const [selectedOption, setSelectedOption] = useState(options[0]);
+
+    return (
+      <HvSimpleGrid cols={3} spacing="sm">
+        <HvMultiButton variant="primary" style={{ width: "232px" }} split>
+          <HvButton>{selectedOption.label}</HvButton>
+          <HvDropDownMenu
+            dataList={options}
+            icon={<DropDownXS />}
+            onClick={(e, item) =>
+              setSelectedOption(
+                options.filter((option) => option.label === item.label)[0]
+              )
+            }
+          />
+        </HvMultiButton>
+        <HvMultiButton variant="primarySubtle" style={{ width: "232px" }} split>
+          <HvButton>{selectedOption.label}</HvButton>
+          <HvDropDownMenu
+            dataList={options}
+            icon={<DropDownXS />}
+            onClick={(e, item) =>
+              setSelectedOption(
+                options.filter((option) => option.label === item.label)[0]
+              )
+            }
+          />
+        </HvMultiButton>
+        <HvMultiButton
+          variant="secondarySubtle"
+          style={{ width: "232px" }}
+          split
+        >
+          <HvButton>{selectedOption.label}</HvButton>
+          <HvDropDownMenu
+            dataList={options}
+            icon={<DropDownXS />}
+            onClick={(e, item) =>
+              setSelectedOption(
+                options.filter((option) => option.label === item.label)[0]
+              )
+            }
+          />
+        </HvMultiButton>
+        <HvMultiButton
+          variant="primary"
+          style={{ width: "228px" }}
+          split
+          size="xs"
+        >
+          <HvDropDownMenu
+            dataList={options}
+            icon={<DropDownXS />}
+            onClick={(e, item) =>
+              setSelectedOption(
+                options.filter((option) => option.label === item.label)[0]
+              )
+            }
+          />
+          <HvButton>{selectedOption.label}</HvButton>
+        </HvMultiButton>
+        <HvMultiButton
+          variant="primarySubtle"
+          style={{ width: "228px" }}
+          split
+          size="xs"
+        >
+          <HvDropDownMenu
+            dataList={options}
+            icon={<DropDownXS />}
+            onClick={(e, item) =>
+              setSelectedOption(
+                options.filter((option) => option.label === item.label)[0]
+              )
+            }
+          />
+          <HvButton>{selectedOption.label}</HvButton>
+        </HvMultiButton>
+        <HvMultiButton
+          variant="secondarySubtle"
+          style={{ width: "228px" }}
+          split
+          size="xs"
+        >
+          <HvDropDownMenu
+            dataList={options}
+            icon={<DropDownXS />}
+            onClick={(e, item) =>
+              setSelectedOption(
+                options.filter((option) => option.label === item.label)[0]
+              )
+            }
+          />
+          <HvButton>{selectedOption.label}</HvButton>
+        </HvMultiButton>
+        <HvMultiButton
+          variant="primary"
+          style={{ width: "240px" }}
+          split
+          size="lg"
+        >
+          <HvButton>{selectedOption.label}</HvButton>
+          <HvDropDownMenu
+            dataList={options}
+            icon={<DropDownXS />}
+            onClick={(e, item) =>
+              setSelectedOption(
+                options.filter((option) => option.label === item.label)[0]
+              )
+            }
+          />
+        </HvMultiButton>
+        <HvMultiButton
+          variant="primarySubtle"
+          style={{ width: "240px" }}
+          split
+          size="lg"
+        >
+          <HvButton>{selectedOption.label}</HvButton>
+          <HvDropDownMenu
+            dataList={options}
+            icon={<DropDownXS />}
+            onClick={(e, item) =>
+              setSelectedOption(
+                options.filter((option) => option.label === item.label)[0]
+              )
+            }
+          />
+        </HvMultiButton>
+        <HvMultiButton
+          variant="secondarySubtle"
+          style={{ width: "240px" }}
+          split
+          size="lg"
+        >
+          <HvButton>{selectedOption.label}</HvButton>
+          <HvDropDownMenu
+            dataList={options}
+            icon={<DropDownXS />}
+            onClick={(e, item) =>
+              setSelectedOption(
+                options.filter((option) => option.label === item.label)[0]
+              )
+            }
+          />
+        </HvMultiButton>
+        <HvMultiButton
+          variant="primary"
+          style={{ width: "232px" }}
+          split
+          disabled
+          size="xl"
+        >
+          <HvButton>{selectedOption.label}</HvButton>
+          <HvDropDownMenu
+            dataList={options}
+            icon={<DropDownXS />}
+            onClick={(e, item) =>
+              setSelectedOption(
+                options.filter((option) => option.label === item.label)[0]
+              )
+            }
+          />
+        </HvMultiButton>
+        <HvMultiButton
+          variant="primarySubtle"
+          style={{ width: "232px" }}
+          split
+          disabled
+          size="xl"
+        >
+          <HvButton>{selectedOption.label}</HvButton>
+          <HvDropDownMenu
+            dataList={options}
+            icon={<DropDownXS />}
+            onClick={(e, item) =>
+              setSelectedOption(
+                options.filter((option) => option.label === item.label)[0]
+              )
+            }
+          />
+        </HvMultiButton>
+        <HvMultiButton
+          variant="secondarySubtle"
+          style={{ width: "232px" }}
+          split
+          disabled
+          size="xl"
+        >
+          <HvButton>{selectedOption.label}</HvButton>
+          <HvDropDownMenu
+            dataList={options}
+            icon={<DropDownXS />}
+            onClick={(e, item) =>
+              setSelectedOption(
+                options.filter((option) => option.label === item.label)[0]
+              )
+            }
+          />
+        </HvMultiButton>
+      </HvSimpleGrid>
     );
   },
 };

--- a/packages/core/src/MultiButton/MultiButton.styles.tsx
+++ b/packages/core/src/MultiButton/MultiButton.styles.tsx
@@ -162,4 +162,33 @@ export const { staticClasses, useClasses } = createClasses("HvMultiButton", {
       },
     },
   },
+  primary: {
+    "& button$button": {
+      borderTop: "unset",
+      borderBottom: "unset",
+
+      "&:first-of-type": {
+        borderLeft: `solid 1px ${theme.colors.primary}`,
+      },
+      "&:last-of-type": {
+        borderRight: `solid 1px ${theme.colors.primary}`,
+      },
+    },
+  },
+  primarySubtle: {
+    "& button$button": {
+      borderTop: `solid 1px ${theme.colors.primary}`,
+      borderBottom: `solid 1px ${theme.colors.primary}`,
+      "&:first-of-type": {
+        borderLeft: `solid 1px ${theme.colors.primary}`,
+      },
+      "&:last-of-type": {
+        borderRight: `solid 1px ${theme.colors.primary}`,
+      },
+    },
+  },
+  primaryGhost: {},
+  secondary: {},
+  secondarySubtle: {},
+  secondaryGhost: {},
 });

--- a/packages/core/src/MultiButton/MultiButton.styles.tsx
+++ b/packages/core/src/MultiButton/MultiButton.styles.tsx
@@ -32,9 +32,6 @@ export const { staticClasses, useClasses } = createClasses("HvMultiButton", {
       borderRadius: 0,
       fontWeight: theme.typography.body.fontWeight,
       fontSize: theme.typography.body.fontSize,
-      "&:active": {
-        backgroundColor: `${theme.colors.atmo3}`,
-      },
       "&:disabled": {
         color: theme.colors.secondary_60,
         borderTop: `solid 1px ${theme.colors.atmo4}`,
@@ -158,6 +155,7 @@ export const { staticClasses, useClasses } = createClasses("HvMultiButton", {
   splitGroup: {
     background: theme.colors.atmo1,
     "& button$button": {
+      marginLeft: -1,
       "&:disabled": {
         borderTop: "none",
         borderBottom: "none",
@@ -188,6 +186,7 @@ export const { staticClasses, useClasses } = createClasses("HvMultiButton", {
     },
     // dropdown menu styles
     "& $button": {
+      marginLeft: -1,
       [`& .${dropDownMenuClasses.icon}`]: {
         "&:disabled": {
           borderTop: "none",
@@ -197,6 +196,9 @@ export const { staticClasses, useClasses } = createClasses("HvMultiButton", {
             borderBottom: "none",
           },
         },
+      },
+      [`& .${dropDownMenuClasses.iconSelected}`]: {
+        zIndex: 2,
       },
       "&$firstButton": {
         [`& .${dropDownMenuClasses.icon}`]: {
@@ -465,7 +467,8 @@ export const { staticClasses, useClasses } = createClasses("HvMultiButton", {
     background: "currentColor",
   },
   splitContainer: {
-    marginLeft: 0,
+    zIndex: 1,
+    marginLeft: -1,
     width: 1,
     height: "100%",
     paddingTop: 4,

--- a/packages/core/src/MultiButton/MultiButton.styles.tsx
+++ b/packages/core/src/MultiButton/MultiButton.styles.tsx
@@ -19,6 +19,7 @@ export const { staticClasses, useClasses } = createClasses("HvMultiButton", {
     },
 
     "& button$button": {
+      minWidth: "unset",
       width: "100%",
       maxWidth: 200,
       padding: 0,
@@ -97,10 +98,7 @@ export const { staticClasses, useClasses } = createClasses("HvMultiButton", {
     },
     // dropdown menu styles
     "& $button": {
-      [`& .${dropDownMenuClasses.container}`]: {
-        width: "unset",
-      },
-      [`& .${dropDownMenuClasses.root}`]: {
+      [`&.${dropDownMenuClasses.container}`]: {
         width: "unset",
       },
       [`& .${dropDownMenuClasses.icon}`]: {

--- a/packages/core/src/MultiButton/MultiButton.styles.tsx
+++ b/packages/core/src/MultiButton/MultiButton.styles.tsx
@@ -30,7 +30,8 @@ export const { staticClasses, useClasses } = createClasses("HvMultiButton", {
       borderLeft: "solid 1px transparent",
       borderRight: "solid 1px transparent",
       borderRadius: 0,
-      ...theme.typography.body,
+      fontWeight: theme.typography.body.fontWeight,
+      fontSize: theme.typography.body.fontSize,
       "&:active": {
         backgroundColor: `${theme.colors.atmo3}`,
       },
@@ -80,7 +81,6 @@ export const { staticClasses, useClasses } = createClasses("HvMultiButton", {
     },
     "& button$button$selected": {
       background: theme.colors.atmo1,
-      height: 34,
       ...theme.typography.label,
       borderRadius: theme.radii.base,
       border: `solid 1px ${theme.colors.secondary}`,

--- a/packages/core/src/MultiButton/MultiButton.styles.tsx
+++ b/packages/core/src/MultiButton/MultiButton.styles.tsx
@@ -5,7 +5,6 @@ import { createClasses } from "../utils/classes";
 export const { staticClasses, useClasses } = createClasses("HvMultiButton", {
   root: {
     display: "flex",
-    height: 32,
     alignItems: "center",
     transition: "none",
     background: theme.colors.atmo2,
@@ -18,7 +17,6 @@ export const { staticClasses, useClasses } = createClasses("HvMultiButton", {
     },
 
     "& button$button": {
-      height: 32,
       width: "100%",
       minWidth: 32,
       maxWidth: 200,

--- a/packages/core/src/MultiButton/MultiButton.styles.tsx
+++ b/packages/core/src/MultiButton/MultiButton.styles.tsx
@@ -44,12 +44,12 @@ export const { staticClasses, useClasses } = createClasses("HvMultiButton", {
           borderRight: "solid 1px transparent",
         },
       },
-      "&:first-of-type": {
+      "&$firstButton": {
         borderLeft: `solid 1px ${theme.colors.atmo4}`,
         borderTopLeftRadius: theme.radii.base,
         borderBottomLeftRadius: theme.radii.base,
       },
-      "&:last-of-type": {
+      "&$lastButton": {
         borderRight: `solid 1px ${theme.colors.atmo4}`,
         borderTopRightRadius: theme.radii.base,
         borderBottomRightRadius: theme.radii.base,
@@ -57,7 +57,7 @@ export const { staticClasses, useClasses } = createClasses("HvMultiButton", {
           borderRight: `solid 1px ${theme.colors.atmo4} !important`,
         },
       },
-      "&:not(:first-of-type)": {
+      "&:not($firstButton)": {
         marginLeft: "-1px",
       },
       "&$selected": {
@@ -86,7 +86,7 @@ export const { staticClasses, useClasses } = createClasses("HvMultiButton", {
       "&:hover": {
         background: theme.colors.atmo3,
       },
-      "&:first-of-type, &:last-of-type": {
+      "&$firstButton, &$lastButton": {
         border: `solid 1px ${theme.colors.secondary}`,
       },
 
@@ -125,12 +125,12 @@ export const { staticClasses, useClasses } = createClasses("HvMultiButton", {
           borderBottom: "solid 1px transparent",
         },
       },
-      "&:first-of-type": {
+      "&$firstButton": {
         borderTop: `solid 1px ${theme.colors.atmo4}`,
         borderTopLeftRadius: theme.radii.base,
         borderTopRightRadius: theme.radii.base,
       },
-      "&:last-of-type": {
+      "&$lastButton": {
         borderBottom: `solid 1px ${theme.colors.atmo4}`,
         borderBottomLeftRadius: theme.radii.base,
         borderBottomRightRadius: theme.radii.base,
@@ -138,7 +138,7 @@ export const { staticClasses, useClasses } = createClasses("HvMultiButton", {
           borderBottom: `solid 1px ${theme.colors.atmo4} !important`,
         },
       },
-      "&:not(:first-of-type)": {
+      "&:not($firstButton)": {
         marginLeft: 0,
         marginTop: -1,
       },
@@ -167,10 +167,10 @@ export const { staticClasses, useClasses } = createClasses("HvMultiButton", {
       borderTop: "unset",
       borderBottom: "unset",
 
-      "&:first-of-type": {
+      "&$firstButton": {
         borderLeft: `solid 1px ${theme.colors.primary}`,
       },
-      "&:last-of-type": {
+      "&$lastButton": {
         borderRight: `solid 1px ${theme.colors.primary}`,
       },
     },
@@ -179,10 +179,10 @@ export const { staticClasses, useClasses } = createClasses("HvMultiButton", {
     "& button$button": {
       borderTop: `solid 1px ${theme.colors.primary}`,
       borderBottom: `solid 1px ${theme.colors.primary}`,
-      "&:first-of-type": {
+      "&$firstButton": {
         borderLeft: `solid 1px ${theme.colors.primary}`,
       },
-      "&:last-of-type": {
+      "&$lastButton": {
         borderRight: `solid 1px ${theme.colors.primary}`,
       },
     },
@@ -191,4 +191,6 @@ export const { staticClasses, useClasses } = createClasses("HvMultiButton", {
   secondary: {},
   secondarySubtle: {},
   secondaryGhost: {},
+  firstButton: {},
+  lastButton: {},
 });

--- a/packages/core/src/MultiButton/MultiButton.styles.tsx
+++ b/packages/core/src/MultiButton/MultiButton.styles.tsx
@@ -62,7 +62,7 @@ export const { staticClasses, useClasses } = createClasses("HvMultiButton", {
           borderRight: `solid 1px ${theme.colors.atmo4}`,
         },
         "&:disabled:hover": {
-          borderRight: `solid 1px ${theme.colors.atmo4} !important`,
+          borderRight: `solid 1px ${theme.colors.atmo4}`,
         },
       },
       "&:not($firstButton)": {
@@ -140,7 +140,7 @@ export const { staticClasses, useClasses } = createClasses("HvMultiButton", {
             borderRight: `solid 1px ${theme.colors.atmo4}`,
           },
           "&:disabled:hover": {
-            borderRight: `solid 1px ${theme.colors.atmo4} !important`,
+            borderRight: `solid 1px ${theme.colors.atmo4}`,
           },
         },
         [`& .${dropDownMenuClasses.iconSelected}`]: {
@@ -149,6 +149,150 @@ export const { staticClasses, useClasses } = createClasses("HvMultiButton", {
       },
       "&:not($firstButton) > button": {
         marginLeft: "-1px",
+      },
+    },
+  },
+  splitGroup: {
+    background: theme.colors.atmo1,
+    "& button$button": {
+      "&:disabled": {
+        borderTop: "none",
+        borderBottom: "none",
+        "&:hover": {
+          borderTop: "none",
+          borderBottom: "none",
+        },
+      },
+      "&$firstButton": {
+        "&:not($selected):disabled": {
+          borderLeft: "none",
+          "&:hover": {
+            borderLeft: "none",
+          },
+        },
+      },
+      "&$lastButton": {
+        "&:not($selected):disabled": {
+          borderRight: "none",
+          "&:hover": {
+            borderRight: "none",
+          },
+        },
+      },
+      "&:not($firstButton)": {
+        marginLeft: 0,
+      },
+    },
+    // dropdown menu styles
+    "& $button": {
+      [`& .${dropDownMenuClasses.icon}`]: {
+        "&:disabled": {
+          borderTop: "none",
+          borderBottom: "none",
+          "&:hover": {
+            borderTop: "none",
+            borderBottom: "none",
+          },
+        },
+      },
+      "&$firstButton": {
+        [`& .${dropDownMenuClasses.icon}`]: {
+          "&:disabled": {
+            borderLeft: "none",
+            "&:hover": {
+              borderLeft: "none",
+            },
+          },
+        },
+      },
+      "&$lastButton": {
+        [`& .${dropDownMenuClasses.icon}`]: {
+          "&:disabled": {
+            borderRight: "none",
+            "&:hover": {
+              borderRight: "none",
+            },
+          },
+        },
+      },
+      "&:not($firstButton) > button": {
+        marginLeft: 0,
+      },
+    },
+    "&$secondarySubtle": {
+      "& button$button": {
+        borderTop: `solid 1px ${theme.colors.secondary}`,
+        borderBottom: `solid 1px ${theme.colors.secondary}`,
+        "&$firstButton": {
+          borderLeft: `solid 1px ${theme.colors.secondary}`,
+        },
+        "&$lastButton": {
+          borderRight: `solid 1px ${theme.colors.secondary}`,
+        },
+        "&:not($selected):disabled": {
+          borderTop: "none",
+          borderBottom: "none",
+          "&:hover": {
+            borderTop: "none",
+            borderBottom: "none",
+          },
+          "&$firstButton": {
+            "&:not($selected):disabled": {
+              borderLeft: "none",
+              "&:hover": {
+                borderLeft: "none",
+              },
+            },
+          },
+          "&$lastButton": {
+            "&:not($selected):disabled": {
+              borderRight: "none",
+              "&:hover": {
+                borderRight: "none",
+              },
+            },
+          },
+        },
+      },
+      "& $button": {
+        [`& .${dropDownMenuClasses.icon}`]: {
+          borderTop: `solid 1px ${theme.colors.secondary}`,
+          borderBottom: `solid 1px ${theme.colors.secondary}`,
+          "&:disabled": {
+            borderTop: "none",
+            borderBottom: "none",
+            "&:hover": {
+              borderTop: "none",
+              borderBottom: "none",
+            },
+          },
+        },
+        "&$firstButton": {
+          [`& .${dropDownMenuClasses.icon}`]: {
+            borderLeft: `solid 1px ${theme.colors.secondary}`,
+            "&:disabled": {
+              borderLeft: "none",
+              "&:hover": {
+                borderLeft: "none",
+              },
+            },
+          },
+        },
+        "&$lastButton": {
+          [`& .${dropDownMenuClasses.icon}`]: {
+            borderRight: `solid 1px ${theme.colors.secondary}`,
+            "&$lastButton": {
+              [`& .${dropDownMenuClasses.icon}`]: {
+                "&:disabled": {
+                  borderRight: "none",
+                  "&:hover": {
+                    borderRight: "none",
+                  },
+                },
+              },
+            },
+          },
+        },
       },
     },
   },
@@ -190,7 +334,7 @@ export const { staticClasses, useClasses } = createClasses("HvMultiButton", {
         borderBottomLeftRadius: theme.radii.base,
         borderBottomRightRadius: theme.radii.base,
         "&:disabled:hover": {
-          borderBottom: `solid 1px ${theme.colors.atmo4} !important`,
+          borderBottom: `solid 1px ${theme.colors.atmo4}`,
         },
       },
       "&:not($firstButton)": {
@@ -298,4 +442,52 @@ export const { staticClasses, useClasses } = createClasses("HvMultiButton", {
   secondaryGhost: {},
   firstButton: {},
   lastButton: {},
+  split: {
+    width: 1,
+    height: "100%",
+    background: "currentColor",
+  },
+  splitContainer: {
+    marginLeft: 0,
+    width: 1,
+    height: "100%",
+    paddingTop: 4,
+    paddingBottom: 4,
+    color: theme.colors.secondary,
+    borderTop: `1px solid ${theme.colors.atmo4}`,
+    borderBottom: `1px solid ${theme.colors.atmo4}`,
+    "&$primary": {
+      color: theme.colors.atmo1,
+      backgroundColor: theme.colors.primary,
+      borderTop: `1px solid ${theme.colors.primary}`,
+      borderBottom: `1px solid ${theme.colors.primary}`,
+    },
+    "&$primarySubtle": {
+      color: theme.colors.primary,
+      borderTop: `1px solid ${theme.colors.primary}`,
+      borderBottom: `1px solid ${theme.colors.primary}`,
+    },
+    "&$primaryGhost": {
+      color: theme.colors.primary,
+      borderTop: `1px solid ${theme.colors.primary}`,
+      borderBottom: `1px solid ${theme.colors.primary}`,
+    },
+    "&$secondarySubtle": {
+      color: theme.colors.secondary,
+      borderTop: `1px solid ${theme.colors.secondary}`,
+      borderBottom: `1px solid ${theme.colors.secondary}`,
+    },
+    "&$secondaryGhost": {
+      color: theme.colors.secondary,
+      borderTop: `1px solid ${theme.colors.secondary}`,
+      borderBottom: `1px solid ${theme.colors.secondary}`,
+    },
+    "&$splitDisabled": {
+      background: theme.colors.atmo3,
+      color: theme.colors.secondary_60,
+      borderTop: "none",
+      borderBottom: "none",
+    },
+  },
+  splitDisabled: {},
 });

--- a/packages/core/src/MultiButton/MultiButton.styles.tsx
+++ b/packages/core/src/MultiButton/MultiButton.styles.tsx
@@ -20,7 +20,6 @@ export const { staticClasses, useClasses } = createClasses("HvMultiButton", {
 
     "& button$button": {
       width: "100%",
-      minWidth: 32,
       maxWidth: 200,
       padding: 0,
       transition: "none",
@@ -98,6 +97,12 @@ export const { staticClasses, useClasses } = createClasses("HvMultiButton", {
     },
     // dropdown menu styles
     "& $button": {
+      [`& .${dropDownMenuClasses.container}`]: {
+        width: "unset",
+      },
+      [`& .${dropDownMenuClasses.root}`]: {
+        width: "unset",
+      },
       [`& .${dropDownMenuClasses.icon}`]: {
         borderTop: `solid 1px ${theme.colors.atmo4}`,
         borderBottom: `solid 1px ${theme.colors.atmo4}`,
@@ -281,14 +286,10 @@ export const { staticClasses, useClasses } = createClasses("HvMultiButton", {
         "&$lastButton": {
           [`& .${dropDownMenuClasses.icon}`]: {
             borderRight: `solid 1px ${theme.colors.secondary}`,
-            "&$lastButton": {
-              [`& .${dropDownMenuClasses.icon}`]: {
-                "&:disabled": {
-                  borderRight: "none",
-                  "&:hover": {
-                    borderRight: "none",
-                  },
-                },
+            "&:disabled": {
+              borderRight: "none",
+              "&:hover": {
+                borderRight: "none",
               },
             },
           },
@@ -306,6 +307,7 @@ export const { staticClasses, useClasses } = createClasses("HvMultiButton", {
       flex: "1 1 20px",
     },
     "& button$button": {
+      minWidth: 32,
       width: "100%",
       borderLeft: `solid 1px ${theme.colors.atmo4}`,
       borderRight: `solid 1px ${theme.colors.atmo4}`,
@@ -383,12 +385,15 @@ export const { staticClasses, useClasses } = createClasses("HvMultiButton", {
         borderTop: "none",
         borderBottom: "none",
       },
+      [`& .${dropDownMenuClasses.iconSelected}`]: {
+        border: `solid 1px ${theme.colors.secondary}`,
+      },
       "&$firstButton": {
         [`& .${dropDownMenuClasses.icon}`]: {
           borderLeft: "none",
         },
         [`& .${dropDownMenuClasses.iconSelected}`]: {
-          border: `solid 1px ${theme.colors.secondary}`,
+          borderLeft: `solid 1px ${theme.colors.secondary}`,
         },
       },
       "&$lastButton": {
@@ -396,7 +401,7 @@ export const { staticClasses, useClasses } = createClasses("HvMultiButton", {
           borderRight: "none",
         },
         [`& .${dropDownMenuClasses.iconSelected}`]: {
-          border: `solid 1px ${theme.colors.secondary}`,
+          borderRight: `solid 1px ${theme.colors.secondary}`,
         },
       },
     },
@@ -439,7 +444,21 @@ export const { staticClasses, useClasses } = createClasses("HvMultiButton", {
   primaryGhost: {},
   secondary: {},
   secondarySubtle: {},
-  secondaryGhost: {},
+  secondaryGhost: {
+    "& button$button": {
+      "&:disabled": {
+        background: theme.colors.atmo3,
+      },
+    },
+    // dropdown menu styles
+    "& $button": {
+      [`& .${dropDownMenuClasses.icon}`]: {
+        "&:disabled": {
+          background: theme.colors.atmo3,
+        },
+      },
+    },
+  },
   firstButton: {},
   lastButton: {},
   split: {
@@ -479,8 +498,6 @@ export const { staticClasses, useClasses } = createClasses("HvMultiButton", {
     },
     "&$secondaryGhost": {
       color: theme.colors.secondary,
-      borderTop: `1px solid ${theme.colors.secondary}`,
-      borderBottom: `1px solid ${theme.colors.secondary}`,
     },
     "&$splitDisabled": {
       background: theme.colors.atmo3,

--- a/packages/core/src/MultiButton/MultiButton.styles.tsx
+++ b/packages/core/src/MultiButton/MultiButton.styles.tsx
@@ -1,5 +1,7 @@
 import { theme } from "@hitachivantara/uikit-styles";
 
+import { dropDownMenuClasses } from "../DropDownMenu";
+
 import { createClasses } from "../utils/classes";
 
 export const { staticClasses, useClasses } = createClasses("HvMultiButton", {
@@ -48,11 +50,17 @@ export const { staticClasses, useClasses } = createClasses("HvMultiButton", {
         borderLeft: `solid 1px ${theme.colors.atmo4}`,
         borderTopLeftRadius: theme.radii.base,
         borderBottomLeftRadius: theme.radii.base,
+        "&:disabled": {
+          borderLeft: `solid 1px ${theme.colors.atmo4}`,
+        },
       },
       "&$lastButton": {
         borderRight: `solid 1px ${theme.colors.atmo4}`,
         borderTopRightRadius: theme.radii.base,
         borderBottomRightRadius: theme.radii.base,
+        "&:disabled": {
+          borderRight: `solid 1px ${theme.colors.atmo4}`,
+        },
         "&:disabled:hover": {
           borderRight: `solid 1px ${theme.colors.atmo4} !important`,
         },
@@ -61,7 +69,13 @@ export const { staticClasses, useClasses } = createClasses("HvMultiButton", {
         marginLeft: "-1px",
       },
       "&$selected": {
+        background: theme.colors.atmo1,
+        ...theme.typography.label,
+        borderRadius: theme.radii.base,
+        border: `solid 1px ${theme.colors.secondary}`,
+        zIndex: 2,
         "&:hover": {
+          background: theme.colors.atmo3,
           "&:not(:disabled)": {
             border: `solid 1px ${theme.colors.secondary}`,
           },
@@ -69,31 +83,72 @@ export const { staticClasses, useClasses } = createClasses("HvMultiButton", {
             border: `solid 1px ${theme.colors.atmo4}`,
           },
         },
+        // prevent the focus ring to be hidden by sibling hover background
+        // even when selected
+        "&.HvIsFocusVisible": {
+          zIndex: 5,
+        },
         "&:disabled": {
           zIndex: 1,
           color: theme.colors.secondary_60,
           background: theme.colors.atmo1,
-          border: `solid 1px ${theme.colors.atmo4}`,
+          border: `solid 1px ${theme.colors.secondary}`,
         },
       },
     },
-    "& button$button$selected": {
-      background: theme.colors.atmo1,
-      ...theme.typography.label,
-      borderRadius: theme.radii.base,
-      border: `solid 1px ${theme.colors.secondary}`,
-      zIndex: 2,
-      "&:hover": {
-        background: theme.colors.atmo3,
+    // dropdown menu styles
+    "& $button": {
+      [`& .${dropDownMenuClasses.icon}`]: {
+        borderTop: `solid 1px ${theme.colors.atmo4}`,
+        borderBottom: `solid 1px ${theme.colors.atmo4}`,
+        borderLeft: "solid 1px transparent",
+        borderRight: "solid 1px transparent",
+        borderRadius: 0,
+        "&:disabled": {
+          borderTop: `solid 1px ${theme.colors.atmo4}`,
+          borderBottom: `solid 1px ${theme.colors.atmo4}`,
+          "&:hover": {
+            borderTop: `solid 1px ${theme.colors.atmo4}`,
+            borderBottom: `solid 1px ${theme.colors.atmo4}`,
+            borderLeft: "solid 1px transparent",
+            borderRight: "solid 1px transparent",
+          },
+        },
       },
-      "&$firstButton, &$lastButton": {
+      [`& .${dropDownMenuClasses.iconSelected}`]: {
         border: `solid 1px ${theme.colors.secondary}`,
       },
-
-      // prevent the focus ring to be hidden by sibling hover background
-      // even when selected
-      "&.HvIsFocusVisible": {
-        zIndex: 5,
+      "&$firstButton": {
+        [`& .${dropDownMenuClasses.icon}`]: {
+          borderLeft: `solid 1px ${theme.colors.atmo4}`,
+          borderTopLeftRadius: theme.radii.base,
+          borderBottomLeftRadius: theme.radii.base,
+          "&:disabled": {
+            borderLeft: `solid 1px ${theme.colors.atmo4}`,
+          },
+        },
+        [`& .${dropDownMenuClasses.iconSelected}`]: {
+          border: `solid 1px ${theme.colors.secondary}`,
+        },
+      },
+      "&$lastButton": {
+        [`& .${dropDownMenuClasses.icon}`]: {
+          borderRight: `solid 1px ${theme.colors.atmo4}`,
+          borderTopRightRadius: theme.radii.base,
+          borderBottomRightRadius: theme.radii.base,
+          "&:disabled": {
+            borderRight: `solid 1px ${theme.colors.atmo4}`,
+          },
+          "&:disabled:hover": {
+            borderRight: `solid 1px ${theme.colors.atmo4} !important`,
+          },
+        },
+        [`& .${dropDownMenuClasses.iconSelected}`]: {
+          border: `solid 1px ${theme.colors.secondary}`,
+        },
+      },
+      "&:not($firstButton) > button": {
+        marginLeft: "-1px",
       },
     },
   },
@@ -164,14 +219,41 @@ export const { staticClasses, useClasses } = createClasses("HvMultiButton", {
   },
   primary: {
     "& button$button": {
-      borderTop: "unset",
-      borderBottom: "unset",
+      borderTop: "none",
+      borderBottom: "none",
 
       "&$firstButton": {
-        borderLeft: `solid 1px ${theme.colors.primary}`,
+        borderLeft: "none",
       },
       "&$lastButton": {
-        borderRight: `solid 1px ${theme.colors.primary}`,
+        borderRight: "none",
+      },
+      "&$selected": {
+        border: `solid 1px ${theme.colors.secondary}`,
+      },
+    },
+
+    // dropdown menu styles
+    "& $button": {
+      [`& .${dropDownMenuClasses.icon}`]: {
+        borderTop: "none",
+        borderBottom: "none",
+      },
+      "&$firstButton": {
+        [`& .${dropDownMenuClasses.icon}`]: {
+          borderLeft: "none",
+        },
+        [`& .${dropDownMenuClasses.iconSelected}`]: {
+          border: `solid 1px ${theme.colors.secondary}`,
+        },
+      },
+      "&$lastButton": {
+        [`& .${dropDownMenuClasses.icon}`]: {
+          borderRight: "none",
+        },
+        [`& .${dropDownMenuClasses.iconSelected}`]: {
+          border: `solid 1px ${theme.colors.secondary}`,
+        },
       },
     },
   },
@@ -184,6 +266,29 @@ export const { staticClasses, useClasses } = createClasses("HvMultiButton", {
       },
       "&$lastButton": {
         borderRight: `solid 1px ${theme.colors.primary}`,
+      },
+    },
+    // dropdown menu styles
+    "& $button": {
+      [`& .${dropDownMenuClasses.icon}`]: {
+        borderTop: `solid 1px ${theme.colors.primary}`,
+        borderBottom: `solid 1px ${theme.colors.primary}`,
+      },
+      "&$firstButton": {
+        [`& .${dropDownMenuClasses.icon}`]: {
+          borderLeft: `solid 1px ${theme.colors.primary}`,
+        },
+        [`& .${dropDownMenuClasses.iconSelected}`]: {
+          border: `solid 1px ${theme.colors.secondary}`,
+        },
+      },
+      "&$lastButton": {
+        [`& .${dropDownMenuClasses.icon}`]: {
+          borderRight: `solid 1px ${theme.colors.primary}`,
+        },
+        [`& .${dropDownMenuClasses.iconSelected}`]: {
+          border: `solid 1px ${theme.colors.secondary}`,
+        },
       },
     },
   },

--- a/packages/core/src/MultiButton/MultiButton.tsx
+++ b/packages/core/src/MultiButton/MultiButton.tsx
@@ -21,6 +21,7 @@ export interface HvMultiButtonProps extends HvBaseProps {
   classes?: HvMultiButtonClasses;
   /** Button size. */
   size?: HvButtonSize;
+  /** Add a split between buttons */
   split?: boolean;
 }
 
@@ -33,6 +34,7 @@ export const HvMultiButton = (props: HvMultiButtonProps) => {
     vertical = false,
     variant = "secondarySubtle",
     size,
+    split,
     ...others
   } = useDefaultProps("HvMultiButton", props);
   const { classes, cx } = useClasses(classesProp);
@@ -44,6 +46,7 @@ export const HvMultiButton = (props: HvMultiButtonProps) => {
         {
           [classes.vertical]: vertical,
           [classes[variant]]: variant,
+          [classes.splitGroup]: split,
         },
         className
       )}
@@ -53,18 +56,31 @@ export const HvMultiButton = (props: HvMultiButtonProps) => {
         if (React.isValidElement(child)) {
           const childIsSelected = !!child.props.selected;
 
-          return cloneElement(child as React.ReactElement, {
-            variant,
-            disabled: disabled || child.props.disabled,
-            size,
-            className: cx(child.props.className, classes.button, {
-              [classes.firstButton]: index === 0,
-              [classes.lastButton]:
-                index === React.Children.count(children) - 1,
-              [classes.selected]: childIsSelected,
-            }),
-            "aria-pressed": childIsSelected,
-          });
+          return (
+            <>
+              {cloneElement(child as React.ReactElement, {
+                variant,
+                disabled: disabled || child.props.disabled,
+                size,
+                className: cx(child.props.className, classes.button, {
+                  [classes.firstButton]: index === 0,
+                  [classes.lastButton]:
+                    index === React.Children.count(children) - 1,
+                  [classes.selected]: childIsSelected,
+                }),
+                "aria-pressed": childIsSelected,
+              })}
+              {split && index < React.Children.count(children) - 1 && (
+                <div
+                  className={cx(classes.splitContainer, classes[variant], {
+                    [classes.splitDisabled]: disabled,
+                  })}
+                >
+                  <div className={cx(classes.split)} />
+                </div>
+              )}
+            </>
+          );
         }
       })}
     </div>

--- a/packages/core/src/MultiButton/MultiButton.tsx
+++ b/packages/core/src/MultiButton/MultiButton.tsx
@@ -1,7 +1,7 @@
 import React, { cloneElement } from "react";
 
 import { useDefaultProps } from "../hooks/useDefaultProps";
-import { HvButtonVariant } from "../Button";
+import { HvButtonSize, HvButtonVariant } from "../Button";
 import { HvBaseProps } from "../types/generic";
 import { ExtractNames } from "../utils/classes";
 
@@ -19,6 +19,9 @@ export interface HvMultiButtonProps extends HvBaseProps {
   variant?: HvButtonVariant;
   /** A Jss Object used to override or extend the styles applied to the component. */
   classes?: HvMultiButtonClasses;
+  /** Button size. */
+  size?: HvButtonSize;
+  split?: boolean;
 }
 
 export const HvMultiButton = (props: HvMultiButtonProps) => {
@@ -29,6 +32,7 @@ export const HvMultiButton = (props: HvMultiButtonProps) => {
     disabled = false,
     vertical = false,
     variant = "secondarySubtle",
+    size,
     ...others
   } = useDefaultProps("HvMultiButton", props);
   const { classes, cx } = useClasses(classesProp);
@@ -39,6 +43,7 @@ export const HvMultiButton = (props: HvMultiButtonProps) => {
         classes.root,
         {
           [classes.vertical]: vertical,
+          [classes[variant]]: variant,
         },
         className
       )}
@@ -51,6 +56,7 @@ export const HvMultiButton = (props: HvMultiButtonProps) => {
           return cloneElement(child as React.ReactElement, {
             variant,
             disabled: disabled || child.props.disabled,
+            size,
             className: cx(child.props.className, classes.button, {
               [classes.selected]: childIsSelected,
             }),

--- a/packages/core/src/MultiButton/MultiButton.tsx
+++ b/packages/core/src/MultiButton/MultiButton.tsx
@@ -68,7 +68,6 @@ export const HvMultiButton = (props: HvMultiButtonProps) => {
                     index === React.Children.count(children) - 1,
                   [classes.selected]: childIsSelected,
                 }),
-                "aria-pressed": childIsSelected,
               })}
               {split && index < React.Children.count(children) - 1 && (
                 <div

--- a/packages/core/src/MultiButton/MultiButton.tsx
+++ b/packages/core/src/MultiButton/MultiButton.tsx
@@ -49,7 +49,7 @@ export const HvMultiButton = (props: HvMultiButtonProps) => {
       )}
       {...others}
     >
-      {React.Children.map(children, (child) => {
+      {React.Children.map(children, (child, index) => {
         if (React.isValidElement(child)) {
           const childIsSelected = !!child.props.selected;
 
@@ -58,6 +58,9 @@ export const HvMultiButton = (props: HvMultiButtonProps) => {
             disabled: disabled || child.props.disabled,
             size,
             className: cx(child.props.className, classes.button, {
+              [classes.firstButton]: index === 0,
+              [classes.lastButton]:
+                index === React.Children.count(children) - 1,
               [classes.selected]: childIsSelected,
             }),
             "aria-pressed": childIsSelected,

--- a/packages/styles/src/themes/ds3.ts
+++ b/packages/styles/src/themes/ds3.ts
@@ -1378,6 +1378,15 @@ const ds3 = makeTheme((theme) => ({
         },
       },
     },
+    HvMultiButton: {
+      classes: {
+        root: {
+          "& button&.HvMultiButton-button&.HvMultiButton-selected": {
+            height: 32,
+          },
+        },
+      },
+    },
     HvTooltip: {
       classes: {
         popper: {


### PR DESCRIPTION
- A style was removed from the `HvMultiButton` and added to `ds3` theme where the selected button would be slightly bigger then the others to match the ds5 specs. Applitools is expected to break because of it.
- Button sizes was added to `HvMultiButton`
- `HvMultiButton` variants style were added. The prop was already there but the styles didn't match ( there was no ds specification so I added the styles that made sense looking at the button variants specs)
- changed the `type` `css` selectors with classes for compatibility  with the `HvDropdownMenu` component (e.g. replaced `first-of-type` with the `firstButton` class)
- Added the `sizes` prop from the `HvButton` to the `HvDropdownMenu` component to create different size split buttons
- Added diferent icon sizes styles to `HvButton` according ds5 to match iconless button height