### PR TITLE
perf(ThemeProvider): optimize rendering

### DIFF
--- a/packages/cli/src/baselines/app-shell/vite/src/providers/Provider.tsx
+++ b/packages/cli/src/baselines/app-shell/vite/src/providers/Provider.tsx
@@ -1,4 +1,4 @@
-import React, { Suspense } from "react";
+import { Suspense } from "react";
 import { I18nextProvider } from "react-i18next";
 
 import useI18nInstance from "../lib/i18n";

--- a/packages/cli/src/baselines/vite/src/components/common/Loading/Loading.tsx
+++ b/packages/cli/src/baselines/vite/src/components/common/Loading/Loading.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { HvLoading } from "@hitachivantara/uikit-react-core";
 
 import classes from "./styles";

--- a/packages/core/src/Select/Select.tsx
+++ b/packages/core/src/Select/Select.tsx
@@ -28,6 +28,7 @@ import { HvListContainer } from "../ListContainer";
 import { HvPanel } from "../Panel";
 import { fixedForwardRef } from "../types/generic";
 import { ExtractNames } from "../utils/classes";
+import { getContainerElement } from "../utils/document";
 import { setId } from "../utils/setId";
 import { staticClasses, useClasses } from "./Select.styles";
 
@@ -270,11 +271,7 @@ export const HvSelect = fixedForwardRef(function HvSelect<
         open={isOpen}
         keepMounted
         disablePortal={!enablePortal}
-        container={
-          enablePortal
-            ? document.getElementById(rootId || "") || document.body
-            : undefined
-        }
+        container={enablePortal ? getContainerElement(rootId) : undefined}
         anchorEl={buttonRef.current}
         className={classes.popper}
         placement={placement}

--- a/packages/core/src/Slider/Slider.tsx
+++ b/packages/core/src/Slider/Slider.tsx
@@ -17,6 +17,7 @@ import { useUniqueId } from "../hooks/useUniqueId";
 import { HvInputProps } from "../Input";
 import { HvBaseProps } from "../types/generic";
 import { ExtractNames } from "../utils/classes";
+import { getElementById } from "../utils/document";
 import { setId } from "../utils/setId";
 import { sliderStyles, staticClasses, useClasses } from "./Slider.styles";
 import { HvSliderInput } from "./SliderInput/SliderInput";
@@ -537,9 +538,7 @@ export const HvSlider = forwardRef<SliderRef, HvSliderProps>((props, ref) => {
           visible={dragging}
           placement="top"
           overlayClassName={classes.sliderTooltip}
-          getTooltipContainer={() =>
-            document.getElementById(indexedHandleId || "") as HTMLElement
-          }
+          getTooltipContainer={() => getElementById(indexedHandleId)!}
         >
           <div
             id={indexedHandleId}

--- a/packages/core/src/Tooltip/Tooltip.tsx
+++ b/packages/core/src/Tooltip/Tooltip.tsx
@@ -1,4 +1,4 @@
-import { forwardRef } from "react";
+import { forwardRef, useEffect, useState } from "react";
 import Fade from "@mui/material/Fade";
 import Tooltip, {
   TooltipProps as MuiTooltipProps,
@@ -82,11 +82,19 @@ export const HvTooltip = forwardRef((props: HvTooltipProps, ref) => {
 
   const { rootId } = useTheme();
   const { classes } = useClasses(classesProp);
+  const [container, setContainer] = useState(() =>
+    getElementById(containerId ?? rootId),
+  );
+
+  // force extra render to get the correct container DOM element
+  useEffect(() => {
+    setContainer(getElementById(containerId ?? rootId));
+  }, [containerId, rootId]);
 
   return (
     <Tooltip
       ref={ref}
-      open={open ?? undefined}
+      open={open}
       enterDelay={enterDelay}
       placement={placement}
       TransitionComponent={TransitionComponent}
@@ -97,9 +105,7 @@ export const HvTooltip = forwardRef((props: HvTooltipProps, ref) => {
         popper: classes.popper,
       }}
       title={title}
-      PopperProps={{
-        container: getElementById(containerId || rootId),
-      }}
+      PopperProps={{ container }}
       {...others}
     >
       {children}

--- a/packages/core/src/providers/Provider.tsx
+++ b/packages/core/src/providers/Provider.tsx
@@ -103,7 +103,7 @@ export const HvProvider = ({
   const scopedRootId = `${scopedRootPrefix}-${generatedId}`;
 
   // Themes
-  const themesList: (HvTheme | HvThemeStructure)[] = processThemes(themes);
+  const themesList = processThemes(themes);
 
   // Emotion cache
   // Moves UI Kit styles to the top of the <head> so they're loaded first

--- a/packages/core/src/utils/theme.ts
+++ b/packages/core/src/utils/theme.ts
@@ -5,7 +5,7 @@ import {
 } from "@hitachivantara/uikit-styles";
 
 import { HvCreateThemeProps, HvTheme } from "../types/theme";
-import { getElementById } from "./document";
+import { getContainerElement, getElementById } from "./document";
 
 /**
  * Sets the element attributes and style for a theme and color mode.
@@ -16,9 +16,7 @@ export const setElementAttrs = (
   colorScheme: string,
   themeRootId?: string,
 ) => {
-  const element = themeRootId
-    ? document.getElementById(themeRootId)
-    : document.body;
+  const element = getContainerElement(themeRootId);
 
   if (element) {
     element.setAttribute(`data-theme`, themeName);

--- a/packages/lab/src/Blade/Blade.tsx
+++ b/packages/lab/src/Blade/Blade.tsx
@@ -1,4 +1,4 @@
-import React, {
+import {
   HTMLAttributes,
   SyntheticEvent,
   useCallback,

--- a/packages/lab/src/Blades/Blades.tsx
+++ b/packages/lab/src/Blades/Blades.tsx
@@ -1,4 +1,4 @@
-import React, {
+import {
   Children,
   cloneElement,
   SyntheticEvent,

--- a/packages/lab/src/Wizard/Wizard.tsx
+++ b/packages/lab/src/Wizard/Wizard.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { ModalProps } from "@mui/material/Modal";
 import {
   ExtractNames,

--- a/packages/lab/src/Wizard/WizardContainer/WizardContainer.tsx
+++ b/packages/lab/src/Wizard/WizardContainer/WizardContainer.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import {
   ExtractNames,
   HvBaseProps,

--- a/packages/lab/src/Wizard/WizardContext/WizardContext.tsx
+++ b/packages/lab/src/Wizard/WizardContext/WizardContext.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, Dispatch, SetStateAction } from "react";
+import { createContext, Dispatch, SetStateAction } from "react";
 
 export type HvWizardTab = {
   name?: string;


### PR DESCRIPTION
- optimize `ThemeProvider` rendering
- remove unused `React` imports

Opening App + switching Theme to `wicked` and then `dawn`:
- Before: 19 renders & more noticeable theme flickering 

https://github.com/lumada-design/hv-uikit-react/assets/638946/84534317-170a-46fd-9f00-8810d722aa6c

- Now: 11 renders & less noticeable theme flickering

https://github.com/lumada-design/hv-uikit-react/assets/638946/c6e4a624-3427-4ff6-83e3-26ffea4f59af


