### PR TITLE
ci: allow secrets to be used across workflows

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -3,9 +3,6 @@ name: Documentation
 on:
   workflow_dispatch:
   workflow_call:
-    secrets:
-      ORG_GHPAGES_DEPLOY_KEY:
-        required: true
     inputs:
       publish-folder:
         type: string

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -13,25 +13,19 @@ jobs:
   static-checks:
     name: Static Checks
     uses: ./.github/workflows/static-checks.yml
-    secrets:
-      ORG_GHPAGES_DEPLOY_KEY: ${{ secrets.ORG_GHPAGES_DEPLOY_KEY }}
+    secrets: inherit
     with:
       a11y-publish: true
 
   applitools:
     name: Applitools Tests
     uses: ./.github/workflows/tests-applitools.yml
-    secrets:
-      APPLITOOLS_API_KEY: ${{ secrets.APPLITOOLS_API_KEY }}
+    secrets: inherit
 
   security-scans:
     name: Security Scans
     uses: ./.github/workflows/security.yml
-    secrets:
-      CODE_DX_URL: ${{ secrets.CODE_DX_URL }}
-      CODE_DX_API_KEY: ${{ secrets.CODE_DX_API_KEY }}
-      BLACKDUCK_URL: "${{ secrets.BLACKDUCK_URL }}"
-      BLACKDUCK_TOKEN: "${{ secrets.BLACKDUCK_TOKEN }}"
+    secrets: inherit
 
   notify-fail:
     name: Notify Fail

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -16,15 +16,13 @@ jobs:
   applitools:
     name: Applitools
     uses: ./.github/workflows/tests-applitools.yml
-    secrets:
-      APPLITOOLS_API_KEY: ${{ secrets.APPLITOOLS_API_KEY }}
+    secrets: inherit
     with:
       batch-id: pr-${{ github.event.number }}
 
   artifacts:
     name: Artifacts
     uses: ./.github/workflows/documentation.yml
-    secrets:
-      ORG_GHPAGES_DEPLOY_KEY: ${{ secrets.ORG_GHPAGES_DEPLOY_KEY }}
+    secrets: inherit
     with:
       publish-folder: pr-${{ github.event.number }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,8 +74,7 @@ jobs:
     needs: [publish]
     if: needs.publish.outputs.published == 'true'
     uses: ./.github/workflows/documentation.yml
-    secrets:
-      ORG_GHPAGES_DEPLOY_KEY: ${{ secrets.ORG_GHPAGES_DEPLOY_KEY }}
+    secrets: inherit
     with:
       publish-folder: ${{ github.ref_name }}
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -3,15 +3,6 @@ name: Security Scans
 on:
   workflow_dispatch:
   workflow_call:
-    secrets:
-      CODE_DX_URL:
-        required: true
-      CODE_DX_API_KEY:
-        required: true
-      BLACKDUCK_URL:
-        required: true
-      BLACKDUCK_TOKEN:
-        required: true
 
 jobs:
   codedx-scans:

--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -3,9 +3,6 @@ name: Checks
 on:
   workflow_dispatch:
   workflow_call:
-    secrets:
-      ORG_GHPAGES_DEPLOY_KEY:
-        required: false
     inputs:
       a11y-publish:
         type: boolean
@@ -65,8 +62,7 @@ jobs:
   a11y:
     name: A11y Tests
     uses: ./.github/workflows/tests-a11y.yml
-    secrets:
-      ORG_GHPAGES_DEPLOY_KEY: ${{ secrets.ORG_GHPAGES_DEPLOY_KEY }}
+    secrets: inherit
     with:
       publish: ${{ inputs.a11y-publish }}
       exit: ${{ inputs.a11y-exit }}

--- a/.github/workflows/tests-a11y.yml
+++ b/.github/workflows/tests-a11y.yml
@@ -3,9 +3,6 @@ name: A11y Tests
 on:
   workflow_dispatch:
   workflow_call:
-    secrets:
-      ORG_GHPAGES_DEPLOY_KEY:
-        required: false
     inputs:
       publish:
         type: boolean

--- a/.github/workflows/tests-applitools.yml
+++ b/.github/workflows/tests-applitools.yml
@@ -3,9 +3,6 @@ name: Applitools
 on:
   workflow_dispatch:
   workflow_call:
-    secrets:
-      APPLITOOLS_API_KEY:
-        required: true
     inputs:
       batch-id:
         type: string


### PR DESCRIPTION
use [`secrets: inherit`](https://docs.github.com/en/enterprise-cloud@latest/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idsecretsinherit) so that workflows may use any secret they need