### PR TITLE
feat: onEvents added to visualisations & sample with tooltip for truncated labels added

### DIFF
--- a/packages/viz/src/BarChart/BarChart.tsx
+++ b/packages/viz/src/BarChart/BarChart.tsx
@@ -79,6 +79,7 @@ export const HvBarChart = forwardRef<ReactECharts, HvBarChartProps>(
       height,
       width,
       onOptionChange,
+      ...others
     } = props;
 
     const chartData = useData({ data, groupBy, sortBy, splitBy, measures });
@@ -140,7 +141,13 @@ export const HvBarChart = forwardRef<ReactECharts, HvBarChartProps>(
     });
 
     return (
-      <HvBaseChart ref={ref} option={option} width={width} height={height} />
+      <HvBaseChart
+        ref={ref}
+        option={option}
+        width={width}
+        height={height}
+        {...others}
+      />
     );
   },
 );

--- a/packages/viz/src/BarChart/stories/BarChart.stories.tsx
+++ b/packages/viz/src/BarChart/stories/BarChart.stories.tsx
@@ -15,6 +15,8 @@ import {
 } from "@hitachivantara/uikit-react-viz";
 
 import { vizDecorator } from "../../BaseChart/stories/utils";
+import { CustomEchartsOptions as CustomEchartsOptionsStory } from "./CustomEchartsOptions";
+import CustomEchartsOptionsRaw from "./CustomEchartsOptions?raw";
 import { renderTooltip } from "./customTooltip";
 import { customChartData } from "./mockData";
 
@@ -484,30 +486,10 @@ export const CustomEchartsOptions: StoryObj<HvBarChartProps> = {
     docs: {
       description: {
         story:
-          "If necessary, you can customize the chart's option and take advantage of the additional properties offered by ECharts.",
+          "If necessary, you can customize the chart's option and take advantage of the additional properties offered by ECharts. In this sample, the Y axis labels are truncated when they are too long and a tooltip is shown when hovered.",
       },
+      source: { code: CustomEchartsOptionsRaw },
     },
   },
-  render: () => {
-    return (
-      <HvBarChart
-        data={{
-          Month: ["January", "February", "March"],
-          "Sales Target": [2000, 1000, 6000],
-        }}
-        groupBy="Month"
-        measures="Sales Target"
-        tooltip={{
-          type: "single",
-        }}
-        onOptionChange={(option) => {
-          if (Array.isArray(option.yAxis) && option.yAxis.length === 1) {
-            option.yAxis = [{ ...option.yAxis[0], splitNumber: 3 }];
-          }
-
-          return option;
-        }}
-      />
-    );
-  },
+  render: () => <CustomEchartsOptionsStory />,
 };

--- a/packages/viz/src/BarChart/stories/CustomEchartsOptions.tsx
+++ b/packages/viz/src/BarChart/stories/CustomEchartsOptions.tsx
@@ -1,0 +1,104 @@
+import { css, keyframes } from "@emotion/css";
+import { theme } from "@hitachivantara/uikit-react-core";
+import { HvBarChart, HvBarChartProps } from "@hitachivantara/uikit-react-viz";
+
+const appear = keyframes`
+  0% { 
+    opacity: 0;
+  }
+  100% { 
+    opacity: 1;
+  } 
+`;
+
+const styles = {
+  root: css({
+    position: "absolute",
+    width: "fit-content",
+    boxShadow: theme.colors.shadow,
+    backgroundColor: theme.colors.atmo1,
+    padding: theme.space.sm,
+    display: "flex",
+    fontFamily: theme.fontFamily.body,
+    fontWeight: theme.fontWeights.normal,
+    fontSize: theme.fontSizes.sm,
+    color: theme.colors.secondary,
+    animation: `${appear} .2s ease-in-out`,
+  }),
+};
+
+const tooltipId = "viz-truncated-tooltip";
+
+const events: HvBarChartProps["onEvents"] = {
+  mouseover: (params, instance) => {
+    if (params.componentType !== "yAxis") return;
+    if (params.targetType !== "axisLabel") return;
+
+    const fullValue = params.value;
+    const targetValue = params.event?.target;
+    const displayValue = targetValue?.style?.text;
+
+    if (fullValue === displayValue) return;
+
+    // Create tooltip
+    const tooltip = document.createElement("div");
+    tooltip.setAttribute("id", tooltipId);
+    tooltip.className = `${styles.root} ${css({
+      left: `${targetValue?.transform[4]}px`,
+      top: `${targetValue?.transform[5]}px`,
+    })}`;
+    tooltip.innerText = fullValue;
+
+    // Add tooltip
+    instance?.getDom().appendChild(tooltip);
+  },
+  mouseout: (params) => {
+    if (params.componentType !== "yAxis") return;
+    if (params.targetType !== "axisLabel") return;
+
+    // Remove tooltip
+    document.getElementById(tooltipId)?.remove();
+  },
+};
+
+export const CustomEchartsOptions = () => {
+  const formatter = (value?: string | number) => `${Number(value) / 1000}k`;
+
+  return (
+    <HvBarChart
+      data={{
+        Group: [
+          "Group 1 with a very very long label",
+          "Group 2",
+          "Group 3 with a very very long label",
+        ],
+        Sales: [2300, 1000, 7800],
+        Target: [2100, 7700, 3000],
+      }}
+      groupBy="Group"
+      measures={["Sales", "Target"]}
+      xAxis={{
+        labelFormatter: formatter,
+      }}
+      tooltip={{
+        valueFormatter: formatter,
+      }}
+      horizontal
+      stack="total"
+      onOptionChange={(option) => {
+        // Truncate axis label
+        option.yAxis[0] = {
+          ...option.yAxis[0],
+          triggerEvent: true,
+          axisLabel: {
+            ...option.yAxis[0].axisLabel,
+            overflow: "truncate",
+            width: 80,
+          },
+        };
+        return option;
+      }}
+      onEvents={events}
+    />
+  );
+};

