### PR TITLE
chore: disable turbosnap for Chromatic

### DIFF
--- a/.config/chromatic.config.json
+++ b/.config/chromatic.config.json
@@ -1,7 +1,6 @@
 {
   "projectId": "Project:66040297ad386b97be078cc9",
   "buildScriptName": "build:doc",
-  "onlyChanged": true,
   "skip": "dependabot/**",
   "forceRebuild": true
 }


### PR DESCRIPTION
In [this run](https://github.com/lumada-design/hv-uikit-react/actions/runs/8600782230/job/23567189116), Chromatic failed due to turbo snap. After doing some [research](https://github.com/chromaui/chromatic-cli/issues/868), I found out that [vite-plugin-turbosnap](https://github.com/IanVS/vite-plugin-turbosnap) was needed. 
However, after more research ([here](https://github.com/chromaui/chromatic-cli/issues/731) and [here](https://www.chromatic.com/docs/setup-turbosnap/#compatibility)), it seems like turbo snap is not compatible with `pull_request` events on CI at the moment. 
Thus, I'm disabling turbo snap until it's compatible with `pull-request` or we decide to change our workflows (in case we really need turbo snap for some reason).