### PR TITLE
refactor: remove lodash & bump to ES2022 syntax

### DIFF
--- a/.config/vite.config.ts
+++ b/.config/vite.config.ts
@@ -23,7 +23,7 @@ export default defineConfig({
     tsconfigPaths(),
   ],
   build: {
-    target: "ES2021",
+    target: "ES2022",
     minify: false,
     emptyOutDir: true,
     lib: {

--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -34,11 +34,11 @@
     "react-router-dom": "^6.20.1",
     "reactflow": "^11.10.1",
     "swr": "^2.2.4",
+    "usehooks-ts": "^2.16.0",
     "yup": "^1.3.2"
   },
   "devDependencies": {
     "@hitachivantara/uikit-uno-preset": "*",
-    "@types/lodash": "^4.14.202",
     "@types/react": "^18.2.43",
     "@types/react-dom": "^18.2.17",
     "@vitejs/plugin-react": "^4.2.1",

--- a/apps/app/src/components/components/Controls/makedata.ts
+++ b/apps/app/src/components/components/Controls/makedata.ts
@@ -1,5 +1,4 @@
 import { HvTableColumnConfig } from "@hitachivantara/uikit-react-core";
-import range from "lodash/range";
 
 export interface NewEntry {
   id: string;
@@ -43,7 +42,7 @@ const newEntry = (i: number): NewEntry => {
   };
 };
 
-export const makeData = (len = 10) => range(len).map(newEntry);
+export const makeData = (len = 10) => [...Array(len).keys()].map(newEntry);
 
 export const getColumns = (): HvTableColumnConfig<NewEntry, string>[] => [
   { Header: "Title", accessor: "name", style: { minWidth: 220 } },

--- a/apps/app/src/generator/CodeEditor/CodeEditor.tsx
+++ b/apps/app/src/generator/CodeEditor/CodeEditor.tsx
@@ -1,6 +1,6 @@
 import { Dispatch, SetStateAction, useEffect, useState } from "react";
 import { css } from "@emotion/css";
-import debounce from "lodash/debounce";
+import { useDebounceCallback } from "usehooks-ts";
 import JSON5 from "json5";
 import { HvIconButton, useTheme } from "@hitachivantara/uikit-react-core";
 import { Download, Reset, Duplicate } from "@hitachivantara/uikit-react-icons";
@@ -89,7 +89,7 @@ const CodeEditor = ({
     }
   };
 
-  const debouncedHandler = debounce(codeChangedHandler, 1000);
+  const debouncedHandler = useDebounceCallback(codeChangedHandler, 1000);
 
   return (
     <div className="relative">

--- a/apps/app/src/generator/GeneratorContext.tsx
+++ b/apps/app/src/generator/GeneratorContext.tsx
@@ -12,8 +12,11 @@ import {
   DeepPartial,
   HvTheme,
 } from "@hitachivantara/uikit-react-core";
-import { HvBaseTheme, HvThemeStructure } from "@hitachivantara/uikit-styles";
-import merge from "lodash/merge";
+import {
+  HvBaseTheme,
+  HvThemeStructure,
+  mergeTheme,
+} from "@hitachivantara/uikit-styles";
 
 import { themeDiff } from "./utils";
 
@@ -86,14 +89,13 @@ const GeneratorProvider = ({ children }: { children: React.ReactNode }) => {
         if (!isBaseChange) {
           if (!isCodeEdit) {
             const diff = themeDiff(prev, changes);
-            return merge({}, prev, diff);
+            return mergeTheme(prev, diff);
           }
           newTheme = createTheme({
             base: changes.base as HvBaseTheme,
             name: prev.name,
           });
-          const merged = merge({}, newTheme, changes);
-          return merged;
+          return mergeTheme(newTheme, changes);
         }
 
         newTheme = createTheme({
@@ -107,9 +109,7 @@ const GeneratorProvider = ({ children }: { children: React.ReactNode }) => {
       // Update theme changes
       if (updateThemeChanges) {
         if (!isCodeEdit) {
-          setThemeChanges((prev) => {
-            return merge({}, prev, changes);
-          });
+          setThemeChanges((prev) => mergeTheme(prev, changes));
         } else {
           setThemeChanges(changes);
         }

--- a/apps/app/src/generator/Typography/Typography.tsx
+++ b/apps/app/src/generator/Typography/Typography.tsx
@@ -10,8 +10,7 @@ import {
 } from "@hitachivantara/uikit-react-core";
 import { HvThemeTokens, HvThemeTypography } from "@hitachivantara/uikit-styles";
 
-import debounce from "lodash/debounce";
-
+import { useDebounceCallback } from "usehooks-ts";
 import { css } from "@emotion/css";
 
 import { extractFontSizeUnit } from "~/generator/utils";
@@ -257,7 +256,10 @@ const Typography = () => {
     });
   };
 
-  const debouncedColorChangedHandler = debounce(colorChangedHandler, 250);
+  const debouncedColorChangedHandler = useDebounceCallback(
+    colorChangedHandler,
+    250
+  );
 
   return (
     <div className="flex flex-col w-full">

--- a/apps/app/src/generator/utils.ts
+++ b/apps/app/src/generator/utils.ts
@@ -46,7 +46,7 @@ export const themeDiff = (a: object, b: object): object => {
         diff[key] = nestedDiff;
       }
     } else if (
-      !Object.prototype.hasOwnProperty.call(a, key) ||
+      !Object.hasOwn(a, key) ||
       a[key as keyof typeof b] !== b[key as keyof typeof b]
     ) {
       diff[key as keyof typeof b] = b[key as keyof typeof b];

--- a/docs/foundation/colors/Colors.stories.tsx
+++ b/docs/foundation/colors/Colors.stories.tsx
@@ -20,7 +20,7 @@ import { themeColors } from "./themeColors";
 function groupColors(colorsJson?: HvThemeColorModeStructure) {
   const colorsMap = new Map<string, string>();
   for (const key in colorsJson) {
-    if (Object.prototype.hasOwnProperty.call(colorsJson, key)) {
+    if (Object.hasOwn(colorsJson, key)) {
       colorsMap.set(key, colorsJson[key]);
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -32985,12 +32985,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/storycrawler/node_modules/chownr": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-      "dev": true
-    },
     "node_modules/storycrawler/node_modules/color-convert": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
@@ -33006,12 +33000,6 @@
       "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
       "dev": true
     },
-    "node_modules/storycrawler/node_modules/devtools-protocol": {
-      "version": "0.0.869402",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.869402.tgz",
-      "integrity": "sha512-VvlVYY+VDJe639yHs5PHISzdWTLL3Aw8rO4cvUtwvoxFd6FHbE4OpHHcde52M6096uYYazAmd4l0o5VuFRO2WA==",
-      "dev": true
-    },
     "node_modules/storycrawler/node_modules/escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
@@ -33021,19 +33009,6 @@
         "node": ">=0.8.0"
       }
     },
-    "node_modules/storycrawler/node_modules/find-up": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-      "dev": true,
-      "dependencies": {
-        "locate-path": "^5.0.0",
-        "path-exists": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/storycrawler/node_modules/has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -33041,80 +33016,6 @@
       "dev": true,
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/storycrawler/node_modules/locate-path": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-      "dev": true,
-      "dependencies": {
-        "p-locate": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/storycrawler/node_modules/p-limit": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-      "dev": true,
-      "dependencies": {
-        "p-try": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/storycrawler/node_modules/p-locate": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-      "dev": true,
-      "dependencies": {
-        "p-limit": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/storycrawler/node_modules/pkg-dir": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
-      "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
-      "dev": true,
-      "dependencies": {
-        "find-up": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/storycrawler/node_modules/puppeteer-core": {
-      "version": "9.1.1",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-9.1.1.tgz",
-      "integrity": "sha512-zbedbitVIGhmgz0nt7eIdLsnaoVZSlNJfBivqm2w67T8LR2bU1dvnruDZ8nQO0zn++Iet7zHbAOdnuS5+H2E7A==",
-      "dev": true,
-      "dependencies": {
-        "debug": "^4.1.0",
-        "devtools-protocol": "0.0.869402",
-        "extract-zip": "^2.0.0",
-        "https-proxy-agent": "^5.0.0",
-        "node-fetch": "^2.6.1",
-        "pkg-dir": "^4.2.0",
-        "progress": "^2.0.1",
-        "proxy-from-env": "^1.1.0",
-        "rimraf": "^3.0.2",
-        "tar-fs": "^2.0.0",
-        "unbzip2-stream": "^1.3.3",
-        "ws": "^7.2.3"
-      },
-      "engines": {
-        "node": ">=10.18.1"
       }
     },
     "node_modules/storycrawler/node_modules/supports-color": {
@@ -33127,39 +33028,6 @@
       },
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/storycrawler/node_modules/tar-fs": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
-      "integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
-      "dev": true,
-      "dependencies": {
-        "chownr": "^1.1.1",
-        "mkdirp-classic": "^0.5.2",
-        "pump": "^3.0.0",
-        "tar-stream": "^2.1.4"
-      }
-    },
-    "node_modules/storycrawler/node_modules/ws": {
-      "version": "7.5.9",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
-      "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
-      "dev": true,
-      "engines": {
-        "node": ">=8.3.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
       }
     },
     "node_modules/stream-read-all": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,6 @@
         "@testing-library/user-event": "^14.5.1",
         "@types/jest": "^29.5.12",
         "@types/leaflet": "^1.9.8",
-        "@types/lodash": "^4.14.202",
         "@types/node": "^20.11.6",
         "@types/react": "^18.2.43",
         "@types/react-dom": "^18.2.17",
@@ -126,11 +125,11 @@
         "react-router-dom": "^6.20.1",
         "reactflow": "^11.10.1",
         "swr": "^2.2.4",
+        "usehooks-ts": "^2.16.0",
         "yup": "^1.3.2"
       },
       "devDependencies": {
         "@hitachivantara/uikit-uno-preset": "*",
-        "@types/lodash": "^4.14.202",
         "@types/react": "^18.2.43",
         "@types/react-dom": "^18.2.17",
         "@vitejs/plugin-react": "^4.2.1",
@@ -4576,9 +4575,9 @@
       "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg=="
     },
     "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.22",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.22.tgz",
-      "integrity": "sha512-Wf963MzWtA2sjrNt+g18IAln9lKnlRp+K2eH4jjIoF1wYeq3aMREpG09xhlhdzS0EjwU7qmUJYangWa+151vZw==",
+      "version": "0.3.25",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
+      "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
       "dev": true,
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -7595,9 +7594,9 @@
       "dev": true
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.12.0.tgz",
-      "integrity": "sha512-+ac02NL/2TCKRrJu2wffk1kZ+RyqxVUlbjSagNgPm94frxtr+XDL12E5Ll1enWskLrtrZ2r8L3wED1orIibV/w==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.12.1.tgz",
+      "integrity": "sha512-iU2Sya8hNn1LhsYyf0N+L4Gf9Qc+9eBTJJJsaOGUp+7x4n2M9dxTt8UvhJl3oeftSjblSlpCfvjA/IfP3g5VjQ==",
       "cpu": [
         "arm"
       ],
@@ -7608,9 +7607,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.12.0.tgz",
-      "integrity": "sha512-OBqcX2BMe6nvjQ0Nyp7cC90cnumt8PXmO7Dp3gfAju/6YwG0Tj74z1vKrfRz7qAv23nBcYM8BCbhrsWqO7PzQQ==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.12.1.tgz",
+      "integrity": "sha512-wlzcWiH2Ir7rdMELxFE5vuM7D6TsOcJ2Yw0c3vaBR3VOsJFVTx9xvwnAvhgU5Ii8Gd6+I11qNHwndDscIm0HXg==",
       "cpu": [
         "arm64"
       ],
@@ -7621,9 +7620,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.12.0.tgz",
-      "integrity": "sha512-X64tZd8dRE/QTrBIEs63kaOBG0b5GVEd3ccoLtyf6IdXtHdh8h+I56C2yC3PtC9Ucnv0CpNFJLqKFVgCYe0lOQ==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.12.1.tgz",
+      "integrity": "sha512-YRXa1+aZIFN5BaImK+84B3uNK8C6+ynKLPgvn29X9s0LTVCByp54TB7tdSMHDR7GTV39bz1lOmlLDuedgTwwHg==",
       "cpu": [
         "arm64"
       ],
@@ -7634,9 +7633,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.12.0.tgz",
-      "integrity": "sha512-cc71KUZoVbUJmGP2cOuiZ9HSOP14AzBAThn3OU+9LcA1+IUqswJyR1cAJj3Mg55HbjZP6OLAIscbQsQLrpgTOg==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.12.1.tgz",
+      "integrity": "sha512-opjWJ4MevxeA8FhlngQWPBOvVWYNPFkq6/25rGgG+KOy0r8clYwL1CFd+PGwRqqMFVQ4/Qd3sQu5t7ucP7C/Uw==",
       "cpu": [
         "x64"
       ],
@@ -7647,9 +7646,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.12.0.tgz",
-      "integrity": "sha512-a6w/Y3hyyO6GlpKL2xJ4IOh/7d+APaqLYdMf86xnczU3nurFTaVN9s9jOXQg97BE4nYm/7Ga51rjec5nfRdrvA==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.12.1.tgz",
+      "integrity": "sha512-uBkwaI+gBUlIe+EfbNnY5xNyXuhZbDSx2nzzW8tRMjUmpScd6lCQYKY2V9BATHtv5Ef2OBq6SChEP8h+/cxifQ==",
       "cpu": [
         "arm"
       ],
@@ -7660,9 +7659,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.12.0.tgz",
-      "integrity": "sha512-0fZBq27b+D7Ar5CQMofVN8sggOVhEtzFUwOwPppQt0k+VR+7UHMZZY4y+64WJ06XOhBTKXtQB/Sv0NwQMXyNAA==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.12.1.tgz",
+      "integrity": "sha512-0bK9aG1kIg0Su7OcFTlexkVeNZ5IzEsnz1ept87a0TUgZ6HplSgkJAnFpEVRW7GRcikT4GlPV0pbtVedOaXHQQ==",
       "cpu": [
         "arm64"
       ],
@@ -7673,9 +7672,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.12.0.tgz",
-      "integrity": "sha512-eTvzUS3hhhlgeAv6bfigekzWZjaEX9xP9HhxB0Dvrdbkk5w/b+1Sxct2ZuDxNJKzsRStSq1EaEkVSEe7A7ipgQ==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.12.1.tgz",
+      "integrity": "sha512-qB6AFRXuP8bdkBI4D7UPUbE7OQf7u5OL+R94JE42Z2Qjmyj74FtDdLGeriRyBDhm4rQSvqAGCGC01b8Fu2LthQ==",
       "cpu": [
         "arm64"
       ],
@@ -7686,9 +7685,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.12.0.tgz",
-      "integrity": "sha512-ix+qAB9qmrCRiaO71VFfY8rkiAZJL8zQRXveS27HS+pKdjwUfEhqo2+YF2oI+H/22Xsiski+qqwIBxVewLK7sw==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.12.1.tgz",
+      "integrity": "sha512-sHig3LaGlpNgDj5o8uPEoGs98RII8HpNIqFtAI8/pYABO8i0nb1QzT0JDoXF/pxzqO+FkxvwkHZo9k0NJYDedg==",
       "cpu": [
         "riscv64"
       ],
@@ -7699,9 +7698,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.12.0.tgz",
-      "integrity": "sha512-TenQhZVOtw/3qKOPa7d+QgkeM6xY0LtwzR8OplmyL5LrgTWIXpTQg2Q2ycBf8jm+SFW2Wt/DTn1gf7nFp3ssVA==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.12.1.tgz",
+      "integrity": "sha512-nD3YcUv6jBJbBNFvSbp0IV66+ba/1teuBcu+fBBPZ33sidxitc6ErhON3JNavaH8HlswhWMC3s5rgZpM4MtPqQ==",
       "cpu": [
         "x64"
       ],
@@ -7712,9 +7711,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.12.0.tgz",
-      "integrity": "sha512-LfFdRhNnW0zdMvdCb5FNuWlls2WbbSridJvxOvYWgSBOYZtgBfW9UGNJG//rwMqTX1xQE9BAodvMH9tAusKDUw==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.12.1.tgz",
+      "integrity": "sha512-7/XVZqgBby2qp/cO0TQ8uJK+9xnSdJ9ct6gSDdEr4MfABrjTyrW6Bau7HQ73a2a5tPB7hno49A0y1jhWGDN9OQ==",
       "cpu": [
         "x64"
       ],
@@ -7725,9 +7724,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.12.0.tgz",
-      "integrity": "sha512-JPDxovheWNp6d7AHCgsUlkuCKvtu3RB55iNEkaQcf0ttsDU/JZF+iQnYcQJSk/7PtT4mjjVG8N1kpwnI9SLYaw==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.12.1.tgz",
+      "integrity": "sha512-CYc64bnICG42UPL7TrhIwsJW4QcKkIt9gGlj21gq3VV0LL6XNb1yAdHVp1pIi9gkts9gGcT3OfUYHjGP7ETAiw==",
       "cpu": [
         "arm64"
       ],
@@ -7738,9 +7737,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.12.0.tgz",
-      "integrity": "sha512-fjtuvMWRGJn1oZacG8IPnzIV6GF2/XG+h71FKn76OYFqySXInJtseAqdprVTDTyqPxQOG9Exak5/E9Z3+EJ8ZA==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.12.1.tgz",
+      "integrity": "sha512-LN+vnlZ9g0qlHGlS920GR4zFCqAwbv2lULrR29yGaWP9u7wF5L7GqWu9Ah6/kFZPXPUkpdZwd//TNR+9XC9hvA==",
       "cpu": [
         "ia32"
       ],
@@ -7751,9 +7750,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.12.0.tgz",
-      "integrity": "sha512-ZYmr5mS2wd4Dew/JjT0Fqi2NPB/ZhZ2VvPp7SmvPZb4Y1CG/LRcS6tcRo2cYU7zLK5A7cdbhWnnWmUjoI4qapg==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.12.1.tgz",
+      "integrity": "sha512-n+vkrSyphvmU0qkQ6QBNXCGr2mKjhP08mPRM/Xp5Ck2FV4NrHU+y6axzDeixUrCBHVUS51TZhjqrKBBsHLKb2Q==",
       "cpu": [
         "x64"
       ],
@@ -8974,9 +8973,9 @@
       }
     },
     "node_modules/@storybook/core-common/node_modules/@types/node": {
-      "version": "18.19.17",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.17.tgz",
-      "integrity": "sha512-SzyGKgwPzuWp2SHhlpXKzCX0pIOfcI4V2eF37nNBJOhwlegQ83omtVQ1XxZpDE06V/d6AQvfQdPfnw0tRC//Ng==",
+      "version": "18.19.22",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.22.tgz",
+      "integrity": "sha512-p3pDIfuMg/aXBmhkyanPshdfJuX5c5+bQjYLIikPLXAUycEogij/c50n/C+8XOA5L93cU4ZRXtn+dNQGi0IZqQ==",
       "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
@@ -9065,9 +9064,9 @@
       }
     },
     "node_modules/@storybook/core-server/node_modules/@types/node": {
-      "version": "18.19.17",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.17.tgz",
-      "integrity": "sha512-SzyGKgwPzuWp2SHhlpXKzCX0pIOfcI4V2eF37nNBJOhwlegQ83omtVQ1XxZpDE06V/d6AQvfQdPfnw0tRC//Ng==",
+      "version": "18.19.22",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.22.tgz",
+      "integrity": "sha512-p3pDIfuMg/aXBmhkyanPshdfJuX5c5+bQjYLIikPLXAUycEogij/c50n/C+8XOA5L93cU4ZRXtn+dNQGi0IZqQ==",
       "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
@@ -9516,9 +9515,9 @@
       }
     },
     "node_modules/@storybook/react/node_modules/@types/node": {
-      "version": "18.19.17",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.17.tgz",
-      "integrity": "sha512-SzyGKgwPzuWp2SHhlpXKzCX0pIOfcI4V2eF37nNBJOhwlegQ83omtVQ1XxZpDE06V/d6AQvfQdPfnw0tRC//Ng==",
+      "version": "18.19.22",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.22.tgz",
+      "integrity": "sha512-p3pDIfuMg/aXBmhkyanPshdfJuX5c5+bQjYLIikPLXAUycEogij/c50n/C+8XOA5L93cU4ZRXtn+dNQGi0IZqQ==",
       "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
@@ -10741,9 +10740,9 @@
       "integrity": "sha512-nG96G3Wp6acyAgJqGasjODb+acrI7KltPiRxzHPXnP3NgI28bpQDRv53olbqGXbfcgF5aiiHmO3xpwEpS5Ld9g=="
     },
     "node_modules/@types/node": {
-      "version": "20.11.19",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.19.tgz",
-      "integrity": "sha512-7xMnVEcZFu0DikYjWOlRq7NTPETrm7teqUT2WkQjrTIkEgUyyGdWsj/Zg8bEJt5TNklzbPD1X3fqfsHw3SpapQ==",
+      "version": "20.11.25",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.25.tgz",
+      "integrity": "sha512-TBHyJxk2b7HceLVGFcpAUjsa5zIdsPWlR6XHfyGzd0SFu+/NFgQgMAl96MSDZgQDvJAvV6BKsFOrt6zIL09JDw==",
       "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
@@ -11989,9 +11988,9 @@
       }
     },
     "node_modules/@wdio/types/node_modules/@types/node": {
-      "version": "18.19.17",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.17.tgz",
-      "integrity": "sha512-SzyGKgwPzuWp2SHhlpXKzCX0pIOfcI4V2eF37nNBJOhwlegQ83omtVQ1XxZpDE06V/d6AQvfQdPfnw0tRC//Ng==",
+      "version": "18.19.22",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.22.tgz",
+      "integrity": "sha512-p3pDIfuMg/aXBmhkyanPshdfJuX5c5+bQjYLIikPLXAUycEogij/c50n/C+8XOA5L93cU4ZRXtn+dNQGi0IZqQ==",
       "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
@@ -23571,9 +23570,9 @@
       }
     },
     "node_modules/lint-staged/node_modules/npm-run-path": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.2.0.tgz",
-      "integrity": "sha512-W4/tgAXFqFA0iL7fk0+uQ3g7wkL8xJmx3XdK0VGb4cHW//eZTtKGvFBBoRKVTpY7n6ze4NL9ly7rgXcHufqXKg==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
+      "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
       "dev": true,
       "dependencies": {
         "path-key": "^4.0.0"
@@ -24110,9 +24109,9 @@
       }
     },
     "node_modules/magic-string": {
-      "version": "0.30.7",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.7.tgz",
-      "integrity": "sha512-8vBuFF/I/+OSLRmdf2wwFCJCz+nSn0m6DPvGH1fS/KiQoSaR+sETbov0eIk9KhEKy8CYqIkIAnbohxT/4H0kuA==",
+      "version": "0.30.8",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.8.tgz",
+      "integrity": "sha512-ISQTe55T2ao7XtlAStud6qwYPZjE4GK1S/BeVPus4jrq6JuOnQ00YKQC581RWhR122W7msZV263KzVeLoqidyQ==",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.4.15"
       },
@@ -27781,9 +27780,9 @@
       }
     },
     "node_modules/nypm/node_modules/npm-run-path": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.2.0.tgz",
-      "integrity": "sha512-W4/tgAXFqFA0iL7fk0+uQ3g7wkL8xJmx3XdK0VGb4cHW//eZTtKGvFBBoRKVTpY7n6ze4NL9ly7rgXcHufqXKg==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
+      "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
       "dev": true,
       "dependencies": {
         "path-key": "^4.0.0"
@@ -32951,9 +32950,9 @@
       }
     },
     "node_modules/storycrawler/node_modules/@types/node": {
-      "version": "18.19.17",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.17.tgz",
-      "integrity": "sha512-SzyGKgwPzuWp2SHhlpXKzCX0pIOfcI4V2eF37nNBJOhwlegQ83omtVQ1XxZpDE06V/d6AQvfQdPfnw0tRC//Ng==",
+      "version": "18.19.22",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.22.tgz",
+      "integrity": "sha512-p3pDIfuMg/aXBmhkyanPshdfJuX5c5+bQjYLIikPLXAUycEogij/c50n/C+8XOA5L93cU4ZRXtn+dNQGi0IZqQ==",
       "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
@@ -33997,15 +33996,12 @@
       }
     },
     "node_modules/tmp": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
