### PR TITLE
fix: bump minimum lab `usehooks-ts` version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8973,9 +8973,9 @@
       }
     },
     "node_modules/@storybook/core-common/node_modules/@types/node": {
-      "version": "18.19.24",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.24.tgz",
-      "integrity": "sha512-eghAz3gnbQbvnHqB+mgB2ZR3aH6RhdEmHGS48BnV75KceQPHqabkxKI0BbUSsqhqy2Ddhc2xD/VAR9ySZd57Lw==",
+      "version": "18.19.26",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.26.tgz",
+      "integrity": "sha512-+wiMJsIwLOYCvUqSdKTrfkS8mpTp+MPINe6+Np4TAGFWWRWiBQ5kSq9nZGCSPkzx9mvT+uEukzpX4MOSCydcvw==",
       "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
@@ -9064,9 +9064,9 @@
       }
     },
     "node_modules/@storybook/core-server/node_modules/@types/node": {
-      "version": "18.19.24",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.24.tgz",
-      "integrity": "sha512-eghAz3gnbQbvnHqB+mgB2ZR3aH6RhdEmHGS48BnV75KceQPHqabkxKI0BbUSsqhqy2Ddhc2xD/VAR9ySZd57Lw==",
+      "version": "18.19.26",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.26.tgz",
+      "integrity": "sha512-+wiMJsIwLOYCvUqSdKTrfkS8mpTp+MPINe6+Np4TAGFWWRWiBQ5kSq9nZGCSPkzx9mvT+uEukzpX4MOSCydcvw==",
       "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
@@ -9218,9 +9218,9 @@
       }
     },
     "node_modules/@storybook/csf": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@storybook/csf/-/csf-0.1.2.tgz",
