### PR TITLE
chore: fail Chromatic job & add missing env url to visual tests workflow

### DIFF
--- a/.github/workflows/tests-visual.yml
+++ b/.github/workflows/tests-visual.yml
@@ -40,9 +40,19 @@ jobs:
           configFile: .config/chromatic.config.json
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
 
-      - name: Notify Fail
-        # Notify fail on Slack for the Nighly since the worklow won't fail if Chromatic does
+      - name: Evaluate Fail
         if: ${{ github.ref_name == 'master' && (steps.publish.outcome == 'failure' || steps.publish.outputs.changeCount != '0' || steps.publish.outputs.errorCount != '0') }}
+        run: exit 1
+
+  # Notify fail on Slack for the Nighly since the worklow won't fail if Chromatic does
+  notify-fail:
+    name: Notify Fail
+    needs: [chromatic]
+    if: failure()
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Notify Fail
         uses: hbfernandes/slack-action@1.0
         env:
           SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}
@@ -56,7 +66,7 @@ jobs:
                   "mrkdwn_in": ["text"],
                   "color": "${{env.COLOR}}",
                   "title": "Chromatic failed",
-                  "title_link": "${{ env.RUN_URL }}"
+                  "title_link": "https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}"
                 }
               ]
             }


### PR DESCRIPTION
- ❌ added in the Nightly when the Chromatic step fails
- Missing env url added to the Slack notification