### PR TITLE
chore: use production build for Chromatic

### DIFF
--- a/.config/chromatic.config.json
+++ b/.config/chromatic.config.json
@@ -1,5 +1,5 @@
 {
   "projectId": "Project:66040297ad386b97be078cc9",
-  "buildScriptName": "build:doc:test",
+  "buildScriptName": "build:doc",
   "skip": "dependabot/**"
 }


### PR DESCRIPTION
- Instead of using a [test build](https://storybook.js.org/docs/api/main-config-build#test) for Chromatic, a production one is used as we now use the build created by Chromatic to review our PRs. Test builds are stripped-down versions of production builds, for instance they don't provide the components' page with all the stories listed ([example](https://66040297ad386b97be078cc9-gufatqkquj.chromatic.com)).