### PR TITLE
fix(BulkActions): select all background color

### DIFF
--- a/packages/core/src/BulkActions/BulkActions.styles.tsx
+++ b/packages/core/src/BulkActions/BulkActions.styles.tsx
@@ -15,18 +15,10 @@ export const { staticClasses, useClasses } = createClasses("HvBulkActions", {
   semantic: {
     backgroundColor: theme.colors.containerBackgroundHover,
     "& $selectAll div": {
-      color: "inherit",
-
       "&:hover:not(:disabled)": {
         backgroundColor: theme.alpha("base_light", 0.3),
       },
-
-      "& *": {
-        color: "inherit",
-        backgroundColor: "transparent",
-      },
     },
-
     "& $selectAll:focus-within div": {
       backgroundColor: theme.alpha("base_light", 0.3),
     },


### PR DESCRIPTION
Applitools was failing frequently because of the "Complete Table" story: [example](https://eyes.applitools.com/app/test-results/00000251688503375750/00000251688503202521/steps/1?accountId=NWMfIF0XfUeh3g9JqZjRrg~~&mode=step-editor). I tested the story locally and it was also happening sometimes. After looking at the code it seems that there's a clash between the `semantic` classe for the `HvBulkActions` and `HvBaseCheckBox` components. I removed some unneeded CSS for the `HvBulkActions` component to fix this (the main problem was with the `backgroundColor` property).