-      "integrity": "sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.3.tgz",
+      "integrity": "sha512-nZD7m9iCPC5g0pYmcaxogYKggSfLsdxl8of3Q/oIbqCqLLIO9IAF0GWjX1z9NZRHPiXv8Wex4yDCaZsgEw0Y8w==",
       "dev": true,
-      "dependencies": {
-        "rimraf": "^3.0.0"
-      },
       "engines": {
-        "node": ">=8.17.0"
+        "node": ">=14.14"
       }
     },
     "node_modules/tmpl": {
@@ -35683,9 +35679,9 @@
       }
     },
     "node_modules/usehooks-ts": {
-      "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/usehooks-ts/-/usehooks-ts-2.14.0.tgz",
-      "integrity": "sha512-jnhrjTRJoJS7cFxz63tRYc5mzTKf/h+Ii8P0PDHymT9qDe4ZA2/gzDRmDR4WGausg5X8wMIdghwi3BBCN9JKow==",
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/usehooks-ts/-/usehooks-ts-2.16.0.tgz",
+      "integrity": "sha512-bez95WqYujxp6hFdM/CpRDiVPirZPxlMzOH2QB8yopoKQMXpscyZoxOjpEdaxvV+CAWUDSM62cWnqHE0E/MZ7w==",
       "dependencies": {
         "lodash.debounce": "^4.0.8"
       },
@@ -36489,9 +36485,9 @@
       }
     },
     "node_modules/vite/node_modules/rollup": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.12.0.tgz",
