### PR TITLE
chore: assertions added to storybook play

### DIFF
--- a/docs/tests/Tags.stories.tsx
+++ b/docs/tests/Tags.stories.tsx
@@ -1,4 +1,5 @@
 import { css } from "@emotion/css";
+import { expect } from "@storybook/jest";
 import { StoryObj } from "@storybook/react";
 import { userEvent, within } from "@storybook/testing-library";
 import { HvTag, theme } from "@hitachivantara/uikit-react-core";
@@ -13,10 +14,17 @@ export default {
 };
 
 export const Main: StoryObj = {
+  // For visual testing
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    const button = canvas.getByRole("button", { name: /asset 2/i });
+    const button = canvas.getByRole("button", {
+      name: /asset 2/i,
+      pressed: false,
+    });
     await userEvent.click(button);
+    await expect(
+      canvas.getByRole("button", { name: /asset 2/i, pressed: true }),
+    ).toBeInTheDocument();
   },
   render: () => (
     <div style={{ display: "flex", gap: 10, flexWrap: "wrap" }}>

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "apps/*"
       ],
       "devDependencies": {
-        "@applitools/eyes-storybook": "^3.47.4",
+        "@applitools/eyes-storybook": "^3.48.1",
         "@commitlint/cli": "^17.8.1",
         "@commitlint/config-conventional": "^17.8.1",
         "@dnd-kit/core": "^6.1.0",
@@ -31,6 +31,7 @@
         "@storybook/addon-links": "^7.6.4",
         "@storybook/addons": "^7.6.4",
         "@storybook/core-common": "^7.6.4",
+        "@storybook/jest": "^0.2.3",
         "@storybook/react": "^7.6.4",
         "@storybook/react-vite": "^7.6.4",
         "@storybook/test-runner": "^0.17.0",
@@ -9041,10 +9042,307 @@
         "url": "https://opencollective.com/storybook"
       }
     },
