### PR TITLE
fix(Dialog): duplicate heading elements

### DIFF
--- a/packages/core/src/Dialog/Dialog.stories.tsx
+++ b/packages/core/src/Dialog/Dialog.stories.tsx
@@ -14,12 +14,11 @@ import {
   HvDialogProps,
   HvDialogTitle,
   HvDialogActions,
-  HvInput,
-  HvTextArea,
-  HvTypography,
-  HvGrid,
   theme,
 } from "@hitachivantara/uikit-react-core";
+
+import { FormStory } from "./stories/FormStory";
+import FormStoryRaw from "./stories/FormStory?raw";
 
 type SimpleDialogProps = Pick<HvDialogProps, "classes" | "variant"> & {
   buttonMessage?: string;
@@ -62,7 +61,6 @@ const SimpleDialog = ({
         {buttonMessage}
       </HvButton>
       <HvDialog
-        disableBackdropClick
         classes={classes}
         open={open}
         onClose={() => setOpen(false)}
@@ -216,87 +214,17 @@ export const SemanticVariants: StoryObj<HvDialogProps> = {
 export const Form: StoryObj<HvDialogProps> = {
   parameters: {
     docs: {
+      source: { code: FormStoryRaw },
       description: {
         story:
           "An example of using a `form` in `HvDialog`. The sample uses the `autofocus` attribute to focus the Title input by default.<br /> \
-          Accessibility-wise, `HvDialog` should have an `aria-labelledby` linking to the most appropriate element, \
-          as well as an optional `aria-describedby` pointing to the main content.",
+          Accessibility-wise, `HvDialogTitle` automatically labels the dialog. A `aria-describedby` can be used to describe the content.",
       },
     },
     eyes: { include: false },
   },
-  decorators: [(Story) => <div style={{ minHeight: 400 }}>{Story()}</div>],
-  render: () => {
-    const [open, setOpen] = useState(false);
-    const [postData, setPostData] = useState({});
-
-    return (
-      <>
-        <HvButton style={{ width: "120px" }} onClick={() => setOpen(true)}>
-          Create a post
-        </HvButton>
-        <br />
-        <br />
-        <HvTypography variant="title4">Data:</HvTypography>
-        <pre>{JSON.stringify(postData, null, 2)}</pre>
-        <HvDialog
-          disableBackdropClick
-          open={open}
-          onClose={() => setOpen(false)}
-          aria-labelledby="hv-dialog-title"
-          aria-describedby="hv-dialog-description"
-        >
-          <HvDialogTitle id="hv-dialog-title" variant="warning">
-            Create a new post
-          </HvDialogTitle>
-          <HvDialogContent indentContent>
-            <div id="hv-dialog-description" style={{ marginBottom: 10 }}>
-              Fill the following form to create a post.
-            </div>
-            <form
-              id="create-post"
-              onSubmit={(event) => {
-                event.preventDefault();
-                const formData = new FormData(event.currentTarget);
-                setPostData(Object.fromEntries(formData.entries()));
-                setOpen(false);
-              }}
-            >
-              <HvGrid container rowSpacing="xs">
-                <HvGrid item xs={12}>
-                  <HvInput
-                    required
-                    name="author"
-                    label="Author"
-                    defaultValue="John Doe"
-                  />
-                </HvGrid>
-                <HvGrid item xs={12}>
-                  <HvInput required name="title" label="Title" autoFocus />
-                </HvGrid>
-                <HvGrid item xs={12}>
-                  <HvTextArea
-                    required
-                    label="Description"
-                    name="content"
-                    rows={4}
-                  />
-                </HvGrid>
-              </HvGrid>
-            </form>
-          </HvDialogContent>
-          <HvDialogActions>
-            <HvButton type="submit" form="create-post" variant="primary">
-              Create
-            </HvButton>
-            <HvButton variant="secondaryGhost" onClick={() => setOpen(false)}>
-              Cancel
-            </HvButton>
-          </HvDialogActions>
-        </HvDialog>
-      </>
-    );
-  },
+  decorators: [(Story) => <div style={{ minHeight: 440 }}>{Story()}</div>],
+  render: () => <FormStory />,
 };
 
 export const LongContent: StoryObj<HvDialogProps> = {

--- a/packages/core/src/Dialog/Title/Title.styles.tsx
+++ b/packages/core/src/Dialog/Title/Title.styles.tsx
@@ -3,13 +3,22 @@ import { theme } from "@hitachivantara/uikit-styles";
 import { createClasses } from "../../utils/classes";
 
 export const { staticClasses, useClasses } = createClasses("HvDialog-Title", {
-  root: { padding: theme.space.sm, margin: 0 },
+  root: {
+    fontFamily: theme.fontFamily.body, // override MUI font
+    padding: theme.space.sm,
+    margin: 0,
+  },
   fullscreen: {},
-  messageContainer: { display: "flex", alignItems: "center" },
+  messageContainer: {
+    display: "flex",
+    alignItems: "center",
+  },
   textWithIcon: {
     marginLeft: theme.space.xs,
     // 32px is the icon width
     marginRight: `calc(32px + ${theme.space.xs})`,
   },
-  titleText: {},
+  titleText: {
+    ...theme.typography.title4,
+  },
 });

--- a/packages/core/src/Dialog/Title/Title.tsx
+++ b/packages/core/src/Dialog/Title/Title.tsx
@@ -3,13 +3,11 @@ import MuiDialogTitle, {
 } from "@mui/material/DialogTitle";
 
 import { useDefaultProps } from "../../hooks/useDefaultProps";
-
-import { HvTypography } from "../../Typography";
 import { ExtractNames } from "../../utils/classes";
 import { iconVariant } from "../../utils/iconVariant";
 
-import { staticClasses, useClasses } from "./Title.styles";
 import { useDialogContext } from "../context";
+import { staticClasses, useClasses } from "./Title.styles";
 
 export { staticClasses as dialogTitleClasses };
 
@@ -66,14 +64,13 @@ export const HvDialogTitle = (props: HvDialogTitleProps) => {
     >
       <div className={classes.messageContainer}>
         {icon}
-        <div className={cx({ [classes.textWithIcon]: !!icon })}>
-          {!isString ? (
-            children
-          ) : (
-            <HvTypography variant="title4" className={classes.titleText}>
-              {children}
-            </HvTypography>
-          )}
+        <div
+          className={cx({
+            [classes.textWithIcon]: !!icon,
+            [classes.titleText]: isString,
+          })}
+        >
+          {children}
         </div>
       </div>
     </MuiDialogTitle>

--- a/packages/core/src/Dialog/stories/FormStory.tsx
+++ b/packages/core/src/Dialog/stories/FormStory.tsx
@@ -1,0 +1,74 @@
+import { useId, useState } from "react";
+import {
+  HvButton,
+  HvDialog,
+  HvDialogActions,
+  HvDialogContent,
+  HvDialogTitle,
+  HvGrid,
+  HvInput,
+  HvTextArea,
+  HvTypography,
+} from "@hitachivantara/uikit-react-core";
+
+const DialogForm = () => (
+  <HvGrid container rowSpacing="xs">
+    <HvGrid item xs={12}>
+      <HvInput required name="author" label="Author" defaultValue="John Doe" />
+    </HvGrid>
+    <HvGrid item xs={12}>
+      <HvInput required name="title" label="Title" autoFocus />
+    </HvGrid>
+    <HvGrid item xs={12}>
+      <HvTextArea name="content" label="Description" rows={4} />
+    </HvGrid>
+  </HvGrid>
+);
+
+export const FormStory = () => {
+  const descId = useId();
+  const [open, setOpen] = useState(false);
+  const [postData, setPostData] = useState({});
+
+  return (
+    <>
+      <HvButton onClick={() => setOpen(true)}>Create a post</HvButton>
+      <br />
+      <br />
+      <HvTypography variant="title4">Data:</HvTypography>
+      <pre>{JSON.stringify(postData, null, 2)}</pre>
+      <HvDialog
+        disableBackdropClick
+        open={open}
+        onClose={() => setOpen(false)}
+        aria-describedby={descId}
+      >
+        <HvDialogTitle>Create a new post</HvDialogTitle>
+        <HvDialogContent>
+          <div id={descId} style={{ marginBottom: 10 }}>
+            Fill the following form to create a post.
+          </div>
+          <form
+            id="create-post"
+            onSubmit={(event) => {
+              event.preventDefault();
+              const formData = new FormData(event.currentTarget);
+              setPostData(Object.fromEntries(formData.entries()));
+              setOpen(false);
+            }}
+          >
+            <DialogForm />
+          </form>
+        </HvDialogContent>
+        <HvDialogActions>
+          <HvButton type="submit" form="create-post">
+            Create
+          </HvButton>
+          <HvButton variant="secondaryGhost" onClick={() => setOpen(false)}>
+            Cancel
+          </HvButton>
+        </HvDialogActions>
+      </HvDialog>
+    </>
+  );
+};


### PR DESCRIPTION
- Fix `HvDialogTitle` having `h4` inside an `h2` by default
  - move `HvTypography variant="title4"` styles to CSS
- review `DialogForm` sample:
  - show source code
  - remove mention to `aria-labelledby` - it's automatically handled by `HvDialog`