### PR TITLE
style: add disableRipple global default

### DIFF
--- a/packages/core/src/providers/ThemeProvider.tsx
+++ b/packages/core/src/providers/ThemeProvider.tsx
@@ -97,6 +97,13 @@ export const HvThemeProvider = ({
   );
 
   const MuiTheme = createTheme({
+    components: {
+      MuiButtonBase: {
+        defaultProps: {
+          disableRipple: true,
+        },
+      },
+    },
     breakpoints: {
       values: {
         ...activeTheme.breakpoints.values,


### PR DESCRIPTION
Add `disableRipple` to MUI theme overrides to disable the ripple effect in our components (eg. Tag)