--- a/packages/viz/src/ConfusionMatrix/ConfusionMatrix.tsx
+++ b/packages/viz/src/ConfusionMatrix/ConfusionMatrix.tsx
@@ -108,6 +108,7 @@ export const HvConfusionMatrix = forwardRef<
     format = "square",
     classes: classesProp,
     onOptionChange,
+    ...others
   } = props;
 
   const { classes } = useClasses(classesProp);
@@ -266,5 +267,5 @@ export const HvConfusionMatrix = forwardRef<
     onOptionChange,
   });
 
-  return <HvBaseChart ref={ref} option={option} {...size} />;
+  return <HvBaseChart ref={ref} option={option} {...size} {...others} />;
 });

--- a/packages/viz/src/DonutChart/DonutChart.tsx
+++ b/packages/viz/src/DonutChart/DonutChart.tsx
@@ -65,6 +65,7 @@ export const HvDonutChart = forwardRef<ReactECharts, HvDonutChartProps>(
       type = "regular",
       slicesNameFormatter,
       onOptionChange,
+      ...others
     } = props;
 
     const chartData = useData({ data, groupBy, measures, sortBy });
@@ -108,7 +109,13 @@ export const HvDonutChart = forwardRef<ReactECharts, HvDonutChartProps>(
     });
 
     return (
-      <HvBaseChart ref={ref} option={option} width={width} height={height} />
+      <HvBaseChart
+        ref={ref}
+        option={option}
+        width={width}
+        height={height}
+        {...others}
+      />
     );
   },
 );

--- a/packages/viz/src/LineChart/LineChart.tsx
+++ b/packages/viz/src/LineChart/LineChart.tsx
@@ -86,6 +86,7 @@ export const HvLineChart = forwardRef<ReactECharts, HvLineChartProps>(
       width,
       height,
       onOptionChange,
+      ...others
     } = props;
 
     const chartData = useData({ data, groupBy, measures, splitBy, sortBy });
@@ -143,7 +144,13 @@ export const HvLineChart = forwardRef<ReactECharts, HvLineChartProps>(
     });
 
     return (
-      <HvBaseChart ref={ref} option={option} width={width} height={height} />
+      <HvBaseChart
+        ref={ref}
+        option={option}
+        width={width}
+        height={height}
+        {...others}
+      />
     );
   },
 );

--- a/packages/viz/src/types/common.ts
+++ b/packages/viz/src/types/common.ts
@@ -1,4 +1,5 @@
-import { Arrayable } from "@hitachivantara/uikit-react-core";
+import type { EChartsType } from "echarts";
+import { Arrayable, HvExtraProps } from "@hitachivantara/uikit-react-core";
 
 import { HvChartAxis } from "./axis";
 import { HvChartData } from "./generic";
@@ -13,6 +14,17 @@ import { HvChartTooltip } from "./tooltip";
 // The "EChartsOption" type is set as "any" which is not very helpful.
 // This type was created to have something a little bit more specific.
 export type HvEChartsOption = Record<string, any>;
+
+// Echarts doesn't provide much information about the params properties so we extend HvExtraProps
+interface EventParams extends HvExtraProps {
+  componentIndex?: number;
+  componentType?: string;
+  dataIndex?: number;
+  value?: any;
+  targetType?: string;
+  type?: string;
+  event?: HvExtraProps;
+}
 
 /** Props common among all charts. */
 export interface HvChartCommonProps {
@@ -38,6 +50,11 @@ export interface HvChartCommonProps {
    * For more information about the ECharts option and the available properties, take a look at their [documentation](https://echarts.apache.org/en/option.html).
    */
   onOptionChange?: (option: HvEChartsOption) => HvEChartsOption;
+  /** Callback to bind events to the chart. */
+  onEvents?: Record<
+    string,
+    (params: EventParams, instance?: EChartsType) => void
+  >;
 }
 
 export interface HvChartXAxis extends HvChartAxis {


### PR DESCRIPTION
- `onEvents` added for the visualisations to trigger events when needed:
   - ℹ️ I had to put `dispose` from `HvBaseChart` in another `useEffect` because having it in the same effect was preventing us from using `onEvents` (the callback was not triggered). 
-  Sample that triggers a tooltip when hovering a truncated y axis label added (based [on](https://github.com/apache/echarts/pull/16315))