### PR TITLE
docs: remove duplicated Main story

### DIFF
--- a/.storybook/blocks/DocsPage.tsx
+++ b/.storybook/blocks/DocsPage.tsx
@@ -1,0 +1,28 @@
+import {
+  Controls,
+  Description,
+  Primary,
+  Stories,
+  Subtitle,
+  Title,
+  useOf,
+} from "@storybook/blocks";
+
+/** @see https://github.com/storybookjs/storybook/blob/v8.0.10/code/ui/blocks/src/blocks/DocsPage.tsx */
+export function DocsPage() {
+  const resolvedOf = useOf("meta", ["meta"]);
+  const { stories } = resolvedOf.csfFile;
+  const isSingleStory = Object.keys(stories).length === 1;
+
+  return (
+    <>
+      <Title />
+      <Subtitle />
+      <Description of="meta" />
+      {isSingleStory ? <Description of="story" /> : null}
+      <Primary />
+      <Controls />
+      {isSingleStory ? null : <Stories includePrimary={false} />}
+    </>
+  );
+}

--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -1,6 +1,7 @@
 import { Preview } from "@storybook/react";
 
 import DocsContainer from "./blocks/DocsContainer";
+import { DocsPage } from "./blocks/DocsPage";
 import ThemeDecorator from "./decorators/withThemeProvider";
 
 import "uno.css";
@@ -10,6 +11,7 @@ export const parameters: Preview["parameters"] = {
   docs: {
     source: { type: "dynamic" },
     container: DocsContainer,
+    page: DocsPage,
   },
   controls: {
     matchers: {


### PR DESCRIPTION
restore `DocsPage` component ([copy of SB's](https://github.com/storybookjs/storybook/blob/v8.0.10/code/ui/blocks/src/blocks/DocsPage.tsx)), and add `includePrimary={false}` to `Stories` component