-      "integrity": "sha512-wz66wn4t1OHIJw3+XU7mJJQV/2NAfw5OAk6G6Hoo3zcvz/XOfQ52Vgi+AN4Uxoxi0KBBwk2g8zPrTDA4btSB/Q==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.12.1.tgz",
+      "integrity": "sha512-ggqQKvx/PsB0FaWXhIvVkSWh7a/PCLQAsMjBc+nA2M8Rv2/HG0X6zvixAB7KyZBRtifBUhy5k8voQX/mRnABPg==",
       "dev": true,
       "dependencies": {
         "@types/estree": "1.0.5"
@@ -36504,19 +36500,19 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.12.0",
-        "@rollup/rollup-android-arm64": "4.12.0",
-        "@rollup/rollup-darwin-arm64": "4.12.0",
-        "@rollup/rollup-darwin-x64": "4.12.0",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.12.0",
-        "@rollup/rollup-linux-arm64-gnu": "4.12.0",
-        "@rollup/rollup-linux-arm64-musl": "4.12.0",
-        "@rollup/rollup-linux-riscv64-gnu": "4.12.0",
-        "@rollup/rollup-linux-x64-gnu": "4.12.0",
-        "@rollup/rollup-linux-x64-musl": "4.12.0",
-        "@rollup/rollup-win32-arm64-msvc": "4.12.0",
-        "@rollup/rollup-win32-ia32-msvc": "4.12.0",
-        "@rollup/rollup-win32-x64-msvc": "4.12.0",
+        "@rollup/rollup-android-arm-eabi": "4.12.1",
+        "@rollup/rollup-android-arm64": "4.12.1",
+        "@rollup/rollup-darwin-arm64": "4.12.1",
+        "@rollup/rollup-darwin-x64": "4.12.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.12.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.12.1",
+        "@rollup/rollup-linux-arm64-musl": "4.12.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.12.1",
+        "@rollup/rollup-linux-x64-gnu": "4.12.1",
+        "@rollup/rollup-linux-x64-musl": "4.12.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.12.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.12.1",
+        "@rollup/rollup-win32-x64-msvc": "4.12.1",
         "fsevents": "~2.3.2"
       }
     },
