### PR TITLE
chore: fix Chromatic forceRebuild option

### DIFF
--- a/.config/chromatic.config.json
+++ b/.config/chromatic.config.json
@@ -1,6 +1,5 @@
 {
   "projectId": "Project:66040297ad386b97be078cc9",
   "buildScriptName": "build:doc",
-  "skip": "dependabot/**",
-  "forceRebuild": true
+  "skip": "dependabot/**"
 }

--- a/.github/workflows/tests-visual.yml
+++ b/.github/workflows/tests-visual.yml
@@ -39,6 +39,7 @@ jobs:
         with:
           configFile: .config/chromatic.config.json
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+          forceRebuild: true
 
       # Notify fail on Slack for the Nighly since the worklow won't fail if Chromatic does
       - name: Notify Fail


### PR DESCRIPTION
As seen in [this run](https://github.com/lumada-design/hv-uikit-react/actions/runs/8610558629/job/23601518112), for some reason `forceRebuild` can't be used in the config file. To fix this, I'm adding it to the GitHub workflow. 