+    "node_modules/@storybook/expect": {
+      "version": "28.1.3-5",
+      "resolved": "https://registry.npmjs.org/@storybook/expect/-/expect-28.1.3-5.tgz",
+      "integrity": "sha512-lS1oJnY1qTAxnH87C765NdfvGhksA6hBcbUVI5CHiSbNsEtr456wtg/z+dT9XlPriq1D5t2SgfNL9dBAoIGyIA==",
+      "dev": true,
+      "dependencies": {
+        "@types/jest": "28.1.3"
+      }
+    },
+    "node_modules/@storybook/expect/node_modules/@jest/schemas": {
+      "version": "28.1.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-28.1.3.tgz",
+      "integrity": "sha512-/l/VWsdt/aBXgjshLWOFyFt3IVdYypu5y2Wn2rOO1un6nkqIn8SLXzgIMYXFyYsRWDyF5EthmKJMIdJvk08grg==",
+      "dev": true,
+      "dependencies": {
+        "@sinclair/typebox": "^0.24.1"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "node_modules/@storybook/expect/node_modules/@sinclair/typebox": {
+      "version": "0.24.51",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.24.51.tgz",
+      "integrity": "sha512-1P1OROm/rdubP5aFDSZQILU0vrLCJ4fvHt6EoqHEM+2D/G5MK3bIaymUKLit8Js9gbns5UyJnkP/TZROLw4tUA==",
+      "dev": true
+    },
+    "node_modules/@storybook/expect/node_modules/@types/jest": {
+      "version": "28.1.3",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-28.1.3.tgz",
+      "integrity": "sha512-Tsbjk8Y2hkBaY/gJsataeb4q9Mubw9EOz7+4RjPkzD5KjTvHHs7cpws22InaoXxAVAhF5HfFbzJjo6oKWqSZLw==",
+      "dev": true,
+      "dependencies": {
+        "jest-matcher-utils": "^28.0.0",
+        "pretty-format": "^28.0.0"
+      }
+    },
+    "node_modules/@storybook/expect/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@storybook/expect/node_modules/diff-sequences": {
+      "version": "28.1.1",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-28.1.1.tgz",
+      "integrity": "sha512-FU0iFaH/E23a+a718l8Qa/19bF9p06kgE0KipMOMadwa3SjnaElKzPaUC0vnibs6/B/9ni97s61mcejk8W1fQw==",
+      "dev": true,
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "node_modules/@storybook/expect/node_modules/jest-diff": {
+      "version": "28.1.3",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-28.1.3.tgz",
+      "integrity": "sha512-8RqP1B/OXzjjTWkqMX67iqgwBVJRgCyKD3L9nq+6ZqJMdvjE8RgHktqZ6jNrkdMT+dJuYNI3rhQpxaz7drJHfw==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "diff-sequences": "^28.1.1",
+        "jest-get-type": "^28.0.2",
+        "pretty-format": "^28.1.3"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "node_modules/@storybook/expect/node_modules/jest-get-type": {
+      "version": "28.0.2",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-28.0.2.tgz",
+      "integrity": "sha512-ioj2w9/DxSYHfOm5lJKCdcAmPJzQXmbM/Url3rhlghrPvT3tt+7a/+oXc9azkKmLvoiXjtV83bEWqi+vs5nlPA==",
+      "dev": true,
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "node_modules/@storybook/expect/node_modules/jest-matcher-utils": {
+      "version": "28.1.3",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-28.1.3.tgz",
+      "integrity": "sha512-kQeJ7qHemKfbzKoGjHHrRKH6atgxMk8Enkk2iPQ3XwO6oE/KYD8lMYOziCkeSB9G4adPM4nR1DE8Tf5JeWH6Bw==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "jest-diff": "^28.1.3",
+        "jest-get-type": "^28.0.2",
+        "pretty-format": "^28.1.3"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "node_modules/@storybook/expect/node_modules/pretty-format": {
+      "version": "28.1.3",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-28.1.3.tgz",
+      "integrity": "sha512-8gFb/To0OmxHR9+ZTb14Df2vNxdGCX8g1xWGUTqUw5TiZvcQf5sHKObd5UcPyLLyowNwDAMTF3XWOG1B6mxl1Q==",
+      "dev": true,
+      "dependencies": {
+        "@jest/schemas": "^28.1.3",
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "node_modules/@storybook/expect/node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/@storybook/global": {
       "version": "5.0.0",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@storybook/jest": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@storybook/jest/-/jest-0.2.3.tgz",
+      "integrity": "sha512-ov5izrmbAFObzKeh9AOC5MlmFxAcf0o5i6YFGae9sDx6DGh6alXsRM+chIbucVkUwVHVlSzdfbLDEFGY/ShaYw==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/expect": "storybook-jest",
+        "@testing-library/jest-dom": "^6.1.2",
+        "@types/jest": "28.1.3",
+        "jest-mock": "^27.3.0"
+      }
+    },
+    "node_modules/@storybook/jest/node_modules/@jest/schemas": {
+      "version": "28.1.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-28.1.3.tgz",
+      "integrity": "sha512-/l/VWsdt/aBXgjshLWOFyFt3IVdYypu5y2Wn2rOO1un6nkqIn8SLXzgIMYXFyYsRWDyF5EthmKJMIdJvk08grg==",
+      "dev": true,
+      "dependencies": {
+        "@sinclair/typebox": "^0.24.1"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "node_modules/@storybook/jest/node_modules/@jest/types": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.5.1.tgz",
+      "integrity": "sha512-Cx46iJ9QpwQTjIdq5VJu2QTMMs3QlEjI0x1QbBP5W1+nMzyc2XmimiRR/CbX9TO0cPTeUlxWMOu8mslYsJ8DEw==",
+      "dev": true,
+      "dependencies": {
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "@types/istanbul-reports": "^3.0.0",
+        "@types/node": "*",
+        "@types/yargs": "^16.0.0",
+        "chalk": "^4.0.0"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/@storybook/jest/node_modules/@sinclair/typebox": {
+      "version": "0.24.51",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.24.51.tgz",
+      "integrity": "sha512-1P1OROm/rdubP5aFDSZQILU0vrLCJ4fvHt6EoqHEM+2D/G5MK3bIaymUKLit8Js9gbns5UyJnkP/TZROLw4tUA==",
+      "dev": true
+    },
+    "node_modules/@storybook/jest/node_modules/@types/jest": {
+      "version": "28.1.3",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-28.1.3.tgz",
+      "integrity": "sha512-Tsbjk8Y2hkBaY/gJsataeb4q9Mubw9EOz7+4RjPkzD5KjTvHHs7cpws22InaoXxAVAhF5HfFbzJjo6oKWqSZLw==",
+      "dev": true,
+      "dependencies": {
+        "jest-matcher-utils": "^28.0.0",
+        "pretty-format": "^28.0.0"
+      }
+    },
+    "node_modules/@storybook/jest/node_modules/@types/yargs": {
+      "version": "16.0.9",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.9.tgz",
+      "integrity": "sha512-tHhzvkFXZQeTECenFoRljLBYPZJ7jAVxqqtEI0qTLOmuultnFp4I9yKE17vTuhf7BkhCu7I4XuemPgikDVuYqA==",
+      "dev": true,
+      "dependencies": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "node_modules/@storybook/jest/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@storybook/jest/node_modules/diff-sequences": {
+      "version": "28.1.1",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-28.1.1.tgz",
+      "integrity": "sha512-FU0iFaH/E23a+a718l8Qa/19bF9p06kgE0KipMOMadwa3SjnaElKzPaUC0vnibs6/B/9ni97s61mcejk8W1fQw==",
+      "dev": true,
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "node_modules/@storybook/jest/node_modules/jest-diff": {
+      "version": "28.1.3",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-28.1.3.tgz",
+      "integrity": "sha512-8RqP1B/OXzjjTWkqMX67iqgwBVJRgCyKD3L9nq+6ZqJMdvjE8RgHktqZ6jNrkdMT+dJuYNI3rhQpxaz7drJHfw==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "diff-sequences": "^28.1.1",
+        "jest-get-type": "^28.0.2",
+        "pretty-format": "^28.1.3"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "node_modules/@storybook/jest/node_modules/jest-get-type": {
+      "version": "28.0.2",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-28.0.2.tgz",
+      "integrity": "sha512-ioj2w9/DxSYHfOm5lJKCdcAmPJzQXmbM/Url3rhlghrPvT3tt+7a/+oXc9azkKmLvoiXjtV83bEWqi+vs5nlPA==",
+      "dev": true,
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "node_modules/@storybook/jest/node_modules/jest-matcher-utils": {
+      "version": "28.1.3",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-28.1.3.tgz",
+      "integrity": "sha512-kQeJ7qHemKfbzKoGjHHrRKH6atgxMk8Enkk2iPQ3XwO6oE/KYD8lMYOziCkeSB9G4adPM4nR1DE8Tf5JeWH6Bw==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "jest-diff": "^28.1.3",
+        "jest-get-type": "^28.0.2",
+        "pretty-format": "^28.1.3"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "node_modules/@storybook/jest/node_modules/jest-mock": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-27.5.1.tgz",
+      "integrity": "sha512-K4jKbY1d4ENhbrG2zuPWaQBvDly+iZ2yAW+T1fATN78hc0sInwn7wZB8XtlNnvHug5RMwV897Xm4LqmPM4e2Og==",
+      "dev": true,
+      "dependencies": {
+        "@jest/types": "^27.5.1",
+        "@types/node": "*"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/@storybook/jest/node_modules/pretty-format": {
+      "version": "28.1.3",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-28.1.3.tgz",
+      "integrity": "sha512-8gFb/To0OmxHR9+ZTb14Df2vNxdGCX8g1xWGUTqUw5TiZvcQf5sHKObd5UcPyLLyowNwDAMTF3XWOG1B6mxl1Q==",
+      "dev": true,
+      "dependencies": {
+        "@jest/schemas": "^28.1.3",
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "node_modules/@storybook/jest/node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
     },
     "node_modules/@storybook/manager": {
       "version": "7.6.17",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "lab:flow": "node scripts/flow-styles"
   },
   "devDependencies": {
-    "@applitools/eyes-storybook": "^3.47.4",
+    "@applitools/eyes-storybook": "^3.48.1",
     "@commitlint/cli": "^17.8.1",
     "@commitlint/config-conventional": "^17.8.1",
     "@dnd-kit/core": "^6.1.0",
@@ -60,6 +60,7 @@
     "@storybook/addon-links": "^7.6.4",
     "@storybook/addons": "^7.6.4",
     "@storybook/core-common": "^7.6.4",
+    "@storybook/jest": "^0.2.3",
     "@storybook/react": "^7.6.4",
     "@storybook/react-vite": "^7.6.4",
     "@storybook/test-runner": "^0.17.0",

--- a/packages/core/src/Accordion/Accordion.stories.tsx
+++ b/packages/core/src/Accordion/Accordion.stories.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState } from "react";
 import { css, CSSInterpolation } from "@emotion/css";
+import { expect } from "@storybook/jest";
 import { Meta, StoryObj } from "@storybook/react";
 import { userEvent, within } from "@storybook/testing-library";
 import {
@@ -80,11 +81,12 @@ export const Disabled: StoryObj<HvAccordionProps> = {
     chromatic: { disableSnapshot: false },
     eyes: { include: true },
   },
-  // Expand non-disabled option for visual tests
+  // For visual testing
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     const button = canvas.getByRole("button", { name: "System" });
     await userEvent.click(button);
+    await expect(canvas.getAllByRole("listitem")).toHaveLength(2);
   },
   render: () => {
     return (

--- a/packages/core/src/BulkActions/BulkActions.stories.tsx
+++ b/packages/core/src/BulkActions/BulkActions.stories.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import styled from "@emotion/styled";
+import { expect } from "@storybook/jest";
 import { Meta, StoryObj } from "@storybook/react";
 import { userEvent, within } from "@storybook/testing-library";
 import {
@@ -195,10 +196,12 @@ export const WithPagination: StoryObj<HvBulkActionsProps> = {
     chromatic: { disableSnapshot: false },
     eyes: { include: true },
   },
+  // For visual testing
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     const checkbox = canvas.getByRole("checkbox", { name: /All/i });
     await userEvent.click(checkbox);
+    await expect(canvas.getByRole("button", { name: /add/i })).toBeEnabled();
   },
   render: () => {
     const pageSizeOptions: number[] = [4, 6, 12, 24, 48, 2000];

--- a/packages/core/src/DatePicker/DatePicker.stories.tsx
+++ b/packages/core/src/DatePicker/DatePicker.stories.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { css, CSSInterpolation, cx } from "@emotion/css";
 import { Global } from "@emotion/react";
+import { expect } from "@storybook/jest";
 import { Decorator, Meta, StoryObj } from "@storybook/react";
 import { userEvent, within } from "@storybook/testing-library";
 import {
@@ -85,10 +86,14 @@ export const Variants: StoryObj<HvDatePickerProps> = {
     eyes: { include: true },
   },
   decorators: [unsetDecorator],
+  // For visual testing and a11y
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     const picker = canvas.getByRole("combobox", { name: /required/i });
     await userEvent.click(picker);
+    await expect(
+      canvas.getByRole("button", { name: "January" }),
+    ).toBeInTheDocument();
   },
   render: () => {
     const value = new Date("2023-01-01");
@@ -218,10 +223,14 @@ export const RangeMode: StoryObj<HvDatePickerProps> = {
     chromatic: { disableSnapshot: false },
     eyes: { include: true },
   },
+  // For visual testing and a11y
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     const picker = canvas.getByRole("combobox", { name: /date/i });
     await userEvent.click(picker);
+    await expect(
+      canvas.getByRole("button", { name: "February" }),
+    ).toBeInTheDocument();
   },
   render: () => {
     return (
@@ -306,10 +315,14 @@ export const WithSelectionList: StoryObj<HvDatePickerProps> = {
     chromatic: { disableSnapshot: false },
     eyes: { include: true },
   },
+  // For visual testing and a11y
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     const picker = canvas.getByRole("combobox", { name: /date/i });
     await userEvent.click(picker);
+    await expect(
+      canvas.getByRole("button", { name: "September" }),
+    ).toBeInTheDocument();
   },
   render: () => {
     const [startDate, setStartDate] = useState(new Date(2020, 8, 5));

--- a/packages/core/src/Dialog/Dialog.stories.tsx
+++ b/packages/core/src/Dialog/Dialog.stories.tsx
@@ -1,4 +1,5 @@
 import { css } from "@emotion/css";
+import { expect } from "@storybook/jest";
 import { Meta, StoryObj } from "@storybook/react";
 import { userEvent, within } from "@storybook/testing-library";
 import isChromatic from "chromatic/isChromatic";
@@ -52,10 +53,12 @@ export const Main: StoryObj<HvDialogProps> = {
     chromatic: { disableSnapshot: false },
     eyes: { include: true },
   },
+  // For visual testing and a11y
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     const button = canvas.getByRole("button", { name: /open dialog/i });
     await userEvent.click(button);
+    await expect(canvas.getByRole("dialog")).toBeInTheDocument();
   },
   render: (args) => <MainStory {...args} />,
 };
@@ -87,10 +90,12 @@ export const SemanticVariants: StoryObj<HvDialogProps> = {
       </div>
     ),
   ],
+  // For visual testing and a11y
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     const button = canvas.getByRole("button", { name: /success/i });
     await userEvent.click(button);
+    await expect(canvas.getByRole("dialog")).toBeInTheDocument();
   },
   render: () => <SemanticVariantsStory />,
 };

--- a/packages/core/src/Drawer/Drawer.stories.tsx
+++ b/packages/core/src/Drawer/Drawer.stories.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { css } from "@emotion/css";
+import { expect } from "@storybook/jest";
 import { Meta, StoryObj } from "@storybook/react";
 import { userEvent, within } from "@storybook/testing-library";
 import {
@@ -49,10 +50,12 @@ export const Main: StoryObj<HvDrawerProps> = {
     chromatic: { disableSnapshot: false },
     eyes: { include: true },
   },
+  // For visual testing and a11y
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     const button = canvas.getByRole("button", { name: /open drawer/i });
     await userEvent.click(button);
+    await expect(canvas.getByText("Lorem Ipsum")).toBeInTheDocument();
   },
   render: (args) => {
     const [open, setOpen] = useState(false);

--- a/packages/core/src/Dropdown/stories/Dropdown.stories.tsx
+++ b/packages/core/src/Dropdown/stories/Dropdown.stories.tsx
@@ -1,4 +1,5 @@
 import { css } from "@emotion/css";
+import { expect } from "@storybook/jest";
 import { Decorator, Meta, StoryObj } from "@storybook/react";
 import { userEvent, within } from "@storybook/testing-library";
 import { HvDropdown, HvDropdownProps } from "@hitachivantara/uikit-react-core";
@@ -98,10 +99,12 @@ export const Variants: StoryObj<HvDropdownProps> = {
       </div>
     ),
   ],
+  // For visual testing and a11y
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     const picker = canvas.getByRole("combobox", { name: /required/i });
     await userEvent.click(picker);
+    await expect(canvas.getByRole("listbox")).toBeInTheDocument();
   },
   render: () => <VariantsStory />,
 };

--- a/packages/core/src/FilterGroup/stories/FilterGroup.stories.tsx
+++ b/packages/core/src/FilterGroup/stories/FilterGroup.stories.tsx
@@ -1,3 +1,4 @@
+import { expect } from "@storybook/jest";
 import { Decorator, Meta, StoryObj } from "@storybook/react";
 import { userEvent, within } from "@storybook/testing-library";
 import {
@@ -37,10 +38,14 @@ export const Main: StoryObj<HvFilterGroupProps> = {
     chromatic: { disableSnapshot: false },
     eyes: { include: true },
   },
+  // For visual testing and a11y
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     const combobox = canvas.getByRole("combobox", { name: /main filter/i });
     await userEvent.click(combobox);
+    await expect(
+      canvas.getByRole("button", { name: /clear filters/i }),
+    ).toBeInTheDocument();
   },
   decorators: [widthDecorator],
   render: () => <MainStory />,

--- a/packages/core/src/Select/Select.stories.tsx
+++ b/packages/core/src/Select/Select.stories.tsx
@@ -1,3 +1,4 @@
+import { expect } from "@storybook/jest";
 import { Decorator, Meta, StoryObj } from "@storybook/react";
 import { userEvent, within } from "@storybook/testing-library";
 import {
@@ -35,10 +36,12 @@ export const Main: StoryObj<HvSelectProps<{}, false>> = {
     chromatic: { disableSnapshot: false },
     eyes: { include: true },
   },
+  // For visual testing and a11y
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     const select = canvas.getByRole("combobox", { name: /country/i });
     await userEvent.click(select);
+    await expect(canvas.getAllByRole("option")).toHaveLength(6);
   },
   render: (args) => {
     return (
@@ -82,10 +85,12 @@ export const Variants: StoryObj<HvSelectProps<{}, false>> = {
       <div className="flex flex-wrap gap-sm [&>*]:w-[200px]">{Story()}</div>
     ),
   ],
+  // For visual testing and a11y
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     const select = canvas.getByRole("combobox", { name: /required/i });
     await userEvent.click(select);
+    await expect(canvas.getAllByRole("option")).toHaveLength(2);
   },
   render: () => {
     return (

--- a/packages/core/src/Table/stories/TableHooks/TableHooks.stories.tsx
+++ b/packages/core/src/Table/stories/TableHooks/TableHooks.stories.tsx
@@ -1,3 +1,4 @@
+import { expect } from "@storybook/jest";
 import { StoryObj } from "@storybook/react";
 import { userEvent, within } from "@storybook/testing-library";
 
@@ -105,10 +106,14 @@ export const UseHvRowExpandStory: StoryObj = {
     chromatic: { disableSnapshot: false },
     eyes: { include: true },
   },
+  // For visual testing and a11y
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     const button = canvas.getAllByRole("button", { name: /expand/i })[0];
     await userEvent.click(button);
+    await expect(
+      canvas.getByText("Expanded content for: Event 1"),
+    ).toBeInTheDocument();
   },
   render: () => <UseHvRowExpand />,
 };
@@ -120,10 +125,12 @@ export const UseHvGroupByStory: StoryObj = {
     chromatic: { disableSnapshot: false },
     eyes: { include: true },
   },
+  // For visual testing and a11y
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     const button = canvas.getAllByRole("button", { name: /collapse/i })[0];
     await userEvent.click(button);
+    await expect(canvas.getByText("Event 2")).toBeInTheDocument();
   },
   render: () => <UseHvGroupBy />,
 };

--- a/packages/core/src/Table/stories/TableSection/TableSection.stories.tsx
+++ b/packages/core/src/Table/stories/TableSection/TableSection.stories.tsx
@@ -1,3 +1,4 @@
+import { expect } from "@storybook/jest";
 import { StoryObj } from "@storybook/react";
 import { userEvent, within } from "@storybook/testing-library";
 
@@ -45,10 +46,12 @@ export const PropsTableSectionStory: StoryObj = {
     chromatic: { disableSnapshot: false },
     eyes: { include: true },
   },
+  // For visual testing
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     const button = canvas.getByRole("button", { name: /expand/i });
     await userEvent.click(button);
+    await expect(canvas.getByText("Event 1")).toBeInTheDocument();
   },
   render: () => <PropsTableSection />,
 };
@@ -71,10 +74,12 @@ export const TableSettingsStory: StoryObj = {
   parameters: {
     docs: { source: { code: TableSettingsRaw } },
   },
+  // For a11y testing
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     const button = canvas.getByRole("button", { name: /settings/i });
     await userEvent.click(button);
+    await expect(canvas.getAllByRole("listitem")).toHaveLength(7);
   },
   render: () => <TableSettings />,
 };

--- a/packages/core/src/TimePicker/TimePicker.stories.tsx
+++ b/packages/core/src/TimePicker/TimePicker.stories.tsx
@@ -1,5 +1,6 @@
 import { useRef, useState } from "react";
 import { css, CSSInterpolation } from "@emotion/css";
+import { expect } from "@storybook/jest";
 import { Decorator, Meta, StoryObj } from "@storybook/react";
 import { userEvent, within } from "@storybook/testing-library";
 import {
@@ -41,10 +42,12 @@ export const Main: StoryObj<HvTimePickerProps> = {
     chromatic: { disableSnapshot: false },
     eyes: { include: true },
   },
+  // For visual testing and a11y
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     const picker = canvas.getByRole("combobox", { name: /time picker/i });
     await userEvent.click(picker);
+    await expect(canvas.getByPlaceholderText("hh")).toBeInTheDocument();
   },
   render: (args) => {
     return <HvTimePicker {...args} />;
@@ -97,10 +100,12 @@ export const Variants: StoryObj<HvTimePickerProps> = {
     chromatic: { disableSnapshot: false },
     eyes: { include: true },
   },
+  // For visual testing and a11y
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     const picker = canvas.getByRole("combobox", { name: /required/i });
     await userEvent.click(picker);
+    await expect(canvas.getByPlaceholderText("hh")).toBeInTheDocument();
   },
   render: () => {
     const value: HvTimePickerValue = { hours: 5, minutes: 30, seconds: 14 };
@@ -187,10 +192,14 @@ export const Format12Hours: StoryObj<HvTimePickerProps> = {
     eyes: { include: true },
   },
   decorators: [makeDecorator({ minHeight: 200, width: 220 })],
+  // For visual testing and a11y
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     const picker = canvas.getByRole("combobox", { name: /time picker/i });
     await userEvent.click(picker);
+    await expect(
+      canvas.getByRole("button", { name: /pm/i }),
+    ).toBeInTheDocument();
   },
   render: () => {
     return (

--- a/packages/core/src/TreeView/stories/TreeView.stories.tsx
+++ b/packages/core/src/TreeView/stories/TreeView.stories.tsx
@@ -1,3 +1,4 @@
+import { expect } from "@storybook/jest";
 import { Meta, StoryObj } from "@storybook/react";
 import { userEvent, within } from "@storybook/testing-library";
 import {
@@ -16,6 +17,12 @@ import { Main as MainStory } from "./Main";
 import MainStoryRaw from "./Main?raw";
 import { VerticalNavigation as VerticalNavigationStory } from "./VerticalNavigation";
 import VerticalNavigationStoryRaw from "./VerticalNavigation?raw";
+
+// Function to emulate pausing between interactions
+const sleep = (ms: number) =>
+  new Promise((resolve) => {
+    setTimeout(() => resolve("Time passed"), ms);
+  });
 
 export default {
   title: "Components/Tree View",
@@ -37,12 +44,16 @@ export const Main: StoryObj<HvTreeViewProps<false>> = {
     chromatic: { disableSnapshot: false },
     eyes: { include: true },
   },
+  // For visual testing
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     const item = canvas.getByText("Documents"); // Not able to get it by role treeitem
     await userEvent.click(item);
+    // Wait before clicking the other item to avoid errors in visual tests
+    await sleep(500);
     const subItem = canvas.getByText("private");
     await userEvent.click(subItem);
+    await expect(canvas.getAllByRole("treeitem")).toHaveLength(5);
   },
   render: () => <MainStory />,
 };
@@ -73,14 +84,19 @@ export const DataObject: StoryObj<HvTreeViewProps<false>> = {
     chromatic: { disableSnapshot: false },
     eyes: { include: true },
   },
+  // For visual testing
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     const item = canvas.getByText("User"); // Not able to get it by role treeitem
     await userEvent.click(item);
+    // Wait before clicking the other item to avoid errors in visual tests
+    await sleep(500);
     const subItem1 = canvas.getByText("Applications");
     await userEvent.click(subItem1);
+    await sleep(500);
     const subItem2 = canvas.getByText("git");
     await userEvent.click(subItem2);
+    await expect(canvas.getAllByRole("treeitem")).toHaveLength(9);
   },
   render: () => <DataObjectStory />,
 };
@@ -108,12 +124,16 @@ export const VerticalNavigation: StoryObj<HvTreeViewProps<false>> = {
     chromatic: { disableSnapshot: false },
     eyes: { include: true },
   },
+  // For visual testing
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     const item = canvas.getByText("Storage"); // Not able to get it by role treeitem
     await userEvent.click(item);
+    // Wait before clicking the other item to avoid errors in visual tests
+    await sleep(500);
     const subItem1 = canvas.getByText("Cloud");
     await userEvent.click(subItem1);
+    await expect(canvas.getAllByRole("treeitem")).toHaveLength(8);
   },
   render: () => <VerticalNavigationStory />,
 };

--- a/packages/core/src/VerticalNavigation/VerticalNavigation.stories.tsx
+++ b/packages/core/src/VerticalNavigation/VerticalNavigation.stories.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { css } from "@emotion/css";
 import { useMediaQuery, useTheme } from "@mui/material";
+import { expect } from "@storybook/jest";
 import { StoryObj } from "@storybook/react";
 import { userEvent, within } from "@storybook/testing-library";
 import {
@@ -630,10 +631,12 @@ export const CollapsibleIconsWithCustomPopupStyles: StoryObj<HvVerticalNavigatio
       chromatic: { disableSnapshot: false },
       eyes: { include: true },
     },
+    // For visual testing and a11y
     play: async ({ canvasElement }) => {
       const canvas = within(canvasElement);
       const button = canvas.getByRole("button", { name: /collapse/i });
       await userEvent.click(button);
+      await expect(canvas.getAllByRole("listitem")).toHaveLength(4);
     },
     render: () => {
       const [navigationDataState, setNavigationDataState] = useState<

--- a/packages/lab/src/Flow/stories/Flow.stories.tsx
+++ b/packages/lab/src/Flow/stories/Flow.stories.tsx
@@ -1,3 +1,4 @@
+import { expect } from "@storybook/jest";
 import { Meta, StoryObj } from "@storybook/react";
 import { userEvent, within } from "@storybook/testing-library";
 import {
@@ -61,12 +62,16 @@ export const Main: StoryObj<HvFlowProps> = {
     chromatic: { disableSnapshot: false },
     eyes: { include: true },
   },
+  // For visual testing
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     const button = canvas.getByRole("button", { name: /add node/i });
     await userEvent.click(button);
     const expand = canvas.getAllByRole("button", { name: /expand group/i })[0];
     await userEvent.click(expand);
+    await expect(
+      canvas.getByRole("searchbox", { name: /search node/i }),
+    ).toBeInTheDocument();
   },
   render: () => <MainStory />,
 };

--- a/packages/lab/src/Wizard/Wizard.stories.tsx
+++ b/packages/lab/src/Wizard/Wizard.stories.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useContext, useState } from "react";
 import { css } from "@emotion/css";
+import { expect } from "@storybook/jest";
 import { Meta, StoryObj } from "@storybook/react";
 import { userEvent, within } from "@storybook/testing-library";
 import isChromatic from "chromatic/isChromatic";
@@ -107,10 +108,12 @@ export const Main: StoryObj<HvWizardProps> = {
     chromatic: { disableSnapshot: false },
     eyes: { include: true },
   },
+  // For visual testing and a11y
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     const button = canvas.getByRole("button", { name: /show wizard/i });
     await userEvent.click(button);
+    await expect(canvas.getByRole("dialog")).toBeInTheDocument();
   },
   render: () => {
     const [show, setShow] = useState(false);
@@ -178,10 +181,12 @@ export const Skippable: StoryObj<HvWizardProps> = {
     chromatic: { disableSnapshot: false },
     eyes: { include: true },
   },
+  // For visual testing and a11y
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     const button = canvas.getByRole("button", { name: /show wizard/i });
     await userEvent.click(button);
+    await expect(canvas.getByRole("dialog")).toBeInTheDocument();
   },
   render: () => {
     const [show, setShow] = useState(false);
@@ -246,12 +251,14 @@ export const ComponentBreakDown: StoryObj<HvWizardProps> = {
     chromatic: { disableSnapshot: false },
     eyes: { include: true },
   },
+  // For visual testing and a11y
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     const button = canvas.getByRole("button", { name: /show wizard/i });
     await userEvent.click(button);
     const summaryButton = canvas.getByRole("button", { name: /summary/i });
     await userEvent.click(summaryButton);
+    await expect(canvas.getByRole("dialog")).toBeInTheDocument();
   },
   render: () => {
     const [open, setOpen] = useState(false);


### PR DESCRIPTION
- Assertions were added to storybook play functions to try to fix the unstable stories (example [here](https://eyes.applitools.com/app/test-results/00000251690157190775/?accountId=NWMfIF0XfUeh3g9JqZjRrg~~) with the tree view component)

ℹ️ I initially added the Interactions addon to storybook to have a [UI tool for interactions](https://storybook.js.org/docs/writing-stories/play-function#setup-the-interactions-addon) but I had to remove it since Applitools was not able to run when used. Once we no longer depend on Applitools, we can add it back. 