### PR TITLE
refactor: remove namespace React imports

### DIFF
--- a/packages/core/src/Accordion/Accordion.tsx
+++ b/packages/core/src/Accordion/Accordion.tsx
@@ -1,9 +1,4 @@
-import React, {
-  SyntheticEvent,
-  useCallback,
-  useMemo,
-  HTMLAttributes,
-} from "react";
+import { useCallback, useMemo } from "react";
 
 import { DropDownXS, DropUpXS } from "@hitachivantara/uikit-react-icons";
 
@@ -47,7 +42,7 @@ export interface HvAccordionProps
   /**
    * An object containing props to be passed onto container holding the accordion children.
    */
-  containerProps?: HTMLAttributes<HTMLDivElement>;
+  containerProps?: React.HTMLAttributes<HTMLDivElement>;
   /**
    * Heading Level to apply to accordion button if ´undefined´ the button won't have a header wrapper.
    */
@@ -93,7 +88,7 @@ export const HvAccordion = (props: HvAccordionProps) => {
   const [isOpen, setIsOpen] = useControlled(expanded, Boolean(defaultExpanded));
 
   const handleAction = useCallback(
-    (event: SyntheticEvent) => {
+    (event: React.SyntheticEvent) => {
       if (!disabled) {
         onChange?.(event, isOpen);
         setIsOpen(!isOpen);
@@ -105,7 +100,7 @@ export const HvAccordion = (props: HvAccordionProps) => {
   );
 
   const handleClick = useCallback(
-    (event: SyntheticEvent) => {
+    (event: React.SyntheticEvent) => {
       handleAction(event);
       event.preventDefault();
       event.stopPropagation();

--- a/packages/core/src/Avatar/Avatar.tsx
+++ b/packages/core/src/Avatar/Avatar.tsx
@@ -1,4 +1,4 @@
-import { CSSProperties, HTMLAttributes, forwardRef } from "react";
+import { forwardRef } from "react";
 
 import { User } from "@hitachivantara/uikit-react-icons";
 import { HvColorAny, getColor, theme } from "@hitachivantara/uikit-styles";
@@ -23,8 +23,6 @@ export type HvAvatarVariant = "circular" | "square";
 export type HvAvatarSize = "xs" | "sm" | "md" | "lg" | "xl";
 
 export interface HvAvatarProps extends HvBaseProps {
-  /** Inline styles to be applied to the root element. */
-  style?: CSSProperties;
   /** The component used for the root node. Either a string to use a DOM element or a component. */
   component?: React.ElementType;
   /** Sets one of the standard sizes of the icons */
@@ -45,7 +43,7 @@ export interface HvAvatarProps extends HvBaseProps {
    * Attributes applied to the `img` element if the component is used to display an image.
    * It can be used to listen for the loading error event.
    */
-  imgProps?: HTMLAttributes<HTMLImageElement>;
+  imgProps?: React.HTMLAttributes<HTMLImageElement>;
   /** A string representing the type of avatar to display, circular or square. */
   variant?: HvAvatarVariant;
   /** A string representing the color of the avatar border that represents its status. */
@@ -117,7 +115,7 @@ export const HvAvatar = forwardRef<any, HvAvatarProps>((props, ref) => {
     );
   }
 
-  const inlineStyle: CSSProperties = {
+  const inlineStyle: React.CSSProperties = {
     ...style,
   };
 
@@ -134,7 +132,7 @@ export const HvAvatar = forwardRef<any, HvAvatarProps>((props, ref) => {
     inlineStyle.color = getColor(color, theme.colors.atmo1);
   }
 
-  const statusInlineStyle: CSSProperties = {};
+  const statusInlineStyle: React.CSSProperties = {};
   if (status) {
     // set the status border. we're using the boxShadow property to set the border
     // to be inside the container and not on its edge.

--- a/packages/core/src/Badge/Badge.styles.tsx
+++ b/packages/core/src/Badge/Badge.styles.tsx
@@ -1,10 +1,8 @@
-import { CSSProperties } from "react";
-
 import { theme } from "@hitachivantara/uikit-styles";
 
 import { createClasses } from "../utils/classes";
 
-const labelBaseStyle: CSSProperties = {
+const labelBaseStyle: React.CSSProperties = {
   ...theme.typography.label,
   padding: "0 5px",
   color: theme.colors.atmo1,

--- a/packages/core/src/BaseCheckBox/BaseCheckBox.tsx
+++ b/packages/core/src/BaseCheckBox/BaseCheckBox.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, useCallback, useState } from "react";
+import { forwardRef, useCallback, useState } from "react";
 
 import MuiCheckbox, {
   CheckboxProps as MuiCheckboxProps,

--- a/packages/core/src/BaseDropdown/BaseDropdown.tsx
+++ b/packages/core/src/BaseDropdown/BaseDropdown.tsx
@@ -1,10 +1,10 @@
-import React, {
+import {
   useMemo,
   useState,
   useCallback,
-  KeyboardEventHandler,
-  AriaAttributes,
   forwardRef,
+  isValidElement,
+  cloneElement,
 } from "react";
 
 import { createPortal } from "react-dom";
@@ -204,12 +204,12 @@ export const HvBaseDropdown = forwardRef<HTMLDivElement, HvBaseDropdownProps>(
       "aria-expanded": ariaExpanded,
       "aria-owns": isOpen ? containerId : undefined,
       "aria-controls": isOpen ? containerId : undefined,
-    } satisfies AriaAttributes;
+    } satisfies React.AriaAttributes;
 
     const headerAriaLabels = {
       "aria-label": ariaLabelProp,
       "aria-labelledby": ariaLabelledByProp,
-    } satisfies AriaAttributes;
+    } satisfies React.AriaAttributes;
 
     const placement: Placement = `bottom-${
       placementProp === "right" ? "start" : "end"
@@ -419,8 +419,8 @@ export const HvBaseDropdown = forwardRef<HTMLDivElement, HvBaseDropdownProps>(
     );
 
     const headerElement =
-      component && React.isValidElement(component)
-        ? React.cloneElement(component as React.ReactElement, {
+      component && isValidElement(component)
+        ? cloneElement(component as React.ReactElement, {
             ref: handleDropdownHeaderRef,
             ...headerControlArias,
           })
@@ -430,7 +430,7 @@ export const HvBaseDropdown = forwardRef<HTMLDivElement, HvBaseDropdownProps>(
       /**
        *  Handle keyboard inside children container.
        */
-      const handleContainerKeyDown: KeyboardEventHandler = (event) => {
+      const handleContainerKeyDown: React.KeyboardEventHandler = (event) => {
         if (isKey(event, "Esc")) {
           handleToggle(event);
         }

--- a/packages/core/src/BaseInput/BaseInput.styles.tsx
+++ b/packages/core/src/BaseInput/BaseInput.styles.tsx
@@ -1,4 +1,3 @@
-import { CSSProperties } from "react";
 import { theme } from "@hitachivantara/uikit-styles";
 
 import { outlineStyles } from "../utils/focusUtils";
@@ -207,7 +206,7 @@ export const { staticClasses, useClasses } = createClasses("HvBaseInput", {
     outline: "none",
     width: "initial",
     flexGrow: 1,
-    ...(theme.typography.body as CSSProperties),
+    ...(theme.typography.body as React.CSSProperties),
 
     "&::placeholder": {
       opacity: 1,

--- a/packages/core/src/BaseInput/validations.ts
+++ b/packages/core/src/BaseInput/validations.ts
@@ -1,5 +1,3 @@
-import { HTMLInputTypeAttribute } from "react";
-
 import { InputBaseComponentProps } from "@mui/material/InputBase";
 
 import validationStates from "../Forms/FormElement/validationStates";
@@ -23,7 +21,7 @@ export const validationTypes = Object.freeze({
 });
 
 /** Returns the input's validation type based in the type of the input. */
-export const computeValidationType = (type: HTMLInputTypeAttribute) => {
+export const computeValidationType = (type: React.HTMLInputTypeAttribute) => {
   switch (type) {
     case "number":
       return validationTypes.number;
@@ -40,7 +38,7 @@ export const computeValidationType = (type: HTMLInputTypeAttribute) => {
  */
 export const hasBuiltInValidations = (
   required: boolean,
-  validationType: HTMLInputTypeAttribute,
+  validationType: React.HTMLInputTypeAttribute,
   minCharQuantity: number | null | undefined,
   maxCharQuantity: number | null | undefined,
   validation?: (value: string) => boolean,

--- a/packages/core/src/BaseRadio/BaseRadio.tsx
+++ b/packages/core/src/BaseRadio/BaseRadio.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, forwardRef } from "react";
+import { useState, useCallback, forwardRef } from "react";
 
 import MuiRadio, { RadioProps as MuiRadioProps } from "@mui/material/Radio";
 

--- a/packages/core/src/BaseSwitch/BaseSwitch.tsx
+++ b/packages/core/src/BaseSwitch/BaseSwitch.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, forwardRef } from "react";
+import { useState, useCallback, forwardRef } from "react";
 
 import MuiSwitch, { SwitchProps as MuiSwitchProps } from "@mui/material/Switch";
 

--- a/packages/core/src/BreadCrumb/BreadCrumb.tsx
+++ b/packages/core/src/BreadCrumb/BreadCrumb.tsx
@@ -1,4 +1,4 @@
-import { isValidElement, MouseEvent } from "react";
+import { isValidElement } from "react";
 
 import { useDefaultProps } from "../hooks/useDefaultProps";
 import { HvBaseProps } from "../types/generic";
@@ -27,7 +27,7 @@ export interface HvBreadCrumbProps
   /** The component used for the link node. Either a string to use a DOM element or a component. */
   component?: React.ElementType;
   /** Function passed to the component. If defined the component prop is used as the link node. */
-  onClick?: (event: MouseEvent<HTMLElement>, data: any) => void;
+  onClick?: (event: React.MouseEvent<HTMLElement>, data: any) => void;
   /** Props passed down to the DropDownMenu sub-menu component. */
   dropDownMenuProps?: Partial<HvDropDownMenuProps>;
   /** A Jss Object used to override or extend the styles applied to the component. */

--- a/packages/core/src/BreadCrumb/Page/Page.tsx
+++ b/packages/core/src/BreadCrumb/Page/Page.tsx
@@ -1,5 +1,3 @@
-import { MouseEvent } from "react";
-
 import { HvTypography } from "../../Typography";
 import { HvOverflowTooltip } from "../../OverflowTooltip";
 import { ExtractNames } from "../../utils/classes";
@@ -14,7 +12,7 @@ export type HvBreadCrumbPageClasses = ExtractNames<typeof useClasses>;
 
 export interface HvBreadCrumbPageProps {
   component?: React.ElementType;
-  onClick?: (event: MouseEvent<HTMLElement>, data: any) => void;
+  onClick?: (event: React.MouseEvent<HTMLElement>, data: any) => void;
   elem: HvBreadCrumbPathElement;
   classes?: HvBreadCrumbPageClasses;
 }
@@ -31,7 +29,7 @@ export const HvBreadCrumbPage = (props: HvBreadCrumbPageProps) => {
 
   const { label, path, ...others } = elem;
 
-  const handleClick = (event: MouseEvent<HTMLElement>) => {
+  const handleClick = (event: React.MouseEvent<HTMLElement>) => {
     event.preventDefault();
     onClick?.(event, elem);
   };

--- a/packages/core/src/BreadCrumb/utils.tsx
+++ b/packages/core/src/BreadCrumb/utils.tsx
@@ -1,5 +1,3 @@
-import { MouseEvent } from "react";
-
 import { MoreOptionsHorizontal } from "@hitachivantara/uikit-react-icons";
 
 import { HvDropDownMenu, HvDropDownMenuProps } from "../DropDownMenu";
@@ -12,7 +10,7 @@ export const pathWithSubMenu = (
   id: string | undefined,
   listRoute: any,
   maxVisible: number,
-  onClick?: (event: MouseEvent<HTMLElement>, data: any) => void,
+  onClick?: (event: React.MouseEvent<HTMLElement>, data: any) => void,
   dropDownMenuProps?: Partial<HvDropDownMenuProps>
 ) => {
   const nbrElemToSubMenu = listRoute.length - maxVisible;

--- a/packages/core/src/Calendar/Calendar.tsx
+++ b/packages/core/src/Calendar/Calendar.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from "react";
+import { useContext } from "react";
 
 import { useDefaultProps } from "../hooks/useDefaultProps";
 

--- a/packages/core/src/Calendar/SingleCalendar/CalendarCell.tsx
+++ b/packages/core/src/Calendar/SingleCalendar/CalendarCell.tsx
@@ -1,4 +1,4 @@
-import { SyntheticEvent, useRef } from "react";
+import { useRef } from "react";
 
 import { HvTypography } from "../../Typography";
 import { ExtractNames } from "../../utils/classes";
@@ -62,7 +62,7 @@ export const HvCalendarCell = (props: HvCalendarCellProps) => {
   const endBookend = isSameDay(endDate, value);
   const isSelecting = isDateSelectionMode && isCellAfterStartingDate;
 
-  const handleClick = (event: SyntheticEvent) => {
+  const handleClick = (event: React.SyntheticEvent) => {
     if (value) {
       onChange?.(event, value);
       if (buttonEl.current) setTimeout(() => buttonEl?.current?.focus());
@@ -143,7 +143,7 @@ export interface HvCalendarCellProps {
   /**
    * Callback to define the input date.
    */
-  onChange?: (event: SyntheticEvent, value: Date | DateRangeProp) => void;
+  onChange?: (event: React.SyntheticEvent, value: Date | DateRangeProp) => void;
   /**
    * Callback to handle input onFocus.
    */

--- a/packages/core/src/Card/Card.stories.tsx
+++ b/packages/core/src/Card/Card.stories.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import styled from "@emotion/styled";
 import {
   Add,
@@ -321,7 +321,7 @@ export const KPICard: StoryObj<HvCardProps> = {
       icon,
     }: {
       value: string;
-      icon: ReactNode;
+      icon: React.ReactNode;
     }) => (
       <HvCardContent>
         <Grid container>
@@ -433,7 +433,11 @@ export const Selectable: StoryObj<HvCardProps> = {
       </HvCardContent>
     );
 
-    const CardClickableContent = ({ children }: { children: ReactNode }) => {
+    const CardClickableContent = ({
+      children,
+    }: {
+      children: React.ReactNode;
+    }) => {
       return (
         <StyledButton
           type="button"

--- a/packages/core/src/Card/Media/Media.tsx
+++ b/packages/core/src/Card/Media/Media.tsx
@@ -1,9 +1,7 @@
-import { ImgHTMLAttributes } from "react";
 import MuiCardMedia, {
   CardMediaProps as MuiCardMediaProps,
 } from "@mui/material/CardMedia";
 
-import { HvBaseProps } from "../../types/generic";
 import { ExtractNames } from "../../utils/classes";
 
 import { staticClasses, useClasses } from "./Media.styles";
@@ -14,8 +12,7 @@ export type HvCardMediaClasses = ExtractNames<typeof useClasses>;
 
 export interface HvCardMediaProps
   extends Omit<MuiCardMediaProps, "classes">,
-    ImgHTMLAttributes<HTMLDivElement>,
-    HvBaseProps<HTMLDivElement, "onClick" | "title"> {
+    React.ImgHTMLAttributes<HTMLDivElement> {
   /** Id to be applied to the root node. */
   id?: string;
   /** The title of the media. */

--- a/packages/core/src/Carousel/Carousel.tsx
+++ b/packages/core/src/Carousel/Carousel.tsx
@@ -1,11 +1,4 @@
-import React, {
-  CSSProperties,
-  Children,
-  useCallback,
-  useEffect,
-  useRef,
-  useState,
-} from "react";
+import { Children, useCallback, useEffect, useRef, useState } from "react";
 import useCarousel from "embla-carousel-react";
 import {
   Backwards,
@@ -36,9 +29,9 @@ export interface HvCarouselProps
   /** A Jss Object used to override or extend the styles applied. */
   classes?: HvCarouselClasses;
   /** Height of the Slider container. If `undefined`, images will keep a 16/9 aspect-ratio */
-  height?: CSSProperties["height"];
+  height?: React.CSSProperties["height"];
   /** Width of the thumbnail. Height will try to maintain a 16/9 aspect-ratio */
-  thumbnailWidth?: CSSProperties["width"];
+  thumbnailWidth?: React.CSSProperties["width"];
   /** Title of the carousel */
   title?: React.ReactNode;
   /** Content slides to be displayed. @see `<HvCarouselSlide />` */

--- a/packages/core/src/Carousel/CarouselControls.tsx
+++ b/packages/core/src/Carousel/CarouselControls.tsx
@@ -1,9 +1,6 @@
-import { MouseEventHandler, ReactNode } from "react";
-
 import { Backwards, Forwards } from "@hitachivantara/uikit-react-icons";
 
 import { useDefaultProps } from "../hooks/useDefaultProps";
-
 import { HvBaseProps } from "../types/generic";
 import { HvButton } from "../Button";
 import { HvPaginationProps } from "../Pagination";
@@ -16,9 +13,9 @@ interface HvCarouselControlsProps
     Pick<HvPaginationProps, "page" | "pages" | "canPrevious" | "canNext"> {
   showDots?: boolean;
   classes?: ExtractNames<typeof useClasses>;
-  actions?: ReactNode;
-  onPreviousClick?: MouseEventHandler<HTMLButtonElement>;
-  onNextClick?: MouseEventHandler<HTMLButtonElement>;
+  actions?: React.ReactNode;
+  onPreviousClick?: React.MouseEventHandler<HTMLButtonElement>;
+  onNextClick?: React.MouseEventHandler<HTMLButtonElement>;
 }
 
 export const HvCarouselControls = (props: HvCarouselControlsProps) => {

--- a/packages/core/src/Carousel/CarouselSlide/CarouselSlide.tsx
+++ b/packages/core/src/Carousel/CarouselSlide/CarouselSlide.tsx
@@ -1,5 +1,3 @@
-import { ImgHTMLAttributes } from "react";
-
 import { ExtractNames } from "../../utils/classes";
 
 import { useClasses } from "./CarouselSlide.styles";
@@ -7,7 +5,7 @@ import { useClasses } from "./CarouselSlide.styles";
 export type HvCarouselSlideClasses = ExtractNames<typeof useClasses>;
 
 export interface HvCarouselSlideProps
-  extends ImgHTMLAttributes<HTMLImageElement> {
+  extends React.ImgHTMLAttributes<HTMLImageElement> {
   /** A Jss Object used to override or extend the styles applied. */
   classes?: HvCarouselSlideClasses;
   /** The width of the Slide. Defaults to `100%` */

--- a/packages/core/src/Carousel/CarouselThumbnails.tsx
+++ b/packages/core/src/Carousel/CarouselThumbnails.tsx
@@ -1,4 +1,4 @@
-import { CSSProperties, MouseEvent, forwardRef } from "react";
+import { forwardRef } from "react";
 
 import { HvBaseProps } from "../types/generic";
 import { HvPaginationProps } from "../Pagination";
@@ -11,10 +11,10 @@ import { useClasses } from "./Carousel.styles";
 interface HvCarouselThumbnailsProps
   extends HvBaseProps<HTMLDivElement, "children">,
     Pick<HvPaginationProps, "page" | "pages" | "canPrevious" | "canNext"> {
-  width?: CSSProperties["width"];
+  width?: React.CSSProperties["width"];
   classes?: ExtractNames<typeof useClasses>;
   onThumbnailClick?: (
-    event: MouseEvent<HTMLButtonElement>,
+    event: React.MouseEvent<HTMLButtonElement>,
     index: number
   ) => void;
   thumbnailProps?: Partial<HvButtonProps>;

--- a/packages/core/src/ColorPicker/ColorPicker.stories.tsx
+++ b/packages/core/src/ColorPicker/ColorPicker.stories.tsx
@@ -1,4 +1,4 @@
-import { CSSProperties, useState } from "react";
+import { useState } from "react";
 import { Decorator, Meta, StoryObj } from "@storybook/react";
 import { fireEvent, screen } from "@storybook/testing-library";
 import {
@@ -10,7 +10,7 @@ import {
 import { css } from "@emotion/css";
 
 const makeDecorator =
-  (styles: CSSProperties): Decorator =>
+  (styles: React.CSSProperties): Decorator =>
   (Story) =>
     <div style={styles}>{Story()}</div>;
 

--- a/packages/core/src/Controls/Controls.tsx
+++ b/packages/core/src/Controls/Controls.tsx
@@ -1,4 +1,4 @@
-import { Children, MouseEvent } from "react";
+import { Children } from "react";
 
 import { useDefaultProps } from "../hooks/useDefaultProps";
 import { HvBaseProps, HvExtraProps } from "../types/generic";
@@ -48,7 +48,10 @@ export interface HvControlsProps extends HvBaseProps {
   /**
    * Callback called when the view switcher button is pressed
    */
-  onViewChange?: (event: MouseEvent<HTMLButtonElement>, id: string) => void;
+  onViewChange?: (
+    event: React.MouseEvent<HTMLButtonElement>,
+    id: string
+  ) => void;
   /**
    * if `true` the button to switch views is not rendered
    */
@@ -79,7 +82,7 @@ export const HvControls = (props: HvControlsProps) => {
   );
 
   const onViewChangeHandler = (
-    evt: MouseEvent<HTMLButtonElement>,
+    evt: React.MouseEvent<HTMLButtonElement>,
     btnId: any
   ) => {
     setCurrentView(btnId);

--- a/packages/core/src/Dropdown/List/List.tsx
+++ b/packages/core/src/Dropdown/List/List.tsx
@@ -1,4 +1,4 @@
-import { MouseEvent, useContext, useEffect, useMemo, useState } from "react";
+import { useContext, useEffect, useMemo, useState } from "react";
 
 import { theme } from "@hitachivantara/uikit-styles";
 
@@ -60,7 +60,7 @@ export interface HvDropdownListProps {
   /**
    * A function to be executed whenever the Cancel button is activated.
    */
-  onCancel: (event: MouseEvent) => void;
+  onCancel: (event: React.MouseEvent) => void;
   /**
    * An object containing all the labels for the dropdown.
    */

--- a/packages/core/src/FileUploader/DropZone/DropZone.styles.tsx
+++ b/packages/core/src/FileUploader/DropZone/DropZone.styles.tsx
@@ -1,4 +1,3 @@
-import { CSSProperties } from "react";
 import { theme } from "@hitachivantara/uikit-styles";
 
 import { createClasses } from "../../utils/classes";
@@ -84,9 +83,9 @@ export const { staticClasses, useClasses } = createClasses("HvDropZone", {
     paddingBottom: 6,
   },
   dragText: {
-    ...(theme.typography.body as CSSProperties),
+    ...(theme.typography.body as React.CSSProperties),
   },
   selectFilesText: {
-    ...(theme.typography.label as CSSProperties),
+    ...(theme.typography.label as React.CSSProperties),
   },
 });

--- a/packages/core/src/FileUploader/DropZone/DropZone.tsx
+++ b/packages/core/src/FileUploader/DropZone/DropZone.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from "react";
+import { useRef, useState } from "react";
 import { Doc } from "@hitachivantara/uikit-react-icons";
 
 import { setId } from "../../utils/setId";

--- a/packages/core/src/Focus/Focus.tsx
+++ b/packages/core/src/Focus/Focus.tsx
@@ -1,4 +1,4 @@
-import React, { RefObject, useState } from "react";
+import { cloneElement, useState } from "react";
 
 import { HvBaseProps } from "../types/generic";
 import { isKey, isOneOfKeys } from "../utils/keyboardUtils";
@@ -27,7 +27,7 @@ export interface HvFocusProps extends HvBaseProps<HTMLElement, "children"> {
   /** Whether the focus is disabled. */
   disabled?: boolean;
   /** The reference to the root element to hold all Focus' context. */
-  rootRef?: RefObject<HTMLElement>;
+  rootRef?: React.RefObject<HTMLElement>;
   /** Show focus when click element. v */
   focusOnClick?: boolean;
   /** Show focus when click element. v */
@@ -440,7 +440,7 @@ export const HvFocus = ({
 
   return (
     <ConditionalWrapper condition={useFalseFocus} wrapper={focusWrapper}>
-      {React.cloneElement(children, {
+      {cloneElement(children, {
         className: cx(
           [classes.root, filterClass],
           {

--- a/packages/core/src/Forms/Adornment/Adornment.tsx
+++ b/packages/core/src/Forms/Adornment/Adornment.tsx
@@ -1,4 +1,4 @@
-import { useContext, forwardRef, MouseEventHandler, ForwardedRef } from "react";
+import { useContext, forwardRef } from "react";
 
 import { HvBaseProps } from "../../types/generic";
 import { ExtractNames } from "../../utils/classes";
@@ -26,7 +26,7 @@ export interface HvAdornmentProps
   /** When the adornment should be displayed. */
   showWhen?: HvFormStatus;
   /** Function to be executed when this element is clicked. */
-  onClick?: MouseEventHandler<HTMLButtonElement> | undefined;
+  onClick?: React.MouseEventHandler<HTMLButtonElement>;
   /** If this property is defined the adornment visibility will be exclusively controlled by this value. */
   isVisible?: boolean;
   /** A Jss Object used to override or extend the styles applied to the component. */
@@ -75,7 +75,7 @@ export const HvAdornment = forwardRef<
     return isClickable ? (
       <button
         id={id}
-        ref={ref as ForwardedRef<HTMLButtonElement>}
+        ref={ref as React.ForwardedRef<HTMLButtonElement>}
         type="button"
         tabIndex={-1}
         aria-controls={input?.[0]?.id}
@@ -96,7 +96,7 @@ export const HvAdornment = forwardRef<
     ) : (
       <div
         id={id}
-        ref={ref as ForwardedRef<HTMLDivElement>}
+        ref={ref as React.ForwardedRef<HTMLDivElement>}
         className={cx(
           classes.root,
           classes.adornment,

--- a/packages/core/src/Forms/Suggestions/Suggestions.tsx
+++ b/packages/core/src/Forms/Suggestions/Suggestions.tsx
@@ -1,10 +1,4 @@
-import React, {
-  forwardRef,
-  useContext,
-  useEffect,
-  useRef,
-  useState,
-} from "react";
+import { forwardRef, useContext, useEffect, useRef, useState } from "react";
 
 import MuiPopper from "@mui/material/Popper";
 import { useForkRef } from "@mui/material/utils";

--- a/packages/core/src/Header/Navigation/MenuBar/MenuBar.tsx
+++ b/packages/core/src/Header/Navigation/MenuBar/MenuBar.tsx
@@ -1,5 +1,3 @@
-import { MouseEvent } from "react";
-
 import { HvBaseProps } from "../../../types/generic";
 
 import { useDefaultProps } from "../../../hooks/useDefaultProps";
@@ -12,7 +10,10 @@ export interface HvHeaderMenuBarProps
   extends HvBaseProps<HTMLDivElement, "onClick"> {
   data: HvHeaderNavigationItemProp[];
   type?: BarProps["type"];
-  onClick?: (event: MouseEvent, selection: HvHeaderNavigationItemProp) => void;
+  onClick?: (
+    event: React.MouseEvent,
+    selection: HvHeaderNavigationItemProp
+  ) => void;
   levels: number;
   currentLevel: number;
   classes?: HvHeaderMenuBarClasses;
@@ -30,7 +31,7 @@ export const HvHeaderMenuBar = (props: HvHeaderMenuBarProps) => {
   } = useDefaultProps("HvHeaderMenuBar", props);
   return (
     <Bar data={data} type={type} classes={classes} {...others}>
-      {data.map((item: HvHeaderNavigationItemProp) => (
+      {data.map((item) => (
         <HvHeaderMenuItem
           key={item.id}
           item={item}

--- a/packages/core/src/Header/Navigation/MenuItem/MenuItem.tsx
+++ b/packages/core/src/Header/Navigation/MenuItem/MenuItem.tsx
@@ -1,4 +1,4 @@
-import React, { MouseEvent, useContext } from "react";
+import { useContext } from "react";
 
 import { HvTypography } from "../../../Typography";
 import { HvBaseProps } from "../../../types/generic";
@@ -21,7 +21,10 @@ export interface HvHeaderMenuItemProps
   extends HvBaseProps<HTMLDivElement, "onClick"> {
   item: HvHeaderNavigationItemProp;
   type?: string;
-  onClick?: (event: MouseEvent, selection: HvHeaderNavigationItemProp) => void;
+  onClick?: (
+    event: React.MouseEvent,
+    selection: HvHeaderNavigationItemProp
+  ) => void;
   levels: number;
   currentLevel: number;
   classes?: HvHeaderMenuItemClasses;

--- a/packages/core/src/Header/Navigation/Navigation.tsx
+++ b/packages/core/src/Header/Navigation/Navigation.tsx
@@ -1,5 +1,3 @@
-import { MouseEvent } from "react";
-
 import { HvBaseProps } from "../../types/generic";
 import { useDefaultProps } from "../../hooks/useDefaultProps";
 import { ExtractNames } from "../../utils/classes";
@@ -21,7 +19,10 @@ export interface HvHeaderNavigationProps
   extends HvBaseProps<HTMLDivElement, "onClick"> {
   data: HvHeaderNavigationItemProp[];
   selected?: string;
-  onClick?: (event: MouseEvent, selection: HvHeaderNavigationItemProp) => void;
+  onClick?: (
+    event: React.MouseEvent,
+    selection: HvHeaderNavigationItemProp
+  ) => void;
   classes?: HvHeaderNavigationClasses;
   /**
    * The number of levels to show: the first level (1) or the first and second level (2).
@@ -46,10 +47,7 @@ export const HvHeaderNavigation = (props: HvHeaderNavigationProps) => {
 
   const selectionPath = useSelectionPath(data, selected);
 
-  const handleClick: HvHeaderMenuBarProps["onClick"] = (
-    event: MouseEvent,
-    selection: HvHeaderNavigationItemProp
-  ) => {
+  const handleClick: HvHeaderMenuBarProps["onClick"] = (event, selection) => {
     event.preventDefault();
 
     onClick?.(event, selection);

--- a/packages/core/src/Header/Navigation/utils/FocusContext.tsx
+++ b/packages/core/src/Header/Navigation/utils/FocusContext.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useMemo, useReducer } from "react";
+import { createContext, useMemo, useReducer } from "react";
 
 type Action = { type: "setItemFocused"; itemFocused: EventTarget & Element };
 

--- a/packages/core/src/InlineEditor/InlineEditor.tsx
+++ b/packages/core/src/InlineEditor/InlineEditor.tsx
@@ -1,4 +1,4 @@
-import React, { useLayoutEffect, useRef, useState } from "react";
+import { useLayoutEffect, useRef, useState } from "react";
 
 import { Edit } from "@hitachivantara/uikit-react-icons";
 

--- a/packages/core/src/Input/Input.tsx
+++ b/packages/core/src/Input/Input.tsx
@@ -1,6 +1,5 @@
-import React, {
-  FocusEvent,
-  HTMLInputTypeAttribute,
+import {
+  cloneElement,
   forwardRef,
   isValidElement,
   useCallback,
@@ -143,7 +142,7 @@ export interface HvInputProps
     value: string
   ) => void;
   /** The input type. */
-  type?: HTMLInputTypeAttribute;
+  type?: React.HTMLInputTypeAttribute;
   /** The placeholder value of the input. */
   placeholder?: string;
   /** Internal labels?. */
@@ -208,12 +207,12 @@ export type HvInputLabels = Partial<typeof DEFAULT_LABELS>;
 /**
  * Find the focused element onBlur.
  */
-const getFocusedElement = (event: FocusEvent) =>
+const getFocusedElement = (event: React.FocusEvent) =>
   isBrowser("ie") ? document.activeElement : event.relatedTarget;
 
 function eventTargetIsInsideContainer(
   container: HTMLElement | null,
-  event: FocusEvent<any>
+  event: React.FocusEvent<any>
 ) {
   return container != null && container.contains(getFocusedElement(event));
 }
@@ -694,7 +693,7 @@ export const HvInput = forwardRef<InputElement, HvInputProps>((props, ref) => {
   const customIconEl = useMemo(
     () =>
       isValidElement(endAdornment) &&
-      React.cloneElement(endAdornment as React.ReactElement, {
+      cloneElement(endAdornment as React.ReactElement, {
         className: cx(endAdornment.props.className, classes.icon),
       }),
     [classes.icon, endAdornment, cx]

--- a/packages/core/src/ListContainer/ListContainer.tsx
+++ b/packages/core/src/ListContainer/ListContainer.tsx
@@ -1,9 +1,11 @@
-import React, {
+import {
   useRef,
   useContext,
   useMemo,
   forwardRef,
   isValidElement,
+  Children,
+  cloneElement,
 } from "react";
 
 import { HvBaseProps } from "../types/generic";
@@ -83,12 +85,12 @@ export const HvListContainer = forwardRef<
   const children = useMemo(() => {
     if (!interactive) return childrenProp;
 
-    const anySelected = React.Children.toArray(childrenProp).some(
+    const anySelected = Children.toArray(childrenProp).some(
       (child) =>
         isValidElement(child) && child.props.selected && !child.props.disabled
     );
 
-    return React.Children.map(childrenProp, (child: any, i) => {
+    return Children.map(childrenProp, (child: any, i) => {
       const tabIndex =
         child.props.tabIndex ||
         (!anySelected && i === 0) ||
@@ -96,7 +98,7 @@ export const HvListContainer = forwardRef<
           ? 0
           : -1;
 
-      return React.cloneElement(child, {
+      return cloneElement(child, {
         tabIndex,
         interactive,
       });

--- a/packages/core/src/ListContainer/ListItem/ListItem.tsx
+++ b/packages/core/src/ListContainer/ListItem/ListItem.tsx
@@ -1,4 +1,11 @@
-import React, { forwardRef, useCallback, useContext, useMemo } from "react";
+import {
+  cloneElement,
+  forwardRef,
+  isValidElement,
+  useCallback,
+  useContext,
+  useMemo,
+} from "react";
 
 import { HvBaseProps } from "../../types/generic";
 import { useDefaultProps } from "../../hooks/useDefaultProps";
@@ -66,7 +73,7 @@ const applyClassNameAndStateToElement = (
 ) => {
   if (element == null) return null;
 
-  return React.cloneElement(element, {
+  return cloneElement(element, {
     className,
     checked: !!selected,
     disabled,
@@ -77,7 +84,7 @@ const applyClassNameAndStateToElement = (
 const applyClassNameToElement = (element, className?: string) => {
   if (element == null) return null;
 
-  return React.cloneElement(element, {
+  return cloneElement(element, {
     className,
   });
 };
@@ -138,7 +145,7 @@ export const HvListItem = forwardRef<any, HvListItemProps>((props, ref) => {
         cx(
           classes.startAdornment,
           { [classes.disabled]: disabled },
-          React.isValidElement(startAdornment)
+          isValidElement(startAdornment)
             ? startAdornment.props.className
             : undefined
         )
@@ -160,7 +167,7 @@ export const HvListItem = forwardRef<any, HvListItemProps>((props, ref) => {
         cx(
           classes.endAdornment,
           { [classes.disabled]: disabled },
-          React.isValidElement(endAdornment)
+          isValidElement(endAdornment)
             ? endAdornment.props.className
             : undefined
         )

--- a/packages/core/src/Loading/Loading.stories.tsx
+++ b/packages/core/src/Loading/Loading.stories.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, SetStateAction, useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import { Meta, StoryObj } from "@storybook/react";
 import {
   HvButton,
@@ -82,7 +82,7 @@ const ButtonDeterminate = ({
   children,
 }: {
   label: string;
-  children: ReactNode;
+  children: React.ReactNode;
 }) => (
   <div>
     <HvTypography variant="caption1">{label}</HvTypography>
@@ -95,8 +95,8 @@ const Progress = ({
   label,
   inc,
 }: {
-  label: (val: number) => ReactNode;
-  inc: SetStateAction<number>;
+  label: (val: number) => React.ReactNode;
+  inc: React.SetStateAction<number>;
 }) => {
   const [value, setValue] = useState(0);
 

--- a/packages/core/src/MultiButton/MultiButton.stories.tsx
+++ b/packages/core/src/MultiButton/MultiButton.stories.tsx
@@ -1,4 +1,4 @@
-import { MouseEvent, useState } from "react";
+import { useState } from "react";
 import { Meta, StoryObj } from "@storybook/react";
 import {
   DropDownXS,
@@ -90,7 +90,7 @@ export const OnlyIcons: StoryObj<HvMultiButtonProps> = {
       { name: "Location", icon: <LocationPin /> },
     ];
 
-    const handleChange = (event: MouseEvent, idx: number) => {
+    const handleChange = (event: React.MouseEvent, idx: number) => {
       const newSelection = selection.includes(idx)
         ? selection.filter((v) => v !== idx)
         : [...selection, idx];
@@ -215,7 +215,7 @@ export const MultipleSelection: StoryObj<HvMultiButtonProps> = {
       "Sunday",
     ];
 
-    const handleChange = (event: MouseEvent, idx: number) => {
+    const handleChange = (event: React.MouseEvent, idx: number) => {
       const newSelection = selection.includes(idx)
         ? selection.filter((v) => v !== idx)
         : [...selection, idx];
@@ -251,7 +251,7 @@ export const EnforcedSelection: StoryObj<HvMultiButtonProps> = {
   render: () => {
     const [selection, setSelection] = useState([0]);
 
-    const handleChange = (event: MouseEvent, idx: number) => {
+    const handleChange = (event: React.MouseEvent, idx: number) => {
       if (idx === 0) return; // enforced
       const newSelection = selection.includes(idx)
         ? selection.filter((v) => v !== idx)
@@ -290,7 +290,7 @@ export const MinimumSelection: StoryObj<HvMultiButtonProps> = {
   render: () => {
     const [selection, setSelection] = useState([1, 2]);
 
-    const handleChange = (event: MouseEvent, idx: number) => {
+    const handleChange = (event: React.MouseEvent, idx: number) => {
       const newSelection = selection.includes(idx)
         ? selection.filter((v) => v !== idx)
         : [...selection, idx];
@@ -329,7 +329,7 @@ export const MaximumSelection: StoryObj<HvMultiButtonProps> = {
   render: () => {
     const [selection, setSelection] = useState<number[]>([]);
 
-    const handleChange = (event: MouseEvent, idx: number) => {
+    const handleChange = (event: React.MouseEvent, idx: number) => {
       const newSelection = selection.includes(idx)
         ? selection.filter((v) => v !== idx)
         : [...selection, idx];
@@ -377,7 +377,7 @@ export const VerticalOrientation: StoryObj<HvMultiButtonProps> = {
       { name: "Location", icon: <LocationPin />, key: 6 },
     ];
 
-    const handleChange = (event: MouseEvent, idx: number) => {
+    const handleChange = (event: React.MouseEvent, idx: number) => {
       const newSelection = selection.includes(idx)
         ? selection.filter((v) => v !== idx)
         : [...selection, idx];

--- a/packages/core/src/MultiButton/MultiButton.tsx
+++ b/packages/core/src/MultiButton/MultiButton.tsx
@@ -1,4 +1,4 @@
-import React, { cloneElement } from "react";
+import { Children, cloneElement, isValidElement } from "react";
 
 import { useDefaultProps } from "../hooks/useDefaultProps";
 import { HvButtonSize, HvButtonVariant } from "../Button";
@@ -53,8 +53,8 @@ export const HvMultiButton = (props: HvMultiButtonProps) => {
       )}
       {...others}
     >
-      {React.Children.map(children, (child, index) => {
-        if (React.isValidElement(child)) {
+      {Children.map(children, (child, index) => {
+        if (isValidElement(child)) {
           const childIsSelected = !!child.props.selected;
 
           return (
@@ -65,12 +65,11 @@ export const HvMultiButton = (props: HvMultiButtonProps) => {
                 size,
                 className: cx(child.props.className, classes.button, {
                   [classes.firstButton]: index === 0,
-                  [classes.lastButton]:
-                    index === React.Children.count(children) - 1,
+                  [classes.lastButton]: index === Children.count(children) - 1,
                   [classes.selected]: childIsSelected,
                 }),
               })}
-              {split && index < React.Children.count(children) - 1 && (
+              {split && index < Children.count(children) - 1 && (
                 <div
                   className={cx(classes.splitContainer, classes[variant], {
                     [classes.splitDisabled]: disabled,

--- a/packages/core/src/Pagination/Pagination.styles.tsx
+++ b/packages/core/src/Pagination/Pagination.styles.tsx
@@ -1,5 +1,3 @@
-import { CSSProperties } from "react";
-
 import { theme } from "@hitachivantara/uikit-styles";
 
 import { inputClasses } from "../Input";
@@ -19,7 +17,7 @@ export const { staticClasses, useClasses } = createClasses("HvPagination", {
     flexWrap: "wrap",
     marginTop: theme.space.sm,
     [`& $pageSizeInput`]: {
-      ...(theme.typography.caption2 as CSSProperties),
+      ...(theme.typography.caption2 as React.CSSProperties),
       "&:focus": {
         padding: 0,
       },
@@ -64,10 +62,10 @@ export const { staticClasses, useClasses } = createClasses("HvPagination", {
     justifyContent: "center",
     height: "24px",
     padding: "8px 0",
-    ...(theme.typography.caption2 as CSSProperties),
+    ...(theme.typography.caption2 as React.CSSProperties),
   },
   totalPagesTextContainer: {
-    ...(theme.typography.caption2 as CSSProperties),
+    ...(theme.typography.caption2 as React.CSSProperties),
   },
   /** Styles applied to the page size selector dropdown element. */
   pageSizeOptionsSelect: {
@@ -75,7 +73,7 @@ export const { staticClasses, useClasses } = createClasses("HvPagination", {
     margin: `0px ${theme.space.xs}`,
     width: "auto",
 
-    ...(theme.typography.caption2 as CSSProperties),
+    ...(theme.typography.caption2 as React.CSSProperties),
   },
   /** Styles applied to the page navigation container. */
   pageNavigator: {

--- a/packages/core/src/Pagination/Pagination.tsx
+++ b/packages/core/src/Pagination/Pagination.tsx
@@ -1,4 +1,4 @@
-import { HTMLAttributes, useCallback, useEffect } from "react";
+import { useCallback, useEffect } from "react";
 import Hidden from "@mui/material/Hidden";
 import {
   Start,
@@ -81,9 +81,9 @@ export interface HvPaginationProps extends HvBaseProps {
   /** An object containing all the labels for the component. */
   labels?: HvPaginationLabels;
   /** Other props to show page component. */
-  showPageProps?: HTMLAttributes<HTMLDivElement>;
+  showPageProps?: React.HTMLAttributes<HTMLDivElement>;
   /** Other props to pagination component. */
-  navigationProps?: HTMLAttributes<HTMLDivElement>;
+  navigationProps?: React.HTMLAttributes<HTMLDivElement>;
   /** Extra properties passed to the input component representing the current pages. */
   currentPageInputProps?: HvInputProps;
   /** A Jss Object used to override or extend the styles applied to the component. */

--- a/packages/core/src/Pagination/Select.tsx
+++ b/packages/core/src/Pagination/Select.tsx
@@ -1,4 +1,4 @@
-import { SyntheticEvent, useState } from "react";
+import { useState } from "react";
 
 import { HvBaseDropdown, HvBaseDropdownProps } from "../BaseDropdown";
 import { HvSelectionList, HvSelectionListProps } from "../SelectionList";

--- a/packages/core/src/Radio/Radio.tsx
+++ b/packages/core/src/Radio/Radio.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, useCallback, useState } from "react";
+import { forwardRef, useCallback, useState } from "react";
 
 import { RadioProps as MuiRadioProps } from "@mui/material/Radio";
 

--- a/packages/core/src/RadioGroup/RadioGroup.stories.tsx
+++ b/packages/core/src/RadioGroup/RadioGroup.stories.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { Meta, StoryObj } from "@storybook/react";
 import { CSSInterpolation, css } from "@emotion/css";
 import {

--- a/packages/core/src/Select/Select.tsx
+++ b/packages/core/src/Select/Select.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-use-before-define */
-import React, { useRef, useState } from "react";
+import { useRef, useState } from "react";
 import type { Placement } from "@popperjs/core";
 import clsx from "clsx";
 

--- a/packages/core/src/SelectionList/SelectionList.tsx
+++ b/packages/core/src/SelectionList/SelectionList.tsx
@@ -1,12 +1,12 @@
-import React, {
+import {
   useCallback,
   useMemo,
   useRef,
   useEffect,
-  ReactNode,
   forwardRef,
+  Children,
+  cloneElement,
 } from "react";
-
 import { useForkRef } from "@mui/material/utils";
 
 import { useDefaultProps } from "../hooks/useDefaultProps";
@@ -87,10 +87,10 @@ export interface HvSelectionListProps
 }
 
 const getValueFromSelectedChildren = (
-  children: ReactNode,
+  children: React.ReactNode,
   multiple: boolean
 ) => {
-  const selectedValues = React.Children.toArray(children)
+  const selectedValues = Children.toArray(children)
     .map((child: any) => {
       const childIsControlled = child?.props?.selected !== undefined;
       const childIsSelected =
@@ -165,7 +165,7 @@ export const HvSelectionList = forwardRef<
     const childValues: any[] = [];
     const childSelectedState: boolean[] = [];
 
-    React.Children.toArray(children).forEach((child: any, i: number) => {
+    Children.toArray(children).forEach((child: any, i: number) => {
       const childValue = child?.props?.value;
       const childIsSelected = multiple
         ? value.indexOf(childValue) !== -1
@@ -270,10 +270,10 @@ export const HvSelectionList = forwardRef<
   );
 
   const modifiedChildren = useMemo(() => {
-    return React.Children.map(children, (child: any, i: number) => {
+    return Children.map(children, (child: any, i: number) => {
       const childIsSelected = selectedState[i];
 
-      return React.cloneElement(child, {
+      return cloneElement(child, {
         role: "option",
         selected: childIsSelected,
         onClick: (evt) =>

--- a/packages/core/src/Slider/Slider.styles.tsx
+++ b/packages/core/src/Slider/Slider.styles.tsx
@@ -1,4 +1,3 @@
-import { CSSProperties } from "react";
 import { theme } from "@hitachivantara/uikit-styles";
 
 import { outlineStyles } from "../utils/focusUtils";
@@ -6,7 +5,7 @@ import { createClasses } from "../utils/classes";
 
 import base from "./base";
 
-const dot: CSSProperties = {
+const dot: React.CSSProperties = {
   position: "absolute",
   bottom: "-1px",
   marginLeft: "0px",
@@ -20,7 +19,7 @@ const dot: CSSProperties = {
   zIndex: "-3",
 };
 
-const dragSquare: CSSProperties = {
+const dragSquare: React.CSSProperties = {
   cursor: "grab",
   width: "calc(100% - 40px)",
   left: "20px",
@@ -34,7 +33,7 @@ const dragSquare: CSSProperties = {
   zIndex: "-2",
 };
 
-const ring: CSSProperties = {
+const ring: React.CSSProperties = {
   width: "32px",
   height: "32px",
   borderRadius: "50%",
@@ -46,7 +45,7 @@ const ring: CSSProperties = {
   left: "-10px",
 };
 
-const border: CSSProperties = {
+const border: React.CSSProperties = {
   width: "20px",
   height: "20px",
   borderRadius: "50%",
@@ -117,7 +116,7 @@ export const sliderStyles = {
     marginTop: "-1px",
   },
   rail: { backgroundColor: theme.colors.atmo4, height: "1px", zIndex: "-3" },
-} satisfies Record<string, CSSProperties>;
+} satisfies Record<string, React.CSSProperties>;
 
 export const { staticClasses, useClasses } = createClasses("HvSlider", {
   sliderBase: { ...base },

--- a/packages/core/src/Slider/Slider.tsx
+++ b/packages/core/src/Slider/Slider.tsx
@@ -1,4 +1,4 @@
-import React, {
+import {
   forwardRef,
   useCallback,
   useEffect,

--- a/packages/core/src/Slider/utils.ts
+++ b/packages/core/src/Slider/utils.ts
@@ -1,5 +1,3 @@
-import { CSSProperties } from "react";
-
 import { theme } from "@hitachivantara/uikit-styles";
 
 import validationStates from "../Forms/FormElement/validationStates";
@@ -134,18 +132,9 @@ export const createMark = (
   markDigits: number,
   disabled: boolean,
   formatMark: (label: React.ReactNode) => React.ReactNode = (mark) => mark
-): {
-  [key: number]: {
-    label: string;
-    style: CSSProperties;
-  };
-} => {
-  const marks: {
-    [key: number]: {
-      label: string;
-      style: CSSProperties;
-    };
-  } = {};
+): Record<number, { label: string; style: React.CSSProperties }> => {
+  const marks: Record<number, { label: string; style: React.CSSProperties }> =
+    {};
 
   if (markProperties.length > 0) {
     markProperties.forEach((markProperty) => {
@@ -207,8 +196,8 @@ export const createMark = (
  */
 export const createTrackStyles = (
   knobProperties: HvKnobProperty[]
-): CSSProperties[] => {
-  const trackStyles: CSSProperties[] = [];
+): React.CSSProperties[] => {
+  const trackStyles: React.CSSProperties[] = [];
 
   if (knobProperties.length > 0) {
     knobProperties.forEach((knobProperty, index) => {
@@ -234,11 +223,11 @@ export const createTrackStyles = (
 export const createKnobStyles = (
   knobProperties: HvKnobProperty[]
 ): {
-  knobInner: CSSProperties[];
-  knobOuterStyle: CSSProperties[];
+  knobInner: React.CSSProperties[];
+  knobOuterStyle: React.CSSProperties[];
 } => {
-  const knobInner: CSSProperties[] = [];
-  const knobOuterStyle: CSSProperties[] = [];
+  const knobInner: React.CSSProperties[] = [];
+  const knobOuterStyle: React.CSSProperties[] = [];
 
   const lastItem = knobProperties.length - 1;
   if (knobProperties.length > 0) {

--- a/packages/core/src/Snackbar/Snackbar.tsx
+++ b/packages/core/src/Snackbar/Snackbar.tsx
@@ -1,4 +1,4 @@
-import { SyntheticEvent, useCallback } from "react";
+import { useCallback } from "react";
 import Slide, { SlideProps } from "@mui/material/Slide";
 import MuiSnackbar, {
   SnackbarCloseReason,
@@ -27,12 +27,10 @@ export interface HvSnackbarProps
    * Typically onClose is used to set state in the parent component, which is used to control the Snackbar open prop.
    * The reason parameter can optionally be used to control the response to onClose, for example ignoring click away.
    * */
-  onClose?:
-    | ((
-        event: Event | SyntheticEvent<any, Event>,
-        reason: SnackbarCloseReason
-      ) => void)
-    | undefined;
+  onClose?: (
+    event: Event | React.SyntheticEvent<any, Event>,
+    reason: SnackbarCloseReason
+  ) => void;
   /** The message to display. */
   label?: React.ReactNode;
   /**

--- a/packages/core/src/SnackbarProvider/SnackbarProvider.tsx
+++ b/packages/core/src/SnackbarProvider/SnackbarProvider.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, ReactNode, useCallback, useMemo } from "react";
+import { forwardRef, useCallback, useMemo } from "react";
 import {
   OptionsObject,
   SnackbarContent,
@@ -45,7 +45,7 @@ export interface HvNotistackSnackMessageProps extends OptionsObject {
   /** class name to apply on the root node */
   className?: string;
   /** Your component tree. */
-  message?: ReactNode;
+  message?: React.ReactNode;
   /** Variant of the snackbar. */
   variant?: HvSnackbarVariant;
   /** Extra values to pass to the snackbar. */
@@ -84,7 +84,7 @@ export const useHvSnackbar = () => {
     snackbarContext;
 
   const enqueueSnackbar = useCallback(
-    (message: ReactNode, options: HvNotistackSnackMessageProps = {}) => {
+    (message: React.ReactNode, options: HvNotistackSnackMessageProps = {}) => {
       const {
         id,
         variant = "success",

--- a/packages/core/src/Stack/Stack.tsx
+++ b/packages/core/src/Stack/Stack.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useRef, useCallback } from "react";
+import { useMemo, useRef, useCallback, Children } from "react";
 
 import { useTheme } from "@mui/material/styles";
 import MuiDivider, {
@@ -118,7 +118,7 @@ export const HvStack = (props: HvStackProps) => {
       )}
       {...others}
     >
-      {React.Children.map(children, (child, i) => {
+      {Children.map(children, (child, i) => {
         return (
           <>
             {divider && i !== 0 && getDividerComponent()}
@@ -130,7 +130,7 @@ export const HvStack = (props: HvStackProps) => {
                 navigationJump={
                   processedDirection === "column"
                     ? 1
-                    : React.Children.count(children) || 0
+                    : Children.count(children) || 0
                 }
                 filterClass="child"
               >

--- a/packages/core/src/Switch/Switch.stories.tsx
+++ b/packages/core/src/Switch/Switch.stories.tsx
@@ -1,4 +1,4 @@
-import { LabelHTMLAttributes, useState } from "react";
+import { useState } from "react";
 import { Decorator, Meta, StoryObj } from "@storybook/react";
 import { css } from "@emotion/css";
 import {
@@ -140,7 +140,9 @@ export const WithLabels: StoryObj<HvSwitchProps> = {
     eyes: { include: false },
   },
   render: () => {
-    const Label: React.FC<LabelHTMLAttributes<HTMLLabelElement>> = (props) => (
+    const Label: React.FC<React.LabelHTMLAttributes<HTMLLabelElement>> = (
+      props
+    ) => (
       // eslint-disable-next-line jsx-a11y/label-has-associated-control
       <label style={{ cursor: "pointer" }} {...props} />
     );

--- a/packages/core/src/Switch/Switch.tsx
+++ b/packages/core/src/Switch/Switch.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, useCallback } from "react";
+import { forwardRef, useCallback } from "react";
 
 import { SwitchProps as MuiSwitchProps } from "@mui/material/Switch";
 

--- a/packages/core/src/Tab/Tab.styles.tsx
+++ b/packages/core/src/Tab/Tab.styles.tsx
@@ -1,5 +1,3 @@
-import { CSSProperties } from "react";
-
 import { theme } from "@hitachivantara/uikit-styles";
 
 import { createClasses } from "../utils/classes";
@@ -13,7 +11,7 @@ export const { staticClasses, useClasses } = createClasses("HvTab", {
     minHeight: 32,
     textTransform: "none",
     fontFamily: theme.fontFamily.body,
-    ...(theme.typography.body as CSSProperties),
+    ...(theme.typography.body as React.CSSProperties),
     "&:hover": {
       backgroundColor: theme.colors.containerBackgroundHover,
       borderRadius: theme.radii.base,

--- a/packages/core/src/Table/Table.tsx
+++ b/packages/core/src/Table/Table.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, TableHTMLAttributes, useMemo, useRef } from "react";
+import { forwardRef, useMemo, useRef } from "react";
 
 import { useDefaultProps } from "../hooks/useDefaultProps";
 import { ExtractNames } from "../utils/classes";
@@ -25,7 +25,8 @@ export type HvTableCellVariant =
   | "default"
   | "none";
 
-export interface HvTableProps extends TableHTMLAttributes<HTMLTableElement> {
+export interface HvTableProps
+  extends React.TableHTMLAttributes<HTMLTableElement> {
   /**
    * The component used for the root node. Either a string to use a HTML element or a component.
    * Defaults to `table`.

--- a/packages/core/src/Table/TableBody/TableBody.tsx
+++ b/packages/core/src/Table/TableBody/TableBody.tsx
@@ -1,4 +1,4 @@
-import React, {
+import {
   Children,
   forwardRef,
   isValidElement,

--- a/packages/core/src/Table/TableCell/TableCell.styles.tsx
+++ b/packages/core/src/Table/TableCell/TableCell.styles.tsx
@@ -1,5 +1,3 @@
-import { CSSProperties } from "react";
-
 import { theme } from "@hitachivantara/uikit-styles";
 
 import { createClasses } from "../../utils/classes";
@@ -24,7 +22,7 @@ export const { staticClasses, useClasses } = createClasses("HvTableCell", {
     backgroundColor: theme.colors.atmo1,
     borderTop: "1px solid transparent",
     borderBottom: `1px solid ${theme.colors.atmo4}`,
-    ...(theme.typography.label as CSSProperties),
+    ...(theme.typography.label as React.CSSProperties),
   },
   /** Styles applied to the cell when it's in the table body. */
   body: {
@@ -33,7 +31,7 @@ export const { staticClasses, useClasses } = createClasses("HvTableCell", {
       height: 32,
     },
     backgroundColor: "inherit",
-    ...(theme.typography.body as CSSProperties),
+    ...(theme.typography.body as React.CSSProperties),
     fontFamily: theme.fontFamily.body,
 
     "&$sorted": {

--- a/packages/core/src/Table/TableCell/TableCell.tsx
+++ b/packages/core/src/Table/TableCell/TableCell.tsx
@@ -1,4 +1,4 @@
-import { CSSProperties, forwardRef, TdHTMLAttributes, useContext } from "react";
+import { forwardRef, useContext } from "react";
 
 import { capitalize } from "../../utils/helpers";
 import { ExtractNames } from "../../utils/classes";
@@ -18,13 +18,13 @@ export { staticClasses as tableCellClasses };
 export type HvTableCellClasses = ExtractNames<typeof useClasses>;
 
 export interface HvTableCellProps
-  extends Omit<TdHTMLAttributes<HTMLTableCellElement>, "align"> {
+  extends Omit<React.TdHTMLAttributes<HTMLTableCellElement>, "align"> {
   /** The component used for the root node. Either a string to use a HTML element or a component. Defaults to td. */
   component?: React.ElementType;
   /** Content to be rendered */
   children?: React.ReactNode;
   /** Inline styles to be applied to the root element. */
-  style?: CSSProperties;
+  style?: React.CSSProperties;
   /** Set the text-align on the table cell content. */
   align?: HvTableCellAlign;
   /** Sets the cell's variant. */

--- a/packages/core/src/Table/TableHeader/TableHeader.tsx
+++ b/packages/core/src/Table/TableHeader/TableHeader.tsx
@@ -1,10 +1,4 @@
-import {
-  forwardRef,
-  HTMLAttributes,
-  ThHTMLAttributes,
-  useContext,
-  useMemo,
-} from "react";
+import { forwardRef, useContext, useMemo } from "react";
 import { hexToRgb, alpha } from "@mui/material/styles";
 
 import { theme } from "@hitachivantara/uikit-styles";
@@ -31,7 +25,7 @@ export { staticClasses as tableHeaderClasses };
 export type HvTableHeaderClasses = ExtractNames<typeof useClasses>;
 
 export interface HvTableHeaderProps
-  extends Omit<ThHTMLAttributes<HTMLTableCellElement>, "align"> {
+  extends Omit<React.ThHTMLAttributes<HTMLTableCellElement>, "align"> {
   /** The component used for the root node. Either a string to use a HTML element or a component. Defaults to th. */
   component?: React.ElementType;
   /** Content to be rendered */
@@ -67,7 +61,7 @@ export interface HvTableHeaderProps
   /** Whether or not the cell is being resized */
   resizing?: boolean;
   /** The resize props injected in the resize handler */
-  resizerProps?: HTMLAttributes<HTMLDivElement>;
+  resizerProps?: React.HTMLAttributes<HTMLDivElement>;
   /** A Jss Object used to override or extend the styles applied to the component. */
   classes?: HvTableHeaderClasses;
   /** Extra props to be passed onto the sort button in the header. */

--- a/packages/core/src/Table/hooks/useHeaderGroups.ts
+++ b/packages/core/src/Table/hooks/useHeaderGroups.ts
@@ -1,4 +1,3 @@
-import { CSSProperties } from "react";
 import { Hooks } from "react-table";
 
 // #region ##### TYPES #####
@@ -9,7 +8,7 @@ export interface UseHvHeaderGroupsInstance {
 
 // props target: <table><thead><tr><th>
 export interface UseHvHeaderGroupsColumnProps {
-  style?: CSSProperties;
+  style?: React.CSSProperties;
   groupColumnMostLeft?: boolean;
   groupColumnMostRight?: boolean;
 }

--- a/packages/core/src/Table/hooks/useResizeColumns.ts
+++ b/packages/core/src/Table/hooks/useResizeColumns.ts
@@ -1,4 +1,3 @@
-import { HTMLAttributes } from "react";
 import { ensurePluginOrder, Hooks } from "react-table";
 
 // #region ##### TYPES #####
@@ -7,7 +6,7 @@ import { ensurePluginOrder, Hooks } from "react-table";
 export interface UseHvResizeColumnProps {
   resizable?: boolean;
   resizing?: boolean;
-  resizerProps?: HTMLAttributes<HTMLDivElement>;
+  resizerProps?: React.HTMLAttributes<HTMLDivElement>;
 }
 
 // getCellProps:

--- a/packages/core/src/Table/hooks/useRowExpand.tsx
+++ b/packages/core/src/Table/hooks/useRowExpand.tsx
@@ -1,4 +1,3 @@
-import { MouseEventHandler } from "react";
 import {
   Hooks,
   TableExpandedToggleProps,
@@ -23,7 +22,7 @@ export type UseHvRowExpandTableOptions = {
 };
 
 export interface UseHvRowExpandRowToggleProps extends TableExpandedToggleProps {
-  onClick?: MouseEventHandler<unknown>;
+  onClick?: React.MouseEventHandler<unknown>;
 }
 
 export interface UseHvRowExpandRowInstance<

--- a/packages/core/src/Table/hooks/useRowSelection.tsx
+++ b/packages/core/src/Table/hooks/useRowSelection.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, useCallback, useMemo } from "react";
+import { useCallback, useMemo } from "react";
 import {
   Hooks,
   IdType,
@@ -28,14 +28,14 @@ export interface UseHvRowSelectionTableColumnProps {
 }
 
 export interface UseHvRowSelectionRowCheckboxProps {
-  onChange?: (e: ChangeEvent, checked?: boolean) => void;
+  onChange?: (e: React.ChangeEvent, checked?: boolean) => void;
   checked?: boolean;
   disabled?: boolean;
   indeterminate?: boolean;
 }
 
 export interface UseHvRowSelectionBulkCheckboxProps {
-  onChange?: (e: ChangeEvent, checked?: boolean) => void;
+  onChange?: (e: React.ChangeEvent, checked?: boolean) => void;
   checked?: boolean;
   indeterminate?: boolean;
 }

--- a/packages/core/src/Table/hooks/useSticky.ts
+++ b/packages/core/src/Table/hooks/useSticky.ts
@@ -1,4 +1,3 @@
-import { CSSProperties } from "react";
 import {
   makePropGetter,
   useGetLatest,
@@ -185,7 +184,7 @@ const getRowProps = () => ({
 });
 
 const getCellProps = (header, isHeaderCell: boolean) => {
-  const props: UseHvTableStickyCellProps & { style: CSSProperties } = {
+  const props: UseHvTableStickyCellProps & { style: React.CSSProperties } = {
     style: {
       display: "inline-flex",
       flex: `${header.totalWidth} ${header.totalMinWidth} auto`,

--- a/packages/core/src/Table/hooks/useTableStyles.ts
+++ b/packages/core/src/Table/hooks/useTableStyles.ts
@@ -1,11 +1,10 @@
-import { CSSProperties } from "react";
 import { clsx } from "clsx";
 import { Hooks } from "react-table";
 
 // #region ##### TYPES #####
 
 export type UseHvTableStylesTableOptions = {
-  style?: CSSProperties;
+  style?: React.CSSProperties;
   className?: string;
   classes?: Record<string, string>;
   component?: any;
@@ -16,15 +15,15 @@ export interface UseHvTableStylesColumnOptions {
   variant?: "checkbox" | "expand" | "actions" | "default" | "none";
   align?: "center" | "inherit" | "justify" | "left" | "right";
 
-  style?: CSSProperties;
+  style?: React.CSSProperties;
   className?: string;
   classes?: Record<string, string>;
 
-  headerStyle?: CSSProperties;
+  headerStyle?: React.CSSProperties;
   headerClassName?: string;
   headerClasses?: Record<string, string>;
 
-  cellStyle?: CSSProperties;
+  cellStyle?: React.CSSProperties;
   cellClassName?: string;
   cellClasses?: Record<string, string>;
 }
@@ -35,7 +34,7 @@ export interface UseHvTableStylesTableRowProps {
 }
 
 export interface UseHvTableStylesTableCellProps {
-  style?: CSSProperties;
+  style?: React.CSSProperties;
   className?: string;
   classes?: Record<string, string>;
   variant?: "checkbox" | "expand" | "actions" | "default" | "none";

--- a/packages/core/src/Table/stories/TableComplete/TableComplete.tsx
+++ b/packages/core/src/Table/stories/TableComplete/TableComplete.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, SyntheticEvent, useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { css } from "@emotion/css";
 import { Ban } from "@hitachivantara/uikit-react-icons";
 import {
@@ -60,7 +60,7 @@ const NoDataRow = ({
   message,
   height = 96,
 }: {
-  message: ReactNode;
+  message: React.ReactNode;
   height?: number;
 }) => (
   <HvTableRow>
@@ -103,13 +103,13 @@ export interface TableProps<T extends object = Record<string, unknown>> {
     selectAllPages?: string;
   };
   onAction?: (
-    event: SyntheticEvent,
+    event: React.SyntheticEvent,
     action: TableAction<T>,
     row: HvRowInstance<T>
   ) => void;
   onSelection?: (selectedRowIds: HvTableState<T>["selectedRowIds"]) => void;
   onBulkAction?: (
-    event: SyntheticEvent,
+    event: React.SyntheticEvent,
     action: HvActionGeneric,
     selectedRows: HvTableInstance<T>["selectedFlatRows"]
   ) => void;

--- a/packages/core/src/Table/stories/TableHooks/UseHvFilters.tsx
+++ b/packages/core/src/Table/stories/TableHooks/UseHvFilters.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, useMemo } from "react";
+import { useMemo } from "react";
 import { Ban } from "@hitachivantara/uikit-react-icons";
 import {
   HvTable,
@@ -24,7 +24,7 @@ const NoDataRow = ({
   message,
   height = 96,
 }: {
-  message: ReactNode;
+  message: React.ReactNode;
   height?: number;
 }) => (
   <HvTableRow>

--- a/packages/core/src/Table/stories/TableRenderers/AllColumnRenderers.tsx
+++ b/packages/core/src/Table/stories/TableRenderers/AllColumnRenderers.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from "react";
+import { Fragment, useMemo, useState } from "react";
 import {
   HvCellProps,
   HvPagination,
@@ -143,7 +143,7 @@ export const AllColumnRenderers = () => {
       prepareRow(row);
 
       return (
-        <React.Fragment key={row.id}>
+        <Fragment key={row.id}>
           <HvTableRow
             {...row.getRowProps({
               "aria-rowindex": index + 1,
@@ -172,7 +172,7 @@ export const AllColumnRenderers = () => {
               </HvTypography>
             </HvTableCell>
           </HvTableRow>
-        </React.Fragment>
+        </Fragment>
       );
     });
   };

--- a/packages/core/src/Table/stories/TableRenderers/DateColumnRenderer.tsx
+++ b/packages/core/src/Table/stories/TableRenderers/DateColumnRenderer.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import {
   HvCellProps,
   HvPagination,
@@ -57,19 +57,13 @@ export const DateColumnRenderer = () => {
       prepareRow(row);
 
       return (
-        <React.Fragment key={row.id}>
-          <HvTableRow
-            {...row.getRowProps({
-              "aria-rowindex": index + 1,
-            })}
-          >
-            {row.cells.map((cell) => (
-              <HvTableCell {...cell.getCellProps()}>
-                {cell.render("Cell")}
-              </HvTableCell>
-            ))}
-          </HvTableRow>
-        </React.Fragment>
+        <HvTableRow {...row.getRowProps({ "aria-rowindex": index + 1 })}>
+          {row.cells.map((cell) => (
+            <HvTableCell {...cell.getCellProps()}>
+              {cell.render("Cell")}
+            </HvTableCell>
+          ))}
+        </HvTableRow>
       );
     });
   };

--- a/packages/core/src/Table/stories/TableRenderers/DropDownColumnRenderer.test.tsx
+++ b/packages/core/src/Table/stories/TableRenderers/DropDownColumnRenderer.test.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 
 import { describe, expect, it, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
@@ -77,19 +77,13 @@ const DropdownColumnRenderer = () => {
       prepareRow(row);
 
       return (
-        <React.Fragment key={row.id}>
-          <HvTableRow
-            {...row.getRowProps({
-              "aria-rowindex": index + 1,
-            })}
-          >
-            {row.cells.map((cell) => (
-              <HvTableCell {...cell.getCellProps()}>
-                {cell.render("Cell")}
-              </HvTableCell>
-            ))}
-          </HvTableRow>
-        </React.Fragment>
+        <HvTableRow {...row.getRowProps({ "aria-rowindex": index + 1 })}>
+          {row.cells.map((cell) => (
+            <HvTableCell {...cell.getCellProps()}>
+              {cell.render("Cell")}
+            </HvTableCell>
+          ))}
+        </HvTableRow>
       );
     });
   };

--- a/packages/core/src/Table/stories/TableRenderers/DropdownColumnRenderer.tsx
+++ b/packages/core/src/Table/stories/TableRenderers/DropdownColumnRenderer.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import {
   HvCellProps,
   HvPagination,
@@ -76,19 +76,13 @@ export const DropdownColumnRenderer = () => {
       prepareRow(row);
 
       return (
-        <React.Fragment key={row.id}>
-          <HvTableRow
-            {...row.getRowProps({
-              "aria-rowindex": index + 1,
-            })}
-          >
-            {row.cells.map((cell) => (
-              <HvTableCell {...cell.getCellProps()}>
-                {cell.render("Cell")}
-              </HvTableCell>
-            ))}
-          </HvTableRow>
-        </React.Fragment>
+        <HvTableRow {...row.getRowProps({ "aria-rowindex": index + 1 })}>
+          {row.cells.map((cell) => (
+            <HvTableCell {...cell.getCellProps()}>
+              {cell.render("Cell")}
+            </HvTableCell>
+          ))}
+        </HvTableRow>
       );
     });
   };

--- a/packages/core/src/Table/stories/TableRenderers/ExpandColumnRenderer.tsx
+++ b/packages/core/src/Table/stories/TableRenderers/ExpandColumnRenderer.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from "react";
+import { Fragment, useMemo, useState } from "react";
 import {
   HvCellProps,
   HvPagination,
@@ -70,7 +70,7 @@ export const ExpandColumnRenderer = () => {
       prepareRow(row);
 
       return (
-        <React.Fragment key={row.id}>
+        <Fragment key={row.id}>
           <HvTableRow
             {...row.getRowProps({
               "aria-rowindex": index + 1,
@@ -84,6 +84,7 @@ export const ExpandColumnRenderer = () => {
           </HvTableRow>
           <HvTableRow style={{ display: row.isExpanded ? undefined : "none" }}>
             <HvTableCell
+              colSpan={100}
               style={{
                 paddingBottom: 0,
                 paddingTop: 0,
@@ -92,15 +93,13 @@ export const ExpandColumnRenderer = () => {
                 backgroundColor: theme.colors.atmo2,
                 borderTop: `solid 1px ${theme.colors.atmo4}`,
               }}
-              // @ts-ignore
-              colSpan="100%"
             >
               <HvTypography>
                 Expanded content for: {row.values.name}
               </HvTypography>
             </HvTableCell>
           </HvTableRow>
-        </React.Fragment>
+        </Fragment>
       );
     });
   };

--- a/packages/core/src/Table/stories/TableRenderers/NumberColumnRenderer.tsx
+++ b/packages/core/src/Table/stories/TableRenderers/NumberColumnRenderer.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import {
   HvCellProps,
   HvPagination,
@@ -58,19 +58,13 @@ export const NumberColumnRenderer = () => {
       prepareRow(row);
 
       return (
-        <React.Fragment key={row.id}>
-          <HvTableRow
-            {...row.getRowProps({
-              "aria-rowindex": index + 1,
-            })}
-          >
-            {row.cells.map((cell) => (
-              <HvTableCell {...cell.getCellProps()}>
-                {cell.render("Cell")}
-              </HvTableCell>
-            ))}
-          </HvTableRow>
-        </React.Fragment>
+        <HvTableRow {...row.getRowProps({ "aria-rowindex": index + 1 })}>
+          {row.cells.map((cell) => (
+            <HvTableCell {...cell.getCellProps()}>
+              {cell.render("Cell")}
+            </HvTableCell>
+          ))}
+        </HvTableRow>
       );
     });
   };

--- a/packages/core/src/Table/stories/TableRenderers/ProgressColumnRenderer.tsx
+++ b/packages/core/src/Table/stories/TableRenderers/ProgressColumnRenderer.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import {
   HvCellProps,
   HvPagination,
@@ -63,19 +63,13 @@ export const ProgressColumnRenderer = () => {
       prepareRow(row);
 
       return (
-        <React.Fragment key={row.id}>
-          <HvTableRow
-            {...row.getRowProps({
-              "aria-rowindex": index + 1,
-            })}
-          >
-            {row.cells.map((cell) => (
-              <HvTableCell {...cell.getCellProps()}>
-                {cell.render("Cell")}
-              </HvTableCell>
-            ))}
-          </HvTableRow>
-        </React.Fragment>
+        <HvTableRow {...row.getRowProps({ "aria-rowindex": index + 1 })}>
+          {row.cells.map((cell) => (
+            <HvTableCell {...cell.getCellProps()}>
+              {cell.render("Cell")}
+            </HvTableCell>
+          ))}
+        </HvTableRow>
       );
     });
   };

--- a/packages/core/src/Table/stories/TableRenderers/SwitchColumnRenderer.tsx
+++ b/packages/core/src/Table/stories/TableRenderers/SwitchColumnRenderer.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import {
   HvCellProps,
   HvPagination,
@@ -74,19 +74,13 @@ export const SwitchColumnRenderer = () => {
       prepareRow(row);
 
       return (
-        <React.Fragment key={row.id}>
-          <HvTableRow
-            {...row.getRowProps({
-              "aria-rowindex": index + 1,
-            })}
-          >
-            {row.cells.map((cell) => (
-              <HvTableCell {...cell.getCellProps()}>
-                {cell.render("Cell")}
-              </HvTableCell>
-            ))}
-          </HvTableRow>
-        </React.Fragment>
+        <HvTableRow {...row.getRowProps({ "aria-rowindex": index + 1 })}>
+          {row.cells.map((cell) => (
+            <HvTableCell {...cell.getCellProps()}>
+              {cell.render("Cell")}
+            </HvTableCell>
+          ))}
+        </HvTableRow>
       );
     });
   };

--- a/packages/core/src/Table/stories/TableRenderers/TagColumnRenderer.tsx
+++ b/packages/core/src/Table/stories/TableRenderers/TagColumnRenderer.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import {
   HvCellProps,
   HvPagination,
@@ -62,19 +62,13 @@ export const TagColumnRenderer = () => {
       prepareRow(row);
 
       return (
-        <React.Fragment key={row.id}>
-          <HvTableRow
-            {...row.getRowProps({
-              "aria-rowindex": index + 1,
-            })}
-          >
-            {row.cells.map((cell) => (
-              <HvTableCell {...cell.getCellProps()}>
-                {cell.render("Cell")}
-              </HvTableCell>
-            ))}
-          </HvTableRow>
-        </React.Fragment>
+        <HvTableRow {...row.getRowProps({ "aria-rowindex": index + 1 })}>
+          {row.cells.map((cell) => (
+            <HvTableCell {...cell.getCellProps()}>
+              {cell.render("Cell")}
+            </HvTableCell>
+          ))}
+        </HvTableRow>
       );
     });
   };

--- a/packages/core/src/Table/stories/TableRenderers/TextColumnRenderer.tsx
+++ b/packages/core/src/Table/stories/TableRenderers/TextColumnRenderer.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import {
   HvCellProps,
   HvPagination,
@@ -58,19 +58,13 @@ export const TextColumnRenderer = () => {
       prepareRow(row);
 
       return (
-        <React.Fragment key={row.id}>
-          <HvTableRow
-            {...row.getRowProps({
-              "aria-rowindex": index + 1,
-            })}
-          >
-            {row.cells.map((cell) => (
-              <HvTableCell {...cell.getCellProps()}>
-                {cell.render("Cell")}
-              </HvTableCell>
-            ))}
-          </HvTableRow>
-        </React.Fragment>
+        <HvTableRow {...row.getRowProps({ "aria-rowindex": index + 1 })}>
+          {row.cells.map((cell) => (
+            <HvTableCell {...cell.getCellProps()}>
+              {cell.render("Cell")}
+            </HvTableCell>
+          ))}
+        </HvTableRow>
       );
     });
   };

--- a/packages/core/src/Table/stories/storiesUtils.tsx
+++ b/packages/core/src/Table/stories/storiesUtils.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import {
   HvEmptyState,
   HvTableCell,

--- a/packages/core/src/Tag/Tag.styles.tsx
+++ b/packages/core/src/Tag/Tag.styles.tsx
@@ -1,5 +1,3 @@
-import { CSSProperties } from "react";
-
 import { theme } from "@hitachivantara/uikit-styles";
 
 import { chipClasses } from "@mui/material/Chip";
@@ -49,7 +47,7 @@ export const { staticClasses, useClasses } = createClasses("HvTag", {
     [`& .${chipClasses.label}`]: {
       paddingLeft: 4,
       paddingRight: 4,
-      ...(theme.typography.caption2 as CSSProperties),
+      ...(theme.typography.caption2 as React.CSSProperties),
       color: "currentcolor",
     },
 

--- a/packages/core/src/Tag/Tag.tsx
+++ b/packages/core/src/Tag/Tag.tsx
@@ -1,4 +1,4 @@
-import React, { HTMLAttributes, forwardRef } from "react";
+import { forwardRef } from "react";
 import { HvColorAny, getColor } from "@hitachivantara/uikit-styles";
 import Chip, { ChipProps as MuiChipProps } from "@mui/material/Chip";
 
@@ -44,7 +44,7 @@ export interface HvTagProps
    */
   deleteButtonArialLabel?: string;
   /** Props to apply to delete icon */
-  deleteButtonProps?: HTMLAttributes<HTMLDivElement>;
+  deleteButtonProps?: React.HTMLAttributes<HTMLDivElement>;
   /** A Jss Object used to override or extend the styles applied to the component. */
   classes?: HvTagClasses;
   /** @ignore */

--- a/packages/core/src/TagsInput/TagsInput.tsx
+++ b/packages/core/src/TagsInput/TagsInput.tsx
@@ -1,4 +1,4 @@
-import React, {
+import {
   forwardRef,
   useCallback,
   useEffect,

--- a/packages/core/src/Tooltip/Tooltip.tsx
+++ b/packages/core/src/Tooltip/Tooltip.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, ReactElement } from "react";
+import { forwardRef } from "react";
 import Tooltip, {
   TooltipProps as MuiTooltipProps,
 } from "@mui/material/Tooltip";
@@ -51,7 +51,7 @@ export interface HvTooltipProps extends Omit<MuiTooltipProps, "classes"> {
   /**
    * Node to apply the tooltip.
    */
-  children: ReactElement;
+  children: React.ReactElement;
   /**
    * Id attribute value of an HTML Element to have the tooltip appended to it.
    */

--- a/packages/core/src/TreeView/TreeItem/DefaultContent.tsx
+++ b/packages/core/src/TreeView/TreeItem/DefaultContent.tsx
@@ -1,4 +1,4 @@
-import { HTMLAttributes, ReactNode, forwardRef } from "react";
+import { forwardRef } from "react";
 
 import { useCss } from "../../hooks/useCss";
 import { ExtractNames, createClasses } from "../../utils/classes";
@@ -17,21 +17,21 @@ export const { useClasses } = createClasses("HvTreeContent", {
 
 export type HvTreeContentClasses = ExtractNames<typeof useClasses>;
 
-export interface HvTreeContentProps extends HTMLAttributes<HTMLElement> {
+export interface HvTreeContentProps extends React.HTMLAttributes<HTMLElement> {
   /** className applied to the root element. */
   className?: string;
   /** Override or extend the styles applied to the component. */
   classes?: HvTreeContentClasses;
   /** The tree node label. */
-  label?: ReactNode;
+  label?: React.ReactNode;
   /** The id of the node. */
   nodeId: string;
   /** The icon to display next to the tree node's label. */
-  icon?: ReactNode;
+  icon?: React.ReactNode;
   /** The icon to display next to the tree node's label. Either an expansion or collapse icon. */
-  expansionIcon?: ReactNode;
+  expansionIcon?: React.ReactNode;
   /** The icon to display next to the tree node's label. Either a parent or end icon. */
-  displayIcon?: ReactNode;
+  displayIcon?: React.ReactNode;
 }
 
 /**

--- a/packages/core/src/TreeView/TreeItem/TreeItem.tsx
+++ b/packages/core/src/TreeView/TreeItem/TreeItem.tsx
@@ -1,14 +1,4 @@
-import {
-  FocusEvent,
-  HTMLAttributes,
-  JSXElementConstructor,
-  ReactNode,
-  forwardRef,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
+import { forwardRef, useEffect, useMemo, useRef, useState } from "react";
 import Collapse from "@mui/material/Collapse";
 import { TransitionProps } from "@mui/material/transitions";
 
@@ -30,52 +20,52 @@ export { staticClasses as treeItemClasses };
 
 export type HvTreeItemClasses = ExtractNames<typeof useClasses>;
 
-export interface HvTreeContentProps extends HTMLAttributes<HTMLElement> {
+export interface HvTreeContentProps extends React.HTMLAttributes<HTMLElement> {
   /** className applied to the root element. */
   className?: string;
   /** Override or extend the styles applied to the component. */
   classes?: HvTreeContentClasses;
   /** The tree node label. */
-  label?: ReactNode;
+  label?: React.ReactNode;
   /** The id of the node. */
   nodeId: string;
   /** The icon to display next to the tree node's label. */
-  icon?: ReactNode;
+  icon?: React.ReactNode;
   /** The icon to display next to the tree node's label. Either an expansion or collapse icon. */
-  expansionIcon?: ReactNode;
+  expansionIcon?: React.ReactNode;
   /** The icon to display next to the tree node's label. Either a parent or end icon. */
-  displayIcon?: ReactNode;
+  displayIcon?: React.ReactNode;
 }
 
-export interface HvTreeItemProps extends HTMLAttributes<HTMLElement> {
+export interface HvTreeItemProps extends React.HTMLAttributes<HTMLElement> {
   /** The element id */
   id?: string;
   /** The id of the node. */
   nodeId: string;
   /** The tree node label. */
-  label?: ReactNode;
+  label?: React.ReactNode;
   /** Override or extend the styles applied to the component. */
   classes?: HvTreeItemClasses;
   /** If `true`, the node is disabled. */
   disabled?: boolean;
   /** The icon to display next to the tree node's label. */
-  icon?: ReactNode;
+  icon?: React.ReactNode;
   /** The component used for the content node. */
-  ContentComponent?: JSXElementConstructor<HvTreeContentProps>;
+  ContentComponent?: React.JSXElementConstructor<HvTreeContentProps>;
   /** Props applied to the content component */
   ContentProps?: HvTreeContentProps;
   /** The content of the component. */
-  children?: ReactNode;
+  children?: React.ReactNode;
   /** className applied to the root element. */
   className?: string;
   /** The icon used to collapse the node. */
-  collapseIcon?: ReactNode;
+  collapseIcon?: React.ReactNode;
   /** The icon displayed next to an end node. */
-  endIcon?: ReactNode;
+  endIcon?: React.ReactNode;
   /** The icon used to expand the node. */
-  expandIcon?: ReactNode;
+  expandIcon?: React.ReactNode;
   /** The component used for the transition. */
-  TransitionComponent?: JSXElementConstructor<TransitionProps>;
+  TransitionComponent?: React.JSXElementConstructor<TransitionProps>;
   /** Props applied to the transition component */
   TransitionProps?: TransitionProps;
 }
@@ -166,7 +156,7 @@ export const HvTreeItem = forwardRef<HTMLLIElement, HvTreeItemProps>(
       return undefined;
     }, [instance, nodeId, label]);
 
-    const handleFocus = (event: FocusEvent<HTMLLIElement, any>) => {
+    const handleFocus = (event: React.FocusEvent<HTMLLIElement>) => {
       // DOM focus stays on the tree which manages focus with aria-activedescendant
       if (event.target === event.currentTarget) {
         const rootElement: any =

--- a/packages/core/src/TreeView/internals/types/events.ts
+++ b/packages/core/src/TreeView/internals/types/events.ts
@@ -1,5 +1,3 @@
-import { SyntheticEvent } from "react";
-
 export interface TreeViewEventLookupElement {
   params: object;
 }
@@ -10,7 +8,7 @@ export type TreeViewEventListener<E extends TreeViewEventLookupElement> = (
 ) => void;
 
 export type MuiBaseEvent =
-  | SyntheticEvent<HTMLElement>
+  | React.SyntheticEvent<HTMLElement>
   | DocumentEventMap[keyof DocumentEventMap]
   | {};
 

--- a/packages/core/src/VerticalNavigation/Actions/Action.tsx
+++ b/packages/core/src/VerticalNavigation/Actions/Action.tsx
@@ -1,4 +1,4 @@
-import { MouseEventHandler, useCallback, useContext } from "react";
+import { useCallback, useContext } from "react";
 
 import { isKey } from "../../utils/keyboardUtils";
 import { setId } from "../../utils/setId";
@@ -37,7 +37,7 @@ export interface HvVerticalNavigationActionProps {
   /**
    * Callback called when clicked.
    */
-  onClick?: MouseEventHandler<HTMLElement>;
+  onClick?: React.MouseEventHandler<HTMLElement>;
 }
 
 export const HvVerticalNavigationAction = ({

--- a/packages/core/src/VerticalNavigation/Header/Header.tsx
+++ b/packages/core/src/VerticalNavigation/Header/Header.tsx
@@ -1,4 +1,4 @@
-import { MouseEventHandler, useContext, useMemo } from "react";
+import { useContext, useMemo } from "react";
 import { Backwards, Forwards, Menu } from "@hitachivantara/uikit-react-icons";
 
 import { ExtractNames } from "../../utils/classes";
@@ -48,7 +48,7 @@ export interface HvVerticalNavigationHeaderProps {
   /**
    * Handler for the collapse button.
    */
-  onCollapseButtonClick?: MouseEventHandler<HTMLElement>;
+  onCollapseButtonClick?: React.MouseEventHandler<HTMLElement>;
 }
 
 export const HvVerticalNavigationHeader = ({

--- a/packages/core/src/VerticalNavigation/VerticalNavigationContext.tsx
+++ b/packages/core/src/VerticalNavigation/VerticalNavigationContext.tsx
@@ -1,7 +1,7 @@
-import { createContext, ComponentProps } from "react";
+import { createContext } from "react";
 
 export type NavigationData<T extends React.ElementType = "a"> =
-  ComponentProps<T> &
+  React.ComponentProps<T> &
     Record<string, any> & {
       /** The id to be applied to the root element. */
       id: string;

--- a/packages/core/src/hooks/useClickOutside.ts
+++ b/packages/core/src/hooks/useClickOutside.ts
@@ -1,9 +1,9 @@
-import { useEffect, RefObject } from "react";
+import { useEffect } from "react";
 
 export type HvClickOutsideEvent = MouseEvent | KeyboardEvent | TouchEvent;
 
 export const useClickOutside = <T extends HTMLElement = HTMLElement>(
-  ref: RefObject<T>,
+  ref: React.RefObject<T>,
   handler: (event: HvClickOutsideEvent) => void
 ) => {
   useEffect(() => {

--- a/packages/core/src/providers/Provider.tsx
+++ b/packages/core/src/providers/Provider.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from "react";
+import { useMemo } from "react";
 
 import createCache, { EmotionCache } from "@emotion/cache";
 import {


### PR DESCRIPTION
The default `import React` is no longer necessary (since the new JSX transform) nor recommended [[1]](https://epicreact.dev/importing-react-through-the-ages/).

- Refactor React imports to destructured imports (it's what we use most frequently)
- Remove unused React imports
- Remove unnecessary `React.Fragments` in table samples