### PR TITLE
fix(Slider) - maxPointValue and minPointValue validation

### DIFF
--- a/packages/core/src/Slider/Slider.test.tsx
+++ b/packages/core/src/Slider/Slider.test.tsx
@@ -1,64 +1,97 @@
 import { useState } from "react";
-import { fireEvent, render } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it } from "vitest";
 
 import { HvSlider } from "./Slider";
 
-const Main = () => <HvSlider label="Failure Rate" defaultValues={[10]} />;
-
 const RangeSliderControlled = () => {
-  const [values, setValues] = useState<number[]>([0, 2]);
+  const [values, setValues] = useState([0, 51]);
 
-  const onChangeHandler = (knobs: number[]) => {
-    setValues(knobs);
-  };
+  return <HvSlider label="Failure Rate" values={values} onChange={setValues} />;
+};
 
-  return (
-    <HvSlider
-      label="Failure Rate"
-      values={values}
-      onChange={onChangeHandler}
-      maxPointValue={10}
-      minPointValue={-10}
-      markStep={10}
-      markDigits={1}
-    />
-  );
+const SingleSliderControlled = () => {
+  const [values, setValues] = useState([0]);
+
+  return <HvSlider label="Failure Rate" values={values} onChange={setValues} />;
+};
+
+const assertRangeSliderValuesChange = async () => {
+  const user = userEvent.setup();
+  const fifty = "50";
+  const fiftyOne = "51";
+  const eighty = "80";
+  const fiftyStyle = "left: 50%;";
+  const fiftyOneStyle = "left: 51%;";
+  const eightyStyle = "left: 80%;";
+
+  const inputs = screen.getAllByRole("textbox");
+  let knobs = screen.getAllByRole("slider");
+  expect(inputs.length).toBe(2);
+  expect(knobs.length).toBe(2);
+
+  fireEvent.change(inputs[0], { target: { value: fifty } });
+  fireEvent.blur(inputs[0]);
+
+  knobs = await screen.findAllByRole("slider");
+  expect(knobs[0]).toHaveStyle(fiftyStyle);
+  expect(knobs[1]).toHaveStyle(fiftyOneStyle);
+  expect(inputs[0]).toHaveValue(fifty);
+  expect(inputs[1]).toHaveValue(fiftyOne);
+
+  const eightyMark = screen.getByText(eighty);
+  await user.click(eightyMark);
+
+  knobs = await screen.findAllByRole("slider");
+  expect(knobs[0]).toHaveStyle(fiftyStyle);
+  expect(knobs[1]).toHaveStyle(eightyStyle);
+  expect(inputs[0]).toHaveValue(fifty);
+};
+
+const assertSingleSliderValueChange = async () => {
+  const user = userEvent.setup();
+  const fifty = "50";
+  const eighty = "80";
+  const fiftyStyle = "left: 50%;";
+  const eightyStyle = "left: 80%;";
+
+  const input = screen.getByRole("textbox");
+  let knob = screen.getByRole("slider");
+  expect(input).toBeInTheDocument();
+  expect(knob).toBeInTheDocument();
+
+  fireEvent.change(input, { target: { value: fifty } });
+  fireEvent.blur(input);
+
+  knob = await screen.findByRole("slider");
+  // The version of the slider is not updating the value now so we are testing with the style
+  expect(knob).toHaveStyle(fiftyStyle);
+  expect(input).toHaveValue(fifty);
+
+  const eightyMark = screen.getByText(eighty);
+  await user.click(eightyMark);
+
+  knob = await screen.findByRole("slider");
+  expect(knob).toHaveStyle(eightyStyle);
+  expect(input).toHaveValue(eighty);
 };
 
 describe("Slider", () => {
-  describe("general structure", () => {
-    it("renders the single slider as expected", () => {
-      const { getByRole, getByText } = render(<Main />);
+  describe("Single", () => {
+    it("renders as expected", () => {
+      render(<HvSlider label="Failure Rate" defaultValues={[10]} />);
 
-      const knob = getByRole("slider");
+      const text = screen.getByText("Failure Rate");
+      const knob = screen.getByRole("slider");
+      const input = screen.getByRole("textbox");
+      expect(text).toBeInTheDocument();
       expect(knob).toBeInTheDocument();
-
-      const input = getByRole("textbox");
       expect(input).toBeInTheDocument();
-
-      const text = getByText("Failure Rate");
-      expect(text).toBeInTheDocument();
     });
 
-    it("renders the range slider as expected", () => {
-      const { getAllByRole, getByText } = render(
-        <HvSlider label="Failure Rate" defaultValues={[10, 40]} />,
-      );
-
-      const knobs = getAllByRole("slider");
-      expect(knobs.length).toBe(2);
-
-      const inputs = getAllByRole("textbox");
-      expect(inputs.length).toBe(2);
-
-      const text = getByText("Failure Rate");
-      expect(text).toBeInTheDocument();
-    });
-
-    it("renders the single slider with an error", () => {
-      const { queryByRole, getByRole, getByText } = render(
+    it("renders an error when statusMessage is set", () => {
+      render(
         <HvSlider
           label="Failure Rate"
           status="invalid"
@@ -66,59 +99,30 @@ describe("Slider", () => {
         />,
       );
 
-      const knob = queryByRole("slider");
+      const knob = screen.queryByRole("slider");
+      const input = screen.getByRole("textbox");
+      const text = screen.getByText("Failure Rate");
+      const warningText = screen.getByText("Invalid");
       expect(knob).not.toBeInTheDocument();
-
-      const input = getByRole("textbox");
       expect(input).toBeInTheDocument();
-
-      const text = getByText("Failure Rate");
       expect(text).toBeInTheDocument();
-
-      const warningText = getByText("Invalid");
       expect(warningText).toBeInTheDocument();
+      expect(input).toBeInvalid();
     });
 
-    it("renders the range slider with an error", () => {
-      const { getAllByRole, getByText } = render(
-        <HvSlider
-          label="Failure Rate"
-          status="invalid"
-          statusMessage="Invalid "
-          defaultValues={[undefined, 53]}
-        />,
-      );
+    it("renders without an input", () => {
+      render(<HvSlider label="Failure Rate" defaultValues={[10]} hideInput />);
 
-      const knobs = getAllByRole("slider");
-      expect(knobs.length).toBe(1);
-
-      const inputs = getAllByRole("textbox");
-      expect(inputs.length).toBe(2);
-
-      const text = getByText("Failure Rate");
-      expect(text).toBeInTheDocument();
-
-      const warningText = getByText("Invalid");
-      expect(warningText).toBeInTheDocument();
-    });
-
-    it("renders the slider without an input", () => {
-      const { getByRole, queryByRole, getByText } = render(
-        <HvSlider label="Failure Rate" defaultValues={[10]} hideInput />,
-      );
-
-      const knob = getByRole("slider");
+      const knob = screen.getByRole("slider");
+      const input = screen.queryByRole("textbox");
+      const text = screen.getByText("Failure Rate");
       expect(knob).toBeInTheDocument();
-
-      const input = queryByRole("textbox");
       expect(input).not.toBeInTheDocument();
-
-      const text = getByText("Failure Rate");
       expect(text).toBeInTheDocument();
     });
 
-    it("renders the slider with no label and no input", () => {
-      const { getByRole, queryByRole } = render(
+    it("renders with no label and no input", () => {
+      render(
         <HvSlider
           knobProps={[{ "aria-label": "no-label-knob" }]}
           hideInput
@@ -126,225 +130,324 @@ describe("Slider", () => {
         />,
       );
 
-      const knob = getByRole("slider");
+      const knob = screen.getByRole("slider");
+      const input = screen.queryByRole("textbox");
+      const text = screen.queryByRole("Failure Rate");
+      expect(knob).toBeInTheDocument();
+      expect(input).not.toBeInTheDocument();
+      expect(text).not.toBeInTheDocument();
+    });
+
+    it("changes its value when uncontrolled by using the input and knob", async () => {
+      render(<HvSlider label="Failure Rate" defaultValues={[10]} />);
+      await assertSingleSliderValueChange();
+    });
+
+    it("changes values when controlled by using the input and knob", async () => {
+      render(<SingleSliderControlled />);
+      await assertSingleSliderValueChange();
+    });
+
+    it("does not change value when disabled by using the input and knob", async () => {
+      const user = userEvent.setup();
+      const fifty = "50";
+      const eighty = "80";
+      const ten = "10";
+      const tenStyle = "left: 10%;";
+      render(<HvSlider label="Failure Rate" defaultValues={[10]} disabled />);
+
+      const input = screen.getByRole("textbox");
+      let knob = screen.getByRole("slider");
+      expect(input).toBeInTheDocument();
       expect(knob).toBeInTheDocument();
 
-      const input = queryByRole("textbox");
-      expect(input).not.toBeInTheDocument();
+      fireEvent.change(input, { target: { value: fifty } });
+      fireEvent.blur(input);
 
-      const text = queryByRole("Failure Rate");
-      expect(text).not.toBeInTheDocument();
+      knob = await screen.findByRole("slider");
+      expect(knob).toHaveStyle(tenStyle);
+      expect(input).toHaveValue(ten);
+
+      const eightyMark = screen.getByText(eighty);
+      await user.click(eightyMark);
+
+      knob = await screen.findByRole("slider");
+      expect(knob).toHaveStyle(tenStyle);
+      expect(input).toHaveValue(ten);
+    });
+
+    it("renders error message on blur when required and removes it when value is typed", async () => {
+      const user = userEvent.setup();
+      const empty = "";
+      const eighty = "80";
+      const ten = "10";
+      const tenStyle = "left: 10%;";
+      const eightyStyle = "left: 80%;";
+      const requiredMessage = "The value is required";
+      let warningText: HTMLElement | null = null;
+      render(<HvSlider label="Failure Rate" required />);
+
+      const input = screen.getByRole("textbox");
+      let knob = screen.queryByRole("slider");
+      expect(input).toBeInTheDocument();
+      expect(knob).not.toBeInTheDocument();
+
+      fireEvent.blur(input);
+
+      warningText = await screen.findByText(requiredMessage);
+      expect(warningText).toBeInTheDocument();
+      expect(input).toHaveValue(empty);
+      expect(input).toBeInvalid();
+
+      const eightyMark = screen.getByText(eighty);
+      await user.click(eightyMark);
+
+      knob = await screen.findByRole("slider");
+      expect(knob).toHaveStyle(eightyStyle);
+      expect(input).toHaveValue(eighty);
+
+      warningText = screen.queryByText(requiredMessage);
+      expect(warningText).not.toBeInTheDocument();
+      expect(input).not.toBeInvalid();
+
+      fireEvent.change(input, { target: { value: empty } });
+      fireEvent.blur(input);
+
+      warningText = await screen.findByText(requiredMessage);
+      expect(warningText).toBeInTheDocument();
+      expect(input).toBeInvalid();
+
+      knob = screen.queryByRole("slider");
+      expect(knob).not.toBeInTheDocument();
+
+      // Fill by input
+      fireEvent.change(input, { target: { value: ten } });
+      fireEvent.blur(input);
+
+      knob = await screen.findByRole("slider");
+      expect(knob).toHaveStyle(tenStyle);
+      expect(input).toHaveValue(ten);
+
+      warningText = screen.queryByText(requiredMessage);
+      expect(warningText).not.toBeInTheDocument();
+      expect(input).not.toBeInvalid();
+    });
+
+    it("does not render error message on blur when value is empty and required is false", async () => {
+      const requiredMessage = "The value is required";
+      const empty = "";
+      let warningText: HTMLElement | null = null;
+      render(<HvSlider label="Failure Rate" />);
+
+      const input = screen.getByRole("textbox");
+      expect(input).toBeInTheDocument();
+
+      fireEvent.blur(input);
+
+      warningText = screen.queryByText(requiredMessage);
+      expect(warningText).not.toBeInTheDocument();
+      expect(input).toHaveValue(empty);
+      expect(input).not.toBeInvalid();
+    });
+
+    it("renders error message when value typed is not between maxPointValue and minPointValue", async () => {
+      const max = "110";
+      const min = "-5";
+      const ten = "10";
+      const outOfRangeMessage = "The value is out of range";
+      let warningText: HTMLElement | null = null;
+      render(<HvSlider label="Failure Rate" />);
+
+      const input = screen.getByRole("textbox");
+      expect(input).toBeInTheDocument();
+
+      fireEvent.change(input, { target: { value: max } });
+      fireEvent.blur(input);
+
+      warningText = await screen.findByText(outOfRangeMessage);
+      expect(warningText).toBeInTheDocument();
+      expect(input).toBeInvalid();
+
+      fireEvent.change(input, { target: { value: min } });
+      fireEvent.blur(input);
+
+      warningText = await screen.findByText(outOfRangeMessage);
+      expect(warningText).toBeInTheDocument();
+      expect(input).toBeInvalid();
+
+      fireEvent.change(input, { target: { value: ten } });
+      fireEvent.blur(input);
+
+      warningText = screen.queryByText(outOfRangeMessage);
+      expect(warningText).not.toBeInTheDocument();
+      expect(input).not.toBeInvalid();
     });
   });
 
-  describe("interactions", () => {
-    describe("single", () => {
-      it("able to change its value when uncontrolled", async () => {
-        const fifty = "50";
-        const eighty = "80";
-        const fiftyStyle = "left: 50%;";
-        const eightyStyle = "left: 80%;";
+  describe("Range", () => {
+    it("renders as expected", () => {
+      render(<HvSlider label="Failure Rate" defaultValues={[10, 40]} />);
 
-        const { getByRole, findByRole, getByText } = render(<Main />);
-
-        const input = getByRole("textbox");
-        expect(input).toBeInTheDocument();
-
-        let knob = getByRole("slider");
-        expect(knob).toBeInTheDocument();
-
-        fireEvent.change(input, { target: { value: fifty } });
-        fireEvent.blur(input);
-
-        knob = await findByRole("slider");
-        // The version of the slider is not updating the value now so we are testing with the style
-        expect(knob).toHaveStyle(fiftyStyle);
-        expect(input).toHaveValue(fifty);
-
-        const eightyMark = getByText(eighty);
-        await userEvent.click(eightyMark);
-
-        knob = await findByRole("slider");
-        expect(knob).toHaveStyle(eightyStyle);
-        expect(input).toHaveValue(eighty);
-      });
-
-      it("does not change value when disable", async () => {
-        const fifty = "50";
-        const eighty = "80";
-        const ten = "10";
-        const tenStyle = "left: 10%;";
-
-        const { getByRole, findByRole, getByText } = render(
-          <HvSlider label="Failure Rate" defaultValues={[10]} disabled />,
-        );
-
-        const input = getByRole("textbox");
-        expect(input).toBeInTheDocument();
-
-        let knob = getByRole("slider");
-        expect(knob).toBeInTheDocument();
-
-        fireEvent.change(input, { target: { value: fifty } });
-        fireEvent.blur(input);
-
-        knob = await findByRole("slider");
-        expect(knob).toHaveStyle(tenStyle);
-        expect(input).toHaveValue(ten);
-
-        const eightyMark = getByText(eighty);
-        userEvent.click(eightyMark);
-
-        knob = await findByRole("slider");
-        expect(knob).toHaveStyle(tenStyle);
-        expect(input).toHaveValue(ten);
-      });
-
-      it("the knobs appear after interaction when blank", async () => {
-        const empty = "";
-        const eighty = "80";
-        const ten = "10";
-        const tenStyle = "left: 10%;";
-        const eightyStyle = "left: 80%;";
-        const requiredMessage = "The value is required";
-        let warningText: HTMLElement | null = null;
-
-        const {
-          getByRole,
-          queryByRole,
-          findByText,
-          findByRole,
-          getByText,
-          queryByText,
-        } = render(<HvSlider label="Failure Rate" required />);
-
-        const input = getByRole("textbox");
-        expect(input).toBeInTheDocument();
-
-        let knob = queryByRole("slider");
-        expect(knob).not.toBeInTheDocument();
-
-        fireEvent.blur(input);
-
-        warningText = await findByText(requiredMessage);
-        expect(warningText).toBeInTheDocument();
-        expect(input).toHaveValue(empty);
-
-        // Click on 80
-        const eightyMark = getByText(eighty);
-        userEvent.click(eightyMark);
-
-        knob = await findByRole("slider");
-        expect(knob).toHaveStyle(eightyStyle);
-        expect(input).toHaveValue(eighty);
-
-        warningText = queryByText(requiredMessage);
-        expect(warningText).not.toBeInTheDocument();
-
-        // empty again
-        fireEvent.change(input, { target: { value: empty } });
-        fireEvent.blur(input);
-
-        warningText = await findByText(requiredMessage);
-        expect(warningText).toBeInTheDocument();
-
-        knob = queryByRole("slider");
-        expect(knob).not.toBeInTheDocument();
-
-        // Fill by input
-        fireEvent.change(input, { target: { value: ten } });
-        fireEvent.blur(input);
-
-        knob = await findByRole("slider");
-        expect(knob).toHaveStyle(tenStyle);
-        expect(input).toHaveValue(ten);
-
-        warningText = queryByText(requiredMessage);
-        expect(warningText).not.toBeInTheDocument();
-      });
+      const knobs = screen.getAllByRole("slider");
+      const inputs = screen.getAllByRole("textbox");
+      const text = screen.getByText("Failure Rate");
+      expect(knobs.length).toBe(2);
+      expect(inputs.length).toBe(2);
+      expect(text).toBeInTheDocument();
     });
 
-    describe("range", () => {
-      it("able to change its value when uncontrolled", async () => {
-        const fifty = "50";
-        const fiftyOne = "51";
-        const fiftyStyle = "left: 50%;";
-        const fiftyOneStyle = "left: 51%;";
+    it("renders an error when statusMessage is set", () => {
+      render(
+        <HvSlider
+          label="Failure Rate"
+          status="invalid"
+          statusMessage="Invalid"
+          defaultValues={[undefined, 53]}
+        />,
+      );
 
-        const { findAllByRole, getAllByRole } = render(
-          <HvSlider label="Failure Rate" defaultValues={[10, 40]} />,
-        );
+      const knobs = screen.getAllByRole("slider");
+      const inputs = screen.getAllByRole("textbox");
+      const text = screen.getByText("Failure Rate");
+      const warningText = screen.getByText("Invalid");
+      expect(knobs.length).toBe(1);
+      expect(inputs.length).toBe(2);
+      expect(text).toBeInTheDocument();
+      expect(warningText).toBeInTheDocument();
+      inputs.map((input) => expect(input).toBeInvalid());
+    });
 
-        const inputs = getAllByRole("textbox");
-        expect(inputs.length).toBe(2);
+    it("changes values when uncontrolled by using the input and knob", async () => {
+      render(<HvSlider label="Failure Rate" defaultValues={[10, 40]} />);
+      await assertRangeSliderValuesChange();
+    });
 
-        let knobs = getAllByRole("slider");
-        expect(knobs.length).toBe(2);
+    it("changes values when controlled by using the input and knob", async () => {
+      render(<RangeSliderControlled />);
+      await assertRangeSliderValuesChange();
+    });
 
-        fireEvent.change(inputs[0], { target: { value: fifty } });
-        fireEvent.blur(inputs[0]);
+    it("does not change values when disabled by using the input and knob", async () => {
+      const user = userEvent.setup();
+      const forty = "40";
+      const ten = "10";
+      const sixty = "60";
+      const tenStyle = "left: 10%;";
+      const fortyStyle = "left: 40%;";
+      render(
+        <HvSlider label="Failure Rate" defaultValues={[10, 40]} disabled />,
+      );
 
-        knobs = await findAllByRole("slider");
-        expect(knobs[0]).toHaveStyle(fiftyStyle);
-        expect(knobs[1]).toHaveStyle(fiftyOneStyle);
-        expect(inputs[0]).toHaveValue(fifty);
-        expect(inputs[1]).toHaveValue(fiftyOne);
-      });
+      const inputs = screen.getAllByRole("textbox");
+      let knobs = screen.getAllByRole("slider");
+      expect(inputs.length).toBe(2);
+      expect(knobs.length).toBe(2);
 
-      it("able to change its value when controlled", async () => {
-        const fifty = "0.0";
-        const fiftyOne = "0.2";
-        const fiftyStyle = "left: 50%;";
-        const fiftyOneStyle = "left: 51%;";
+      fireEvent.change(inputs[0], { target: { value: sixty } });
+      fireEvent.blur(inputs[0]);
 
-        const { getAllByRole, findAllByRole } = render(
-          <RangeSliderControlled />,
-        );
+      knobs = await screen.findAllByRole("slider");
+      expect(knobs[0]).toHaveStyle(tenStyle);
+      expect(knobs[1]).toHaveStyle(fortyStyle);
+      expect(inputs[0]).toHaveValue(ten);
+      expect(inputs[1]).toHaveValue(forty);
 
-        const inputs = getAllByRole("textbox");
-        expect(inputs.length).toBe(2);
+      const sixtyMark = screen.getByText(sixty);
+      await user.click(sixtyMark);
 
-        let knobs = getAllByRole("slider");
-        expect(knobs.length).toBe(2);
+      knobs = await screen.findAllByRole("slider");
+      expect(knobs[0]).toHaveStyle(tenStyle);
+      expect(knobs[1]).toHaveStyle(fortyStyle);
+      expect(inputs[0]).toHaveValue(ten);
+      expect(inputs[1]).toHaveValue(forty);
+    });
 
-        fireEvent.change(inputs[0], { target: { value: fifty } });
-        fireEvent.blur(inputs[0]);
-        fireEvent.change(inputs[1], { target: { value: fiftyOne } });
-        fireEvent.blur(inputs[1]);
+    it("renders error message on blur when required and removes it when value is typed", async () => {
+      const fifty = "50";
+      const fiftyOne = "51";
+      const fiftyStyle = "left: 50%;";
+      const fiftyOneStyle = "left: 51%;";
+      const requiredMessage = "The value is required";
+      const empty = "";
+      let warningText: HTMLElement | null = null;
+      render(
+        <HvSlider
+          label="Failure Rate"
+          required
+          defaultValues={[undefined, undefined]}
+        />,
+      );
 
-        knobs = await findAllByRole("slider");
-        expect(knobs[0]).toHaveStyle(fiftyStyle);
-        expect(knobs[1]).toHaveStyle(fiftyOneStyle);
-        expect(inputs[0]).toHaveValue(fifty);
-        expect(inputs[1]).toHaveValue(fiftyOne);
-      });
+      const inputs = screen.getAllByRole("textbox");
+      let knobs = screen.queryAllByRole("slider");
+      expect(inputs.length).toBe(2);
+      expect(knobs.length).toBe(0);
 
-      it("does not change value when disable", async () => {
-        const forty = "40";
-        const ten = "10";
-        const fifty = "50";
-        const tenStyle = "left: 10%;";
-        const fortyStyle = "left: 40%;";
+      fireEvent.blur(inputs[0]);
 
-        const { getAllByRole, findAllByRole } = render(
-          <HvSlider label="Failure Rate" defaultValues={[10, 40]} disabled />,
-        );
+      warningText = await screen.findByText(requiredMessage);
+      expect(warningText).toBeInTheDocument();
+      expect(inputs[0]).toHaveValue(empty);
+      expect(inputs[0]).toBeInvalid();
+      expect(inputs[1]).toHaveValue(empty);
+      expect(inputs[1]).toBeInvalid();
 
-        const inputs = getAllByRole("textbox");
-        expect(inputs.length).toBe(2);
+      fireEvent.change(inputs[0], { target: { value: fifty } });
+      fireEvent.blur(inputs[0]);
 
-        let knobs = getAllByRole("slider");
-        expect(knobs.length).toBe(2);
+      knobs = await screen.findAllByRole("slider");
+      warningText = screen.queryByText(requiredMessage);
+      expect(knobs[0]).toHaveStyle(fiftyStyle);
+      expect(knobs[1]).toHaveStyle(fiftyOneStyle);
+      expect(inputs[0]).toHaveValue(fifty);
+      expect(inputs[1]).toHaveValue(fiftyOne);
+      expect(warningText).not.toBeInTheDocument();
+      expect(inputs[0]).not.toBeInvalid();
+      expect(inputs[1]).not.toBeInvalid();
+    });
 
-        fireEvent.change(inputs[0], { target: { value: fifty } });
-        fireEvent.blur(inputs[0]);
+    it("renders error message when value typed is between maxPointValue and minPointValue", async () => {
+      const max = "110";
+      const min = "-5";
+      const ten = "10";
+      const twenty = "20";
+      const outOfRangeMessage = "The value is out of range";
+      let warningText: HTMLElement | null = null;
+      render(
+        <HvSlider
+          label="Failure Rate"
+          defaultValues={[undefined, undefined]}
+        />,
+      );
 
-        knobs = await findAllByRole("slider");
-        expect(knobs[0]).toHaveStyle(tenStyle);
-        expect(knobs[1]).toHaveStyle(fortyStyle);
-        expect(inputs[0]).toHaveValue(ten);
-        expect(inputs[1]).toHaveValue(forty);
-      });
+      const inputs = screen.getAllByRole("textbox");
+      expect(inputs.length).toBe(2);
+
+      fireEvent.change(inputs[0], { target: { value: max } });
+      fireEvent.blur(inputs[0]);
+
+      warningText = await screen.findByText(outOfRangeMessage);
+      expect(warningText).toBeInTheDocument();
+      expect(inputs[0]).toBeInvalid();
+      expect(inputs[1]).toBeInvalid();
+
+      fireEvent.change(inputs[0], { target: { value: min } });
+      fireEvent.blur(inputs[0]);
+
+      warningText = await screen.findByText(outOfRangeMessage);
+      expect(warningText).toBeInTheDocument();
+      expect(inputs[0]).toBeInvalid();
+      expect(inputs[1]).toBeInvalid();
+
+      fireEvent.change(inputs[0], { target: { value: ten } });
+      fireEvent.blur(inputs[0]);
+      fireEvent.change(inputs[1], { target: { value: twenty } });
+      fireEvent.blur(inputs[1]);
+
+      warningText = screen.queryByText(outOfRangeMessage);
+      expect(warningText).not.toBeInTheDocument();
+      expect(inputs[0]).not.toBeInvalid();
+      expect(inputs[1]).not.toBeInvalid();
     });
   });
 });


### PR DESCRIPTION
Addresses: https://github.com/lumada-design/hv-uikit-react/issues/4164

- When the values are not between `maxPointValue` and `minPointValue`, the slider is invalid.
- Tests updated and new tests added.