### PR TITLE
chore: remove generated id prefixes

### DIFF
--- a/packages/core/src/Accordion/Accordion.tsx
+++ b/packages/core/src/Accordion/Accordion.tsx
@@ -86,7 +86,7 @@ export const HvAccordion = (props: HvAccordionProps) => {
     ...others
   } = useDefaultProps("HvAccordion", props);
 
-  const id = useUniqueId(idProp, "hvaccordion");
+  const id = useUniqueId(idProp);
 
   const { classes, cx } = useClasses(classesProp);
 

--- a/packages/core/src/AppSwitcher/Action/Action.tsx
+++ b/packages/core/src/AppSwitcher/Action/Action.tsx
@@ -122,7 +122,7 @@ export const HvAppSwitcherAction = ({
   );
 
   const isLink = url != null;
-  const descriptionElementId = useUniqueId(id, "hvAction-description");
+  const descriptionElementId = useUniqueId(id);
 
   const renderApplication = useCallback(
     (children: React.ReactNode) => {

--- a/packages/core/src/BaseDropdown/BaseDropdown.tsx
+++ b/packages/core/src/BaseDropdown/BaseDropdown.tsx
@@ -193,7 +193,7 @@ export const HvBaseDropdown = forwardRef<HTMLDivElement, HvBaseDropdownProps>(
 
     const ariaExpanded = ariaExpandedProp ?? (ariaRole ? !!isOpen : undefined);
 
-    const id = useUniqueId(idProp, "hvbasedropdown");
+    const id = useUniqueId(idProp);
     const containerId = setId(id, "children-container");
 
     const headerControlArias = {

--- a/packages/core/src/CheckBox/CheckBox.tsx
+++ b/packages/core/src/CheckBox/CheckBox.tsx
@@ -95,7 +95,7 @@ export const HvCheckBox = forwardRef<HTMLButtonElement, HvCheckBoxProps>(
 
     const { classes, cx } = useClasses(classesProp);
 
-    const elementId = useUniqueId(id, "hvcheckbox");
+    const elementId = useUniqueId(id);
 
     const [focusVisible, setFocusVisible] = useState<boolean>(false);
 

--- a/packages/core/src/CheckBoxGroup/CheckBoxGroup.tsx
+++ b/packages/core/src/CheckBoxGroup/CheckBoxGroup.tsx
@@ -192,7 +192,7 @@ export const HvCheckBoxGroup = forwardRef<HTMLDivElement, HvCheckBoxGroupProps>(
 
     const [validationMessage] = useControlled(statusMessage, "Required");
 
-    const elementId = useUniqueId(id, "hvcheckboxgroup");
+    const elementId = useUniqueId(id);
 
     const selectionAnchor = useRef(undefined);
 

--- a/packages/core/src/ColorPicker/ColorPicker.tsx
+++ b/packages/core/src/ColorPicker/ColorPicker.tsx
@@ -166,7 +166,7 @@ export const HvColorPicker = forwardRef<HTMLDivElement, HvColorPickerProps>(
       savedColorsValue,
       defaultSavedColorsValue
     );
-    const elementId = useUniqueId(id, "hvdropdown");
+    const elementId = useUniqueId(id);
     const hasLabel = label != null;
     const hasDescription = description != null;
 

--- a/packages/core/src/DatePicker/DatePicker.tsx
+++ b/packages/core/src/DatePicker/DatePicker.tsx
@@ -195,7 +195,7 @@ export const HvDatePicker = forwardRef<HTMLDivElement, HvDatePickerProps>(
     const { classes, cx } = useClasses(classesProp);
     const labels = useLabels(DEFAULT_LABELS, labelsProp);
 
-    const elementId = useUniqueId(id, "hvdatepicker");
+    const elementId = useUniqueId(id);
 
     const [validationState, setValidationState] = useControlled(
       status,

--- a/packages/core/src/DropDownMenu/DropDownMenu.tsx
+++ b/packages/core/src/DropDownMenu/DropDownMenu.tsx
@@ -92,7 +92,7 @@ export const HvDropDownMenu = (props: HvDropDownMenuProps) => {
 
   const { classes, cx, css } = useClasses(classesProp);
   const [open, setOpen] = useControlled(expanded, Boolean(defaultExpanded));
-  const id = useUniqueId(idProp, "dropdown-menu");
+  const id = useUniqueId(idProp);
   const focusNodes = getPrevNextFocus(setId(id, "icon-button"));
 
   const listId = setId(id, "list");

--- a/packages/core/src/Dropdown/Dropdown.tsx
+++ b/packages/core/src/Dropdown/Dropdown.tsx
@@ -234,7 +234,7 @@ export const HvDropdown = forwardRef<HTMLDivElement, HvDropdownProps>(
 
     const labels = useLabels(DEFAULT_LABELS, labelsProp);
 
-    const elementId = useUniqueId(id, "hvdropdown");
+    const elementId = useUniqueId(id);
 
     const [validationState, setValidationState] = useControlled(
       status,

--- a/packages/core/src/FileUploader/DropZone/DropZone.tsx
+++ b/packages/core/src/FileUploader/DropZone/DropZone.tsx
@@ -131,7 +131,7 @@ export const HvDropZone = (props: HvDropZoneProps) => {
     disabled = false,
     onFilesAdded,
   } = useDefaultProps("HvDropZone", props);
-  const id = useUniqueId(idProp, "dropzone");
+  const id = useUniqueId(idProp);
 
   const { classes, cx } = useClasses(classesProp);
 

--- a/packages/core/src/FileUploader/FileList/FileList.tsx
+++ b/packages/core/src/FileUploader/FileList/FileList.tsx
@@ -44,7 +44,7 @@ export const HvFileList = (props: HvFileListProps) => {
   } = useDefaultProps("HvFileList", props);
   const { classes } = useClasses(classesProp);
 
-  const elementId = useUniqueId(id, "hvfilelist");
+  const elementId = useUniqueId(id);
 
   const hasFiles = list.length > 0;
   if (!hasFiles) return null;

--- a/packages/core/src/FilterGroup/FilterGroup.tsx
+++ b/packages/core/src/FilterGroup/FilterGroup.tsx
@@ -152,7 +152,7 @@ export const HvFilterGroup = forwardRef<HTMLDivElement, HvFilterGroupProps>(
     const { classes, cx } = useClasses(classesProp);
     const [validationMessage] = useControlled(statusMessage, "Required");
 
-    const elementId = useUniqueId(id, "hvfiltergroup");
+    const elementId = useUniqueId(id);
 
     const labels = useLabels(DEFAULT_LABELS, labelsProp);
 

--- a/packages/core/src/Forms/FormElement/FormElement.tsx
+++ b/packages/core/src/Forms/FormElement/FormElement.tsx
@@ -80,7 +80,7 @@ export const HvFormElement = (props: HvFormElementProps) => {
 
   const { classes, cx } = useClasses(classesProp);
 
-  const elementId = useUniqueId(id, "hvformelement");
+  const elementId = useUniqueId(id);
 
   const contextValue = useMemo(
     () => ({

--- a/packages/core/src/Input/Input.tsx
+++ b/packages/core/src/Input/Input.tsx
@@ -279,7 +279,7 @@ export const HvInput = forwardRef<InputElement, HvInputProps>((props, ref) => {
   } = useDefaultProps("HvInput", props);
   const { classes, cx } = useClasses(classesProp);
   const labels = useLabels(DEFAULT_LABELS, labelsProp);
-  const elementId = useUniqueId(id, "hvinput");
+  const elementId = useUniqueId(id);
 
   const inputRef = useRef<HTMLInputElement>(null);
   const forkedRef = useForkRef(ref, inputRef, inputRefProp);

--- a/packages/core/src/Radio/Radio.tsx
+++ b/packages/core/src/Radio/Radio.tsx
@@ -162,7 +162,7 @@ export const HvRadio = forwardRef<HTMLButtonElement, HvRadioProps>(
 
     const { classes, cx } = useClasses(classesProp);
 
-    const elementId = useUniqueId(id, "hvradio");
+    const elementId = useUniqueId(id);
 
     const [focusVisible, setFocusVisible] = useState(false);
 

--- a/packages/core/src/RadioGroup/RadioGroup.tsx
+++ b/packages/core/src/RadioGroup/RadioGroup.tsx
@@ -151,7 +151,7 @@ export const HvRadioGroup = forwardRef<HTMLDivElement, HvRadioGroupProps>(
 
     const { classes, cx } = useClasses(classesProp);
 
-    const elementId = useUniqueId(id, "hvradiogroup");
+    const elementId = useUniqueId(id);
 
     const [value, setValue] = useControlled(
       valueProp,

--- a/packages/core/src/ScrollTo/Horizontal/ScrollToHorizontal.tsx
+++ b/packages/core/src/ScrollTo/Horizontal/ScrollToHorizontal.tsx
@@ -139,7 +139,7 @@ export const HvScrollToHorizontal = (props: HvScrollToHorizontalProps) => {
 
   const { activeTheme } = useTheme();
 
-  const elementId = useUniqueId(id, "hvHorizontalScrollto");
+  const elementId = useUniqueId(id);
 
   const [selectedIndex, setScrollTo, elements] = useScrollTo(
     defaultSelectedIndex,

--- a/packages/core/src/ScrollTo/Vertical/ScrollToVertical.tsx
+++ b/packages/core/src/ScrollTo/Vertical/ScrollToVertical.tsx
@@ -125,7 +125,7 @@ export const HvScrollToVertical = (props: HvScrollToVerticalProps) => {
 
   const { classes, cx } = useClasses(classesProp);
 
-  const elementId = useUniqueId(id, "hvVerticalScrollto");
+  const elementId = useUniqueId(id);
 
   const [selectedIndex, setScrollTo, elements] = useScrollTo(
     defaultSelectedIndex,

--- a/packages/core/src/Section/Section.tsx
+++ b/packages/core/src/Section/Section.tsx
@@ -71,7 +71,7 @@ export const HvSection = forwardRef<HTMLDivElement, HvSectionProps>(
       Boolean(defaultExpanded)
     );
 
-    const elementId = useUniqueId(id, "hvSection");
+    const elementId = useUniqueId(id);
     const contentId = setId(elementId, "content");
 
     const showContent = expandable ? !!isOpen : true;

--- a/packages/core/src/SelectionList/SelectionList.tsx
+++ b/packages/core/src/SelectionList/SelectionList.tsx
@@ -143,7 +143,7 @@ export const HvSelectionList = forwardRef<
 
   const { classes, cx } = useClasses(classesProp);
 
-  const elementId = useUniqueId(id, "hvselectionlist");
+  const elementId = useUniqueId(id);
 
   const [value, setValue] = useControlled(
     valueProp,

--- a/packages/core/src/Slider/Slider.tsx
+++ b/packages/core/src/Slider/Slider.tsx
@@ -228,7 +228,7 @@ export const HvSlider = forwardRef<SliderRef, HvSliderProps>((props, ref) => {
   // Signals that the user has manually edited the input value
   const isDirty = useRef(false);
 
-  const elementId = useUniqueId(id, "hvSlider");
+  const elementId = useUniqueId(id);
 
   const sliderInputId = setId(elementId, "input");
 

--- a/packages/core/src/Switch/Switch.tsx
+++ b/packages/core/src/Switch/Switch.tsx
@@ -151,7 +151,7 @@ export const HvSwitch = forwardRef<HTMLButtonElement, HvSwitchProps>(
 
     const { classes, cx } = useClasses(classesProp);
 
-    const elementId = useUniqueId(id, "hvswitch");
+    const elementId = useUniqueId(id);
 
     const [isChecked, setIsChecked] = useControlled(
       checked,

--- a/packages/core/src/TableSection/TableSection.tsx
+++ b/packages/core/src/TableSection/TableSection.tsx
@@ -26,7 +26,7 @@ export const HvTableSection = forwardRef<HTMLDivElement, HvTableSectionProps>(
     } = useDefaultProps("HvTableSection", props);
 
     const { classes } = useClasses(classesProp);
-    const elementId = useUniqueId(id, "hvTableSection");
+    const elementId = useUniqueId(id);
 
     return (
       <HvSection id={elementId} ref={ref} classes={classes} {...others}>

--- a/packages/core/src/TagsInput/TagsInput.tsx
+++ b/packages/core/src/TagsInput/TagsInput.tsx
@@ -190,7 +190,7 @@ export const HvTagsInput = forwardRef<HTMLUListElement, HvTagsInputProps>(
 
     const { classes, cx, css } = useClasses(classesProp);
 
-    const elementId = useUniqueId(id, "hvTagsInput");
+    const elementId = useUniqueId(id);
 
     const hasLabel = textAreaLabel != null;
     const hasDescription = description != null;

--- a/packages/core/src/TextArea/TextArea.tsx
+++ b/packages/core/src/TextArea/TextArea.tsx
@@ -203,7 +203,7 @@ export const HvTextArea = forwardRef<any, HvTextAreaProps>((props, ref) => {
 
   const { classes, cx } = useClasses(classesProp);
 
-  const elementId = useUniqueId(id, "hvtextarea");
+  const elementId = useUniqueId(id);
 
   // Signals that the user has manually edited the input value
   const isDirty = useRef<boolean>(false);

--- a/packages/core/src/TimePicker/TimePicker.tsx
+++ b/packages/core/src/TimePicker/TimePicker.tsx
@@ -174,7 +174,7 @@ export const HvTimePicker = forwardRef<HTMLDivElement, HvTimePickerProps>(
       ...others
     } = useDefaultProps("HvTimePicker", props);
 
-    const id = useUniqueId(idProp, "hvtimepicker");
+    const id = useUniqueId(idProp);
 
     const { classes, cx } = useClasses(classesProp);
 

--- a/packages/core/src/VerticalNavigation/TreeView/TreeView.tsx
+++ b/packages/core/src/VerticalNavigation/TreeView/TreeView.tsx
@@ -163,7 +163,7 @@ export const HvVerticalNavigationTreeView = forwardRef(
     const treeviewMode = mode === "treeview";
     const multiSelect = selectable && multiSelectProp;
 
-    const treeId = useUniqueId(idProp, "hvtreeview");
+    const treeId = useUniqueId(idProp);
     const treeRef = useRef<HTMLDivElement>(null);
     const handleRef = useForkRef(treeRef, ref);
 

--- a/packages/core/src/hooks/useUniqueId.ts
+++ b/packages/core/src/hooks/useUniqueId.ts
@@ -9,7 +9,13 @@ let count = 0;
 
 export const useUniqueId = (
   deterministicId?: string,
-  idPrefix?: string
+  /**
+   * @deprecated
+   * Users should pick between a fully deterministic or fully generated id
+   * @example
+   * useUniqueId(setId(idPrefix, deterministicId))
+   * */
+  idPrefix?: string,
 ): string => {
   const [id, setId] = React.useState<string | undefined>(useReactId());
 

--- a/packages/core/src/providers/Provider.tsx
+++ b/packages/core/src/providers/Provider.tsx
@@ -102,7 +102,8 @@ export const HvProvider = ({
   emotionCache: emotionCacheProp,
   classNameKey = defaultCacheKey,
 }: HvProviderProps) => {
-  const scopedRootId = useUniqueId(undefined, scopedRootPrefix);
+  const generatedId = useUniqueId();
+  const scopedRootId = `${scopedRootPrefix}-${generatedId}`;
 
   // Themes
   const themesList: (HvTheme | HvThemeStructure)[] = processThemes(themes);

--- a/packages/core/src/utils/setId.ts
+++ b/packages/core/src/utils/setId.ts
@@ -3,6 +3,7 @@ import { uniqueId } from "./helpers";
 export const setId = (...args: any[]) =>
   args.some((arg) => arg == null) ? undefined : args.join("-");
 
+/** @deprecated use `useUniqueId` instead */
 export const setUid = (id: string, suffix: string) => {
   const uid = setId(id, suffix);
   return uid ? uniqueId(uid) : undefined;

--- a/packages/lab/src/Blade/Blade.tsx
+++ b/packages/lab/src/Blade/Blade.tsx
@@ -188,7 +188,7 @@ export const HvBlade = (props: HvBladeProps) => {
     [handleAction]
   );
 
-  const id = useUniqueId(idProp, "hvblade");
+  const id = useUniqueId(idProp);
   const bladeHeaderId = setId(id, "button");
   const bladeContainerId = setId(id, "container");
   const bladeHeader = useMemo(() => {

--- a/packages/lab/src/Flow/DroppableFlow.tsx
+++ b/packages/lab/src/Flow/DroppableFlow.tsx
@@ -143,7 +143,7 @@ export const HvDroppableFlow = ({
 }: HvDroppableFlowProps) => {
   const { classes, cx } = useClasses(classesProp);
 
-  const elementId = useUniqueId(id, "hvFlow");
+  const elementId = useUniqueId(id);
 
   const reactFlowInstance = useFlowInstance();
 

--- a/packages/lab/src/Flow/Sidebar/Sidebar.tsx
+++ b/packages/lab/src/Flow/Sidebar/Sidebar.tsx
@@ -92,8 +92,8 @@ export const HvFlowSidebar = ({
 
   const labels = useLabels(DEFAULT_LABELS, labelsProps);
 
-  const drawerElementId = useUniqueId(id, "hvFlowSidebarDrawer");
-  const groupsElementId = useUniqueId(id, "hvFlowSidebarGroups");
+  const drawerElementId = useUniqueId(id);
+  const groupsElementId = useUniqueId(id);
 
   // The sidebar is droppable to distinguish between the canvas and the sidebar
   // Otherwise items dropped inside the sidebar will be added to the canvas

--- a/packages/lab/src/Flow/Sidebar/SidebarGroup/SidebarGroupItem/DraggableSidebarGroupItem.tsx
+++ b/packages/lab/src/Flow/Sidebar/SidebarGroup/SidebarGroupItem/DraggableSidebarGroupItem.tsx
@@ -27,8 +27,7 @@ export const HvFlowDraggableSidebarGroupItem = ({
   ...others
 }: HvFlowDraggableSidebarGroupItemProps) => {
   const itemRef = useRef<HTMLElement>(null);
-
-  const elementId = useUniqueId(id, `hvFlowDraggableItem-${type}`);
+  const elementId = useUniqueId(id);
 
   const { attributes, listeners, setNodeRef, isDragging, transform } =
     useDraggable({


### PR DESCRIPTION
remove prefixes from the `useUniqueId`'s generated ids as:
- they make the ids needlessly longer (`hvbasedropdown-:ba:` instead of `:ba:`)
- can lead to confusion when testing as the `hv<ComponentName>` makes it seem like a stable id
- ~remove `setUid` (unused for a long time now); we should use `useUniqueId` instead~