### PR TITLE
build: remove duplicated sourcemaps

### DIFF
--- a/.config/vite.config.ts
+++ b/.config/vite.config.ts
@@ -30,7 +30,6 @@ export default defineConfig({
       name: pkg.name,
       entry: resolve(process.cwd(), "src/index.ts"),
     },
-    sourcemap: "hidden",
     rollupOptions: {
       output: [
         {
@@ -43,6 +42,7 @@ export default defineConfig({
             : "[name].mjs",
           exports: "named",
           interop: "auto",
+          sourcemap: "hidden",
         },
         {
           format: "cjs",


### PR DESCRIPTION
we're duplicating source maps in cjs and esm "bundles", leading to needlessly larger packages