-      "integrity": "sha512-ePrvE/pS1vsKR9Xr+o+YwdqNgHUyXvg+1Xjx0h9LrVx7Zq4zNe06pd63F5EvzTbCbJsHj7GHr9tkiaqm7U8WRA==",
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@storybook/csf/-/csf-0.1.3.tgz",
+      "integrity": "sha512-IPZvXXo4b3G+gpmgBSBqVM81jbp2ePOKsvhgJdhyZJtkYQCII7rg9KKLQhvBQM5sLaF1eU6r0iuwmyynC9d9SA==",
       "dev": true,
       "dependencies": {
         "type-fest": "^2.19.0"
@@ -9509,9 +9509,9 @@
       }
     },
     "node_modules/@storybook/react/node_modules/@types/node": {
-      "version": "18.19.24",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.24.tgz",
-      "integrity": "sha512-eghAz3gnbQbvnHqB+mgB2ZR3aH6RhdEmHGS48BnV75KceQPHqabkxKI0BbUSsqhqy2Ddhc2xD/VAR9ySZd57Lw==",
+      "version": "18.19.26",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.26.tgz",
+      "integrity": "sha512-+wiMJsIwLOYCvUqSdKTrfkS8mpTp+MPINe6+Np4TAGFWWRWiBQ5kSq9nZGCSPkzx9mvT+uEukzpX4MOSCydcvw==",
       "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
@@ -10734,9 +10734,9 @@
       "integrity": "sha512-nG96G3Wp6acyAgJqGasjODb+acrI7KltPiRxzHPXnP3NgI28bpQDRv53olbqGXbfcgF5aiiHmO3xpwEpS5Ld9g=="
     },
     "node_modules/@types/node": {
-      "version": "20.11.28",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.28.tgz",
-      "integrity": "sha512-M/GPWVS2wLkSkNHVeLkrF2fD5Lx5UC4PxA0uZcKc6QqbIQUJyW1jVjueJYi1z8n0I5PxYrtpnPnWglE+y9A0KA==",
+      "version": "20.11.30",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.30.tgz",
+      "integrity": "sha512-dHM6ZxwlmuZaRmUPfv1p+KrdD1Dci04FbdEm/9wEMouFqxYoFl5aMkt0VMAUtYRQDyYvD41WJLukhq/ha3YuTw==",
       "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
@@ -11982,9 +11982,9 @@
       }
     },
     "node_modules/@wdio/types/node_modules/@types/node": {
-      "version": "18.19.24",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.24.tgz",
-      "integrity": "sha512-eghAz3gnbQbvnHqB+mgB2ZR3aH6RhdEmHGS48BnV75KceQPHqabkxKI0BbUSsqhqy2Ddhc2xD/VAR9ySZd57Lw==",
+      "version": "18.19.26",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.26.tgz",
+      "integrity": "sha512-+wiMJsIwLOYCvUqSdKTrfkS8mpTp+MPINe6+Np4TAGFWWRWiBQ5kSq9nZGCSPkzx9mvT+uEukzpX4MOSCydcvw==",
       "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
@@ -29401,9 +29401,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.35",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.35.tgz",
-      "integrity": "sha512-u5U8qYpBCpN13BsiEB0CbR1Hhh4Gc0zLFuedrHJKMctHCHAGrMdG0PRM/KErzAL3CU6/eckEtmHNB3x6e3c0vA==",
+      "version": "8.4.37",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.37.tgz",
+      "integrity": "sha512-7iB/v/r7Woof0glKLH8b1SPHrsX7uhdO+Geb41QpF/+mWZHU3uxxSlN+UXGVit1PawOYDToO+AbZzhBzWRDwbQ==",
       "dev": true,
       "funding": [
         {
@@ -29422,7 +29422,7 @@
       "dependencies": {
         "nanoid": "^3.3.7",
         "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
+        "source-map-js": "^1.2.0"
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
@@ -32548,9 +32548,9 @@
       }
     },
     "node_modules/source-map-js": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
-      "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.0.tgz",
+      "integrity": "sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -33047,9 +33047,9 @@
       }
     },
     "node_modules/storycrawler/node_modules/@types/node": {
-      "version": "18.19.24",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.24.tgz",
-      "integrity": "sha512-eghAz3gnbQbvnHqB+mgB2ZR3aH6RhdEmHGS48BnV75KceQPHqabkxKI0BbUSsqhqy2Ddhc2xD/VAR9ySZd57Lw==",
+      "version": "18.19.26",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.26.tgz",
+      "integrity": "sha512-+wiMJsIwLOYCvUqSdKTrfkS8mpTp+MPINe6+Np4TAGFWWRWiBQ5kSq9nZGCSPkzx9mvT+uEukzpX4MOSCydcvw==",
       "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
@@ -36984,9 +36984,9 @@
       }
     },
     "node_modules/webdriver/node_modules/@types/node": {
-      "version": "18.19.24",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.24.tgz",
-      "integrity": "sha512-eghAz3gnbQbvnHqB+mgB2ZR3aH6RhdEmHGS48BnV75KceQPHqabkxKI0BbUSsqhqy2Ddhc2xD/VAR9ySZd57Lw==",
+      "version": "18.19.26",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.26.tgz",
+      "integrity": "sha512-+wiMJsIwLOYCvUqSdKTrfkS8mpTp+MPINe6+Np4TAGFWWRWiBQ5kSq9nZGCSPkzx9mvT+uEukzpX4MOSCydcvw==",
       "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
@@ -37783,8 +37783,8 @@
         "react-grid-layout": "^1.4.4",
         "reactflow": "^11.10.1",
         "uid": "^2.0.2",
-        "usehooks-ts": "^2.9.1",
-        "zustand": "^4.4.7"
+        "usehooks-ts": "^2.16.0",
+        "zustand": "^4.5.2"
       },
       "devDependencies": {
         "@playwright/test": "^1.41.1",

--- a/packages/lab/package.json
+++ b/packages/lab/package.json
@@ -50,8 +50,8 @@
     "react-grid-layout": "^1.4.4",
     "reactflow": "^11.10.1",
     "uid": "^2.0.2",
-    "usehooks-ts": "^2.9.1",
-    "zustand": "^4.4.7"
+    "usehooks-ts": "^2.16.0",
+    "zustand": "^4.5.2"
   },
   "devDependencies": {
     "@playwright/test": "^1.41.1",


### PR DESCRIPTION
We're using `useDebounceCallback` which is only available from `usehooks-ts@2.12`