### PR TITLE
fix(a11y): fix issues

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -60,6 +60,11 @@ export const parameters: Preview["parameters"] = {
           id: "color-contrast",
           enabled: false,
         },
+        {
+          // disable because all stories have a `aria-hidden="true"` in the root
+          id: "aria-hidden-focus",
+          enabled: false,
+        },
       ],
     },
   },

--- a/docs/tests/Header.stories.tsx
+++ b/docs/tests/Header.stories.tsx
@@ -16,6 +16,14 @@ export default {
     // Enables Chromatic snapshot
     chromatic: { disableSnapshot: false },
     eyes: { include: true },
+    a11y: {
+      config: {
+        rules: [
+          { id: "landmark-no-duplicate-banner", enabled: false },
+          { id: "landmark-unique", enabled: false },
+        ],
+      },
+    },
   },
 };
 

--- a/packages/core/src/CheckBoxGroup/CheckBoxGroup.styles.tsx
+++ b/packages/core/src/CheckBoxGroup/CheckBoxGroup.styles.tsx
@@ -5,8 +5,8 @@ import { createClasses } from "../utils/classes";
 export const { staticClasses, useClasses } = createClasses("HvCheckBoxGroup", {
   root: {
     display: "inline-block",
-    padding: 0,
-    margin: 0,
+    padding: 4,
+    margin: -4,
     overflow: "hidden",
     verticalAlign: "top",
   },

--- a/packages/core/src/Dialog/Dialog.tsx
+++ b/packages/core/src/Dialog/Dialog.tsx
@@ -110,7 +110,6 @@ export const HvDialog = (props: HvDialogProps) => {
           ),
         },
       }}
-      aria-modal
       {...others}
     >
       <HvIconButton

--- a/packages/core/src/FilterGroup/Counter/Counter.tsx
+++ b/packages/core/src/FilterGroup/Counter/Counter.tsx
@@ -12,7 +12,7 @@ export type HvFilterGroupCounterClasses = ExtractNames<typeof useClasses>;
 
 export interface HvFilterGroupCounterProps {
   className?: string;
-  id?: string;
+  groupId?: string;
   classes?: HvFilterGroupCounterClasses;
 }
 