@@ -36663,9 +36659,9 @@
       }
     },
     "node_modules/vitest/node_modules/npm-run-path": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.2.0.tgz",
-      "integrity": "sha512-W4/tgAXFqFA0iL7fk0+uQ3g7wkL8xJmx3XdK0VGb4cHW//eZTtKGvFBBoRKVTpY7n6ze4NL9ly7rgXcHufqXKg==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
+      "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
       "dev": true,
       "dependencies": {
         "path-key": "^4.0.0"
@@ -36887,9 +36883,9 @@
       }
     },
     "node_modules/webdriver/node_modules/@types/node": {
-      "version": "18.19.17",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.17.tgz",
-      "integrity": "sha512-SzyGKgwPzuWp2SHhlpXKzCX0pIOfcI4V2eF37nNBJOhwlegQ83omtVQ1XxZpDE06V/d6AQvfQdPfnw0tRC//Ng==",
+      "version": "18.19.22",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.22.tgz",
+      "integrity": "sha512-p3pDIfuMg/aXBmhkyanPshdfJuX5c5+bQjYLIikPLXAUycEogij/c50n/C+8XOA5L93cU4ZRXtn+dNQGi0IZqQ==",
       "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
@@ -37610,7 +37606,6 @@
         "dayjs": "^1.11.10",
         "detect-browser": "^5.3.0",
         "embla-carousel-react": "^8.0.0-rc15",
-        "lodash": "^4.17.21",
         "notistack": "^2.0.8",
         "rc-slider": "^10.5.0",
         "rc-tooltip": "^6.1.2",
@@ -37681,7 +37676,6 @@
         "@hitachivantara/uikit-react-icons": "^5.8.6",
         "@hitachivantara/uikit-styles": "^5.22.0",
         "@types/react-grid-layout": "^1.3.5",
-        "lodash": "^4.17.21",
         "react-grid-layout": "^1.4.4",
         "reactflow": "^11.10.1",
         "uid": "^2.0.2",

--- a/package.json
+++ b/package.json
@@ -125,6 +125,11 @@
     "zod": "^3.22.4",
     "zustand": "^4.4.7"
   },
