### PR TITLE
refactor(AvatarGroup): refactor the component to remove legacy React APIs

### DIFF
--- a/packages/core/src/Avatar/Avatar.tsx
+++ b/packages/core/src/Avatar/Avatar.tsx
@@ -22,6 +22,9 @@ export type HvAvatarClasses = ExtractNames<typeof useClasses>;
 
 export type HvAvatarVariant = "circular" | "square";
 
+/** @deprecated use `HvSize` instead */
+export type HvAvatarSize = "xs" | "sm" | "md" | "lg" | "xl";
+
 export interface HvAvatarProps extends HvBaseProps {
   /** The component used for the root node. Either a string to use a DOM element or a component. */
   component?: React.ElementType;

--- a/packages/core/src/Avatar/Avatar.tsx
+++ b/packages/core/src/Avatar/Avatar.tsx
@@ -1,8 +1,14 @@
 import { forwardRef } from "react";
 import MuiAvatar, { AvatarProps as MuiAvatarProps } from "@mui/material/Avatar";
 import { User } from "@hitachivantara/uikit-react-icons";
-import { getColor, HvColorAny, theme } from "@hitachivantara/uikit-styles";
+import {
+  getColor,
+  HvColorAny,
+  HvSize,
+  theme,
+} from "@hitachivantara/uikit-styles";
 
+import { useAvatarGroupContext } from "../AvatarGroup/AvatarGroupContext";
 import { useDefaultProps } from "../hooks/useDefaultProps";
 import { useImageLoaded } from "../hooks/useImageLoaded";
 import { HvBaseProps } from "../types/generic";
@@ -16,13 +22,11 @@ export type HvAvatarClasses = ExtractNames<typeof useClasses>;
 
 export type HvAvatarVariant = "circular" | "square";
 
-export type HvAvatarSize = "xs" | "sm" | "md" | "lg" | "xl";
-
 export interface HvAvatarProps extends HvBaseProps {
   /** The component used for the root node. Either a string to use a DOM element or a component. */
   component?: React.ElementType;
   /** Sets one of the standard sizes of the icons */
-  size?: HvAvatarSize;
+  size?: HvSize;
   /** A color representing the foreground color of the avatar's letters or the generic User icon fallback. */
   color?: HvColorAny;
   /** A String representing the background color of the avatar. */
@@ -63,7 +67,7 @@ export const HvAvatar = forwardRef<any, HvAvatarProps>((props, ref) => {
     classes: classesProp,
     children: childrenProp,
     component = "div",
-    size = "sm",
+    size: sizeProp,
     backgroundColor = "secondary",
     color = "atmo1",
     src,
@@ -78,6 +82,10 @@ export const HvAvatar = forwardRef<any, HvAvatarProps>((props, ref) => {
     ...others
   } = useDefaultProps("HvAvatar", props);
   const { classes, cx } = useClasses(classesProp);
+
+  const avatarGroupContext = useAvatarGroupContext();
+
+  const size = sizeProp || avatarGroupContext?.size || "sm";
 
   let children: React.ReactNode;
 

--- a/packages/core/src/AvatarGroup/AvatarGroup.styles.tsx
+++ b/packages/core/src/AvatarGroup/AvatarGroup.styles.tsx
@@ -10,11 +10,62 @@ export const { staticClasses, useClasses } = createClasses("HvAvatarGroup", {
       border: `2px solid ${theme.colors.atmo2}`,
       boxSizing: "content-box",
     },
+    "&$row": {
+      flexDirection: "row",
+      justifyContent: "flex-start",
+
+      [`& .${avatarClasses.container}`]: {
+        "&:not(:first-of-type)": {
+          marginLeft: "var(--spacing)",
+        },
+      },
+      "&$toBack": {
+        flexDirection: "row-reverse",
+        justifyContent: "flex-end",
+        [`& .${avatarClasses.container}`]: {
+          "&:last-of-type": {
+            marginLeft: 0,
+          },
+          "&:not(:last-of-type)": {
+            marginLeft: "var(--spacing)",
+          },
+        },
+      },
+    },
+    "&$column": {
+      flexDirection: "column",
+      [`& .${avatarClasses.container}`]: {
+        "&:not(:first-of-type)": {
+          marginTop: "var(--spacing)",
+        },
+      },
+      "&$toBack": {
+        flexDirection: "column-reverse",
+        [`& .${avatarClasses.container}`]: {
+          "&:last-of-type": {
+            marginTop: 0,
+          },
+          "&:not(:last-of-type)": {
+            marginTop: "var(--spacing)",
+          },
+        },
+      },
+    },
+    [`&$highlight`]: {
+      [`& .${avatarClasses.status}:hover`]: {
+        zIndex: theme.zIndices.popover,
+      },
+    },
   },
   row: {
     flexDirection: "row",
+    justifyContent: "flex-start",
+    "&$toBack": {
+      flexDirection: "row-reverse",
+      justifyContent: "flex-end",
+    },
   },
-  column: {
-    flexDirection: "column",
-  },
+  column: {},
+  highlight: {},
+  toBack: {},
 });

--- a/packages/core/src/AvatarGroup/AvatarGroupContext.tsx
+++ b/packages/core/src/AvatarGroup/AvatarGroupContext.tsx
@@ -1,0 +1,32 @@
+import { createContext, useContext, useMemo } from "react";
+import { HvSize } from "@hitachivantara/uikit-styles";
+
+type HvAvatarGroupContextProviderProps = {
+  size: HvSize;
+  children: React.ReactNode;
+};
+
+type HvAvatarGroupContextProp = {
+  size: HvSize;
+};
+
+export const HvAvatarGroupContext =
+  createContext<HvAvatarGroupContextProp | null>(null);
+
+export const HvAvatarGroupProvider = ({
+  size,
+  children,
+}: HvAvatarGroupContextProviderProps) => {
+  const value = useMemo(() => ({ size }), [size]);
+
+  return (
+    <HvAvatarGroupContext.Provider value={value}>
+      {children}
+    </HvAvatarGroupContext.Provider>
+  );
+};
+
+export const useAvatarGroupContext = () => {
+  const context = useContext(HvAvatarGroupContext);
+  return context;
+};

--- a/packages/core/src/AvatarGroup/stories/AvatarGroup.stories.tsx
+++ b/packages/core/src/AvatarGroup/stories/AvatarGroup.stories.tsx
@@ -25,12 +25,12 @@ export default meta;
 
 export const Main: StoryObj<HvAvatarGroupProps> = {
   args: {
-    size: "sm",
+    size: "md",
     spacing: "loose",
     toBack: true,
     maxVisible: 5,
     direction: "row",
-    highlight: false,
+    highlight: true,
   },
   argTypes: {
     classes: { control: { disable: true } },
@@ -41,10 +41,10 @@ export const Main: StoryObj<HvAvatarGroupProps> = {
         <HvAvatar alt="Ben" src="https://i.imgur.com/56Eeg1g.png" />
         <HvAvatar alt="Beatrice" src="https://i.imgur.com/bE7vg3N.png" />
         <HvAvatar alt="Wayne" src="https://i.imgur.com/ea22egF.png" />
-        <HvAvatar alt="Clara Soul" src="https://i.imgur.com/6sYhSb6.png" />
-        <HvAvatar alt="Ben" src="https://i.imgur.com/56Eeg1g.png" />
-        <HvAvatar alt="Beatrice" src="https://i.imgur.com/bE7vg3N.png" />
-        <HvAvatar alt="Wayne" src="https://i.imgur.com/ea22egF.png" />
+        <HvAvatar alt="Clara" src="https://i.imgur.com/6sYhSb6.png" />
+        <HvAvatar alt="Steve" src="https://i.imgur.com/8we9311.jpeg" />
+        <HvAvatar alt="Sarah" src="https://i.imgur.com/2aJYRLM.jpeg" />
+        <HvAvatar alt="Cristina" src="https://i.imgur.com/fj50fND.jpeg" />
       </HvAvatarGroup>
     );
   },
@@ -53,56 +53,63 @@ export const Main: StoryObj<HvAvatarGroupProps> = {
 export const Sizes: StoryObj<HvAvatarGroupProps> = {
   render: () => {
     return (
-      <div style={{ display: "flex", gap: 20 }}>
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "row",
+          justifyContent: "flex-start",
+          gap: 20,
+        }}
+      >
         <div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
           <HvAvatarGroup size="xs" maxVisible={3}>
             <HvAvatar alt="Ben" src="https://i.imgur.com/56Eeg1g.png" />
             <HvAvatar alt="Beatrice" src="https://i.imgur.com/bE7vg3N.png" />
             <HvAvatar alt="Wayne" src="https://i.imgur.com/ea22egF.png" />
-            <HvAvatar alt="Clara Soul" src="https://i.imgur.com/6sYhSb6.png" />
-            <HvAvatar alt="Ben" src="https://i.imgur.com/56Eeg1g.png" />
-            <HvAvatar alt="Beatrice" src="https://i.imgur.com/bE7vg3N.png" />
-            <HvAvatar alt="Wayne" src="https://i.imgur.com/ea22egF.png" />
+            <HvAvatar alt="Clara" src="https://i.imgur.com/6sYhSb6.png" />
+            <HvAvatar alt="Steve" src="https://i.imgur.com/8we9311.jpeg" />
+            <HvAvatar alt="Sarah" src="https://i.imgur.com/2aJYRLM.jpeg" />
+            <HvAvatar alt="Cristina" src="https://i.imgur.com/fj50fND.jpeg" />
           </HvAvatarGroup>
 
           <HvAvatarGroup size="sm" maxVisible={3}>
             <HvAvatar alt="Ben" src="https://i.imgur.com/56Eeg1g.png" />
             <HvAvatar alt="Beatrice" src="https://i.imgur.com/bE7vg3N.png" />
             <HvAvatar alt="Wayne" src="https://i.imgur.com/ea22egF.png" />
-            <HvAvatar alt="Clara Soul" src="https://i.imgur.com/6sYhSb6.png" />
-            <HvAvatar alt="Ben" src="https://i.imgur.com/56Eeg1g.png" />
-            <HvAvatar alt="Beatrice" src="https://i.imgur.com/bE7vg3N.png" />
-            <HvAvatar alt="Wayne" src="https://i.imgur.com/ea22egF.png" />
+            <HvAvatar alt="Clara" src="https://i.imgur.com/6sYhSb6.png" />
+            <HvAvatar alt="Steve" src="https://i.imgur.com/8we9311.jpeg" />
+            <HvAvatar alt="Sarah" src="https://i.imgur.com/2aJYRLM.jpeg" />
+            <HvAvatar alt="Cristina" src="https://i.imgur.com/fj50fND.jpeg" />
           </HvAvatarGroup>
 
           <HvAvatarGroup size="md" maxVisible={3}>
             <HvAvatar alt="Ben" src="https://i.imgur.com/56Eeg1g.png" />
             <HvAvatar alt="Beatrice" src="https://i.imgur.com/bE7vg3N.png" />
             <HvAvatar alt="Wayne" src="https://i.imgur.com/ea22egF.png" />
-            <HvAvatar alt="Clara Soul" src="https://i.imgur.com/6sYhSb6.png" />
-            <HvAvatar alt="Ben" src="https://i.imgur.com/56Eeg1g.png" />
-            <HvAvatar alt="Beatrice" src="https://i.imgur.com/bE7vg3N.png" />
-            <HvAvatar alt="Wayne" src="https://i.imgur.com/ea22egF.png" />
+            <HvAvatar alt="Clara" src="https://i.imgur.com/6sYhSb6.png" />
+            <HvAvatar alt="Steve" src="https://i.imgur.com/8we9311.jpeg" />
+            <HvAvatar alt="Sarah" src="https://i.imgur.com/2aJYRLM.jpeg" />
+            <HvAvatar alt="Cristina" src="https://i.imgur.com/fj50fND.jpeg" />
           </HvAvatarGroup>
 
           <HvAvatarGroup size="lg" maxVisible={3}>
             <HvAvatar alt="Ben" src="https://i.imgur.com/56Eeg1g.png" />
             <HvAvatar alt="Beatrice" src="https://i.imgur.com/bE7vg3N.png" />
             <HvAvatar alt="Wayne" src="https://i.imgur.com/ea22egF.png" />
-            <HvAvatar alt="Clara Soul" src="https://i.imgur.com/6sYhSb6.png" />
-            <HvAvatar alt="Ben" src="https://i.imgur.com/56Eeg1g.png" />
-            <HvAvatar alt="Beatrice" src="https://i.imgur.com/bE7vg3N.png" />
-            <HvAvatar alt="Wayne" src="https://i.imgur.com/ea22egF.png" />
+            <HvAvatar alt="Clara" src="https://i.imgur.com/6sYhSb6.png" />
+            <HvAvatar alt="Steve" src="https://i.imgur.com/8we9311.jpeg" />
+            <HvAvatar alt="Sarah" src="https://i.imgur.com/2aJYRLM.jpeg" />
+            <HvAvatar alt="Cristina" src="https://i.imgur.com/fj50fND.jpeg" />
           </HvAvatarGroup>
 
           <HvAvatarGroup size="xl" maxVisible={3}>
             <HvAvatar alt="Ben" src="https://i.imgur.com/56Eeg1g.png" />
             <HvAvatar alt="Beatrice" src="https://i.imgur.com/bE7vg3N.png" />
             <HvAvatar alt="Wayne" src="https://i.imgur.com/ea22egF.png" />
-            <HvAvatar alt="Clara Soul" src="https://i.imgur.com/6sYhSb6.png" />
-            <HvAvatar alt="Ben" src="https://i.imgur.com/56Eeg1g.png" />
-            <HvAvatar alt="Beatrice" src="https://i.imgur.com/bE7vg3N.png" />
-            <HvAvatar alt="Wayne" src="https://i.imgur.com/ea22egF.png" />
+            <HvAvatar alt="Clara" src="https://i.imgur.com/6sYhSb6.png" />
+            <HvAvatar alt="Steve" src="https://i.imgur.com/8we9311.jpeg" />
+            <HvAvatar alt="Sarah" src="https://i.imgur.com/2aJYRLM.jpeg" />
+            <HvAvatar alt="Cristina" src="https://i.imgur.com/fj50fND.jpeg" />
           </HvAvatarGroup>
         </div>
         <div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
@@ -110,50 +117,50 @@ export const Sizes: StoryObj<HvAvatarGroupProps> = {
             <HvAvatar alt="Ben" src="https://i.imgur.com/56Eeg1g.png" />
             <HvAvatar alt="Beatrice" src="https://i.imgur.com/bE7vg3N.png" />
             <HvAvatar alt="Wayne" src="https://i.imgur.com/ea22egF.png" />
-            <HvAvatar alt="Clara Soul" src="https://i.imgur.com/6sYhSb6.png" />
-            <HvAvatar alt="Ben" src="https://i.imgur.com/56Eeg1g.png" />
-            <HvAvatar alt="Beatrice" src="https://i.imgur.com/bE7vg3N.png" />
-            <HvAvatar alt="Wayne" src="https://i.imgur.com/ea22egF.png" />
+            <HvAvatar alt="Clara" src="https://i.imgur.com/6sYhSb6.png" />
+            <HvAvatar alt="Steve" src="https://i.imgur.com/8we9311.jpeg" />
+            <HvAvatar alt="Sarah" src="https://i.imgur.com/2aJYRLM.jpeg" />
+            <HvAvatar alt="Cristina" src="https://i.imgur.com/fj50fND.jpeg" />
           </HvAvatarGroup>
 
           <HvAvatarGroup size="sm" spacing="compact" maxVisible={3}>
             <HvAvatar alt="Ben" src="https://i.imgur.com/56Eeg1g.png" />
             <HvAvatar alt="Beatrice" src="https://i.imgur.com/bE7vg3N.png" />
             <HvAvatar alt="Wayne" src="https://i.imgur.com/ea22egF.png" />
-            <HvAvatar alt="Clara Soul" src="https://i.imgur.com/6sYhSb6.png" />
-            <HvAvatar alt="Ben" src="https://i.imgur.com/56Eeg1g.png" />
-            <HvAvatar alt="Beatrice" src="https://i.imgur.com/bE7vg3N.png" />
-            <HvAvatar alt="Wayne" src="https://i.imgur.com/ea22egF.png" />
+            <HvAvatar alt="Clara" src="https://i.imgur.com/6sYhSb6.png" />
+            <HvAvatar alt="Steve" src="https://i.imgur.com/8we9311.jpeg" />
+            <HvAvatar alt="Sarah" src="https://i.imgur.com/2aJYRLM.jpeg" />
+            <HvAvatar alt="Cristina" src="https://i.imgur.com/fj50fND.jpeg" />
           </HvAvatarGroup>
 
           <HvAvatarGroup size="md" spacing="compact" maxVisible={3}>
             <HvAvatar alt="Ben" src="https://i.imgur.com/56Eeg1g.png" />
             <HvAvatar alt="Beatrice" src="https://i.imgur.com/bE7vg3N.png" />
             <HvAvatar alt="Wayne" src="https://i.imgur.com/ea22egF.png" />
-            <HvAvatar alt="Clara Soul" src="https://i.imgur.com/6sYhSb6.png" />
-            <HvAvatar alt="Ben" src="https://i.imgur.com/56Eeg1g.png" />
-            <HvAvatar alt="Beatrice" src="https://i.imgur.com/bE7vg3N.png" />
-            <HvAvatar alt="Wayne" src="https://i.imgur.com/ea22egF.png" />
+            <HvAvatar alt="Clara" src="https://i.imgur.com/6sYhSb6.png" />
+            <HvAvatar alt="Steve" src="https://i.imgur.com/8we9311.jpeg" />
+            <HvAvatar alt="Sarah" src="https://i.imgur.com/2aJYRLM.jpeg" />
+            <HvAvatar alt="Cristina" src="https://i.imgur.com/fj50fND.jpeg" />
           </HvAvatarGroup>
 
           <HvAvatarGroup size="lg" spacing="compact" maxVisible={3}>
             <HvAvatar alt="Ben" src="https://i.imgur.com/56Eeg1g.png" />
             <HvAvatar alt="Beatrice" src="https://i.imgur.com/bE7vg3N.png" />
             <HvAvatar alt="Wayne" src="https://i.imgur.com/ea22egF.png" />
-            <HvAvatar alt="Clara Soul" src="https://i.imgur.com/6sYhSb6.png" />
-            <HvAvatar alt="Ben" src="https://i.imgur.com/56Eeg1g.png" />
-            <HvAvatar alt="Beatrice" src="https://i.imgur.com/bE7vg3N.png" />
-            <HvAvatar alt="Wayne" src="https://i.imgur.com/ea22egF.png" />
+            <HvAvatar alt="Clara" src="https://i.imgur.com/6sYhSb6.png" />
+            <HvAvatar alt="Steve" src="https://i.imgur.com/8we9311.jpeg" />
+            <HvAvatar alt="Sarah" src="https://i.imgur.com/2aJYRLM.jpeg" />
+            <HvAvatar alt="Cristina" src="https://i.imgur.com/fj50fND.jpeg" />
           </HvAvatarGroup>
 
           <HvAvatarGroup size="xl" spacing="compact" maxVisible={3}>
             <HvAvatar alt="Ben" src="https://i.imgur.com/56Eeg1g.png" />
             <HvAvatar alt="Beatrice" src="https://i.imgur.com/bE7vg3N.png" />
             <HvAvatar alt="Wayne" src="https://i.imgur.com/ea22egF.png" />
-            <HvAvatar alt="Clara Soul" src="https://i.imgur.com/6sYhSb6.png" />
-            <HvAvatar alt="Ben" src="https://i.imgur.com/56Eeg1g.png" />
-            <HvAvatar alt="Beatrice" src="https://i.imgur.com/bE7vg3N.png" />
-            <HvAvatar alt="Wayne" src="https://i.imgur.com/ea22egF.png" />
+            <HvAvatar alt="Clara" src="https://i.imgur.com/6sYhSb6.png" />
+            <HvAvatar alt="Steve" src="https://i.imgur.com/8we9311.jpeg" />
+            <HvAvatar alt="Sarah" src="https://i.imgur.com/2aJYRLM.jpeg" />
+            <HvAvatar alt="Cristina" src="https://i.imgur.com/fj50fND.jpeg" />
           </HvAvatarGroup>
         </div>
       </div>
@@ -168,10 +175,10 @@ export const Vertical: StoryObj<HvAvatarGroupProps> = {
         <HvAvatar alt="Ben" src="https://i.imgur.com/56Eeg1g.png" />
         <HvAvatar alt="Beatrice" src="https://i.imgur.com/bE7vg3N.png" />
         <HvAvatar alt="Wayne" src="https://i.imgur.com/ea22egF.png" />
-        <HvAvatar alt="Clara Soul" src="https://i.imgur.com/6sYhSb6.png" />
-        <HvAvatar alt="Ben" src="https://i.imgur.com/56Eeg1g.png" />
-        <HvAvatar alt="Beatrice" src="https://i.imgur.com/bE7vg3N.png" />
-        <HvAvatar alt="Wayne" src="https://i.imgur.com/ea22egF.png" />
+        <HvAvatar alt="Clara" src="https://i.imgur.com/6sYhSb6.png" />
+        <HvAvatar alt="Steve" src="https://i.imgur.com/8we9311.jpeg" />
+        <HvAvatar alt="Sarah" src="https://i.imgur.com/2aJYRLM.jpeg" />
+        <HvAvatar alt="Cristina" src="https://i.imgur.com/fj50fND.jpeg" />
       </HvAvatarGroup>
     );
   },
@@ -195,6 +202,10 @@ export const CustomOverflow: StoryObj<HvAvatarGroupProps> = {
 export const WithTooltip: StoryObj<HvAvatarGroupProps> = {
   parameters: {
     docs: {
+      description: {
+        story:
+          "The `HvAvatarGroup` component accepts `HvAvatar` as children. But you can wrap them with a `HvTooltip` component to display a tooltip on hover.",
+      },
       source: {
         code: WithTooltipRaw,
       },

--- a/packages/core/src/AvatarGroup/stories/CustomOverflow.tsx
+++ b/packages/core/src/AvatarGroup/stories/CustomOverflow.tsx
@@ -16,10 +16,10 @@ export const CustomOverflow = () => {
       <HvAvatar alt="Ben" src="https://i.imgur.com/56Eeg1g.png" />
       <HvAvatar alt="Beatrice" src="https://i.imgur.com/bE7vg3N.png" />
       <HvAvatar alt="Wayne" src="https://i.imgur.com/ea22egF.png" />
-      <HvAvatar alt="Clara Soul" src="https://i.imgur.com/6sYhSb6.png" />
-      <HvAvatar alt="Ben" src="https://i.imgur.com/56Eeg1g.png" />
-      <HvAvatar alt="Beatrice" src="https://i.imgur.com/bE7vg3N.png" />
-      <HvAvatar alt="Wayne" src="https://i.imgur.com/ea22egF.png" />
+      <HvAvatar alt="Clara" src="https://i.imgur.com/6sYhSb6.png" />
+      <HvAvatar alt="Steve" src="https://i.imgur.com/8we9311.jpeg" />
+      <HvAvatar alt="Sarah" src="https://i.imgur.com/2aJYRLM.jpeg" />
+      <HvAvatar alt="Cristina" src="https://i.imgur.com/fj50fND.jpeg" />
     </HvAvatarGroup>
   );
 };

--- a/packages/core/src/AvatarGroup/stories/WithTooltip.tsx
+++ b/packages/core/src/AvatarGroup/stories/WithTooltip.tsx
@@ -16,7 +16,7 @@ export const WithTooltip = () => {
     <HvAvatarGroup maxVisible={4} size="lg" highlight>
       {users.map((u) => (
         <HvTooltip key={u.img} title={u.name} enterDelay={10}>
-          <HvAvatar alt={u.name} src={u.img} />
+          <HvAvatar role="img" alt={u.name} src={u.img} />
         </HvTooltip>
       ))}
     </HvAvatarGroup>

--- a/packages/core/src/AvatarGroup/stories/WithTooltip.tsx
+++ b/packages/core/src/AvatarGroup/stories/WithTooltip.tsx
@@ -2,43 +2,23 @@ import {
   HvAvatar,
   HvAvatarGroup,
   HvTooltip,
-  HvTypography,
 } from "@hitachivantara/uikit-react-core";
 
 export const WithTooltip = () => {
   const users = [
-    {
-      name: "Ben",
-      img: "https://i.imgur.com/56Eeg1g.png",
-    },
-    {
-      name: "Beatrice",
-      img: "https://i.imgur.com/bE7vg3N.png",
-    },
-    {
-      name: "Wayne",
-      img: "https://i.imgur.com/ea22egF.png",
-    },
-    {
-      name: "Clara Soul",
-      img: "https://i.imgur.com/6sYhSb6.png",
-    },
+    { name: "Ben", img: "https://i.imgur.com/56Eeg1g.png" },
+    { name: "Beatrice", img: "https://i.imgur.com/bE7vg3N.png" },
+    { name: "Wayne", img: "https://i.imgur.com/ea22egF.png" },
+    { name: "Clara", img: "https://i.imgur.com/6sYhSb6.png" },
   ];
 
   return (
-    <HvTooltip
-      title={
-        <div style={{ display: "flex", flexDirection: "column" }}>
-          <HvTypography variant="label">Allowed users: </HvTypography>
-          <HvTypography>{users.map((u) => u.name).join(", ")}</HvTypography>
-        </div>
-      }
-    >
-      <HvAvatarGroup maxVisible={2}>
-        {users.map((u) => (
+    <HvAvatarGroup maxVisible={4} size="lg" highlight>
+      {users.map((u) => (
+        <HvTooltip key={u.img} title={u.name} enterDelay={10}>
           <HvAvatar alt={u.name} src={u.img} />
-        ))}
-      </HvAvatarGroup>
-    </HvTooltip>
+        </HvTooltip>
+      ))}
+    </HvAvatarGroup>
   );
 };

--- a/packages/lab/src/StepNavigation/DefaultNavigation/Step/Step.tsx
+++ b/packages/lab/src/StepNavigation/DefaultNavigation/Step/Step.tsx
@@ -1,10 +1,10 @@
 import {
   ExtractNames,
   HvAvatar,
-  HvAvatarSize,
   HvBaseProps,
   HvButton,
   HvButtonProps,
+  HvSize,
 } from "@hitachivantara/uikit-react-core";
 import {
   HourGlass,
@@ -33,7 +33,7 @@ export interface HvStepProps
   /** Title of the step. */
   title: string;
   /** Sets one of the standard sizes of the step */
-  size?: HvAvatarSize;
+  size?: HvSize;
   /** Number of the step. */
   number?: number;
   /**


### PR DESCRIPTION
This PR includes a refactor of the `HvAvatarGroup` component. It started just by allowing `HvAvatar` components  to be wrapped with an `HvTooltip` inside the avatar group and evolved to include a more profound refactor that removes legacy React APIs (`Children.map`, `cloneElement`). 

The Applitools errors are expected.