### PR TITLE
fix(Drawer): remove onclose trigger

### DIFF
--- a/packages/core/src/Drawer/Drawer.tsx
+++ b/packages/core/src/Drawer/Drawer.tsx
@@ -114,10 +114,6 @@ export const HvDrawer = (props: HvDrawerProps) => {
             classes: {
               root: classes.background,
             },
-            onClick: (event) => {
-              if (disableBackdropClick) return;
-              onClose?.(event, "backdropClick");
-            },
           },
         },
       })}


### PR DESCRIPTION
It was reported in ui-kit channel that `onClose` was being triggered twice when clicking the backdrop. This code seems to me to be redundant and removing it fixed it. 