+  "overrides": {
+    "storycrawler": {
+      "puppeteer-core": "20.9.0"
+    }
+  },
   "husky": {
     "hooks": {
       "pre-commit": "lint-staged",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,6 @@
     "@testing-library/user-event": "^14.5.1",
     "@types/jest": "^29.5.12",
     "@types/leaflet": "^1.9.8",
-    "@types/lodash": "^4.14.202",
     "@types/node": "^20.11.6",
     "@types/react": "^18.2.43",
     "@types/react-dom": "^18.2.17",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -57,7 +57,6 @@
     "dayjs": "^1.11.10",
     "detect-browser": "^5.3.0",
     "embla-carousel-react": "^8.0.0-rc15",
-    "lodash": "^4.17.21",
     "notistack": "^2.0.8",
     "rc-slider": "^10.5.0",
     "rc-tooltip": "^6.1.2",

--- a/packages/core/src/BulkActions/BulkActions.stories.tsx
+++ b/packages/core/src/BulkActions/BulkActions.stories.tsx
@@ -10,7 +10,8 @@ import {
   HvActionGeneric,
   theme,
 } from "@hitachivantara/uikit-react-core";
-import uniqueId from "lodash/uniqueId";
+
+const uniqueId = () => Math.random().toString(36).slice(2, 9);
 
 const actions: HvActionGeneric[] = [
   { id: "add", label: "Add", icon: <Add /> },

--- a/packages/core/src/Calendar/utils.tsx
+++ b/packages/core/src/Calendar/utils.tsx
@@ -1,7 +1,6 @@
 import dayjs from "dayjs";
 
-import capitalize from "lodash/capitalize";
-
+import { capitalize } from "../utils/helpers";
 import { DateRangeProp } from "./types";
 
 /**

--- a/packages/core/src/Carousel/Carousel.tsx
+++ b/packages/core/src/Carousel/Carousel.tsx
@@ -20,14 +20,12 @@ import { HvButton } from "../Button";
 import { useTheme } from "../hooks/useTheme";
 import { HvTypography } from "../Typography";
 import { HvContainer } from "../Container";
+import { clamp } from "../utils/helpers";
 import { ExtractNames } from "../utils/classes";
 import { HvCarouselControls } from "./CarouselControls";
 import { HvCarouselThumbnails } from "./CarouselThumbnails";
 import { staticClasses, useClasses } from "./Carousel.styles";
 import { HvIconButton } from "../IconButton";
-
-const clamp = (num: number, max: number, min = 0) =>
-  Math.min(Math.max(num, min), max);
 
 export { staticClasses as carouselClasses };
 
@@ -162,7 +160,7 @@ export const HvCarousel = (props: HvCarouselProps) => {
     if (!controller) return;
 
     controller.reInit();
-    setSelectedIndex((currentIndex) => clamp(currentIndex, numSlides, 0));
+    setSelectedIndex((currentIndex) => clamp(currentIndex, numSlides));
   }, [numSlides, controller]);
 
   const canPrev = controller?.canScrollPrev() ?? false;

--- a/packages/core/src/Controls/makedata.ts
+++ b/packages/core/src/Controls/makedata.ts
@@ -1,5 +1,4 @@
-import range from "lodash/range";
-
+import { range } from "../utils/helpers";
 import { HvTableColumnConfig } from "../Table";
 
 export interface NewEntry {

--- a/packages/core/src/DotPagination/DotPagination.tsx
+++ b/packages/core/src/DotPagination/DotPagination.tsx
@@ -4,6 +4,7 @@ import { CurrentStep, OtherStep } from "@hitachivantara/uikit-react-icons";
 import { HvRadio } from "../Radio";
 import { HvRadioGroup, HvRadioGroupProps } from "../RadioGroup";
 import { ExtractNames } from "../utils/classes";
+import { range } from "../utils/helpers";
 
 import { useDefaultProps } from "../hooks/useDefaultProps";
 
@@ -69,8 +70,6 @@ const getSelectorIcons = (
     ),
   };
 };
-
-const range = (n: number) => Array.from(Array(n), (_, i) => i);
 
 /**
  * Pagination is the process of dividing a document into discrete pages. It relates to how users interact with structured content on a website or application.

--- a/packages/core/src/FileUploader/DropZone/DropZone.tsx
+++ b/packages/core/src/FileUploader/DropZone/DropZone.tsx
@@ -1,12 +1,9 @@
 import React, { useRef, useState } from "react";
-
-import uniqueId from "lodash/uniqueId";
-
 import { Doc } from "@hitachivantara/uikit-react-icons";
 
 import { setId } from "../../utils/setId";
 import { useUniqueId } from "../../hooks/useUniqueId";
-
+import { uniqueId } from "../../utils/helpers";
 import { HvTypography } from "../../Typography";
 import { HvInfoMessage, HvLabel } from "../../Forms";
 import { ExtractNames } from "../../utils/classes";

--- a/packages/core/src/FilterGroup/FilterGroupContext.tsx
+++ b/packages/core/src/FilterGroup/FilterGroupContext.tsx
@@ -7,8 +7,8 @@ import {
   useMemo,
   useState,
 } from "react";
-import isEqual from "lodash/isEqual";
 
+import { isEqual } from "../utils/helpers";
 import { useDefaultProps } from "../hooks/useDefaultProps";
 import { useSavedState } from "../utils/useSavedState";
 import { HvFilterGroupFilters, HvFilterGroupValue } from "./types";

--- a/packages/core/src/FilterGroup/RightPanel/RightPanel.tsx
+++ b/packages/core/src/FilterGroup/RightPanel/RightPanel.tsx
@@ -1,5 +1,4 @@
 import { useCallback, useContext, useEffect, useMemo, useState } from "react";
-import cloneDeep from "lodash/cloneDeep";
 
 import { HvCheckBox } from "../../CheckBox";
 import { HvInput } from "../../Input";
@@ -106,7 +105,7 @@ export const HvFilterGroupRightPanel = ({
   };
 
   const handleSelectAll = useCallback(() => {
-    const newFilterValues = cloneDeep(filterValues);
+    const newFilterValues = structuredClone(filterValues);
 
     if (anySelected) {
       if (searchStr !== "") {

--- a/packages/core/src/Grid/Grid.tsx
+++ b/packages/core/src/Grid/Grid.tsx
@@ -1,8 +1,6 @@
 import { forwardRef } from "react";
 import MuiGrid, { GridProps as MuiGridProps } from "@mui/material/Grid";
 
-import isString from "lodash/isString";
-
 import { useDefaultProps } from "../hooks/useDefaultProps";
 import { useWidth } from "../hooks/useWidth";
 import { ExtractNames } from "../utils/classes";
@@ -149,7 +147,7 @@ export interface HvGridProps extends Omit<MuiGridProps, "classes" | "columns"> {
 function getGridSpacing(spacing: HvGridProps["spacing"]) {
   let gridSpacing: MuiGridProps["spacing"];
 
-  if (isString(spacing)) {
+  if (typeof spacing === "string") {
     if (spacing === "auto") {
       gridSpacing = BREAKPOINT_GUTTERS;
     } else {

--- a/packages/core/src/Loading/Loading.tsx
+++ b/packages/core/src/Loading/Loading.tsx
@@ -1,7 +1,6 @@
 import { HvColorAny, getColor } from "@hitachivantara/uikit-styles";
 
-import range from "lodash/range";
-
+import { range } from "../utils/helpers";
 import { HvBaseProps } from "../types/generic";
 import { ExtractNames } from "../utils/classes";
 import { useDefaultProps } from "../hooks/useDefaultProps";
@@ -62,7 +61,7 @@ export const HvLoading = (props: HvLoadingProps) => {
       {...others}
     >
       <div className={classes.barContainer}>
-        {range(0, 3).map((e) => (
+        {range(3).map((e) => (
           <div
             key={e}
             style={inline}

--- a/packages/core/src/MultiButton/MultiButton.stories.tsx
+++ b/packages/core/src/MultiButton/MultiButton.stories.tsx
@@ -1,5 +1,4 @@
 import { MouseEvent, useState } from "react";
-import range from "lodash/range";
 import { Meta, StoryObj } from "@storybook/react";
 import {
   DropDownXS,
@@ -264,7 +263,7 @@ export const EnforcedSelection: StoryObj<HvMultiButtonProps> = {
     return (
       <div style={{ width: "600px" }}>
         <HvMultiButton>
-          {range(5).map((i) => (
+          {[...Array(5).keys()].map((i) => (
             <HvButton
               key={`ef-${i}`}
               startIcon={<LocationPin />}
@@ -303,7 +302,7 @@ export const MinimumSelection: StoryObj<HvMultiButtonProps> = {
     return (
       <div style={{ width: "800px" }}>
         <HvMultiButton>
-          {range(5).map((i) => (
+          {[...Array(5).keys()].map((i) => (
             <HvButton
               key={`ms-${i}`}
               startIcon={<LocationPin />}
@@ -342,7 +341,7 @@ export const MaximumSelection: StoryObj<HvMultiButtonProps> = {
     return (
       <div style={{ width: "800px" }}>
         <HvMultiButton>
-          {range(5).map((i) => (
+          {[...Array(5).keys()].map((i) => (
             <HvButton
               key={`maxse-${i}`}
               startIcon={<LocationPin />}

--- a/packages/core/src/ProgressBar/ProgressBar.tsx
+++ b/packages/core/src/ProgressBar/ProgressBar.tsx
@@ -1,10 +1,9 @@
-import clamp from "lodash/clamp";
-
 import { useDefaultProps } from "../hooks/useDefaultProps";
 
 import { HvBaseProps } from "../types/generic";
 import { HvTypography, HvTypographyProps } from "../Typography";
 
+import { clamp } from "../utils/helpers";
 import { ExtractNames } from "../utils/classes";
 
 import { staticClasses, useClasses } from "./ProgressBar.styles";
@@ -52,7 +51,7 @@ export const HvProgressBar = (props: HvProgressBarProps) => {
 
   const { classes, cx } = useClasses(classesProp);
 
-  const clampedValue = clamp(value, 0, 100);
+  const clampedValue = clamp(value, 100);
 
   return (
     <div

--- a/packages/core/src/QueryBuilder/QueryBuilder.tsx
+++ b/packages/core/src/QueryBuilder/QueryBuilder.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useMemo, useReducer, useRef, useState } from "react";
-import cloneDeep from "lodash/cloneDeep";
 import isEqual from "lodash/isEqual";
 
 import { useDefaultProps } from "../hooks/useDefaultProps";
@@ -126,7 +125,7 @@ export const HvQueryBuilder = (props: HvQueryBuilderProps) => {
   const [state, dispatchAction] = useReducer(
     reducer,
     // Deep clone is needed to make sure that the "query" prop and "initialQuery" are not mutated
-    cloneDeep(initialQuery.current)
+    structuredClone(initialQuery.current)
   );
 
   const value = useMemo(
@@ -178,7 +177,7 @@ export const HvQueryBuilder = (props: HvQueryBuilderProps) => {
       }
 
       onChange?.(clearNodeIds(state) as HvQueryBuilderChangedQuery);
-      setPrevState(cloneDeep(state));
+      setPrevState(structuredClone(state));
     }
   }, [initialState, onChange, prevState, state]);
 

--- a/packages/core/src/QueryBuilder/QueryBuilder.tsx
+++ b/packages/core/src/QueryBuilder/QueryBuilder.tsx
@@ -1,8 +1,8 @@
 import { useEffect, useMemo, useReducer, useRef, useState } from "react";
-import isEqual from "lodash/isEqual";
 
 import { useDefaultProps } from "../hooks/useDefaultProps";
 import { ExtractNames } from "../utils/classes";
+import { isEqual } from "../utils/helpers";
 
 import { ConfirmationDialog } from "./ConfirmationDialog";
 import {

--- a/packages/core/src/QueryBuilder/Rule/Value/DateTimeValue/DateTimeValue.tsx
+++ b/packages/core/src/QueryBuilder/Rule/Value/DateTimeValue/DateTimeValue.tsx
@@ -1,5 +1,4 @@
 import { memo, useCallback, useMemo, useState } from "react";
-import uniqueId from "lodash/uniqueId";
 import dayjs from "dayjs";
 import { useTheme } from "@mui/material/styles";
 import useMediaQuery from "@mui/material/useMediaQuery";
@@ -7,6 +6,7 @@ import useMediaQuery from "@mui/material/useMediaQuery";
 import { HvWarningText } from "../../../../Forms";
 import { HvTimePicker, HvTimePickerValue } from "../../../../TimePicker";
 import { HvDatePicker } from "../../../../DatePicker";
+import { uniqueId } from "../../../../utils/helpers";
 
 import { useQueryBuilderContext } from "../../../Context";
 import { padTime, parseDate, parseTime } from "./utils";

--- a/packages/core/src/QueryBuilder/Rule/Value/NumericValue/NumericValue.tsx
+++ b/packages/core/src/QueryBuilder/Rule/Value/NumericValue/NumericValue.tsx
@@ -1,11 +1,9 @@
 import { memo, useCallback, useState } from "react";
-import uniqueId from "lodash/uniqueId";
-import isEmpty from "lodash/isEmpty";
 import { useTheme } from "@mui/material/styles";
 import useMediaQuery from "@mui/material/useMediaQuery";
 
 import { HvInput } from "../../../../Input";
-
+import { uniqueId } from "../../../../utils/helpers";
 import { useQueryBuilderContext } from "../../../Context";
 import { useClasses } from "./Numeric.styles";
 import { HvQueryBuilderNumericRange } from "../../../types";
@@ -34,7 +32,7 @@ export const NumericValue = ({
 
   const onSingleValueChange = useCallback(
     (_, data: string) => {
-      const numericData = isEmpty(data) ? null : Number(data);
+      const numericData = !data ? null : Number(data);
       dispatchAction({
         type: "set-value",
         id,
@@ -46,7 +44,7 @@ export const NumericValue = ({
 
   const onRangeValueChange = useCallback(
     (_, data: string, from = true) => {
-      const numericData = isEmpty(data) ? null : Number(data);
+      const numericData = !data ? null : Number(data);
       const currentValue = value;
       const numericRange = {
         from: currentValue?.from,

--- a/packages/core/src/Snackbar/Snackbar.tsx
+++ b/packages/core/src/Snackbar/Snackbar.tsx
@@ -5,8 +5,8 @@ import MuiSnackbar, {
   SnackbarOrigin,
   SnackbarProps as MuiSnackbarProps,
 } from "@mui/material/Snackbar";
-import capitalize from "lodash/capitalize";
 
+import { capitalize } from "../utils/helpers";
 import { ExtractNames } from "../utils/classes";
 import { setId } from "../utils/setId";
 import { HvActionGeneric, HvActionsGenericProps } from "../ActionsGeneric";

--- a/packages/core/src/Stack/Stack.tsx
+++ b/packages/core/src/Stack/Stack.tsx
@@ -5,9 +5,6 @@ import MuiDivider, {
   DividerProps as MuiDividerProps,
 } from "@mui/material/Divider";
 
-import isString from "lodash/isString";
-import isBoolean from "lodash/isBoolean";
-
 import { HvBreakpoints } from "@hitachivantara/uikit-styles";
 
 import { useWidth } from "../hooks/useWidth";
@@ -51,7 +48,7 @@ export interface HvStackProps extends HvBaseProps {
  *                     smaller than the current one to use.
  */
 const getDirection = (direction: any, width: any, breakpoints: any) => {
-  if (isString(direction)) return direction;
+  if (typeof direction === "string") return direction;
 
   for (let i = breakpoints.indexOf(width); i >= 0; i -= 1) {
     if (direction[breakpoints[i]] !== undefined) {
@@ -95,7 +92,7 @@ export const HvStack = (props: HvStackProps) => {
    *                   we use the custom divider the user passed.
    */
   const getDividerComponent = useCallback(() => {
-    if (isBoolean(divider) && divider) {
+    if (typeof divider === "boolean" && divider) {
       return (
         <MuiDivider
           orientation={

--- a/packages/core/src/Table/Table.test.tsx
+++ b/packages/core/src/Table/Table.test.tsx
@@ -1,4 +1,3 @@
-import range from "lodash/range";
 import { describe, expect, it } from "vitest";
 import { render, within } from "@testing-library/react";
 
@@ -67,15 +66,15 @@ describe("Simple Table", () => {
       <HvTable>
         <HvTableHead>
           <HvTableRow>
-            {range(NUM_COLS).map((id) => (
+            {[...Array(NUM_COLS).keys()].map((id) => (
               <HvTableHeader key={id}>{`Sample Header ${id}`}</HvTableHeader>
             ))}
           </HvTableRow>
         </HvTableHead>
         <HvTableBody>
-          {range(NUM_ROWS).map((id) => (
+          {[...Array(NUM_ROWS).keys()].map((id) => (
             <HvTableRow key={id}>
-              {range(NUM_COLS).map((id2) => (
+              {[...Array(NUM_COLS).keys()].map((id2) => (
                 <HvTableCell key={id2}>{`Sample Cell ${id2}`}</HvTableCell>
               ))}
             </HvTableRow>
@@ -104,15 +103,15 @@ describe("List Row", () => {
       <HvTable variant="listrow">
         <HvTableHead>
           <HvTableRow>
-            {range(NUM_COLS).map((id) => (
+            {[...Array(NUM_COLS).keys()].map((id) => (
               <HvTableHeader key={id}>{`Sample Header ${id}`}</HvTableHeader>
             ))}
           </HvTableRow>
         </HvTableHead>
         <HvTableBody withNavigation>
-          {range(NUM_ROWS).map((id) => (
+          {[...Array(NUM_ROWS).keys()].map((id) => (
             <HvTableRow key={id}>
-              {range(NUM_COLS).map((id2) => (
+              {[...Array(NUM_COLS).keys()].map((id2) => (
                 <HvTableCell key={id2}>{`Sample Cell ${id2}`}</HvTableCell>
               ))}
             </HvTableRow>
@@ -150,7 +149,7 @@ describe("Header Only Table", () => {
       <HvTable>
         <HvTableHead>
           <HvTableRow>
-            {range(NUM_COLS).map((id) => (
+            {[...Array(NUM_COLS).keys()].map((id) => (
               <HvTableHeader key={id}>{`Header ${id}`}</HvTableHeader>
             ))}
           </HvTableRow>

--- a/packages/core/src/Table/TableCell/TableCell.tsx
+++ b/packages/core/src/Table/TableCell/TableCell.tsx
@@ -1,6 +1,6 @@
 import { CSSProperties, forwardRef, TdHTMLAttributes, useContext } from "react";
-import capitalize from "lodash/capitalize";
 
+import { capitalize } from "../../utils/helpers";
 import { ExtractNames } from "../../utils/classes";
 import { useDefaultProps } from "../../hooks/useDefaultProps";
 

--- a/packages/core/src/Table/TableHeader/TableHeader.tsx
+++ b/packages/core/src/Table/TableHeader/TableHeader.tsx
@@ -5,9 +5,6 @@ import {
   useContext,
   useMemo,
 } from "react";
-
-import capitalize from "lodash/capitalize";
-
 import { hexToRgb, alpha } from "@mui/material/styles";
 
 import { theme } from "@hitachivantara/uikit-styles";
@@ -15,8 +12,8 @@ import { theme } from "@hitachivantara/uikit-styles";
 import { HvTypography, HvTypographyProps } from "../../Typography";
 import { useTheme } from "../../hooks/useTheme";
 import { ExtractNames } from "../../utils/classes";
+import { capitalize } from "../../utils/helpers";
 import { HvButton, HvButtonProps } from "../../Button";
-
 import { useDefaultProps } from "../../hooks/useDefaultProps";
 
 import TableContext from "../TableContext";

--- a/packages/core/src/Table/stories/TableComplete/TableComplete.tsx
+++ b/packages/core/src/Table/stories/TableComplete/TableComplete.tsx
@@ -31,8 +31,6 @@ import {
 
 import { LoadingContainer } from "../TableSamples/LoadingContainer";
 
-const range = (n: number) => [...Array(n).keys()];
-
 const classes = {
   root: css({}),
   container: css({
@@ -308,7 +306,7 @@ export const TableComplete = <T extends object>(props: TableProps<T>) => {
               {!data || data.length === 0 ? (
                 <NoDataRow message={labels.empty} />
               ) : (
-                range(pageSize ?? 0).map(renderTableRow)
+                [...Array(pageSize).keys()].map(renderTableRow)
               )}
             </HvTableBody>
           </HvTable>

--- a/packages/core/src/Table/stories/TableHooks/UseHvFilters.tsx
+++ b/packages/core/src/Table/stories/TableHooks/UseHvFilters.tsx
@@ -18,7 +18,7 @@ import {
   useHvFilters,
 } from "@hitachivantara/uikit-react-core";
 
-import { makeData, getColumns, AssetEvent, range } from "../storiesUtils";
+import { makeData, getColumns, AssetEvent } from "../storiesUtils";
 
 const NoDataRow = ({
   message,
@@ -111,7 +111,7 @@ export const UseHvFilters = () => {
             </HvTableHead>
             <HvTableBody {...getTableBodyProps()}>
               {page.length > 0 ? (
-                range(pageSize ?? 0).map(renderTableRow)
+                [...Array(pageSize ?? 0).keys()].map(renderTableRow)
               ) : (
                 <NoDataRow message="No data" />
               )}

--- a/packages/core/src/Table/stories/TableHooks/UseHvPagination.tsx
+++ b/packages/core/src/Table/stories/TableHooks/UseHvPagination.tsx
@@ -1,5 +1,4 @@
 import { useMemo } from "react";
-import range from "lodash/range";
 import {
   HvTable,
   HvTableBody,
@@ -69,7 +68,7 @@ export const UseHvPagination = () => {
             ))}
           </HvTableHead>
           <HvTableBody {...getTableBodyProps()}>
-            {pageSize && range(pageSize).map(renderTableRow)}
+            {pageSize && [...Array(pageSize).keys()].map(renderTableRow)}
           </HvTableBody>
         </HvTable>
       </HvTableContainer>

--- a/packages/core/src/Table/stories/TableSection/CompleteTableSection.tsx
+++ b/packages/core/src/Table/stories/TableSection/CompleteTableSection.tsx
@@ -1,5 +1,4 @@
 import { useState, useCallback, useMemo } from "react";
-import range from "lodash/range";
 import {
   HvTableContainer,
   HvTable,
@@ -127,7 +126,7 @@ export const CompleteTableSection = () => {
             ))}
           </HvTableHead>
           <HvTableBody {...getTableBodyProps()}>
-            {pageSize && range(pageSize).map(renderTableRow)}
+            {pageSize && [...Array(pageSize).keys()].map(renderTableRow)}
           </HvTableBody>
         </HvTable>
       </HvTableContainer>

--- a/packages/core/src/Table/stories/TableSection/PropsTableSection.tsx
+++ b/packages/core/src/Table/stories/TableSection/PropsTableSection.tsx
@@ -1,5 +1,4 @@
 import { useState, useMemo } from "react";
-import range from "lodash/range";
 import {
   HvTableContainer,
   HvTable,
@@ -106,7 +105,7 @@ export const PropsTableSection = () => {
             ))}
           </HvTableHead>
           <HvTableBody {...getTableBodyProps()}>
-            {pageSize && range(pageSize).map(renderTableRow)}
+            {pageSize && [...Array(pageSize).keys()].map(renderTableRow)}
           </HvTableBody>
         </HvTable>
       </HvTableContainer>

--- a/packages/core/src/Table/stories/TableSection/SimpleTableSection.tsx
+++ b/packages/core/src/Table/stories/TableSection/SimpleTableSection.tsx
@@ -1,5 +1,4 @@
 import { useState, useMemo } from "react";
-import range from "lodash/range";
 import {
   HvTableContainer,
   HvTable,
@@ -77,7 +76,7 @@ export const SimpleTableSection = () => {
             ))}
           </HvTableHead>
           <HvTableBody {...getTableBodyProps()}>
-            {pageSize && range(pageSize).map(renderTableRow)}
+            {pageSize && [...Array(pageSize).keys()].map(renderTableRow)}
           </HvTableBody>
         </HvTable>
       </HvTableContainer>

--- a/packages/core/src/Table/stories/TableSection/TableEditable.tsx
+++ b/packages/core/src/Table/stories/TableSection/TableEditable.tsx
@@ -26,12 +26,7 @@ import {
 } from "@hitachivantara/uikit-react-core";
 import { Add, Delete, Edit } from "@hitachivantara/uikit-react-icons";
 
-import {
-  AssetEvent,
-  getEditableColumns,
-  range,
-  useServerData,
-} from "../storiesUtils";
+import { AssetEvent, getEditableColumns, useServerData } from "../storiesUtils";
 import { LoadingContainer } from "../TableSamples/LoadingContainer";
 
 const slide = keyframes`
@@ -580,7 +575,7 @@ const Table = <T extends Data>({
               {data?.length === 0 ? (
                 <EmptyRow />
               ) : (
-                range(pageSize ?? 0).map(renderTableRow)
+                [...Array(pageSize ?? 0).keys()].map(renderTableRow)
               )}
             </HvTableBody>
           </HvTable>

--- a/packages/core/src/Table/stories/TableSection/TableFilter.tsx
+++ b/packages/core/src/Table/stories/TableSection/TableFilter.tsx
@@ -27,7 +27,7 @@ import {
 } from "@hitachivantara/uikit-react-core";
 import { Add, Close, Filters } from "@hitachivantara/uikit-react-icons";
 
-import { AssetEvent, getColumns, makeData, range } from "../storiesUtils";
+import { AssetEvent, getColumns, makeData } from "../storiesUtils";
 
 const EmptyRow = () => (
   <HvTableRow>
@@ -315,7 +315,7 @@ export const TableFilter = () => {
               {data.length === 0 ? (
                 <EmptyRow />
               ) : (
-                range(pageSize ?? 0).map(renderTableRow)
+                [...Array(pageSize ?? 0).keys()].map(renderTableRow)
               )}
             </HvTableBody>
           </HvTable>

--- a/packages/core/src/Table/stories/TableSection/TableSettings.tsx
+++ b/packages/core/src/Table/stories/TableSection/TableSettings.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from "react";
-import range from "lodash/range";
+import { css } from "@emotion/css";
 import {
   HvBaseDropdown,
   HvListContainer,
@@ -46,8 +46,6 @@ import {
   PreviewOff,
   Settings,
 } from "@hitachivantara/uikit-react-icons";
-
-import { css } from "@emotion/css";
 
 import { AssetEvent, getColumns, makeData } from "../storiesUtils";
 
@@ -524,7 +522,7 @@ export const TableSettings = () => {
             ))}
           </HvTableHead>
           <HvTableBody {...getTableBodyProps()}>
-            {pageSize && range(pageSize).map(renderTableRow)}
+            {pageSize && [...Array(pageSize).keys()].map(renderTableRow)}
           </HvTableBody>
         </HvTable>
       </HvTableContainer>

--- a/packages/core/src/Table/stories/storiesUtils.tsx
+++ b/packages/core/src/Table/stories/storiesUtils.tsx
@@ -53,8 +53,6 @@ export type AssetEvent = {
   selected?: boolean;
 };
 
-export const range = (n: number) => Array.from({ length: n }, (_, i) => i);
-
 // If a Cell gets a value, it has to return a react element
 const getCell = (value: string) => value as unknown as React.ReactElement;
 
@@ -142,12 +140,13 @@ const controlledSelectedEntry = (i: number): AssetEvent => {
 };
 
 export const makeRenderersData = (len: number = 10) =>
-  range(len).map(newRendererEntry);
+  [...Array(len).keys()].map(newRendererEntry);
 
-export const makeData = (len: number = 10) => range(len).map(makeEvent);
+export const makeData = (len: number = 10) =>
+  [...Array(len).keys()].map(makeEvent);
 
 export const makeSelectedData = (len: number = 10) =>
-  range(len).map(controlledSelectedEntry);
+  [...Array(len).keys()].map(controlledSelectedEntry);
 
 // https://react-table.tanstack.com/docs/api/useTable#column-options
 // width is only used if explicitly passed in column.getHeaderProps

--- a/packages/core/src/TagsInput/TagsInput.stories.tsx
+++ b/packages/core/src/TagsInput/TagsInput.stories.tsx
@@ -12,7 +12,6 @@ import {
   tagsInputClasses,
   theme,
 } from "@hitachivantara/uikit-react-core";
-import isEmpty from "lodash/isEmpty";
 
 import countryNamesArray from "./countries";
 
@@ -421,12 +420,12 @@ export const Suggestions: StoryObj<HvTagsInputProps> = {
     const countries = countryNamesArray;
 
     const suggestionHandler = (val: string) => {
-      if (typeof val !== "string" || isEmpty(val)) return null;
+      if (typeof val !== "string" || !val) return null;
       const foundCountries = countries.filter((country) =>
         country.toUpperCase().startsWith(val.toUpperCase())
       );
 
-      if (isEmpty(foundCountries)) return null;
+      if (foundCountries.length === 0) return null;
 
       return foundCountries.map((country, idx) => ({
         id: `c_${idx}`,
@@ -478,12 +477,12 @@ export const UnrestrictedSuggestions: StoryObj<HvTagsInputProps> = {
     const [statusMsg, setStatusMsg] = useState("");
 
     const suggestionHandler = (val: string) => {
-      if (typeof val !== "string" || isEmpty(val)) return null;
+      if (typeof val !== "string" || !val) return null;
       const foundOptions = options.filter((option) =>
         option.toUpperCase().startsWith(val.toUpperCase())
       );
 
-      if (isEmpty(foundOptions)) return null;
+      if (foundOptions.length === 0) return null;
 
       return foundOptions.map((option, idx) => ({
         id: `c_${idx}`,
@@ -492,7 +491,7 @@ export const UnrestrictedSuggestions: StoryObj<HvTagsInputProps> = {
     };
 
     const suggestionValidation = (val: string) => {
-      if (typeof val !== "string" || isEmpty(val)) return false;
+      if (typeof val !== "string" || !val) return false;
 
       if (!val.startsWith("Option")) {
         setStatus("invalid");

--- a/packages/core/src/VerticalNavigation/Navigation/Navigation.tsx
+++ b/packages/core/src/VerticalNavigation/Navigation/Navigation.tsx
@@ -1,12 +1,10 @@
 import { useCallback, useMemo, useContext, useEffect, useState } from "react";
 
-import uniqueId from "lodash/uniqueId";
-
+import { uniqueId } from "../../utils/helpers";
 import { wrapperTooltip } from "../../utils/wrapperTooltip";
 import { setId } from "../../utils/setId";
 import { useControlled } from "../../hooks/useControlled";
 import { HvBaseProps } from "../../types/generic";
-
 import { ExtractNames } from "../../utils/classes";
 
 import {

--- a/packages/core/src/utils/classes.ts
+++ b/packages/core/src/utils/classes.ts
@@ -23,7 +23,7 @@ const deepRenameKeys = <T extends object>(
 ): T => {
   const result: any = {};
   for (const key in obj) {
-    if (Object.prototype.hasOwnProperty.call(obj, key)) {
+    if (Object.hasOwn(obj, key)) {
       const newKey = mapFn(key);
       const value = obj[key];
       result[newKey] =

--- a/packages/core/src/utils/helpers.ts
+++ b/packages/core/src/utils/helpers.ts
@@ -1,0 +1,32 @@
+export const uniqueId = (prefix = "") => {
+  return `${prefix}${Math.random().toString(36).slice(2, 9)}`;
+};
+
+export const range = (length: number, start = 0) => {
+  return Array.from({ length: length - start }, (_, i) => i + start);
+};
+
+export const capitalize = (string = "") => {
+  return string.charAt(0).toUpperCase() + string.slice(1).toLowerCase();
+};
+
+export const clamp = (value: number, max = 100, min = 0) => {
+  return Math.min(Math.max(value, min), max);
+};
+
+export function isEqual(obj1: unknown, obj2: unknown) {
+  if (!obj1 || !obj2 || typeof obj1 !== "object" || typeof obj2 !== "object") {
+    return obj1 === obj2;
+  }
+
+  const keys1 = Object.keys(obj1);
+  const keys2 = Object.keys(obj2);
+
+  if (keys1.length !== keys2.length) return false;
+
+  for (const key of keys1) {
+    if (!isEqual(obj1[key], obj2[key])) return false;
+  }
+
+  return true;
+}

--- a/packages/core/src/utils/setId.ts
+++ b/packages/core/src/utils/setId.ts
@@ -1,4 +1,4 @@
-import uniqueId from "lodash/uniqueId";
+import { uniqueId } from "./helpers";
 
 export const setId = (...args: any[]) =>
   args.some((arg) => arg == null) ? undefined : args.join("-");

--- a/packages/icons/scripts/svgToSprite.ts
+++ b/packages/icons/scripts/svgToSprite.ts
@@ -64,7 +64,7 @@ fs.mkdir(outputFolder, { recursive: true }, (err) => {
       : { icons: [inputPath] };
 
   for (const groupName in svgPathsByGroup) {
-    if (Object.prototype.hasOwnProperty.call(svgPathsByGroup, groupName)) {
+    if (Object.hasOwn(svgPathsByGroup, groupName)) {
       const svgPaths = svgPathsByGroup[groupName];
       const symbolsSvgPath = path.resolve(
         process.cwd(),

--- a/packages/lab/package.json
+++ b/packages/lab/package.json
@@ -47,7 +47,6 @@
     "@hitachivantara/uikit-react-icons": "^5.8.6",
     "@hitachivantara/uikit-styles": "^5.22.0",
     "@types/react-grid-layout": "^1.3.5",
-    "lodash": "^4.17.21",
     "react-grid-layout": "^1.4.4",
     "reactflow": "^11.10.1",
     "uid": "^2.0.2",

--- a/packages/lab/src/Flow/Sidebar/Sidebar.tsx
+++ b/packages/lab/src/Flow/Sidebar/Sidebar.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
-import debounce from "lodash/debounce";
+import { useDebounceCallback } from "usehooks-ts";
 import {
   DndContextProps,
   DragOverlay,
@@ -155,7 +155,7 @@ export const HvFlowSidebar = ({
     }
   };
 
-  const handleDebouncedSearch = debounce(handleSearch, 500);
+  const handleDebouncedSearch = useDebounceCallback(handleSearch, 500);
 
   return (
     <HvDrawer

--- a/packages/styles/src/utils.ts
+++ b/packages/styles/src/utils.ts
@@ -72,8 +72,11 @@ export const mapCSSVars = <T extends object>(
   return vars;
 };
 
-export const mergeTheme = (...objects) => {
-  const isObject = (obj) => obj && typeof obj === "object";
+// TODO: review in v6:
+// - typings: accept any or theme object?
+// - arguments: source/target themes, or any number of theme objects?
+export const mergeTheme = (...objects: any[]) => {
+  const isObject = (obj: unknown) => obj && typeof obj === "object";
 
   return objects.reduce((prev, obj) => {
     Object.keys(obj).forEach((key) => {
@@ -81,9 +84,9 @@ export const mergeTheme = (...objects) => {
       const oVal = obj[key];
 
       if (isObject(pVal) && isObject(oVal)) {
-        prev[key] = pVal ? oVal : mergeTheme(pVal, oVal);
+        prev[key] = mergeTheme(pVal, oVal);
       } else {
-        prev[key] = oVal;
+        prev[key] = oVal !== undefined ? oVal : pVal;
       }
     });
 

--- a/templates/Form/index.tsx
+++ b/templates/Form/index.tsx
@@ -1,4 +1,3 @@
-import isEmpty from "lodash/isEmpty";
 import { Formik } from "formik";
 import * as yup from "yup";
 import {
@@ -53,12 +52,12 @@ const onSubmit = (data, { setSubmitting }) => {
  * @param {String} val - the value entered on the input
  */
 const suggestionHandler = (val) => {
-  if (typeof val !== "string" || isEmpty(val)) return null;
+  if (typeof val !== "string" || !val) return null;
   const foundCountries = allCountries.filter((country) =>
     country.toUpperCase().startsWith(val.toUpperCase())
   );
 
-  if (isEmpty(foundCountries)) return null;
+  if (foundCountries.length === 0) return null;
 
   return foundCountries.map((country, idx) => ({
     id: `c_${idx}`,

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
     "module": "ESNext",
-    "target": "ES2021",
-    "lib": ["DOM", "ES2021", "dom.iterable"],
+    "target": "ES2022",
+    "lib": ["DOM", "ES2022", "dom.iterable"],
     "moduleResolution": "Node",
     "resolveJsonModule": true,
     "esModuleInterop": true,


### PR DESCRIPTION
- Bump the syntax to the ES2022 baseline
- Remove usage of `lodash` in samples, so that users don't need to install it
- Inline `range` (Array(n)) utility in table samples not to depend on external utils
- Remove usage of `lodash` in components, to reduce the bundle size
  - even the simplest lodash utilities (eg. [range](https://bundlejs.com/?q=lodash%2Frange&treeshake=%5B*%5D&text=%22export+%7Bfn%7D%22&config=%7B%22analysis%22%3Atrue%7D)) require lots of other internal utilities, bloating the final bundles of even the simplest components (eg. `HvLoading`)