### PR TITLE
docs: use styles object according to Emotion best-practices

### DIFF
--- a/packages/core/src/Accordion/Accordion.stories.tsx
+++ b/packages/core/src/Accordion/Accordion.stories.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from "react";
-import { css, CSSInterpolation } from "@emotion/css";
+import { css } from "@emotion/css";
 import { expect } from "@storybook/jest";
 import { Meta, StoryObj } from "@storybook/react";
 import { userEvent, within } from "@storybook/testing-library";
@@ -26,18 +26,18 @@ import {
 import { FacetSearch } from "./stories/FacetSearchSample";
 import FacetSearchRaw from "./stories/FacetSearchSample?raw";
 
-const styles: { [key: string]: CSSInterpolation } = {
-  listContainer: {
+const classes = {
+  listContainer: css({
     "& > li": {
       paddingLeft: 32,
     },
-  },
-  formContainer: {
+  }),
+  formContainer: css({
     padding: "0 32px",
     "& > div": {
       paddingTop: 17,
     },
-  },
+  }),
 };
 
 const meta: Meta<typeof HvAccordion> = {
@@ -63,7 +63,7 @@ export const Main: StoryObj<HvAccordionProps> = {
     return (
       <HvAccordion {...args}>
         <HvListContainer
-          className={css(styles.listContainer)}
+          className={classes.listContainer}
           interactive
           condensed
         >
@@ -93,7 +93,7 @@ export const Disabled: StoryObj<HvAccordionProps> = {
       <div style={{ maxWidth: 300 }}>
         <HvAccordion label="Analytics" headingLevel={3} disabled>
           <HvListContainer
-            className={css(styles.listContainer)}
+            className={classes.listContainer}
             interactive
             condensed
           >
@@ -103,7 +103,7 @@ export const Disabled: StoryObj<HvAccordionProps> = {
         </HvAccordion>
         <HvAccordion label="System" headingLevel={3}>
           <HvListContainer
-            className={css(styles.listContainer)}
+            className={classes.listContainer}
             interactive
             condensed
           >
@@ -113,7 +113,7 @@ export const Disabled: StoryObj<HvAccordionProps> = {
         </HvAccordion>
         <HvAccordion label="Data" headingLevel={3} disabled>
           <HvListContainer
-            className={css(styles.listContainer)}
+            className={classes.listContainer}
             interactive
             condensed
           >
@@ -203,7 +203,7 @@ export const Controlled: StoryObj<HvAccordionProps> = {
             onChange={() => handleToggle("personalInformation")}
             expanded={expandedState.personalInformation}
           >
-            <div className={css(styles.formContainer)}>
+            <div className={classes.formContainer}>
               <HvInput label="Name" placeholder="Insert first name" required />
               <HvInput label="Email" placeholder="Insert your email" required />
               <HvInput label="Phone" placeholder="Insert your phone number" />
@@ -220,7 +220,7 @@ export const Controlled: StoryObj<HvAccordionProps> = {
             onChange={() => handleToggle("billingAddress")}
             expanded={expandedState.billingAddress}
           >
-            <div className={css(styles.formContainer)}>
+            <div className={classes.formContainer}>
               <HvInput label="Address 1" placeholder="Insert first name" />
               <HvInput label="Address 2" placeholder="Insert address" />
               <HvInput label="City" placeholder="Insert city name" />
@@ -233,7 +233,7 @@ export const Controlled: StoryObj<HvAccordionProps> = {
             onChange={() => handleToggle("shippingAddress")}
             expanded={expandedState.shippingAddress}
           >
-            <div className={css(styles.formContainer)}>
+            <div className={classes.formContainer}>
               <HvInput label="Address 1" placeholder="Insert first name" />
               <HvInput label="Address 2" placeholder="Insert address" />
               <HvInput label="City" placeholder="Insert city name" />

--- a/packages/core/src/CheckBoxGroup/CheckBoxGroup.stories.tsx
+++ b/packages/core/src/CheckBoxGroup/CheckBoxGroup.stories.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { css, CSSInterpolation } from "@emotion/css";
+import { css } from "@emotion/css";
 import { Meta, StoryObj } from "@storybook/react";
 import {
   HvCheckBox,
@@ -46,16 +46,16 @@ export const Variants: StoryObj<HvCheckBoxGroupProps> = {
     eyes: { include: true },
   },
   render: () => {
-    const styles: { root: CSSInterpolation } = {
-      root: {
+    const classes = {
+      root: css({
         display: "flex",
         justifyContent: "space-around",
         flexWrap: "wrap",
-      },
+      }),
     };
 
     return (
-      <div className={css(styles.root)}>
+      <div className={classes.root}>
         <HvCheckBoxGroup showSelectAll required label="Required">
           <HvCheckBox label="Checkbox 1" value="1" />
           <HvCheckBox label="Checkbox 2" value="2" checked />

--- a/packages/core/src/Container/Container.stories.tsx
+++ b/packages/core/src/Container/Container.stories.tsx
@@ -1,4 +1,4 @@
-import { css, CSSInterpolation } from "@emotion/css";
+import { css } from "@emotion/css";
 import { Meta, StoryObj } from "@storybook/react";
 import {
   HvContainer,
@@ -30,8 +30,8 @@ export const Main: StoryObj<HvContainerProps> = {
     eyes: { include: true },
   },
   render: (args) => {
-    const styles: { [key: string]: CSSInterpolation } = {
-      content: {
+    const classes = {
+      content: css({
         border: "1px solid",
         borderColor: theme.colors.atmo4,
         backgroundColor: theme.colors.atmo3,
@@ -40,20 +40,23 @@ export const Main: StoryObj<HvContainerProps> = {
         justifyContent: "center",
         alignItems: "center",
         flexDirection: "column",
-      },
-      row: { display: "flex", flexDirection: "row" },
+      }),
+      row: css({
+        display: "flex",
+        flexDirection: "row",
+      }),
     };
 
     const width = useWidth();
 
     return (
       <HvContainer {...args}>
-        <div className={css(styles.content)}>
-          <div className={css(styles.row)}>
+        <div className={classes.content}>
+          <div className={classes.row}>
             <HvTypography variant="label">Current width:</HvTypography>
             <HvTypography variant="body">{width}</HvTypography>
           </div>
-          <div className={css(styles.row)}>
+          <div className={classes.row}>
             <HvTypography variant="label">maxWidth:</HvTypography>
             <HvTypography variant="body">{args.maxWidth}</HvTypography>
           </div>

--- a/packages/core/src/DatePicker/DatePicker.stories.tsx
+++ b/packages/core/src/DatePicker/DatePicker.stories.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { css, CSSInterpolation, cx } from "@emotion/css";
+import { css, cx } from "@emotion/css";
 import { Global } from "@emotion/react";
 import { expect } from "@storybook/jest";
 import { Decorator, Meta, StoryObj } from "@storybook/react";
@@ -98,19 +98,19 @@ export const Variants: StoryObj<HvDatePickerProps> = {
   render: () => {
     const value = new Date("2023-01-01");
 
-    const styles: { root: CSSInterpolation } = {
-      root: {
+    const classes = {
+      root: css({
         display: "flex",
         gap: 20,
         flexFlow: "row",
         "& > div": {
           width: 200,
         },
-      },
+      }),
     };
 
     return (
-      <div className={css(styles.root)}>
+      <div className={classes.root}>
         <HvDatePicker required label="Required" value={value} />
         <HvDatePicker disabled label="Disabled" value={value} />
         <HvDatePicker readOnly label="Read-only" value={value} />

--- a/packages/core/src/FileUploader/Preview/Preview.styles.tsx
+++ b/packages/core/src/FileUploader/Preview/Preview.styles.tsx
@@ -15,10 +15,7 @@ export const { staticClasses, useClasses } = createClasses(
     },
     overlay: {
       position: "absolute",
-      top: 0,
-      bottom: 0,
-      left: 0,
-      right: 0,
+      inset: 0,
       display: "none",
       justifyContent: "center",
       alignItems: "center",

--- a/packages/core/src/Kpi/Kpi.stories.tsx
+++ b/packages/core/src/Kpi/Kpi.stories.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import ReactChart from "react-google-charts";
-import { css, CSSInterpolation, cx } from "@emotion/css";
+import { css, cx } from "@emotion/css";
 import { Meta, StoryObj } from "@storybook/react";
 import {
   cardClasses,
@@ -89,32 +89,32 @@ export const AverageService: StoryObj<HvKpiProps> = {
     },
   },
   render: () => {
-    const styles: { [key: string]: CSSInterpolation } = {
-      root: { width: 280 },
-      contentContainer: {
+    const classes = {
+      root: css({ width: 280 }),
+      contentContainer: css({
         padding: "12px 16px 22px 16px",
-      },
-      valueContainer: {
+      }),
+      valueContainer: css({
         display: "flex",
         alignItems: "center",
-      },
-      title: { padding: "0px 24px 16px 0px" },
-      value: { paddingRight: "10px" },
+      }),
+      title: css({ padding: "0px 24px 16px 0px" }),
+      value: css({ paddingRight: "10px" }),
     };
 
     return (
       <HvCard
-        className={css(styles.root)}
+        className={classes.root}
         statusColor="positive"
         bgcolor="atmo2"
         icon={<Level0Good title="Good" color="positive" />}
       >
-        <div className={css(styles.contentContainer)}>
-          <HvTypography className={css(styles.title)} variant="label">
+        <div className={classes.contentContainer}>
+          <HvTypography className={classes.title} variant="label">
             Avg. service time
           </HvTypography>
-          <div className={css(styles.valueContainer)}>
-            <HvTypography className={css(styles.value)} variant="title2">
+          <div className={classes.valueContainer}>
+            <HvTypography className={classes.value} variant="title2">
               12 414
             </HvTypography>
             <TopXS title="Up" color="positive" />
@@ -135,37 +135,37 @@ export const IOPS: StoryObj<HvKpiProps> = {
   render: () => {
     const [selected, setSelected] = useState(false);
 
-    const styles: { [key: string]: CSSInterpolation } = {
-      trendChartContainer: {
+    const classes = {
+      trendChartContainer: css({
         pointerEvents: "none",
         marginRight: -8,
         marginBottom: -1,
-      },
-      root: { width: 280, cursor: "pointer" },
-      title: { padding: "0px 24px 16px 0px" },
-      time: { color: theme.colors.secondary_80 },
-      trendTextContainer: {
+      }),
+      root: css({ width: 280, cursor: "pointer" }),
+      title: css({ padding: "0px 24px 16px 0px" }),
+      time: css({ color: theme.colors.secondary_80 }),
+      trendTextContainer: css({
         display: "flex",
         flexDirection: "column",
         alignItems: "flex-end",
         justifyContent: "center",
         paddingLeft: "4px",
-      },
-      trendContainer: {
+      }),
+      trendContainer: css({
         display: "flex",
         justifyContent: "flex-end",
         alignItems: "flex-end",
-      },
-      valueContainer: {
+      }),
+      valueContainer: css({
         display: "flex",
         alignItems: "center",
         justifyContent: "space-between",
-      },
-      contentContainer: { padding: "12px 16px 22px 16px" },
+      }),
+      contentContainer: css({ padding: "12px 16px 22px 16px" }),
     };
 
     const TrendChart = () => (
-      <div className={css(styles.trendChartContainer)}>
+      <div className={classes.trendChartContainer}>
         <ReactChart
           width="40px"
           height="30px"
@@ -205,7 +205,7 @@ export const IOPS: StoryObj<HvKpiProps> = {
 
     return (
       <HvCard
-        className={css(styles.root)}
+        className={classes.root}
         selectable
         selected={selected}
         onClick={() => setSelected(!selected)}
@@ -220,17 +220,17 @@ export const IOPS: StoryObj<HvKpiProps> = {
         statusColor="negative"
         icon={<Level2Average title="Bad" color="negative" />}
       >
-        <div className={css(styles.contentContainer)}>
-          <HvTypography className={css(styles.title)} variant="label">
+        <div className={classes.contentContainer}>
+          <HvTypography className={classes.title} variant="label">
             Total IOPS
           </HvTypography>
-          <div className={css(styles.valueContainer)}>
+          <div className={classes.valueContainer}>
             <HvTypography variant="title2">113 227</HvTypography>
-            <div className={css(styles.trendContainer)}>
+            <div className={classes.trendContainer}>
               <TrendChart />
-              <div className={css(styles.trendTextContainer)}>
+              <div className={classes.trendTextContainer}>
                 <HvTypography variant="caption2">-0,15%</HvTypography>
-                <HvTypography variant="caption2" className={css(styles.time)}>
+                <HvTypography variant="caption2" className={classes.time}>
                   Last 24h
                 </HvTypography>
               </div>
@@ -284,31 +284,31 @@ export const Gauge: StoryObj<HvKpiProps> = {
     },
   },
   render: () => {
-    const styles: { [key: string]: CSSInterpolation } = {
-      root: { width: 222 },
-      title: {
+    const classes = {
+      root: css({ width: 222 }),
+      title: css({
         padding: "0px 24px 10px 24px",
         textAlign: "center",
-      },
-      contentContainer: {
+      }),
+      contentContainer: css({
         display: "flex",
         flexDirection: "column",
         alignItems: "center",
         justifyContent: "flex-start",
         padding: "12px 16px 22px 16px",
-      },
-      gaugeContainer: {
+      }),
+      gaugeContainer: css({
         position: "relative",
-      },
-      gaugeOuterSemiCircle: {
+      }),
+      gaugeOuterSemiCircle: css({
         position: "relative",
         width: "122px",
         height: "61px",
         borderRadius: "61px 61px 0px 0px",
         backgroundColor: theme.colors.positive,
         overflow: "hidden",
-      },
-      gaugeInnerSemiCircle: {
+      }),
+      gaugeInnerSemiCircle: css({
         position: "absolute",
         width: "110px",
         height: "55px",
@@ -318,8 +318,8 @@ export const Gauge: StoryObj<HvKpiProps> = {
         left: 0,
         right: 0,
         margin: "auto",
-      },
-      gaugeMask: {
+      }),
+      gaugeMask: css({
         position: "absolute",
         width: "122px",
         height: "61px",
@@ -330,8 +330,8 @@ export const Gauge: StoryObj<HvKpiProps> = {
         margin: "auto",
         backgroundColor: theme.colors.atmo4,
         transformOrigin: "bottom center",
-      },
-      gaugeIndicatorContainer: {
+      }),
+      gaugeIndicatorContainer: css({
         position: "absolute",
         zIndex: 10,
         display: "flex",
@@ -341,7 +341,7 @@ export const Gauge: StoryObj<HvKpiProps> = {
         right: 0,
         margin: "auto",
         bottom: -8,
-      },
+      }),
     };
 
     const GaugeChart = ({
@@ -349,19 +349,19 @@ export const Gauge: StoryObj<HvKpiProps> = {
       unit,
       percentage,
     }: Record<string, React.ReactNode>) => (
-      <div className={css(styles.gaugeContainer)}>
-        <div className={css(styles.gaugeOuterSemiCircle)}>
+      <div className={classes.gaugeContainer}>
+        <div className={classes.gaugeOuterSemiCircle}>
           <div
             className={cx(
-              css(styles.gaugeMask),
+              classes.gaugeMask,
               css({
                 transform: `rotate(${percentage}deg)`,
               }),
             )}
           />
-          <div className={css(styles.gaugeInnerSemiCircle)} />
+          <div className={classes.gaugeInnerSemiCircle} />
         </div>
-        <div className={css(styles.gaugeIndicatorContainer)}>
+        <div className={classes.gaugeIndicatorContainer}>
           <HvTypography variant="title2">{indicator}</HvTypography>
           {unit && (
             <HvTypography
@@ -377,13 +377,13 @@ export const Gauge: StoryObj<HvKpiProps> = {
 
     return (
       <HvCard
-        className={css(styles.root)}
+        className={classes.root}
         statusColor="positive"
         bgcolor="atmo2"
         icon={<Level0Good title="Good" color="positive" />}
       >
-        <div className={css(styles.contentContainer)}>
-          <HvTypography className={css(styles.title)} variant="label">
+        <div className={classes.contentContainer}>
+          <HvTypography className={classes.title} variant="label">
             KPI description
           </HvTypography>
           <GaugeChart indicator="3,460" unit="t/h" percentage={125} />
@@ -434,31 +434,31 @@ export const StatusTrain: StoryObj<HvKpiProps> = {
       },
     ];
 
-    const styles: { [key: string]: CSSInterpolation } = {
-      storyRoot: {
+    const classes = {
+      storyRoot: css({
         display: "flex",
         flexWrap: "wrap",
         alignItems: "flex-start",
         gap: theme.space.sm,
-      },
-      root: { width: 280 },
-      dataContainer: {
+      }),
+      root: css({ width: 280 }),
+      dataContainer: css({
         marginTop: theme.space.sm,
         display: "flex",
         flexWrap: "wrap",
         gap: theme.space.sm,
-      },
-      contentContainer: {
+      }),
+      contentContainer: css({
         display: "flex",
         flexDirection: "column",
         alignItems: "flex-start",
         justifyContent: "flex-start",
         padding: theme.space.xs,
-      },
-      alarmContainer: {
+      }),
+      alarmContainer: css({
         display: "flex",
         alignItems: "center",
-      },
+      }),
     };
 
     const renderAlarm = (type: AlarmType, value: number) => {
@@ -484,7 +484,7 @@ export const StatusTrain: StoryObj<HvKpiProps> = {
       }
 
       return (
-        <div className={css(styles.alarmContainer)}>
+        <div className={classes.alarmContainer}>
           {icon}
           <HvTypography variant="caption1">{value}</HvTypography>
         </div>
@@ -492,29 +492,29 @@ export const StatusTrain: StoryObj<HvKpiProps> = {
     };
 
     return (
-      <div className={css(styles.storyRoot)}>
+      <div className={classes.storyRoot}>
         <HvCard
-          className={css(styles.root)}
+          className={classes.root}
           statusColor="positive"
           bgcolor="atmo2"
           icon={<Level0Good color="positive" />}
         >
-          <div className={css(styles.contentContainer)}>
+          <div className={classes.contentContainer}>
             <HvTypography variant="label">Alarms</HvTypography>
-            <div className={css(styles.dataContainer)}>
+            <div className={classes.dataContainer}>
               {dataAlarms.map((obj) => renderAlarm(obj.type, obj.value))}
             </div>
           </div>
         </HvCard>
         <HvCard
-          className={css(styles.root)}
+          className={classes.root}
           statusColor="negative"
           bgcolor="atmo2"
           icon={<Level3Bad color="negative" />}
         >
-          <div className={css(styles.contentContainer)}>
+          <div className={classes.contentContainer}>
             <HvTypography variant="label">Transport</HvTypography>
-            <div className={css(styles.dataContainer)}>
+            <div className={classes.dataContainer}>
               {dataTransport.map((obj) => renderAlarm(obj.type, obj.value))}
             </div>
           </div>
@@ -535,14 +535,14 @@ export const Small: StoryObj<HvKpiProps> = {
   render: () => {
     const [selected, setSelected] = useState(false);
 
-    const styles: { [key: string]: CSSInterpolation } = {
-      storyRoot: {
+    const classes = {
+      storyRoot: css({
         display: "flex",
         flexWrap: "wrap",
         alignItems: "flex-start",
         gap: theme.space.sm,
-      },
-      root: {
+      }),
+      root: css({
         width: 280,
         cursor: "pointer",
         backgroundColor: theme.colors.atmo1,
@@ -554,43 +554,43 @@ export const Small: StoryObj<HvKpiProps> = {
             backgroundColor: theme.colors.primary_20,
           },
         },
-      },
-      semanticBar: {
+      }),
+      semanticBar: css({
         height: 1,
-      },
-      selectable: {
+      }),
+      selectable: css({
         "&:hover": {
           outline: `1px solid ${theme.colors.primary_20}`,
         },
-      },
-      contentContainer: {
+      }),
+      contentContainer: css({
         display: "flex",
         padding: theme.space.xs,
-      },
-      textContainer: {
+      }),
+      textContainer: css({
         display: "flex",
         flexDirection: "column",
         marginLeft: theme.space.xs,
-      },
-      valueContainer: { display: "flex", alignItems: "flex-end" },
-      caption: { color: theme.colors.secondary_80 },
-      unit: {
+      }),
+      valueContainer: css({ display: "flex", alignItems: "flex-end" }),
+      caption: css({ color: theme.colors.secondary_80 }),
+      unit: css({
         padding: "0px 2px 5px 2px",
-      },
-      rootLoading: {
+      }),
+      rootLoading: css({
         width: 280,
-      },
-      loadingContainer: {
+      }),
+      loadingContainer: css({
         display: "flex",
         alignItems: "center",
         justifyContent: "center",
         padding: theme.space.md,
         gap: theme.space.xs,
-      },
+      }),
     };
 
     return (
-      <div className={css(styles.storyRoot)}>
+      <div className={classes.storyRoot}>
         <HvCard
           selectable
           selected={selected}
@@ -604,37 +604,37 @@ export const Small: StoryObj<HvKpiProps> = {
           }}
           aria-pressed={selected}
           classes={{
-            semanticBar: css(styles.semanticBar),
-            selectable: css(styles.selectable),
-            root: css(styles.root),
+            semanticBar: classes.semanticBar,
+            selectable: classes.selectable,
+            root: classes.root,
           }}
         >
-          <div className={css(styles.contentContainer)}>
+          <div className={classes.contentContainer}>
             <Level3Bad color="negative" />
-            <div className={css(styles.textContainer)}>
-              <div className={css(styles.valueContainer)}>
+            <div className={classes.textContainer}>
+              <div className={classes.valueContainer}>
                 <HvTypography variant="title2">7</HvTypography>
                 <HvTypography
                   variant="caption1"
-                  className={cx(css(styles.caption), css(styles.unit))}
+                  className={cx(classes.caption, classes.unit)}
                 >
                   %
                 </HvTypography>
               </div>
-              <HvTypography variant="caption1" className={css(styles.caption)}>
+              <HvTypography variant="caption1" className={classes.caption}>
                 Invalid services
               </HvTypography>
             </div>
           </div>
         </HvCard>
         <HvCard
-          className={css(styles.rootLoading)}
+          className={classes.rootLoading}
           bgcolor="atmo2"
           classes={{
-            semanticBar: css(styles.semanticBar),
+            semanticBar: classes.semanticBar,
           }}
         >
-          <div className={css(styles.loadingContainer)}>
+          <div className={classes.loadingContainer}>
             <HvLoading small />
             <HvTypography>Loading data...</HvTypography>
           </div>
@@ -664,9 +664,9 @@ export const Column: StoryObj<HvKpiProps> = {
       { value: 3980, severity: "5" },
     ];
 
-    const styles: { [key: string]: CSSInterpolation } = {
-      root: { width: "fit-content" },
-      contentContainer: {
+    const classes = {
+      root: css({ width: "fit-content" }),
+      contentContainer: css({
         display: "flex",
         flexDirection: "column",
         padding: theme.space.sm,
@@ -674,23 +674,23 @@ export const Column: StoryObj<HvKpiProps> = {
         "& > *:not(:last-child)": {
           paddingBottom: theme.space.xs,
         },
-      },
-      semanticBar: {
+      }),
+      semanticBar: css({
         height: 1,
-      },
-      severityContainer: {
+      }),
+      severityContainer: css({
         display: "flex",
         justifyContent: "space-between",
-      },
-      valueContainer: {
+      }),
+      valueContainer: css({
         display: "flex",
         paddingLeft: theme.space.md,
         alignItems: "flex-end",
-      },
-      unit: {
+      }),
+      unit: css({
         color: theme.colors.secondary_80,
         padding: "0px 2px 5px 2px",
-      },
+      }),
     };
 
     const renderSeverity = (value: number, type: SeverityType) => {
@@ -716,11 +716,11 @@ export const Column: StoryObj<HvKpiProps> = {
       }
 
       return (
-        <div className={css(styles.severityContainer)}>
+        <div className={classes.severityContainer}>
           {icon}
-          <div className={css(styles.valueContainer)}>
+          <div className={classes.valueContainer}>
             <HvTypography variant="title2">{value}</HvTypography>
-            <HvTypography variant="caption1" className={css(styles.unit)}>
+            <HvTypography variant="caption1" className={classes.unit}>
               GB
             </HvTypography>
           </div>
@@ -730,13 +730,13 @@ export const Column: StoryObj<HvKpiProps> = {
 
     return (
       <HvCard
-        className={css(styles.root)}
+        className={classes.root}
         bgcolor="atmo1"
         classes={{
-          semanticBar: css(styles.semanticBar),
+          semanticBar: classes.semanticBar,
         }}
       >
-        <div className={css(styles.contentContainer)}>
+        <div className={classes.contentContainer}>
           {data.map((obj) => renderSeverity(obj.value, obj.severity))}
         </div>
       </HvCard>

--- a/packages/core/src/RadioGroup/RadioGroup.stories.tsx
+++ b/packages/core/src/RadioGroup/RadioGroup.stories.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { css, CSSInterpolation } from "@emotion/css";
+import { css } from "@emotion/css";
 import { Meta, StoryObj } from "@storybook/react";
 import {
   HvFormStatus,
@@ -46,16 +46,16 @@ export const Variants: StoryObj<HvRadioGroupProps> = {
     eyes: { include: true },
   },
   render: () => {
-    const styles: { root: CSSInterpolation } = {
-      root: {
+    const classes = {
+      root: css({
         display: "flex",
         justifyContent: "space-around",
         flexWrap: "wrap",
-      },
+      }),
     };
 
     return (
-      <div className={css(styles.root)}>
+      <div className={classes.root}>
         <HvRadioGroup required label="Required">
           <HvRadio label="Radio 1" value="1" />
           <HvRadio label="Radio 2" value="2" checked />

--- a/packages/core/src/SelectionList/SelectionList.stories.tsx
+++ b/packages/core/src/SelectionList/SelectionList.stories.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { css, CSSInterpolation } from "@emotion/css";
+import { css } from "@emotion/css";
 import { Meta, StoryObj } from "@storybook/react";
 import {
   HvFormStatus,
@@ -50,19 +50,19 @@ export const Variants: StoryObj<HvSelectionListProps> = {
     eyes: { include: true },
   },
   render: () => {
-    const styles: { root: CSSInterpolation } = {
-      root: {
+    const classes = {
+      root: css({
         display: "flex",
         justifyContent: "space-around",
         flexWrap: "wrap",
         "& > div": {
           width: 175,
         },
-      },
+      }),
     };
 
     return (
-      <div className={css(styles.root)}>
+      <div className={classes.root}>
         <HvSelectionList required label="Required">
           <HvListItem value="1">ListItem 1</HvListItem>
           <HvListItem value="2" selected>

--- a/packages/core/src/Skeleton/Skeleton.styles.tsx
+++ b/packages/core/src/Skeleton/Skeleton.styles.tsx
@@ -75,10 +75,7 @@ export const { staticClasses, useClasses } = createClasses("HvSkeleton", {
       content: "''",
       position: "absolute",
       transform: "translateX(-100%)",
-      bottom: 0,
-      left: 0,
-      right: 0,
-      top: 0,
+      inset: 0,
     },
   },
 });

--- a/packages/core/src/TagsInput/TagsInput.stories.tsx
+++ b/packages/core/src/TagsInput/TagsInput.stories.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { css, CSSInterpolation } from "@emotion/css";
+import { css } from "@emotion/css";
 import styled from "@emotion/styled";
 import { Meta, StoryObj } from "@storybook/react";
 import {
@@ -66,18 +66,18 @@ export const Variants: StoryObj<HvTagsInputProps> = {
     eyes: { include: true },
   },
   render: () => {
-    const styles: { root: CSSInterpolation } = {
-      root: {
+    const classes = {
+      root: css({
         display: "flex",
         flexDirection: "column",
         justifyContent: "space-between",
         flexWrap: "wrap",
         gap: 20,
-      },
+      }),
     };
 
     return (
-      <div className={css(styles.root)}>
+      <div className={classes.root}>
         <HvTagsInput
           label="Required"
           aria-label="Required"

--- a/packages/core/src/TextArea/TextArea.stories.tsx
+++ b/packages/core/src/TextArea/TextArea.stories.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { css, CSSInterpolation } from "@emotion/css";
+import { css } from "@emotion/css";
 import { Meta, StoryObj } from "@storybook/react";
 import { HvTextArea, HvTextAreaProps } from "@hitachivantara/uikit-react-core";
 
@@ -193,8 +193,8 @@ export const Variants: StoryObj<HvTextAreaProps> = {
     eyes: { include: true },
   },
   render: () => {
-    const styles: { root: CSSInterpolation } = {
-      root: {
+    const classes = {
+      root: css({
         display: "flex",
         justifyContent: "space-between",
         flexWrap: "wrap",
@@ -202,11 +202,11 @@ export const Variants: StoryObj<HvTextAreaProps> = {
         "& > div": {
           width: 130,
         },
-      },
+      }),
     };
 
     return (
-      <div className={css(styles.root)}>
+      <div className={classes.root}>
         <HvTextArea
           rows={5}
           label="Required"

--- a/packages/core/src/TimePicker/TimePicker.stories.tsx
+++ b/packages/core/src/TimePicker/TimePicker.stories.tsx
@@ -110,19 +110,19 @@ export const Variants: StoryObj<HvTimePickerProps> = {
   render: () => {
     const value: HvTimePickerValue = { hours: 5, minutes: 30, seconds: 14 };
 
-    const styles: { root: CSSInterpolation } = {
-      root: {
+    const classes = {
+      root: css({
         display: "flex",
         gap: 20,
         flexWrap: "wrap",
         "& > div": {
           width: 200,
         },
-      },
+      }),
     };
 
     return (
-      <div className={css(styles.root)}>
+      <div className={classes.root}>
         <HvTimePicker required label="Required" defaultValue={value} />
         <HvTimePicker disabled label="Disabled" defaultValue={value} />
         <HvTimePicker readOnly label="Read-only" defaultValue={value} />

--- a/packages/viz/src/BarChart/stories/customTooltip.ts
+++ b/packages/viz/src/BarChart/stories/customTooltip.ts
@@ -1,39 +1,39 @@
-import { css, CSSInterpolation, cx } from "@emotion/css";
+import { css, cx } from "@emotion/css";
 import { theme } from "@hitachivantara/uikit-react-core";
 import { HvChartTooltipParams } from "@hitachivantara/uikit-react-viz";
 
 import { customTooltipData } from "./mockData";
 
-const styles: { [key: string]: CSSInterpolation } = {
-  root: {
+const classes = {
+  root: css({
     display: "flex",
     flexDirection: "column",
     backgroundColor: theme.colors.atmo1,
     width: "fit-content",
     minWidth: 220,
     boxShadow: theme.colors.shadow,
-  },
-  container: {
+  }),
+  container: css({
     padding: theme.spacing("15px", "sm"),
     display: "flex",
     flexDirection: "column",
-  },
-  containerBorder: {
+  }),
+  containerBorder: css({
     borderBottom: `3px solid ${theme.colors.atmo2}`,
-  },
-  valuesContainer: {
+  }),
+  valuesContainer: css({
     display: "flex",
     justifyContent: "space-between",
     alignItems: "center",
     width: "100%",
-  },
-  title: {
+  }),
+  title: css({
     marginBottom: 10,
-  },
-  separator: {
+  }),
+  separator: css({
     marginRight: theme.space.md,
-  },
-  thresholdContainer: {
+  }),
+  thresholdContainer: css({
     display: "flex",
     alignItems: "center",
     "& > div": {
@@ -43,20 +43,20 @@ const styles: { [key: string]: CSSInterpolation } = {
         marginLeft: 0,
       },
     },
-  },
-  label: {
+  }),
+  label: css({
     fontFamily: theme.fontFamily.body,
     fontWeight: theme.fontWeights.semibold,
     fontSize: theme.fontSizes.sm,
     color: theme.colors.secondary,
-  },
-  text: {
+  }),
+  text: css({
     fontFamily: theme.fontFamily.body,
     fontWeight: theme.fontWeights.normal,
     fontSize: theme.fontSizes.sm,
     color: theme.colors.secondary,
-  },
-  icon: {
+  }),
+  icon: css({
     display: "flex",
     "& svg": {
       margin: "auto",
@@ -64,7 +64,7 @@ const styles: { [key: string]: CSSInterpolation } = {
     },
     width: 32,
     height: 32,
-  },
+  }),
 };
 
 const percentage = (value: number) => Math.round(value * 100);
@@ -86,7 +86,7 @@ const thresholdSwitcher = (
 };
 
 const renderSvgContent = (content: string) => `
-  <div class="${css(styles.icon)}">
+  <div class="${classes.icon}">
     <svg viewBox="0 0 16 16" height="16" width="16">${content}</svg>
   </div>
 `;
@@ -121,52 +121,45 @@ export const renderTooltip = (params?: HvChartTooltipParams) => {
   );
 
   return `
-      <div class="${css(styles.root)}">
-        <div class="${cx(css(styles.container), css(styles.containerBorder))}">
+      <div class="${classes.root}">
+        <div class="${cx(classes.container, classes.containerBorder)}">
           <div>
-            <p class="${css(styles.label)}">${metric?.metric}</p>
+            <p class="${classes.label}">${metric?.metric}</p>
           </div>
         </div>
-        <div class="${cx(css(styles.container), css(styles.containerBorder))}">
-          <div class="${cx(css(styles.valuesContainer), css(styles.title))}">
-            <div class="${cx(css(styles.label), css(styles.separator))}">
+        <div class="${cx(classes.container, classes.containerBorder)}">
+          <div class="${cx(classes.valuesContainer, classes.title)}">
+            <div class="${cx(classes.label, classes.separator)}">
               ${colorValue?.name}
             </div>
-            <div class="${css(styles.thresholdContainer)}">
+            <div class="${classes.thresholdContainer}">
               ${iconSwitcher(colorValue?.name || "")}
-              <p class="${css(styles.text)}">${
+              <p class="${classes.text}">${
                 metric?.value ? percentage(metric.value) : "-"
               }%</p>
             </div>
           </div>
-          <div class="${css(styles.valuesContainer)}">
-            <div class="${cx(css(styles.label), css(styles.separator))}">
+          <div class="${classes.valuesContainer}">
+            <div class="${cx(classes.label, classes.separator)}">
               Total times
             </div>
-            <div class="${css(styles.text)}">${
-              customTooltipData.totalTimes
-            }</div>
+            <div class="${classes.text}">${customTooltipData.totalTimes}</div>
           </div>
         </div>
-        <div class="${css(styles.container)}">
-          <p class="${cx(css(styles.title), css(styles.label))}">
+        <div class="${classes.container}">
+          <p class="${cx(classes.title, classes.label)}">
             Thresholds
           </p>
             ${metric?.threshold
               ?.map(
                 (threshold, index) =>
                   `
-              <div key="${threshold.name}" class="${css(
-                styles.valuesContainer,
-              )}">
-                <div class="${cx(
-                  css(styles.thresholdContainer),
-                  css(styles.separator),
-                )}">
+              <div key="${threshold.name}" class="${classes.valuesContainer}">
+                <div class="${cx(classes.thresholdContainer, classes.separator)}">
                   ${iconSwitcher(threshold.name)}
-                  <p class="${css(styles.label)}">${threshold.name}</p>
+                  <p class="${classes.label}">${threshold.name}</p>
                 </div>
-                <div class="${css(styles.text)}">
+                <div class="${classes.text}">
                   ${thresholdSwitcher(threshold.value, index, metric.threshold)}
                 </div>
               </div>

--- a/packages/viz/src/DonutChart/DonutChart.stories.tsx
+++ b/packages/viz/src/DonutChart/DonutChart.stories.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from "react";
-import { css, CSSInterpolation } from "@emotion/css";
+import { css } from "@emotion/css";
 import { Meta, StoryObj } from "@storybook/react";
 import {
   HvCheckBox,
@@ -122,9 +122,9 @@ export const Total: StoryObj<HvDonutChartProps> = {
     },
   },
   render: () => {
-    const styles: { [key: string]: CSSInterpolation } = {
-      root: { position: "relative", height: "100%" },
-      content: {
+    const classes = {
+      root: css({ position: "relative", height: "100%" }),
+      content: css({
         display: "flex",
         flexDirection: "column",
         justifyContent: "center",
@@ -133,7 +133,7 @@ export const Total: StoryObj<HvDonutChartProps> = {
         top: "50%",
         left: "50%",
         transform: "translate(-50%, -50%)",
-      },
+      }),
     };
 
     const data = {
@@ -142,9 +142,9 @@ export const Total: StoryObj<HvDonutChartProps> = {
     };
 
     return (
-      <div className={css(styles.root)}>
+      <div className={classes.root}>
         <HvDonutChart data={data} groupBy="Country" measure="Tickets Sold" />
-        <div className={css(styles.content)}>
+        <div className={classes.content}>
           <Ticket iconSize="M" />
           <HvTypography variant="title3">
             {data["Tickets Sold"].reduce((acc, value) => acc + value, 0)}


### PR DESCRIPTION
remove usage of "inline" `{ [key: string]: CSSInterpolation }` typings object in favour of the [Emotion best-practices](https://emotion.sh/docs/best-practices#consider-defining-styles-outside-your-components)