@@ -33,7 +33,7 @@ const getExistingFiltersById = (
 export const HvFilterGroupCounter = (props: HvFilterGroupCounterProps) => {
   const {
     className,
-    id,
+    groupId,
     classes: classesProp,
   } = useDefaultProps("HvFilterGroupCounter", props);
   const { classes, cx } = useClasses(classesProp);
@@ -44,19 +44,17 @@ export const HvFilterGroupCounter = (props: HvFilterGroupCounterProps) => {
   } = useContext(HvFilterGroupContext);
 
   const options =
-    id && filterOptions.find((option) => option.id === id)
-      ? ([
-          filterOptions.find((option) => option.id === id),
-        ] as HvFilterGroupFilters)
+    groupId && filterOptions.find((option) => option.id === groupId)
+      ? [filterOptions.find((option) => option.id === groupId)!]
       : filterOptions;
-  const optionIdx = filterOptions.findIndex((option) => option.id === id);
+  const optionIdx = filterOptions.findIndex((option) => option.id === groupId);
 
   let groupsCounter = 0;
   appliedFilters.forEach((fg, i) => {
     groupsCounter += getExistingFiltersById(i, filterValues, filterOptions);
   });
 
-  const partialCounter = id
+  const partialCounter = groupId
     ? getExistingFiltersById(optionIdx, filterValues, filterOptions) || 0
     : groupsCounter;
 

--- a/packages/core/src/FilterGroup/LeftPanel/LeftPanel.tsx
+++ b/packages/core/src/FilterGroup/LeftPanel/LeftPanel.tsx
@@ -1,10 +1,10 @@
 import { useContext } from "react";
 
 import { HvListContainer, HvListItem } from "../../ListContainer";
+import { HvOverflowTooltip } from "../../OverflowTooltip";
 import { HvPanel } from "../../Panel";
 import { ExtractNames } from "../../utils/classes";
 import { setId } from "../../utils/setId";
-import { wrapperTooltip } from "../../utils/wrapperTooltip";
 import { HvFilterGroupCounter } from "../Counter";
 import { HvFilterGroupContext } from "../FilterGroupContext";
 import { staticClasses, useClasses } from "./LeftPanel.styles";
@@ -26,7 +26,7 @@ export const HvFilterGroupLeftPanel = ({
   emptyElement,
   classes: classesProp,
 }: HvFilterGroupLeftPanelProps) => {
-  const { classes, cx } = useClasses(classesProp);
+  const { classes } = useClasses(classesProp);
   const { filterOptions, activeGroup, setActiveGroup } =
     useContext(HvFilterGroupContext);
 
@@ -34,22 +34,17 @@ export const HvFilterGroupLeftPanel = ({
     <HvPanel id={setId(id, "leftPanel")} className={className}>
       {filterOptions.length > 0 ? (
         <HvListContainer id={setId(id, "leftPanel-list")} condensed interactive>
-          {filterOptions.map((group, index) => {
-            const ItemText = wrapperTooltip(true, group.name, group.name);
-
-            return (
-              <HvListItem
-                id={group.id}
-                key={group.name}
-                className={cx(classes.listItem)}
-                onClick={() => setActiveGroup(index)}
-                selected={filterOptions[activeGroup].id === group.id}
-                endAdornment={<HvFilterGroupCounter id={group.id} />}
-              >
-                <ItemText />
-              </HvListItem>
-            );
-          })}
+          {filterOptions.map((group, index) => (
+            <HvListItem
+              key={group.id || group.name}
+              className={classes.listItem}
+              onClick={() => setActiveGroup(index)}
+              selected={filterOptions[activeGroup].id === group.id}
+              endAdornment={<HvFilterGroupCounter groupId={group.id} />}
+            >
+              <HvOverflowTooltip data={group.name} />
+            </HvListItem>
+          ))}
         </HvListContainer>
       ) : (
         emptyElement

--- a/packages/core/src/FilterGroup/RightPanel/RightPanel.styles.tsx
+++ b/packages/core/src/FilterGroup/RightPanel/RightPanel.styles.tsx
@@ -9,11 +9,8 @@ export const { staticClasses, useClasses } = createClasses(name, {
     marginBottom: theme.spacing("xs"),
   },
   list: {
-    width: "calc(100% + 8px)",
     height: "calc(100% - 70px)",
     overflowY: "auto",
-    margin: -4,
-    padding: 4,
   },
   selectAllContainer: {
     // Prevent the focus ring to be hidden by sibling hover background

--- a/packages/core/src/FilterGroup/RightPanel/RightPanel.tsx
+++ b/packages/core/src/FilterGroup/RightPanel/RightPanel.tsx
@@ -34,9 +34,9 @@ export const HvFilterGroupRightPanel = ({
   classes: classesProp,
 }: HvFilterGroupRightPanelProps) => {
   const { classes } = useClasses(classesProp);
-  const [searchStr, setSearchStr] = useState<string>("");
-  const [allSelected, setAllSelected] = useState<boolean>(false);
-  const [anySelected, setAnySelected] = useState<boolean>(false);
+  const [searchStr, setSearchStr] = useState("");
+  const [allSelected, setAllSelected] = useState(false);
+  const [anySelected, setAnySelected] = useState(false);
 
   const {
     filterOptions,

--- a/packages/core/src/Header/Header.stories.tsx
+++ b/packages/core/src/Header/Header.stories.tsx
@@ -264,12 +264,12 @@ export const CombinedNavigation: StoryObj<HvHeaderProps> = {
     };
 
     const muiTheme = useTheme();
-    const isLarge = useMediaQuery(muiTheme.breakpoints.up("md"));
+    const isLgUp = useMediaQuery(muiTheme.breakpoints.up("lg"));
 
     return (
       <div>
         <HvHeader position="relative">
-          {!isLarge && (
+          {!isLgUp && (
             <HvButton
               icon
               onClick={() => console.log("menu")}
@@ -280,7 +280,7 @@ export const CombinedNavigation: StoryObj<HvHeaderProps> = {
             </HvButton>
           )}
 
-          {isLarge && (
+          {isLgUp && (
             <HvHeaderNavigation
               data={navigationDataCombined}
               selected={selectedHeaderItem.id}

--- a/packages/core/src/Header/Header.stories.tsx
+++ b/packages/core/src/Header/Header.stories.tsx
@@ -264,12 +264,12 @@ export const CombinedNavigation: StoryObj<HvHeaderProps> = {
     };
 
     const muiTheme = useTheme();
-    const isLgUp = useMediaQuery(muiTheme.breakpoints.up("lg"));
+    const isLarge = useMediaQuery(muiTheme.breakpoints.up("md"));
 
     return (
       <div>
         <HvHeader position="relative">
-          {!isLgUp && (
+          {!isLarge && (
             <HvButton
               icon
               onClick={() => console.log("menu")}
@@ -280,11 +280,12 @@ export const CombinedNavigation: StoryObj<HvHeaderProps> = {
             </HvButton>
           )}
 
-          {isLgUp && (
+          {isLarge && (
             <HvHeaderNavigation
               data={navigationDataCombined}
               selected={selectedHeaderItem.id}
               onClick={handleChange}
+              aria-label="Header Navigation"
               levels={1}
             />
           )}
@@ -300,6 +301,7 @@ export const CombinedNavigation: StoryObj<HvHeaderProps> = {
               collapsible
               defaultExpanded
               selected={selected}
+              aria-label="Vertical Navigation"
               onChange={(event, data) => {
                 event.preventDefault();
 

--- a/packages/core/src/Input/Input.tsx
+++ b/packages/core/src/Input/Input.tsx
@@ -52,7 +52,6 @@ import { useUniqueId } from "../hooks/useUniqueId";
 import { HvTooltip } from "../Tooltip";
 import { HvInputSuggestion, HvValidationMessages } from "../types/forms";
 import { HvBaseProps } from "../types/generic";
-import { isBrowser } from "../utils/browser";
 import { ExtractNames } from "../utils/classes";
 import { isKey } from "../utils/keyboardUtils";
 import { setId } from "../utils/setId";
@@ -200,17 +199,11 @@ const DEFAULT_LABELS = {
 
 export type HvInputLabels = Partial<typeof DEFAULT_LABELS>;
 
-/**
- * Find the focused element onBlur.
- */
-const getFocusedElement = (event: React.FocusEvent) =>
-  isBrowser("ie") ? document.activeElement : event.relatedTarget;
-
 function eventTargetIsInsideContainer(
   container: HTMLElement | null,
   event: React.FocusEvent<any>,
 ) {
-  return container != null && container.contains(getFocusedElement(event));
+  return !!container?.contains(event.relatedTarget);
 }
 
 /** Changes a given `input`'s `value`, triggering its `onChange` */

--- a/packages/core/src/Kpi/Kpi.stories.tsx
+++ b/packages/core/src/Kpi/Kpi.stories.tsx
@@ -28,9 +28,22 @@ import {
   Train,
 } from "@hitachivantara/uikit-react-icons";
 
+import { Selectable as SelectableStory } from "./stories/Selectable";
+import SelectableStoryRaw from "./stories/Selectable?raw";
+
 const meta: Meta<typeof HvKpi> = {
   title: "Visualizations/KPI",
   component: HvKpi,
+  parameters: {
+    a11y: {
+      config: {
+        rules: [
+          // disable react-google-chart's labelling elements without role
+          { id: "aria-allowed-attr", enabled: false },
+        ],
+      },
+    },
+  },
 };
 export default meta;
 
@@ -253,239 +266,13 @@ export const StorageArray: StoryObj<HvKpiProps> = {
 export const Selectable: StoryObj<HvKpiProps> = {
   parameters: {
     docs: {
+      source: { code: SelectableStoryRaw },
       description: {
-        story: "A selectable KPI with the total numbers of event.",
+        story: "A selectable KPI with the total numbers of events.",
       },
     },
   },
-  render: () => {
-    const [selected, setSelected] = useState(false);
-
-    const styles: { [key: string]: CSSInterpolation } = {
-      trendChartContainer: {
-        pointerEvents: "none",
-        marginRight: -8,
-        marginBottom: -1,
-      },
-      root: { width: 280, cursor: "pointer" },
-      title: {
-        padding: "0px 24px 8px 24px",
-      },
-      time: { color: theme.colors.secondary_80 },
-      trendTextContainer: {
-        display: "flex",
-        flexDirection: "column",
-        alignItems: "flex-end",
-        justifyContent: "flex-end",
-        paddingLeft: "4px",
-      },
-      trendContainer: {
-        paddingTop: "8px",
-        display: "flex",
-        justifyContent: "center",
-        alignItems: "flex-end",
-      },
-      contentContainer: {
-        display: "flex",
-        flexDirection: "column",
-        alignItems: "center",
-        justifyContent: "flex-start",
-        padding: "12px 16px 22px 16px",
-      },
-    };
-
-    const TrendChart = () => (
-      <div className={css(styles.trendChartContainer)}>
-        <ReactChart
-          width="40px"
-          height="30px"
-          chartType="AreaChart"
-          data={[
-            ["Year", "Sales"],
-            ["2019", 1200],
-            ["2020", 2100],
-            ["2021", 3200],
-            ["2022", 3500],
-          ]}
-          options={{
-            legend: "none",
-            colors: ["green"],
-            tooltip: {
-              trigger: "none",
-            },
-            hAxis: {
-              minValue: 0,
-              maxValue: 10,
-              gridlines: {
-                color: "transparent",
-              },
-              baselineColor: "transparent",
-            },
-            backgroundColor: "transparent",
-            vAxis: {
-              gridlines: {
-                color: "transparent",
-              },
-              baselineColor: "transparent",
-            },
-          }}
-        />
-      </div>
-    );
-
-    return (
-      <HvCard
-        className={css(styles.root)}
-        selectable
-        selected={selected}
-        onClick={() => setSelected(!selected)}
-        tabIndex={0}
-        role="button"
-        onKeyDown={(event) => {
-          if (event.code === "Enter" || event.code === "Space") {
-            setSelected(!selected);
-          }
-        }}
-        aria-pressed={selected}
-        statusColor="sema0"
-      >
-        <div className={css(styles.contentContainer)}>
-          <HvTypography className={css(styles.title)} variant="label">
-            Total number of events
-          </HvTypography>
-          <HvTypography variant="title2">508K</HvTypography>
-          <div className={css(styles.trendContainer)}>
-            <TrendChart />
-            <div className={css(styles.trendTextContainer)}>
-              <HvTypography variant="caption2">+82,15%</HvTypography>
-              <HvTypography variant="caption2" className={css(styles.time)}>
-                Last 24h
-              </HvTypography>
-            </div>
-          </div>
-        </div>
-      </HvCard>
-    );
-  },
-};
-
-export const SelectableSemantic: StoryObj<HvKpiProps> = {
-  parameters: {
-    docs: {
-      description: {
-        story: "A selectable KPI with the total numbers of event.",
-      },
-    },
-  },
-  render: () => {
-    const [selected, setSelected] = useState(false);
-
-    const styles: { [key: string]: CSSInterpolation } = {
-      trendChartContainer: {
-        pointerEvents: "none",
-        marginRight: -8,
-        marginBottom: -1,
-      },
-      root: { width: 280, cursor: "pointer" },
-      title: {
-        padding: "0px 24px 8px 24px",
-      },
-      time: { color: theme.colors.secondary_80 },
-      trendTextContainer: {
-        display: "flex",
-        flexDirection: "column",
-        alignItems: "flex-end",
-        justifyContent: "flex-end",
-        paddingLeft: "4px",
-      },
-      trendContainer: {
-        paddingTop: "8px",
-        display: "flex",
-        justifyContent: "center",
-        alignItems: "flex-end",
-      },
-      contentContainer: {
-        display: "flex",
-        flexDirection: "column",
-        alignItems: "center",
-        justifyContent: "flex-start",
-        padding: "12px 16px 22px 16px",
-      },
-    };
-
-    const TrendChart = () => (
-      <div className={css(styles.trendChartContainer)}>
-        <ReactChart
-          width="40px"
-          height="30px"
-          chartType="AreaChart"
-          data={[
-            ["Year", "Sales"],
-            ["2019", 3500],
-            ["2020", 3200],
-            ["2021", 2100],
-            ["2022", 1200],
-          ]}
-          options={{
-            legend: "none",
-            colors: ["red"],
-            tooltip: {
-              trigger: "none",
-            },
-            hAxis: {
-              minValue: 0,
-              maxValue: 10,
-              gridlines: {
-                color: "transparent",
-              },
-              baselineColor: "transparent",
-            },
-            backgroundColor: "transparent",
-            vAxis: {
-              gridlines: {
-                color: "transparent",
-              },
-              baselineColor: "transparent",
-            },
-          }}
-        />
-      </div>
-    );
-
-    return (
-      <HvCard
-        className={css(styles.root)}
-        selectable
-        selected={selected}
-        onClick={() => setSelected(!selected)}
-        tabIndex={0}
-        role="button"
-        onKeyDown={(event) => {
-          if (event.code === "Enter" || event.code === "Space") {
-            setSelected(!selected);
-          }
-        }}
-        aria-pressed={selected}
-        statusColor="negative"
-      >
-        <div className={css(styles.contentContainer)}>
-          <HvTypography className={css(styles.title)} variant="label">
-            Total number of events
-          </HvTypography>
-          <HvTypography variant="title2">508K</HvTypography>
-          <div className={css(styles.trendContainer)}>
-            <TrendChart />
-            <div className={css(styles.trendTextContainer)}>
-              <HvTypography variant="caption2">-82,15%</HvTypography>
-              <HvTypography className={css(styles.time)} variant="caption2">
-                Last 24h
-              </HvTypography>
-            </div>
-          </div>
-        </div>
-      </HvCard>
-    );
-  },
+  render: () => <SelectableStory />,
 };
 
 export const Gauge: StoryObj<HvKpiProps> = {

--- a/packages/core/src/Kpi/stories/Selectable.tsx
+++ b/packages/core/src/Kpi/stories/Selectable.tsx
@@ -1,0 +1,128 @@
+import { useId, useState } from "react";
+import ReactChart from "react-google-charts";
+import { css } from "@emotion/css";
+import { HvCard, HvTypography, theme } from "@hitachivantara/uikit-react-core";
+
+const classes = {
+  trendChartContainer: css({
+    pointerEvents: "none",
+    marginRight: -8,
+    marginBottom: -1,
+  }),
+  card: css({
+    width: 280,
+    cursor: "pointer",
+  }),
+  title: css({
+    padding: "0px 24px 8px 24px",
+  }),
+  time: css({
+    color: theme.colors.secondary_80,
+  }),
+  trendTextContainer: css({
+    display: "flex",
+    flexDirection: "column",
+    alignItems: "flex-end",
+    justifyContent: "flex-end",
+    paddingLeft: "4px",
+  }),
+  trendContainer: css({
+    paddingTop: "8px",
+    display: "flex",
+    justifyContent: "center",
+    alignItems: "flex-end",
+  }),
+  contentContainer: css({
+    display: "flex",
+    flexDirection: "column",
+    alignItems: "center",
+    justifyContent: "flex-start",
+    padding: "12px 16px 22px 16px",
+  }),
+};
+
+const TrendChart = () => (
+  <div className={classes.trendChartContainer}>
+    <ReactChart
+      width="40px"
+      height="30px"
+      chartType="AreaChart"
+      data={[
+        ["Year", "Sales"],
+        ["2019", 1200],
+        ["2020", 2100],
+        ["2021", 3200],
+        ["2022", 3500],
+      ]}
+      options={{
+        legend: "none",
+        colors: ["red"],
+        tooltip: {
+          trigger: "none",
+        },
+        hAxis: {
+          minValue: 0,
+          maxValue: 10,
+          gridlines: {
+            color: "transparent",
+          },
+          baselineColor: "transparent",
+        },
+        backgroundColor: "transparent",
+        vAxis: {
+          gridlines: {
+            color: "transparent",
+          },
+          baselineColor: "transparent",
+        },
+      }}
+    />
+  </div>
+);
+
+export const Selectable = () => {
+  const [selected, setSelected] = useState(false);
+  const titleId = useId();
+
+  return (
+    <HvCard
+      className={classes.card}
+      selectable
+      selected={selected}
+      onClick={() => setSelected(!selected)}
+      tabIndex={0}
+      role="button"
+      aria-labelledby={titleId}
+      onKeyDown={(event) => {
+        if (event.code === "Enter" || event.code === "Space") {
+          setSelected(!selected);
+        }
+      }}
+      aria-pressed={selected}
+      statusColor="negative"
+    >
+      <div className={classes.contentContainer}>
+        <HvTypography
+          id={titleId}
+          component="h2"
+          className={classes.title}
+          variant="label"
+        >
+          Total number of events
+        </HvTypography>
+        <HvTypography component="div" variant="title2">
+          508K
+        </HvTypography>
+        <div className={classes.trendContainer}>
+          <TrendChart />
+          <div className={classes.trendTextContainer}>
+            <HvTypography variant="caption2">-42,15%</HvTypography>
+            <HvTypography variant="caption2" className={classes.time}>
+              Last 24h
+            </HvTypography>
+          </div>
+        </div>
+      </div>
+    </HvCard>
+  );
+};

--- a/packages/core/src/ScrollTo/Horizontal/HorizontalScrollListItem/HorizontalScrollListItem.styles.tsx
+++ b/packages/core/src/ScrollTo/Horizontal/HorizontalScrollListItem/HorizontalScrollListItem.styles.tsx
@@ -7,51 +7,44 @@ const name = "HvHorizontalScrollListItem";
 
 export const { staticClasses, useClasses } = createClasses(name, {
   root: {
-    padding: "10px 0",
+    padding: theme.spacing("xs", 0),
+    maxWidth: 120,
   },
   button: {
     display: "flex",
+    flexDirection: "column",
     justifyContent: "center",
     alignItems: "center",
-    height: "48px",
-    cursor: "pointer",
-    borderBottom: "none",
-    "&:hover": {
-      backgroundColor: "transparent",
-
-      "& $notSelected": {
-        height: "6px",
-        width: "6px",
-        backgroundColor: theme.colors.secondary,
-      },
-
-      "& $notSelectedRoot": {
-        backgroundColor: theme.colors.containerBackgroundHover,
-      },
-    },
-    "&:focus": {
-      outline: "none",
-    },
     "&:focus-visible": {
       ...outlineStyles,
     },
   },
   text: {
-    display: "flex",
-    flexDirection: "column",
-    alignItems: "center",
-    justifyContent: "center",
-    height: "48px",
-    borderBottom: "none",
-
-    "& p": {
-      padding: "3px 10px",
-      maxWidth: "120px",
-      textOverflow: "ellipsis",
-      overflow: "hidden",
-    },
+    margin: theme.spacing("xs", "xs", "0"),
   },
   selected: {
-    borderBottom: "none",
+    fontWeight: theme.typography.label.fontWeight,
+  },
+  bullet: {
+    display: "flex",
+    justifyContent: "center",
+    alignItems: "center",
+    minHeight: 24,
+    height: 24,
+    width: 24,
+    fontSize: 4,
+    color: theme.colors.secondary_60,
+
+    "& > span": {
+      margin: "auto",
+      width: "1em",
+      height: "1em",
+      backgroundColor: "currentcolor",
+      borderRadius: "50%",
+    },
+  },
+  bulletSelected: {
+    fontSize: 6,
+    color: theme.colors.secondary,
   },
 });

--- a/packages/core/src/ScrollTo/Horizontal/HorizontalScrollListItem/HorizontalScrollListItem.tsx
+++ b/packages/core/src/ScrollTo/Horizontal/HorizontalScrollListItem/HorizontalScrollListItem.tsx
@@ -1,6 +1,9 @@
 import { useDefaultProps } from "../../../hooks/useDefaultProps";
+import {
+  HvOverflowTooltip,
+  HvOverflowTooltipProps,
+} from "../../../OverflowTooltip";
 import { HvBaseProps } from "../../../types/generic";
-import { HvTypographyProps } from "../../../Typography";
 import { ExtractNames } from "../../../utils/classes";
 import { setId } from "../../../utils/setId";
 import { staticClasses, useClasses } from "./HorizontalScrollListItem.styles";
@@ -12,24 +15,10 @@ export type HvHorizontalScrollListItemClasses = ExtractNames<typeof useClasses>;
 export interface HvHorizontalScrollListItemProps
   extends HvBaseProps<HTMLDivElement | HTMLAnchorElement> {
   /** The text to render.  */
-  children: React.ReactNode;
-  /** A function component that renders a typography wrapped with a tooltip. */
-  tooltipWrapper: React.FunctionComponent<{
-    id?: string;
-    className?: string;
-    variant?: HvTypographyProps["variant"];
-    children?: React.ReactNode;
-  }>;
+  label?: React.ReactNode;
   /** Whether the element is selected. */
   selected?: boolean;
-  /** The function to be executed when the element is clicked. */
-  onClick?: (
-    event: React.MouseEvent<HTMLDivElement | HTMLAnchorElement>,
-  ) => void;
-  /** The function to be executed when the element is clicked. */
-  onKeyDown?: (
-    event: React.KeyboardEvent<HTMLDivElement | HTMLAnchorElement>,
-  ) => void;
+  tooltipPlacement: HvOverflowTooltipProps["placement"];
   /** A Jss Object used to override or extend the styles applied. */
   classes?: HvHorizontalScrollListItemClasses;
 
@@ -39,6 +28,8 @@ export interface HvHorizontalScrollListItemProps
    * If this is not set, the element will be rendered as a div with a button role.
    */
   href?: string;
+  /** @deprecated remove in v6 */
+  iconClasses?: string;
 }
 
 /**
@@ -52,18 +43,14 @@ export const HvHorizontalScrollListItem = (
     className,
     classes: classesProp,
     selected,
-    children,
-    onClick,
-    onKeyDown,
-    tooltipWrapper,
+    label,
+    tooltipPlacement,
     href,
+    iconClasses,
     ...others
   } = useDefaultProps("HvHorizontalScrollListItem", props);
   const { classes, cx } = useClasses(classesProp);
-  const variant = selected ? "label" : "body";
-  const labelId = setId(id, "label");
   const buttonId = setId(id, "button");
-  const Tooltip = tooltipWrapper;
 
   const Component = href != null ? "a" : "div";
 
@@ -73,20 +60,23 @@ export const HvHorizontalScrollListItem = (
         id={buttonId}
         role={href == null ? "button" : undefined}
         tabIndex={0}
-        onClick={onClick}
-        onKeyDown={onKeyDown}
         className={classes.button}
-        aria-labelledby={labelId}
         href={href}
         {...others}
       >
-        <Tooltip
-          id={labelId}
+        <HvOverflowTooltip
           className={cx(classes.text, { [classes.selected]: selected })}
-          variant={variant}
+          placement={tooltipPlacement}
+          data={label}
+        />
+        <div
+          aria-hidden
+          className={cx(classes.bullet, iconClasses, {
+            [classes.bulletSelected]: selected,
+          })}
         >
-          {children}
-        </Tooltip>
+          <span />
+        </div>
       </Component>
     </li>
   );

--- a/packages/core/src/ScrollTo/Horizontal/ScrollToHorizontal.stories.tsx
+++ b/packages/core/src/ScrollTo/Horizontal/ScrollToHorizontal.stories.tsx
@@ -27,11 +27,16 @@ export const Main: StoryObj<HvScrollToHorizontalProps> = {
     classes: { control: { disable: true } },
     options: { control: { disable: true } },
   },
+  parameters: {
+    // Enables Chromatic snapshot
+    chromatic: { disableSnapshot: false },
+    eyes: { include: true },
+  },
   render: (args) => {
     const options = [
       { label: "Server status summary", value: "mainId1" },
       { label: "Optimization", value: "mainId2" },
-      { label: "Performance analysis", value: "mainId3" },
+      { label: "Performance analysis review", value: "mainId3" },
       { label: "Insights", value: "mainId4" },
     ];
 
@@ -78,34 +83,5 @@ export const Main: StoryObj<HvScrollToHorizontalProps> = {
         </HvContainer>
       </>
     );
-  },
-};
-
-export const Overflow: StoryObj<HvScrollToHorizontalProps> = {
-  parameters: {
-    docs: {
-      description: {
-        story: "Scroll to with big strings on the items.",
-      },
-    },
-    // Enables Chromatic snapshot
-    chromatic: { disableSnapshot: false },
-    eyes: { include: true },
-  },
-  render: () => {
-    const options = [
-      { label: "Server status summaryssssssssssssssssssss", value: "Id1" },
-      { label: "Optimization", value: "Id2" },
-      { label: "Performance analysis", value: "Id3" },
-      { label: "Insightssssssssssssssssssssssssssssss", value: "Id4" },
-      { label: "Analytics", value: "Id5" },
-      { label: "Indicators", value: "Id6" },
-      { label: "Settings", value: "Id7" },
-      { label: "Monitoring", value: "Id8" },
-      { label: "About", value: "Id9" },
-      { label: "Markers", value: "Id10" },
-    ];
-
-    return <HvScrollToHorizontal options={options} navigationMode="none" />;
   },
 };

--- a/packages/core/src/ScrollTo/Horizontal/ScrollToHorizontal.styles.tsx
+++ b/packages/core/src/ScrollTo/Horizontal/ScrollToHorizontal.styles.tsx
@@ -25,25 +25,8 @@ export const { staticClasses, useClasses } = createClasses(
       top: 0,
       left: 0,
     },
-    notSelectedRoot: {
-      display: "flex",
-      justifyContent: "center",
-      alignItems: "center",
-      height: "16px",
-      width: "16px",
-      borderRadius: "50%",
-    },
-    notSelected: {
-      height: "4px",
-      width: "4px",
-      borderRadius: "50%",
-      display: "inline-block",
-      backgroundColor: theme.colors.secondary_60,
-    },
-    selected: {
-      display: "flex",
-      height: "16px",
-      width: "16px",
-    },
+    notSelectedRoot: {},
+    notSelected: {},
+    selected: {},
   },
 );

--- a/packages/core/src/ScrollTo/Horizontal/ScrollToHorizontal.tsx
+++ b/packages/core/src/ScrollTo/Horizontal/ScrollToHorizontal.tsx
@@ -1,19 +1,14 @@
-import { useCallback, useMemo } from "react";
 import { useTheme as useMuiTheme } from "@mui/material/styles";
 import useMediaQuery from "@mui/material/useMediaQuery";
-import { CurrentStep } from "@hitachivantara/uikit-react-icons";
 import { theme } from "@hitachivantara/uikit-styles";
 
 import { useDefaultProps } from "../../hooks/useDefaultProps";
-import { useTheme } from "../../hooks/useTheme";
-import { useUniqueId } from "../../hooks/useUniqueId";
 import { HvBaseProps } from "../../types/generic";
 import { ExtractNames } from "../../utils/classes";
 import { isKey } from "../../utils/keyboardUtils";
 import { setId } from "../../utils/setId";
-import { HvScrollToTooltipPositions } from "../types";
+import { HvScrollToOption, HvScrollToTooltipPositions } from "../types";
 import { useScrollTo } from "../useScrollTo";
-import { withTooltip } from "../withTooltip";
 import { HvHorizontalScrollListItem } from "./HorizontalScrollListItem";
 import { staticClasses, useClasses } from "./ScrollToHorizontal.styles";
 
@@ -21,19 +16,12 @@ export { staticClasses as scrollToHorizontalClasses };
 
 export type HvScrollToHorizontalClasses = ExtractNames<typeof useClasses>;
 
-export interface HvScrollToHorizontalOption {
-  key?: string;
-  label: string;
-  value: string;
-  offset?: number;
-}
-
 export type HvScrollToHorizontalPositions = "sticky" | "fixed" | "relative";
 
 export interface HvScrollToHorizontalProps
   extends HvBaseProps<HTMLOListElement, "onChange" | "onClick"> {
   /** An Array of Objects with Label and Value. Label is the displayed Element and Value is the local navigation location applied */
-  options: HvScrollToHorizontalOption[];
+  options: HvScrollToOption[];
   /**
    * Should the active element be reflected in the URL.
    *
@@ -136,10 +124,6 @@ export const HvScrollToHorizontal = (props: HvScrollToHorizontalProps) => {
   const downSm = useMediaQuery(muiTheme.breakpoints.down("sm"));
   const upMd = useMediaQuery(muiTheme.breakpoints.up("md"));
 
-  const { activeTheme } = useTheme();
-
-  const elementId = useUniqueId(id);
-
   const [selectedIndex, setScrollTo, elements] = useScrollTo(
     defaultSelectedIndex,
     scrollElementId,
@@ -150,81 +134,34 @@ export const HvScrollToHorizontal = (props: HvScrollToHorizontalProps) => {
     onChange,
   );
 
-  const handleSelection = (
-    event:
-      | React.MouseEvent<HTMLDivElement | HTMLAnchorElement>
-      | React.KeyboardEvent<HTMLDivElement | HTMLAnchorElement>,
-    value: string,
-    index: number,
-  ) => {
-    event.preventDefault();
+  const tabs = elements.map((option, index) => (
+    <HvHorizontalScrollListItem
+      id={setId(id, `item-${index}`)}
+      onClick={(event) => {
+        event.preventDefault();
 
-    const wrappedOnChange = () => {
-      onChange?.(event, index);
-    };
+        setScrollTo(event, option.value, index, () => onChange?.(event, index));
+        onClick?.(event, index);
+      }}
+      onKeyDown={(event) => {
+        if (isKey(event, "Enter") !== true) return;
+        event.preventDefault();
 
-    setScrollTo(event, value, index, wrappedOnChange);
-  };
-
-  const tooltipWrappers = useMemo(() => {
-    return options.map((option) => {
-      return withTooltip(option.label, "div", tooltipPosition);
-    });
-  }, [options, tooltipPosition]);
-
-  const NotSelected = useCallback(() => {
-    return (
-      <div className={classes.notSelectedRoot}>
-        <div className={classes.notSelected} />
-      </div>
-    );
-  }, [classes.notSelectedRoot, classes.notSelected]);
-
-  const Selected = useCallback(() => {
-    return (
-      <CurrentStep
-        height={activeTheme?.scrollTo.dotSelectedSize}
-        width={activeTheme?.scrollTo.dotSelectedSize}
-        className={classes.selected}
-      />
-    );
-  }, [classes.selected, activeTheme?.scrollTo.dotSelectedSize]);
-
-  const tabs = elements.map((option, index) => {
-    const selected = selectedIndex === index;
-    const tooltipWrapper = tooltipWrappers[index];
-
-    return (
-      <HvHorizontalScrollListItem
-        id={setId(elementId, `item-${index}`)}
-        onClick={(event) => {
-          if (navigationMode !== "none") {
-            event.preventDefault();
-          }
-
-          handleSelection(event, option.value, index);
-          onClick?.(event, index);
-        }}
-        onKeyDown={(event) => {
-          if (isKey(event, "Enter") === true) {
-            if (navigationMode !== "none") {
-              event.preventDefault();
-            }
-
-            handleSelection(event, option.value, index);
-            onEnter?.(event, index);
-          }
-        }}
-        href={navigationMode !== "none" ? option.href : undefined}
-        tooltipWrapper={tooltipWrapper}
-        selected={selected}
-        key={option.key || option.label}
-      >
-        <p>{option.label}</p>
-        {selected ? <Selected /> : <NotSelected />}
-      </HvHorizontalScrollListItem>
-    );
-  });
+        setScrollTo(event, option.value, index, () => onChange?.(event, index));
+        onEnter?.(event, index);
+      }}
+      href={navigationMode !== "none" ? option.href : undefined}
+      tooltipPlacement={tooltipPosition}
+      selected={selectedIndex === index}
+      key={option.key || option.label}
+      label={option.label}
+      iconClasses={cx({
+        [classes.selected]: selectedIndex === index,
+        [classes.notSelected]: selectedIndex !== index,
+        [classes.notSelectedRoot]: selectedIndex !== index,
+      })}
+    />
+  ));
 
   return (
     <ol
@@ -252,7 +189,7 @@ export const HvScrollToHorizontal = (props: HvScrollToHorizontalProps) => {
         },
         className,
       )}
-      id={elementId}
+      id={id}
       {...others}
     >
       {tabs}

--- a/packages/core/src/ScrollTo/Vertical/ScrollToVertical.tsx
+++ b/packages/core/src/ScrollTo/Vertical/ScrollToVertical.tsx
@@ -1,5 +1,4 @@
 import { useDefaultProps } from "../../hooks/useDefaultProps";
-import { useUniqueId } from "../../hooks/useUniqueId";
 import { HvBaseProps } from "../../types/generic";
 import { ExtractNames } from "../../utils/classes";
 import { isKey } from "../../utils/keyboardUtils";
@@ -124,8 +123,6 @@ export const HvScrollToVertical = (props: HvScrollToVerticalProps) => {
 
   const { classes, cx } = useClasses(classesProp);
 
-  const elementId = useUniqueId(id);
-
   const [selectedIndex, setScrollTo, elements] = useScrollTo(
     defaultSelectedIndex,
     scrollElementId,
@@ -136,42 +133,21 @@ export const HvScrollToVertical = (props: HvScrollToVerticalProps) => {
     onChange,
   );
 
-  const handleSelection = (
-    event:
-      | React.MouseEvent<HTMLDivElement | HTMLAnchorElement>
-      | React.KeyboardEvent<HTMLDivElement | HTMLAnchorElement>,
-    value: string,
-    index: number,
-  ) => {
-    event.preventDefault();
-
-    const wrappedOnChange = () => {
-      onChange?.(event, index);
-    };
-
-    setScrollTo(event, value, index, wrappedOnChange);
-  };
-
   const tabs = elements.map((option, index) => (
     <HvVerticalScrollListItem
-      id={setId(elementId, `item-${index}`)}
+      id={setId(id, `item-${index}`)}
       onClick={(event) => {
-        if (navigationMode !== "none") {
-          event.preventDefault();
-        }
+        event.preventDefault();
 
-        handleSelection(event, option.value, index);
+        setScrollTo(event, option.value, index, () => onChange?.(event, index));
         onClick?.(event, index);
       }}
       onKeyDown={(event) => {
-        if (isKey(event, "Enter") === true) {
-          if (navigationMode !== "none") {
-            event.preventDefault();
-          }
+        if (isKey(event, "Enter") !== true) return;
+        event.preventDefault();
 
-          handleSelection(event, option.value, index);
-          onEnter?.(event, index);
-        }
+        setScrollTo(event, option.value, index, () => onChange?.(event, index));
+        onEnter?.(event, index);
       }}
       href={navigationMode !== "none" ? option.href : undefined}
       tooltipPlacement={tooltipPosition}
@@ -194,7 +170,7 @@ export const HvScrollToVertical = (props: HvScrollToVerticalProps) => {
         className,
       )}
       style={{ top: `calc(50% - ${positionOffset}px)`, ...style }}
-      id={elementId}
+      id={id}
       {...others}
     >
       {tabs}

--- a/packages/core/src/ScrollTo/Vertical/VerticalScrollListItem/VerticalScrollListItem.styles.ts
+++ b/packages/core/src/ScrollTo/Vertical/VerticalScrollListItem/VerticalScrollListItem.styles.ts
@@ -14,12 +14,18 @@ export const { staticClasses, useClasses } = createClasses(name, {
     justifyContent: "center",
     alignItems: "center",
   },
-  notSelected: {
-    height: "4px",
-    width: "4px",
+  icon: {
+    width: "1em",
+    height: "1em",
     borderRadius: "50%",
+    fontSize: 6,
+    color: theme.colors.secondary,
     display: "inline-block",
-    backgroundColor: theme.colors.secondary_60,
+    backgroundColor: "currentcolor",
+  },
+  notSelected: {
+    fontSize: 4,
+    color: theme.colors.secondary_60,
   },
   // TODO: remove in v6 (use classes.button)
   text: {},
@@ -35,9 +41,8 @@ export const { staticClasses, useClasses } = createClasses(name, {
       backgroundColor: theme.colors.containerBackgroundHover,
 
       "& $notSelected": {
-        height: "6px",
-        width: "6px",
-        backgroundColor: theme.colors.secondary,
+        fontSize: 6,
+        color: theme.colors.secondary,
       },
     },
     "&:focus": {

--- a/packages/core/src/ScrollTo/Vertical/VerticalScrollListItem/VerticalScrollListItem.tsx
+++ b/packages/core/src/ScrollTo/Vertical/VerticalScrollListItem/VerticalScrollListItem.tsx
@@ -1,7 +1,4 @@
-import { CurrentStep } from "@hitachivantara/uikit-react-icons";
-
 import { useDefaultProps } from "../../../hooks/useDefaultProps";
-import { useTheme } from "../../../hooks/useTheme";
 import { HvTooltip, HvTooltipProps } from "../../../Tooltip";
 import { HvBaseProps } from "../../../types/generic";
 import { ExtractNames } from "../../../utils/classes";
@@ -17,14 +14,6 @@ export interface HvVerticalScrollListItemProps
   classes?: HvVerticalScrollListItemClasses;
   /** Whether the element is selected. */
   selected?: boolean;
-  /** The function to be executed when the element is clicked. */
-  onClick?: (
-    event: React.MouseEvent<HTMLDivElement | HTMLAnchorElement>,
-  ) => void;
-  /** The function to be executed when the element is clicked. */
-  onKeyDown?: (
-    event: React.KeyboardEvent<HTMLDivElement | HTMLAnchorElement>,
-  ) => void;
   label?: React.ReactNode;
   tooltipPlacement?: HvTooltipProps["placement"];
 
@@ -48,23 +37,11 @@ export const HvVerticalScrollListItem = (
     classes: classesProp,
     selected,
     label,
-    onClick,
-    onKeyDown,
     tooltipPlacement = "left",
     href,
     ...others
   } = useDefaultProps("HvVerticalScrollListItem", props);
   const { classes, cx } = useClasses(classesProp);
-  const { activeTheme } = useTheme();
-
-  const icon = selected ? (
-    <CurrentStep
-      height={activeTheme?.scrollTo.dotSelectedSize}
-      width={activeTheme?.scrollTo.dotSelectedSize}
-    />
-  ) : (
-    <div className={classes.notSelected} />
-  );
 
   const Component = href != null ? "a" : "div";
 
@@ -74,13 +51,15 @@ export const HvVerticalScrollListItem = (
         <Component
           role={href == null ? "button" : undefined}
           tabIndex={0}
-          onClick={onClick}
-          onKeyDown={onKeyDown}
           className={cx(classes.button, classes.text)}
           href={href}
           {...others}
         >
-          {icon}
+          <div
+            className={cx(classes.icon, {
+              [classes.notSelected]: !selected,
+            })}
+          />
         </Component>
       </HvTooltip>
     </li>

--- a/packages/core/src/ScrollTo/types.ts
+++ b/packages/core/src/ScrollTo/types.ts
@@ -1,12 +1,16 @@
 export type HvScrollToTooltipPositions = "left" | "right" | "top" | "bottom";
 
 export interface HvScrollToOption {
-  key?: string;
+  key?: React.Key;
   label: string;
   value: string;
   offset?: number;
 }
 
+/** @deprecated use `HvScrollToOption` */
 export type HvScrollToVerticalOption = HvScrollToOption;
+
+/** @deprecated use `HvScrollToOption` */
+export type HvScrollToHorizontalOption = HvScrollToOption;
 
 export type HvScrollToVerticalPositions = "absolute" | "fixed" | "relative";

--- a/packages/core/src/Section/Section.stories.tsx
+++ b/packages/core/src/Section/Section.stories.tsx
@@ -64,7 +64,7 @@ export const WithActions: StoryObj<HvSectionProps> = {
     a11y: {
       config: {
         rules: [
-          { id: "aria-prohibited-attr", enabled: false },
+          { id: "aria-allowed-attr", enabled: false },
           { id: "color-contrast", enabled: false },
         ],
       },

--- a/packages/core/src/Select/Select.stories.tsx
+++ b/packages/core/src/Select/Select.stories.tsx
@@ -35,6 +35,18 @@ export const Main: StoryObj<HvSelectProps<{}, false>> = {
     // Enables Chromatic snapshot
     chromatic: { disableSnapshot: false },
     eyes: { include: true },
+    a11y: {
+      config: {
+        rules: [
+          // Axe isn't (incorrectly) identifying the ul <-> li hierarchy
+          // on HvSelect with grouping (HvOptionGroup)
+          { id: "list", enabled: false },
+          { id: "listitem", enabled: false },
+          { id: "aria-required-parent", enabled: false },
+          { id: "aria-required-children", enabled: false },
+        ],
+      },
+    },
   },
   // For visual testing and a11y
   play: async ({ canvasElement }) => {

--- a/packages/core/src/Switch/Switch.stories.tsx
+++ b/packages/core/src/Switch/Switch.stories.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { css } from "@emotion/css";
 import { Decorator, Meta, StoryObj } from "@storybook/react";
 import {
@@ -143,13 +143,16 @@ export const WithLabels: StoryObj<HvSwitchProps> = {
     },
   },
   render: () => {
-    const Label: React.FC<React.LabelHTMLAttributes<HTMLLabelElement>> = (
-      props,
-    ) => (
-      // eslint-disable-next-line jsx-a11y/label-has-associated-control
-      <label style={{ cursor: "pointer" }} {...props} />
+    const inputRef = useRef<HTMLButtonElement>(null);
+
+    const ToggleLabel = (props: React.HTMLAttributes<HTMLDivElement>) => (
+      <div
+        aria-hidden
+        style={{ cursor: "pointer" }}
+        onClick={() => inputRef.current?.click()}
+        {...props}
+      />
     );
-    Label.displayName = "Label";
 
     return (
       <>
@@ -164,14 +167,9 @@ export const WithLabels: StoryObj<HvSwitchProps> = {
           </HvInfoMessage>
         </div>
         <div className={css({ display: "flex", alignItems: "center", gap: 8 })}>
-          <Label htmlFor="switch-input">Off</Label>
-          <HvBaseSwitch
-            id="switch-input"
-            aria-labelledby="switch-label"
-            aria-describedby="switch-description"
-            defaultChecked
-          />
-          <Label htmlFor="switch-input">On</Label>
+          <ToggleLabel>Off</ToggleLabel>
+          <HvBaseSwitch inputRef={inputRef} id="switch-input" defaultChecked />
+          <ToggleLabel>On</ToggleLabel>
         </div>
       </>
     );

--- a/packages/core/src/Table/stories/TableHooks/TableHooks.stories.tsx
+++ b/packages/core/src/Table/stories/TableHooks/TableHooks.stories.tsx
@@ -151,6 +151,15 @@ export const UseHvHeaderGroupsStory: StoryObj = {
     // Enables Chromatic snapshot
     chromatic: { disableSnapshot: false },
     eyes: { include: true },
+    a11y: {
+      config: {
+        rules: [
+          // the th cells without data are hidden to the a11y tree,
+          // but axe-core doesn't correctly understand that
+          { id: "th-has-data-cells", enabled: false },
+        ],
+      },
+    },
   },
   render: () => <UseHvHeaderGroups />,
 };

--- a/packages/lab/src/Dashboard/Dashboard.stories.tsx
+++ b/packages/lab/src/Dashboard/Dashboard.stories.tsx
@@ -91,7 +91,7 @@ export const DataDriven: StoryObj<HvDashboardProps> = {
     a11y: {
       config: {
         rules: [
-          { id: "aria-prohibited-attr", enabled: false },
+          { id: "aria-allowed-attr", enabled: false },
           { id: "color-contrast", enabled: false },
         ],
       },

--- a/packages/lab/src/Flow/stories/Flow.stories.tsx
+++ b/packages/lab/src/Flow/stories/Flow.stories.tsx
@@ -42,7 +42,7 @@ const meta: Meta<typeof HvFlow> = {
       config: {
         rules: [
           { id: "nested-interactive", enabled: false },
-          { id: "aria-prohibited-attr", enabled: false },
+          { id: "aria-allowed-attr", enabled: false },
           { id: "color-contrast", enabled: false },
         ],
       },

--- a/packages/styles/src/themes/ds3.ts
+++ b/packages/styles/src/themes/ds3.ts
@@ -915,6 +915,9 @@ const ds3 = makeTheme((theme) => ({
     },
     HvHorizontalScrollListItem: {
       classes: {
+        root: {
+          maxWidth: 180,
+        },
         button: {
           height: "32px",
           borderBottom: "2px solid transparent",
@@ -931,13 +934,14 @@ const ds3 = makeTheme((theme) => ({
         text: {
           height: "32px",
           borderBottom: "2px solid transparent",
-          "& p": {
-            padding: "8px 10px",
-            maxWidth: "180px",
-          },
+          padding: "8px 10px",
+          margin: 0,
         },
         selected: {
           borderBottom: `2px solid ${theme.colors.secondary}`,
+        },
+        bullet: {
+          display: "none",
         },
       },
     },
@@ -955,10 +959,12 @@ const ds3 = makeTheme((theme) => ({
     },
     HvVerticalScrollListItem: {
       classes: {
+        icon: {
+          fontSize: "10px",
+        },
         notSelected: {
-          height: "6px",
-          width: "6px",
-          backgroundColor: theme.colors.atmo4,
+          color: theme.colors.atmo4,
+          fontSize: "6px",
         },
         text: {
           height: "32px",
@@ -971,9 +977,8 @@ const ds3 = makeTheme((theme) => ({
           cursor: "pointer",
           "&:hover": {
             "& .HvVerticalScrollListItem-notSelected": {
-              height: "10px",
-              width: "10px",
-              backgroundColor: theme.colors.atmo4,
+              fontSize: "10px",
+              color: theme.colors.atmo4,
             },
           },
         },
@@ -1141,22 +1146,6 @@ const ds3 = makeTheme((theme) => ({
       classes: {
         root: {
           backgroundColor: theme.alpha("atmo2", 0.8),
-        },
-        notSelectedRoot: {
-          display: "none",
-          height: "32px",
-          width: "32px",
-          borderRadius: "0%",
-        },
-        notSelected: {
-          height: "6px",
-          width: "6px",
-          backgroundColor: theme.colors.atmo4,
-        },
-        selected: {
-          display: "none",
-          height: "32px",
-          width: "32px",
         },
       },
     },
@@ -1495,7 +1484,7 @@ const ds3 = makeTheme((theme) => ({
     cancelButtonVariant: "secondaryGhost",
   },
   scrollTo: {
-    dotSelectedSize: 10,
+    dotSelectedSize: 10, // TODO - remove in v6
     backgroundColorOpacity: 0.8, // TODO - remove in v6
   },
   colorPicker: {


### PR DESCRIPTION
- fix a11y issues found by new tool
- rename `aria-prohibited-attr` > `aria-allowed-attr`
- merge KPI Selectable stories & use `?raw` loader
- refactor `ScrollTo` to better address the tooltip + label issues
  - move the tooltip logic to the `*ScrollListItem.tsx` & leverage `HvOverflowTooltip`
  - move the "bullet" icon to `*ScrollListItem.tsx` to not include it in the tooltip
    - always use a rounded div, instead of div + icon - simplifying the logic & making it easier to customise (no need for the `activeTheme` tokens anymore)
  - small fixes in spacing (using DS5 units instead of DS3)
- refactor `HvList` to use `HvOverflowTooltip`
  - fixes tooltip a11y issues in components using it