### PR TITLE
chore: remove continue on error from a11y workflow

### DIFF
--- a/.github/workflows/tests-a11y.yml
+++ b/.github/workflows/tests-a11y.yml
@@ -8,7 +8,6 @@ jobs:
   run-tests:
     name: A11y Tests
     runs-on: ubuntu-latest
-    continue-on-error: true
 
     steps:
       - name: Checkout


### PR DESCRIPTION
As discussed in this [PR](https://github.com/lumada-design/hv-uikit-react/pull/4100), since all a11y issues are now fixed, we should "strict" check a11y issues in PRs and the nightly: these workflows will break if errors are found.