### PR TITLE
chore: enable `react/`jsx-key rule & apply fixes

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -24,6 +24,7 @@
   "rules": {
     "arrow-body-style": "off",
     "prefer-arrow-callback": "off",
+    "react/jsx-key": "error",
     "react/prop-types": "off",
     "react/no-unused-prop-types": "off",
     "react/require-default-props": "off",

--- a/apps/app/src/pages/Flow/DashboardPreview/Renderers/Table.tsx
+++ b/apps/app/src/pages/Flow/DashboardPreview/Renderers/Table.tsx
@@ -130,9 +130,15 @@ export const Table = ({
         <HvTable {...getTableProps()}>
           <HvTableHead>
             {headerGroups.map((headerGroup) => (
-              <HvTableRow {...headerGroup.getHeaderGroupProps()}>
+              <HvTableRow
+                {...headerGroup.getHeaderGroupProps()}
+                key={headerGroup.getHeaderGroupProps().key}
+              >
                 {headerGroup.headers.map((col) => (
-                  <HvTableHeader {...col.getHeaderProps()}>
+                  <HvTableHeader
+                    {...col.getHeaderProps()}
+                    key={col.getHeaderProps().key}
+                  >
                     {col.render("Header")}
                   </HvTableHeader>
                 ))}
@@ -142,12 +148,16 @@ export const Table = ({
           <HvTableBody {...getTableBodyProps()}>
             {page.length > 0 ? (
               page.map((row) => {
+                const { key, ...rowProps } = row.getRowProps();
                 prepareRow(row);
 
                 return (
-                  <HvTableRow {...row.getRowProps()}>
+                  <HvTableRow key={key} {...rowProps}>
                     {row.cells.map((cell) => (
-                      <HvTableCell {...cell.getCellProps()}>
+                      <HvTableCell
+                        {...cell.getCellProps()}
+                        key={cell.getCellProps().key}
+                      >
                         {cell.render("Cell")}
                       </HvTableCell>
                     ))}

--- a/docs/tests/Table.stories.tsx
+++ b/docs/tests/Table.stories.tsx
@@ -88,29 +88,21 @@ export const Main: StoryObj = {
         useHvTableSticky,
       );
 
-    const renderTableRow = (row) => {
-      prepareRow(row);
-
-      return (
-        <HvTableRow {...row.getRowProps()}>
-          {row.cells.map((cell) => (
-            <HvTableCell {...cell.getCellProps()}>
-              {cell.render("Cell")}
-            </HvTableCell>
-          ))}
-        </HvTableRow>
-      );
-    };
-
     return (
       <HvTableSection>
         <HvTableContainer tabIndex={0}>
           <HvTable {...getTableProps()}>
             <HvTableHead>
               {headerGroups.map((headerGroup) => (
-                <HvTableRow {...headerGroup.getHeaderGroupProps()}>
+                <HvTableRow
+                  {...headerGroup.getHeaderGroupProps()}
+                  key={headerGroup.getHeaderGroupProps().key}
+                >
                   {headerGroup.headers.map((col) => (
-                    <HvTableHeader {...col.getHeaderProps()}>
+                    <HvTableHeader
+                      {...col.getHeaderProps()}
+                      key={col.getHeaderProps().key}
+                    >
                       {col.render("Header")}
                     </HvTableHeader>
                   ))}
@@ -118,7 +110,23 @@ export const Main: StoryObj = {
               ))}
             </HvTableHead>
             <HvTableBody {...getTableBodyProps()}>
-              {rows.map(renderTableRow)}
+              {rows.map((row) => {
+                prepareRow(row);
+                const { key, ...rowProps } = row.getRowProps();
+
+                return (
+                  <HvTableRow key={key} {...rowProps}>
+                    {row.cells.map((cell) => (
+                      <HvTableCell
+                        {...cell.getCellProps()}
+                        key={cell.getCellProps().key}
+                      >
+                        {cell.render("Cell")}
+                      </HvTableCell>
+                    ))}
+                  </HvTableRow>
+                );
+              })}
             </HvTableBody>
           </HvTable>
         </HvTableContainer>

--- a/packages/cli/src/templates/AssetInventory/ListView.tsx
+++ b/packages/cli/src/templates/AssetInventory/ListView.tsx
@@ -32,14 +32,18 @@ export const ListView = ({ id, instance, columns }: ListViewProps) => {
         </HvTableHead>
         <HvTableBody withNavigation {...instance.getTableBodyProps()}>
           {instance.page.map((row) => {
+            const { key, ...rowProps } = row.getRowProps();
             instance.prepareRow(row);
             return (
-              <HvTableRow {...row.getRowProps()}>
-                {row.cells.map((cell) => (
-                  <HvTableCell {...cell.getCellProps()}>
-                    {cell.render("Cell")}
-                  </HvTableCell>
-                ))}
+              <HvTableRow key={key} {...rowProps}>
+                {row.cells.map((cell) => {
+                  const { key: cellKey, ...cellProps } = cell.getCellProps();
+                  return (
+                    <HvTableCell key={cellKey} {...cellProps}>
+                      {cell.render("Cell")}
+                    </HvTableCell>
+                  );
+                })}
               </HvTableRow>
             );
           })}

--- a/packages/cli/src/templates/DetailsView/Table.tsx
+++ b/packages/cli/src/templates/DetailsView/Table.tsx
@@ -71,14 +71,18 @@ export const Table = ({ modelId }: TableProps) => {
           </HvTableHead>
           <HvTableBody {...instance.getTableBodyProps()}>
             {instance.page.map((row) => {
+              const { key, ...rowProps } = row.getRowProps();
               instance.prepareRow(row);
               return (
-                <HvTableRow {...row.getRowProps()}>
-                  {row.cells.map((cell) => (
-                    <HvTableCell {...cell.getCellProps()}>
-                      {cell.render("Cell")}
-                    </HvTableCell>
-                  ))}
+                <HvTableRow key={key} {...rowProps}>
+                  {row.cells.map((cell) => {
+                    const { key: cellKey, ...cellProps } = cell.getCellProps();
+                    return (
+                      <HvTableCell key={cellKey} {...cellProps}>
+                        {cell.render("Cell")}
+                      </HvTableCell>
+                    );
+                  })}
                 </HvTableRow>
               );
             })}

--- a/packages/cli/src/templates/ListView/Table.tsx
+++ b/packages/cli/src/templates/ListView/Table.tsx
@@ -33,14 +33,18 @@ export const Table = ({ instance, id }: TableProps) => {
         </HvTableHead>
         <HvTableBody withNavigation {...instance.getTableBodyProps()}>
           {instance.page.map((row) => {
+            const { key, ...rowProps } = row.getRowProps();
             instance.prepareRow(row);
             return (
-              <HvTableRow {...row.getRowProps()}>
-                {row.cells.map((cell) => (
-                  <HvTableCell {...cell.getCellProps()}>
-                    {cell.render("Cell")}
-                  </HvTableCell>
-                ))}
+              <HvTableRow key={key} {...rowProps}>
+                {row.cells.map((cell) => {
+                  const { key: cellKey, ...cellProps } = cell.getCellProps();
+                  return (
+                    <HvTableCell key={cellKey} {...cellProps}>
+                      {cell.render("Cell")}
+                    </HvTableCell>
+                  );
+                })}
               </HvTableRow>
             );
           })}

--- a/packages/core/src/Accordion/Accordion.stories.tsx
+++ b/packages/core/src/Accordion/Accordion.stories.tsx
@@ -338,9 +338,15 @@ export const Typography: StoryObj<HvAccordionProps> = {
           <HvTable {...getTableProps()}>
             <HvTableHead {...getTableHeadProps?.()}>
               {headerGroups.map((headerGroup) => (
-                <HvTableRow {...headerGroup.getHeaderGroupProps()}>
+                <HvTableRow
+                  {...headerGroup.getHeaderGroupProps()}
+                  key={headerGroup.getHeaderGroupProps().key}
+                >
                   {headerGroup.headers.map((col) => (
-                    <HvTableHeader {...col.getHeaderProps()}>
+                    <HvTableHeader
+                      {...col.getHeaderProps()}
+                      key={col.getHeaderProps().key}
+                    >
                       {col.render("Header")}
                     </HvTableHeader>
                   ))}
@@ -350,11 +356,15 @@ export const Typography: StoryObj<HvAccordionProps> = {
             <HvTableBody {...getTableBodyProps()}>
               {rows.map((row) => {
                 prepareRow(row);
+                const { key, ...rowProps } = row.getRowProps();
 
                 return (
-                  <HvTableRow {...row.getRowProps()}>
+                  <HvTableRow key={key} {...rowProps}>
                     {row.cells.map((cell) => (
-                      <HvTableCell {...cell.getCellProps()}>
+                      <HvTableCell
+                        {...cell.getCellProps()}
+                        key={cell.getCellProps().key}
+                      >
                         {cell.render("Cell")}
                       </HvTableCell>
                     ))}

--- a/packages/core/src/ActionsGeneric/ActionsGeneric.tsx
+++ b/packages/core/src/ActionsGeneric/ActionsGeneric.tsx
@@ -109,7 +109,6 @@ export const HvActionsGeneric = (props: HvActionsGenericProps) => {
       : (icon as Function)?.({ isDisabled: disabled });
 
     const commonButtonProps: HvButtonProps = {
-      key: actionId || idx,
       id: actionId,
       variant,
       className: classes.button,
@@ -118,18 +117,19 @@ export const HvActionsGeneric = (props: HvActionsGenericProps) => {
       ...other,
     };
 
+    const key = actionId || idx;
     const isIcon = iconOnly ?? iconOnlyProp;
 
     if (isIcon) {
       return (
-        <HvIconButton {...commonButtonProps} title={label}>
+        <HvIconButton key={key} {...commonButtonProps} title={label}>
           {renderedIcon}
         </HvIconButton>
       );
     }
 
     return (
-      <HvButton {...commonButtonProps} startIcon={renderedIcon}>
+      <HvButton key={key} {...commonButtonProps} startIcon={renderedIcon}>
         {label}
       </HvButton>
     );

--- a/packages/core/src/Carousel/Carousel.test.tsx
+++ b/packages/core/src/Carousel/Carousel.test.tsx
@@ -14,8 +14,8 @@ const setup = ({ title = "TITLE", numImages = 10, onChange = () => {} }) => {
       onChange={onChange}
       renderThumbnail={(i) => <img src={`/image-${i}`} alt={`label-${i}`} />}
     >
-      {Array.from(Array(numImages), (el, i) => (
-        <HvCarouselSlide src={`/image-${i}`} alt={`label-${i}`} />
+      {[...Array(numImages).keys()].map((i) => (
+        <HvCarouselSlide key={i} src={`/image-${i}`} alt={`label-${i}`} />
       ))}
     </HvCarousel>,
   );

--- a/packages/core/src/Dropdown/stories/CustomDropdown.tsx
+++ b/packages/core/src/Dropdown/stories/CustomDropdown.tsx
@@ -167,22 +167,30 @@ export const CustomDropdown = () => {
             <HvTypography variant="title4">Column Types</HvTypography>
             <HvSelect label="User ID" placeholder="Select an option">
               {options.map((option) => (
-                <HvOption value={option.value}>{option.label}</HvOption>
+                <HvOption key={option.value} value={option.value}>
+                  {option.label}
+                </HvOption>
               ))}
             </HvSelect>
             <HvSelect label="Name" placeholder="Select an option">
               {options.map((option) => (
-                <HvOption value={option.value}>{option.label}</HvOption>
+                <HvOption key={option.value} value={option.value}>
+                  {option.label}
+                </HvOption>
               ))}
             </HvSelect>
             <HvSelect label="Email" placeholder="Select an option">
               {options.map((option) => (
-                <HvOption value={option.value}>{option.label}</HvOption>
+                <HvOption key={option.value} value={option.value}>
+                  {option.label}
+                </HvOption>
               ))}
             </HvSelect>
             <HvSelect label="Telephone" placeholder="Select an option">
               {options.map((option) => (
-                <HvOption value={option.value}>{option.label}</HvOption>
+                <HvOption key={option.value} value={option.value}>
+                  {option.label}
+                </HvOption>
               ))}
             </HvSelect>
             <HvSimpleGrid cols={2}>

--- a/packages/core/src/MultiButton/stories/VerticalOrientation.tsx
+++ b/packages/core/src/MultiButton/stories/VerticalOrientation.tsx
@@ -3,12 +3,12 @@ import { HvButton, HvMultiButton } from "@hitachivantara/uikit-react-core";
 import { LocationPin, Map } from "@hitachivantara/uikit-react-icons";
 
 const buttons = [
-  { name: "Map", icon: <Map />, key: 1 },
-  { name: "Location", icon: <LocationPin />, key: 2 },
-  { name: "Map", icon: <Map />, key: 3 },
-  { name: "Location", icon: <LocationPin />, key: 4 },
-  { name: "Map", icon: <Map />, key: 5 },
-  { name: "Location", icon: <LocationPin />, key: 6 },
+  { name: "Map", icon: <Map /> },
+  { name: "Location", icon: <LocationPin /> },
+  { name: "Map", icon: <Map /> },
+  { name: "Location", icon: <LocationPin /> },
+  { name: "Map", icon: <Map /> },
+  { name: "Location", icon: <LocationPin /> },
 ];
 
 export const VerticalOrientation = () => {
@@ -26,7 +26,7 @@ export const VerticalOrientation = () => {
       <HvMultiButton vertical style={{ width: "32px" }}>
         {buttons.map(({ name, icon }, i) => (
           <HvButton
-            key={`${buttons[i].key}`}
+            key={`${name}-${i}`}
             aria-label={name}
             selected={selection.includes(i)}
             onClick={() => handleChange(i)}
@@ -38,7 +38,7 @@ export const VerticalOrientation = () => {
       <HvMultiButton vertical style={{ marginLeft: "20px", width: "120px" }}>
         {buttons.map(({ name, icon }, i) => (
           <HvButton
-            key={`${buttons[i].key}`}
+            key={`${name}-${i}`}
             aria-label={name}
             startIcon={icon}
             selected={selection.includes(i)}

--- a/packages/core/src/Table/stories/TableComplete/TableComplete.tsx
+++ b/packages/core/src/Table/stories/TableComplete/TableComplete.tsx
@@ -254,11 +254,12 @@ export const TableComplete = <T extends object>(props: TableProps<T>) => {
     }
 
     prepareRow(row);
+    const { key, ...rowProps } = row.getRowProps({ "aria-rowindex": i + 1 });
 
     return (
-      <HvTableRow {...row.getRowProps({ "aria-rowindex": i + 1 })}>
+      <HvTableRow key={key} {...rowProps}>
         {row.cells.map((cell) => (
-          <HvTableCell {...cell.getCellProps()}>
+          <HvTableCell {...cell.getCellProps()} key={cell.getCellProps().key}>
             {cell.render("Cell")}
           </HvTableCell>
         ))}
@@ -285,9 +286,15 @@ export const TableComplete = <T extends object>(props: TableProps<T>) => {
           <HvTable {...getTableProps()}>
             <HvTableHead {...getTableHeadProps?.()}>
               {headerGroups.map((headerGroup) => (
-                <HvTableRow {...headerGroup.getHeaderGroupProps()}>
+                <HvTableRow
+                  {...headerGroup.getHeaderGroupProps()}
+                  key={headerGroup.getHeaderGroupProps().key}
+                >
                   {headerGroup.headers.map((col) => (
-                    <HvTableHeader {...col.getHeaderProps()}>
+                    <HvTableHeader
+                      {...col.getHeaderProps()}
+                      key={col.getHeaderProps().key}
+                    >
                       {col.render("Header")}
                     </HvTableHeader>
                   ))}

--- a/packages/core/src/Table/stories/TableHooks/AlternativeLayout.tsx
+++ b/packages/core/src/Table/stories/TableHooks/AlternativeLayout.tsx
@@ -59,9 +59,15 @@ const SampleTable = ({ columns, data, layoutHook, component }) => {
         <HvTable {...getTableProps()} component={component}>
           <HvTableHead>
             {headerGroups.map((headerGroup) => (
-              <HvTableRow {...headerGroup.getHeaderGroupProps()}>
+              <HvTableRow
+                {...headerGroup.getHeaderGroupProps()}
+                key={headerGroup.getHeaderGroupProps().key}
+              >
                 {headerGroup.headers.map((col) => (
-                  <HvTableHeader {...col.getHeaderProps()}>
+                  <HvTableHeader
+                    {...col.getHeaderProps()}
+                    key={col.getHeaderProps().key}
+                  >
                     {col.render("Header")}
                   </HvTableHeader>
                 ))}
@@ -71,10 +77,15 @@ const SampleTable = ({ columns, data, layoutHook, component }) => {
           <HvTableBody {...getTableBodyProps()}>
             {page.map((row) => {
               prepareRow(row);
+              const { key, ...rowProps } = row.getRowProps();
+
               return (
-                <HvTableRow {...row.getRowProps()}>
+                <HvTableRow key={key} {...rowProps}>
                   {row.cells.map((cell) => (
-                    <HvTableCell {...cell.getCellProps()}>
+                    <HvTableCell
+                      {...cell.getCellProps()}
+                      key={cell.getCellProps().key}
+                    >
                       {cell.render("Cell")}
                     </HvTableCell>
                   ))}

--- a/packages/core/src/Table/stories/TableHooks/ColumnResize.tsx
+++ b/packages/core/src/Table/stories/TableHooks/ColumnResize.tsx
@@ -63,9 +63,15 @@ export const ColumnResize = () => {
       <HvTable {...getTableProps()}>
         <HvTableHead>
           {headerGroups.map((headerGroup) => (
-            <HvTableRow {...headerGroup.getHeaderGroupProps()}>
+            <HvTableRow
+              {...headerGroup.getHeaderGroupProps()}
+              key={headerGroup.getHeaderGroupProps().key}
+            >
               {headerGroup.headers.map((col) => (
-                <HvTableHeader {...col.getHeaderProps({ align: col.align })}>
+                <HvTableHeader
+                  {...col.getHeaderProps({ align: col.align })}
+                  key={col.getHeaderProps().key}
+                >
                   {col.render("Header")}
                 </HvTableHeader>
               ))}
@@ -75,12 +81,14 @@ export const ColumnResize = () => {
         <HvTableBody {...getTableBodyProps()}>
           {rows.map((row) => {
             prepareRow(row);
+            const { key, ...rowProps } = row.getRowProps();
 
             return (
-              <HvTableRow hover {...row.getRowProps()}>
+              <HvTableRow hover key={key} {...rowProps}>
                 {row.cells.map((cell) => (
                   <HvTableCell
                     {...cell.getCellProps({ align: cell.column.align })}
+                    key={cell.getCellProps().key}
                   >
                     {cell.render("Cell")}
                   </HvTableCell>

--- a/packages/core/src/Table/stories/TableHooks/UseHvBulkActions.tsx
+++ b/packages/core/src/Table/stories/TableHooks/UseHvBulkActions.tsx
@@ -103,9 +103,15 @@ export const UseHvBulkActions = () => {
         <HvTable {...getTableProps()}>
           <HvTableHead>
             {headerGroups.map((headerGroup) => (
-              <HvTableRow {...headerGroup.getHeaderGroupProps()}>
+              <HvTableRow
+                {...headerGroup.getHeaderGroupProps()}
+                key={headerGroup.getHeaderGroupProps().key}
+              >
                 {headerGroup.headers.map((col) => (
-                  <HvTableHeader {...col.getHeaderProps()}>
+                  <HvTableHeader
+                    {...col.getHeaderProps()}
+                    key={col.getHeaderProps().key}
+                  >
                     {col.render("Header")}
                   </HvTableHeader>
                 ))}
@@ -116,11 +122,15 @@ export const UseHvBulkActions = () => {
             {page?.length ? (
               page.map((row) => {
                 prepareRow(row);
+                const { key, ...rowProps } = row.getRowProps();
 
                 return (
-                  <HvTableRow {...row.getRowProps()}>
+                  <HvTableRow key={key} {...rowProps}>
                     {row.cells.map((cell) => (
-                      <HvTableCell {...cell.getCellProps()}>
+                      <HvTableCell
+                        {...cell.getCellProps()}
+                        key={cell.getCellProps().key}
+                      >
                         {cell.render("Cell")}
                       </HvTableCell>
                     ))}

--- a/packages/core/src/Table/stories/TableHooks/UseHvFilters.tsx
+++ b/packages/core/src/Table/stories/TableHooks/UseHvFilters.tsx
@@ -71,7 +71,7 @@ export const UseHvFilters = () => {
     return (
       <HvTableRow {...row.getRowProps()}>
         {row.cells.map((cell) => (
-          <HvTableCell {...cell.getCellProps()}>
+          <HvTableCell {...cell.getCellProps()} key={cell.getCellProps().key}>
             {cell.render("Cell")}
           </HvTableCell>
         ))}
@@ -100,9 +100,15 @@ export const UseHvFilters = () => {
           <HvTable {...getTableProps()}>
             <HvTableHead>
               {headerGroups.map((headerGroup) => (
-                <HvTableRow {...headerGroup.getHeaderGroupProps()}>
+                <HvTableRow
+                  {...headerGroup.getHeaderGroupProps()}
+                  key={headerGroup.getHeaderGroupProps().key}
+                >
                   {headerGroup.headers.map((col) => (
-                    <HvTableHeader {...col.getHeaderProps()}>
+                    <HvTableHeader
+                      {...col.getHeaderProps()}
+                      key={col.getHeaderProps().key}
+                    >
                       {col.render("Header")}
                     </HvTableHeader>
                   ))}

--- a/packages/core/src/Table/stories/TableHooks/UseHvGroupBy.tsx
+++ b/packages/core/src/Table/stories/TableHooks/UseHvGroupBy.tsx
@@ -41,9 +41,15 @@ export const UseHvGroupBy = () => {
       <HvTable {...getTableProps()}>
         <HvTableHead>
           {headerGroups.map((headerGroup) => (
-            <HvTableRow {...headerGroup.getHeaderGroupProps()}>
+            <HvTableRow
+              {...headerGroup.getHeaderGroupProps()}
+              key={headerGroup.getHeaderGroupProps().key}
+            >
               {headerGroup.headers.map((col) => (
-                <HvTableHeader {...col.getHeaderProps()}>
+                <HvTableHeader
+                  {...col.getHeaderProps()}
+                  key={col.getHeaderProps().key}
+                >
                   {col.render("Header")}
                 </HvTableHeader>
               ))}
@@ -53,19 +59,24 @@ export const UseHvGroupBy = () => {
         <HvTableBody {...getTableBodyProps()}>
           {rows.map((row) => {
             prepareRow(row);
+            const { key, ...rowProps } = row.getRowProps();
 
             return (
               <HvTableRow
-                {...row.getRowProps()}
+                key={key}
                 style={{
                   backgroundColor:
                     row.subRows.length > 0
                       ? theme.colors.atmo1
                       : theme.table.rowExpandBackgroundColor,
                 }}
+                {...rowProps}
               >
                 {row.cells.map((cell) => (
-                  <HvTableCell {...cell.getCellProps()}>
+                  <HvTableCell
+                    {...cell.getCellProps()}
+                    key={cell.getCellProps().key}
+                  >
                     {cell.isGrouped ? (
                       // If it's a grouped cell, add an expander and row count
                       <>

--- a/packages/core/src/Table/stories/TableHooks/UseHvHeaderGroups.tsx
+++ b/packages/core/src/Table/stories/TableHooks/UseHvHeaderGroups.tsx
@@ -31,9 +31,15 @@ export const UseHvHeaderGroups = () => {
       <HvTable {...getTableProps()}>
         <HvTableHead>
           {headerGroups.map((headerGroup) => (
-            <HvTableRow {...headerGroup.getHeaderGroupProps()}>
+            <HvTableRow
+              {...headerGroup.getHeaderGroupProps()}
+              key={headerGroup.getHeaderGroupProps().key}
+            >
               {headerGroup.headers.map((col) => (
-                <HvTableHeader {...col.getHeaderProps()}>
+                <HvTableHeader
+                  {...col.getHeaderProps()}
+                  key={col.getHeaderProps().key}
+                >
                   {col.render("Header")}
                 </HvTableHeader>
               ))}
@@ -43,11 +49,15 @@ export const UseHvHeaderGroups = () => {
         <HvTableBody {...getTableBodyProps()}>
           {rows.map((row) => {
             prepareRow(row);
+            const { key, ...rowProps } = row.getRowProps();
 
             return (
-              <HvTableRow {...row.getRowProps()}>
+              <HvTableRow key={key} {...rowProps}>
                 {row.cells.map((cell) => (
-                  <HvTableCell {...cell.getCellProps()}>
+                  <HvTableCell
+                    {...cell.getCellProps()}
+                    key={cell.getCellProps().key}
+                  >
                     {cell.render("Cell")}
                   </HvTableCell>
                 ))}

--- a/packages/core/src/Table/stories/TableHooks/UseHvHooks.tsx
+++ b/packages/core/src/Table/stories/TableHooks/UseHvHooks.tsx
@@ -23,9 +23,15 @@ export const UseHvHooks = () => {
       <HvTable {...getTableProps()}>
         <HvTableHead>
           {headerGroups.map((headerGroup) => (
-            <HvTableRow {...headerGroup.getHeaderGroupProps()}>
+            <HvTableRow
+              {...headerGroup.getHeaderGroupProps()}
+              key={headerGroup.getHeaderGroupProps().key}
+            >
               {headerGroup.headers.map((col) => (
-                <HvTableHeader {...col.getHeaderProps()}>
+                <HvTableHeader
+                  {...col.getHeaderProps()}
+                  key={col.getHeaderProps().key}
+                >
                   {col.render("Header")}
                 </HvTableHeader>
               ))}
@@ -35,11 +41,15 @@ export const UseHvHooks = () => {
         <HvTableBody {...getTableBodyProps()}>
           {rows.map((row) => {
             prepareRow(row);
+            const { key, ...rowProps } = row.getRowProps();
 
             return (
-              <HvTableRow {...row.getRowProps()}>
+              <HvTableRow key={key} {...rowProps}>
                 {row.cells.map((cell) => (
-                  <HvTableCell {...cell.getCellProps()}>
+                  <HvTableCell
+                    {...cell.getCellProps()}
+                    key={cell.getCellProps().key}
+                  >
                     {cell.render("Cell")}
                   </HvTableCell>
                 ))}

--- a/packages/core/src/Table/stories/TableHooks/UseHvPagination.tsx
+++ b/packages/core/src/Table/stories/TableHooks/UseHvPagination.tsx
@@ -44,7 +44,7 @@ export const UseHvPagination = () => {
     return (
       <HvTableRow {...row.getRowProps()}>
         {row.cells.map((cell) => (
-          <HvTableCell {...cell.getCellProps()}>
+          <HvTableCell {...cell.getCellProps()} key={cell.getCellProps().key}>
             {cell.render("Cell")}
           </HvTableCell>
         ))}
@@ -58,9 +58,15 @@ export const UseHvPagination = () => {
         <HvTable {...getTableProps()}>
           <HvTableHead>
             {headerGroups.map((headerGroup) => (
-              <HvTableRow {...headerGroup.getHeaderGroupProps()}>
+              <HvTableRow
+                {...headerGroup.getHeaderGroupProps()}
+                key={headerGroup.getHeaderGroupProps().key}
+              >
                 {headerGroup.headers.map((col) => (
-                  <HvTableHeader {...col.getHeaderProps()}>
+                  <HvTableHeader
+                    {...col.getHeaderProps()}
+                    key={col.getHeaderProps().key}
+                  >
                     {col.render("Header")}
                   </HvTableHeader>
                 ))}

--- a/packages/core/src/Table/stories/TableHooks/UseHvRowExpand.tsx
+++ b/packages/core/src/Table/stories/TableHooks/UseHvRowExpand.tsx
@@ -37,9 +37,15 @@ export const UseHvRowExpand = () => {
       <HvTable {...getTableProps()}>
         <HvTableHead>
           {headerGroups.map((headerGroup) => (
-            <HvTableRow {...headerGroup.getHeaderGroupProps()}>
+            <HvTableRow
+              {...headerGroup.getHeaderGroupProps()}
+              key={headerGroup.getHeaderGroupProps().key}
+            >
               {headerGroup.headers.map((col) => (
-                <HvTableHeader {...col.getHeaderProps()}>
+                <HvTableHeader
+                  {...col.getHeaderProps()}
+                  key={col.getHeaderProps().key}
+                >
                   {col.render("Header")}
                 </HvTableHeader>
               ))}
@@ -49,12 +55,16 @@ export const UseHvRowExpand = () => {
         <HvTableBody {...getTableBodyProps()}>
           {rows.map((row) => {
             prepareRow(row);
+            const { key, ...rowProps } = row.getRowProps();
 
             return (
-              <Fragment key={row.id}>
-                <HvTableRow {...row.getRowProps()}>
+              <Fragment key={key}>
+                <HvTableRow {...rowProps}>
                   {row.cells.map((cell) => (
-                    <HvTableCell {...cell.getCellProps()}>
+                    <HvTableCell
+                      {...cell.getCellProps()}
+                      key={cell.getCellProps().key}
+                    >
                       {cell.render("Cell")}
                     </HvTableCell>
                   ))}

--- a/packages/core/src/Table/stories/TableHooks/UseHvRowSelection.tsx
+++ b/packages/core/src/Table/stories/TableHooks/UseHvRowSelection.tsx
@@ -25,9 +25,15 @@ export const UseHvSelection = () => {
       <HvTable {...getTableProps()}>
         <HvTableHead>
           {headerGroups.map((headerGroup) => (
-            <HvTableRow {...headerGroup.getHeaderGroupProps()}>
+            <HvTableRow
+              {...headerGroup.getHeaderGroupProps()}
+              key={headerGroup.getHeaderGroupProps().key}
+            >
               {headerGroup.headers.map((col) => (
-                <HvTableHeader {...col.getHeaderProps()}>
+                <HvTableHeader
+                  {...col.getHeaderProps()}
+                  key={col.getHeaderProps().key}
+                >
                   {col.render("Header")}
                 </HvTableHeader>
               ))}
@@ -37,10 +43,15 @@ export const UseHvSelection = () => {
         <HvTableBody {...getTableBodyProps()}>
           {rows.map((row) => {
             prepareRow(row);
+            const { key, ...rowProps } = row.getRowProps();
+
             return (
-              <HvTableRow {...row.getRowProps()}>
+              <HvTableRow key={key} {...rowProps}>
                 {row.cells.map((cell) => (
-                  <HvTableCell {...cell.getCellProps()}>
+                  <HvTableCell
+                    {...cell.getCellProps()}
+                    key={cell.getCellProps().key}
+                  >
                     {cell.render("Cell")}
                   </HvTableCell>
                 ))}

--- a/packages/core/src/Table/stories/TableHooks/UseHvRowSelectionControlled.tsx
+++ b/packages/core/src/Table/stories/TableHooks/UseHvRowSelectionControlled.tsx
@@ -29,9 +29,15 @@ export const UseHvSelectionControlled = () => {
       <HvTable {...getTableProps()}>
         <HvTableHead>
           {headerGroups.map((headerGroup) => (
-            <HvTableRow {...headerGroup.getHeaderGroupProps()}>
+            <HvTableRow
+              {...headerGroup.getHeaderGroupProps()}
+              key={headerGroup.getHeaderGroupProps().key}
+            >
               {headerGroup.headers.map((col) => (
-                <HvTableHeader {...col.getHeaderProps()}>
+                <HvTableHeader
+                  {...col.getHeaderProps()}
+                  key={col.getHeaderProps().key}
+                >
                   {col.render("Header")}
                 </HvTableHeader>
               ))}
@@ -41,9 +47,11 @@ export const UseHvSelectionControlled = () => {
         <HvTableBody {...getTableBodyProps()}>
           {rows.map((row, index) => {
             prepareRow(row);
+            const { key, ...rowProps } = row.getRowProps();
 
             return (
               <HvTableRow
+                key={key}
                 onChange={(event) => {
                   const newData = [...data];
                   newData[index].selected = (
@@ -51,10 +59,13 @@ export const UseHvSelectionControlled = () => {
                   ).checked;
                   setData(newData);
                 }}
-                {...row.getRowProps()}
+                {...rowProps}
               >
                 {row.cells.map((cell) => (
-                  <HvTableCell {...cell.getCellProps()}>
+                  <HvTableCell
+                    {...cell.getCellProps()}
+                    key={cell.getCellProps().key}
+                  >
                     {cell.render("Cell")}
                   </HvTableCell>
                 ))}

--- a/packages/core/src/Table/stories/TableHooks/UseHvRowSelectionLocked.tsx
+++ b/packages/core/src/Table/stories/TableHooks/UseHvRowSelectionLocked.tsx
@@ -83,9 +83,15 @@ export const LockedSelection = () => {
         <HvTable {...getTableProps()}>
           <HvTableHead>
             {headerGroups.map((headerGroup) => (
-              <HvTableRow {...headerGroup.getHeaderGroupProps()}>
+              <HvTableRow
+                {...headerGroup.getHeaderGroupProps()}
+                key={headerGroup.getHeaderGroupProps().key}
+              >
                 {headerGroup.headers.map((col) => (
-                  <HvTableHeader {...col.getHeaderProps()}>
+                  <HvTableHeader
+                    {...col.getHeaderProps()}
+                    key={col.getHeaderProps().key}
+                  >
                     {col.render("Header")}
                   </HvTableHeader>
                 ))}
@@ -93,12 +99,17 @@ export const LockedSelection = () => {
             ))}
           </HvTableHead>
           <HvTableBody {...getTableBodyProps()}>
-            {page.map((row) => {
+            {rows.map((row) => {
               prepareRow(row);
+              const { key, ...rowProps } = row.getRowProps();
+
               return (
-                <HvTableRow {...row.getRowProps()}>
+                <HvTableRow key={key} {...rowProps}>
                   {row.cells.map((cell) => (
-                    <HvTableCell {...cell.getCellProps()}>
+                    <HvTableCell
+                      {...cell.getCellProps()}
+                      key={cell.getCellProps().key}
+                    >
                       {cell.render("Cell")}
                     </HvTableCell>
                   ))}

--- a/packages/core/src/Table/stories/TableHooks/UseHvRowState.tsx
+++ b/packages/core/src/Table/stories/TableHooks/UseHvRowState.tsx
@@ -81,11 +81,15 @@ export const UseHvRowState = () => {
       <HvTable {...getTableProps()}>
         <HvTableHead>
           {headerGroups.map((headerGroup) => (
-            <HvTableRow {...headerGroup.getHeaderGroupProps()}>
+            <HvTableRow
+              {...headerGroup.getHeaderGroupProps()}
+              key={headerGroup.getHeaderGroupProps().key}
+            >
               {headerGroup.headers.map((col) => (
                 <HvTableHeader
                   {...col.getHeaderProps()}
                   aria-hidden={col.variant === "actions" ? true : undefined}
+                  key={col.getHeaderProps().key}
                 >
                   {col.render("Header")}
                 </HvTableHeader>
@@ -96,10 +100,15 @@ export const UseHvRowState = () => {
         <HvTableBody {...getTableBodyProps()}>
           {rows.map((row) => {
             prepareRow(row);
+            const { key, ...rowProps } = row.getRowProps();
+
             return (
-              <HvTableRow {...row.getRowProps()}>
+              <HvTableRow key={key} {...rowProps}>
                 {row.cells.map((cell) => (
-                  <HvTableCell {...cell.getCellProps()}>
+                  <HvTableCell
+                    {...cell.getCellProps()}
+                    key={cell.getCellProps().key}
+                  >
                     {cell.render("Cell")}
                   </HvTableCell>
                 ))}

--- a/packages/core/src/Table/stories/TableHooks/UseHvSortBy.tsx
+++ b/packages/core/src/Table/stories/TableHooks/UseHvSortBy.tsx
@@ -42,9 +42,15 @@ export const UseHvSortBy = () => {
       <HvTable {...getTableProps()}>
         <HvTableHead>
           {headerGroups.map((headerGroup) => (
-            <HvTableRow {...headerGroup.getHeaderGroupProps()}>
+            <HvTableRow
+              {...headerGroup.getHeaderGroupProps()}
+              key={headerGroup.getHeaderGroupProps().key}
+            >
               {headerGroup.headers.map((col) => (
-                <HvTableHeader {...col.getHeaderProps()}>
+                <HvTableHeader
+                  {...col.getHeaderProps()}
+                  key={col.getHeaderProps().key}
+                >
                   {col.render("Header")}
                 </HvTableHeader>
               ))}
@@ -54,11 +60,15 @@ export const UseHvSortBy = () => {
         <HvTableBody {...getTableBodyProps()}>
           {rows.map((row) => {
             prepareRow(row);
+            const { key, ...rowProps } = row.getRowProps();
 
             return (
-              <HvTableRow {...row.getRowProps()}>
+              <HvTableRow key={key} {...rowProps}>
                 {row.cells.map((cell) => (
-                  <HvTableCell {...cell.getCellProps()}>
+                  <HvTableCell
+                    {...cell.getCellProps()}
+                    key={cell.getCellProps().key}
+                  >
                     {cell.render("Cell")}
                   </HvTableCell>
                 ))}

--- a/packages/core/src/Table/stories/TableHooks/UseHvTableSticky.tsx
+++ b/packages/core/src/Table/stories/TableHooks/UseHvTableSticky.tsx
@@ -66,9 +66,15 @@ export const UseHvTableSticky = () => {
       <HvTable {...getTableProps()}>
         <HvTableHead {...getTableHeadProps?.()}>
           {headerGroups.map((headerGroup) => (
-            <HvTableRow {...headerGroup.getHeaderGroupProps()}>
+            <HvTableRow
+              {...headerGroup.getHeaderGroupProps()}
+              key={headerGroup.getHeaderGroupProps().key}
+            >
               {headerGroup.headers.map((col) => (
-                <HvTableHeader {...col.getHeaderProps()}>
+                <HvTableHeader
+                  {...col.getHeaderProps()}
+                  key={col.getHeaderProps().key}
+                >
                   {col.render("Header")}
                 </HvTableHeader>
               ))}
@@ -78,11 +84,15 @@ export const UseHvTableSticky = () => {
         <HvTableBody tabIndex={0} {...getTableBodyProps()}>
           {rows.map((row) => {
             prepareRow(row);
+            const { key, ...rowProps } = row.getRowProps();
 
             return (
-              <HvTableRow {...row.getRowProps()}>
+              <HvTableRow key={key} {...rowProps}>
                 {row.cells.map((cell) => (
-                  <HvTableCell {...cell.getCellProps()}>
+                  <HvTableCell
+                    {...cell.getCellProps()}
+                    key={cell.getCellProps().key}
+                  >
                     {cell.render("Cell")}
                   </HvTableCell>
                 ))}

--- a/packages/core/src/Table/stories/TableRenderers/AllColumnRenderers.tsx
+++ b/packages/core/src/Table/stories/TableRenderers/AllColumnRenderers.tsx
@@ -139,18 +139,18 @@ export const AllColumnRenderers = () => {
   );
 
   const rowRenderer = (pages: HvRowInstance<NewRendererEntry, string>[]) => {
-    return pages.map((row, index) => {
+    return pages.map((row, i) => {
       prepareRow(row);
+      const { key, ...rowProps } = row.getRowProps({ "aria-rowindex": i + 1 });
 
       return (
-        <Fragment key={row.id}>
-          <HvTableRow
-            {...row.getRowProps({
-              "aria-rowindex": index + 1,
-            })}
-          >
+        <Fragment key={key}>
+          <HvTableRow {...rowProps}>
             {row.cells.map((cell) => (
-              <HvTableCell {...cell.getCellProps()}>
+              <HvTableCell
+                {...cell.getCellProps()}
+                key={cell.getCellProps().key}
+              >
                 {cell.render("Cell")}
               </HvTableCell>
             ))}

--- a/packages/core/src/Table/stories/TableRenderers/DateColumnRenderer.tsx
+++ b/packages/core/src/Table/stories/TableRenderers/DateColumnRenderer.tsx
@@ -53,13 +53,14 @@ export const DateColumnRenderer = () => {
   );
 
   const rowRenderer = (pages: HvRowInstance<NewRendererEntry, string>[]) => {
-    return pages.map((row, index) => {
+    return pages.map((row, i) => {
       prepareRow(row);
+      const { key, ...rowProps } = row.getRowProps({ "aria-rowindex": i + 1 });
 
       return (
-        <HvTableRow {...row.getRowProps({ "aria-rowindex": index + 1 })}>
+        <HvTableRow key={key} {...rowProps}>
           {row.cells.map((cell) => (
-            <HvTableCell {...cell.getCellProps()}>
+            <HvTableCell {...cell.getCellProps()} key={cell.getCellProps().key}>
               {cell.render("Cell")}
             </HvTableCell>
           ))}

--- a/packages/core/src/Table/stories/TableRenderers/DropDownColumnRenderer.test.tsx
+++ b/packages/core/src/Table/stories/TableRenderers/DropDownColumnRenderer.test.tsx
@@ -71,13 +71,14 @@ const DropdownColumnRenderer = () => {
     );
 
   const rowRenderer = (pages: HvRowInstance<NewRendererEntry, string>[]) => {
-    return pages.map((row, index) => {
+    return pages.map((row, i) => {
       prepareRow(row);
+      const { key, ...rowProps } = row.getRowProps({ "aria-rowindex": i + 1 });
 
       return (
-        <HvTableRow {...row.getRowProps({ "aria-rowindex": index + 1 })}>
+        <HvTableRow key={key} {...rowProps}>
           {row.cells.map((cell) => (
-            <HvTableCell {...cell.getCellProps()}>
+            <HvTableCell {...cell.getCellProps()} key={cell.getCellProps().key}>
               {cell.render("Cell")}
             </HvTableCell>
           ))}

--- a/packages/core/src/Table/stories/TableRenderers/DropdownColumnRenderer.tsx
+++ b/packages/core/src/Table/stories/TableRenderers/DropdownColumnRenderer.tsx
@@ -72,13 +72,14 @@ export const DropdownColumnRenderer = () => {
   );
 
   const rowRenderer = (pages: HvRowInstance<NewRendererEntry, string>[]) => {
-    return pages.map((row, index) => {
+    return pages.map((row, i) => {
       prepareRow(row);
+      const { key, ...rowProps } = row.getRowProps({ "aria-rowindex": i + 1 });
 
       return (
-        <HvTableRow {...row.getRowProps({ "aria-rowindex": index + 1 })}>
+        <HvTableRow key={key} {...rowProps}>
           {row.cells.map((cell) => (
-            <HvTableCell {...cell.getCellProps()}>
+            <HvTableCell {...cell.getCellProps()} key={cell.getCellProps().key}>
               {cell.render("Cell")}
             </HvTableCell>
           ))}

--- a/packages/core/src/Table/stories/TableRenderers/ExpandColumnRenderer.tsx
+++ b/packages/core/src/Table/stories/TableRenderers/ExpandColumnRenderer.tsx
@@ -66,18 +66,18 @@ export const ExpandColumnRenderer = () => {
   );
 
   const rowRenderer = (pages: HvRowInstance<NewRendererEntry, string>[]) => {
-    return pages.map((row, index) => {
+    return pages.map((row, i) => {
       prepareRow(row);
+      const { key, ...rowProps } = row.getRowProps({ "aria-rowindex": i + 1 });
 
       return (
-        <Fragment key={row.id}>
-          <HvTableRow
-            {...row.getRowProps({
-              "aria-rowindex": index + 1,
-            })}
-          >
+        <Fragment key={key}>
+          <HvTableRow {...rowProps}>
             {row.cells.map((cell) => (
-              <HvTableCell {...cell.getCellProps()}>
+              <HvTableCell
+                {...cell.getCellProps()}
+                key={cell.getCellProps().key}
+              >
                 {cell.render("Cell")}
               </HvTableCell>
             ))}

--- a/packages/core/src/Table/stories/TableRenderers/NumberColumnRenderer.tsx
+++ b/packages/core/src/Table/stories/TableRenderers/NumberColumnRenderer.tsx
@@ -54,13 +54,14 @@ export const NumberColumnRenderer = () => {
   );
 
   const rowRenderer = (pages: HvRowInstance<NewRendererEntry, string>[]) => {
-    return pages.map((row, index) => {
+    return pages.map((row, i) => {
       prepareRow(row);
+      const { key, ...rowProps } = row.getRowProps({ "aria-rowindex": i + 1 });
 
       return (
-        <HvTableRow {...row.getRowProps({ "aria-rowindex": index + 1 })}>
+        <HvTableRow key={key} {...rowProps}>
           {row.cells.map((cell) => (
-            <HvTableCell {...cell.getCellProps()}>
+            <HvTableCell {...cell.getCellProps()} key={cell.getCellProps().key}>
               {cell.render("Cell")}
             </HvTableCell>
           ))}

--- a/packages/core/src/Table/stories/TableRenderers/ProgressColumnRenderer.tsx
+++ b/packages/core/src/Table/stories/TableRenderers/ProgressColumnRenderer.tsx
@@ -59,13 +59,14 @@ export const ProgressColumnRenderer = () => {
   );
 
   const rowRenderer = (pages: HvRowInstance<NewRendererEntry, string>[]) => {
-    return pages.map((row, index) => {
+    return pages.map((row, i) => {
       prepareRow(row);
+      const { key, ...rowProps } = row.getRowProps({ "aria-rowindex": i + 1 });
 
       return (
-        <HvTableRow {...row.getRowProps({ "aria-rowindex": index + 1 })}>
+        <HvTableRow key={key} {...rowProps}>
           {row.cells.map((cell) => (
-            <HvTableCell {...cell.getCellProps()}>
+            <HvTableCell {...cell.getCellProps()} key={cell.getCellProps().key}>
               {cell.render("Cell")}
             </HvTableCell>
           ))}

--- a/packages/core/src/Table/stories/TableRenderers/SwitchColumnRenderer.tsx
+++ b/packages/core/src/Table/stories/TableRenderers/SwitchColumnRenderer.tsx
@@ -70,13 +70,14 @@ export const SwitchColumnRenderer = () => {
   );
 
   const rowRenderer = (pages: HvRowInstance<NewRendererEntry, string>[]) => {
-    return pages.map((row, index) => {
+    return pages.map((row, i) => {
       prepareRow(row);
+      const { key, ...rowProps } = row.getRowProps({ "aria-rowindex": i + 1 });
 
       return (
-        <HvTableRow {...row.getRowProps({ "aria-rowindex": index + 1 })}>
+        <HvTableRow key={key} {...rowProps}>
           {row.cells.map((cell) => (
-            <HvTableCell {...cell.getCellProps()}>
+            <HvTableCell {...cell.getCellProps()} key={cell.getCellProps().key}>
               {cell.render("Cell")}
             </HvTableCell>
           ))}

--- a/packages/core/src/Table/stories/TableRenderers/TagColumnRenderer.tsx
+++ b/packages/core/src/Table/stories/TableRenderers/TagColumnRenderer.tsx
@@ -58,13 +58,14 @@ export const TagColumnRenderer = () => {
   );
 
   const rowRenderer = (pages: HvRowInstance<NewRendererEntry, string>[]) => {
-    return pages.map((row, index) => {
+    return pages.map((row, i) => {
       prepareRow(row);
+      const { key, ...rowProps } = row.getRowProps({ "aria-rowindex": i + 1 });
 
       return (
-        <HvTableRow {...row.getRowProps({ "aria-rowindex": index + 1 })}>
+        <HvTableRow key={key} {...rowProps}>
           {row.cells.map((cell) => (
-            <HvTableCell {...cell.getCellProps()}>
+            <HvTableCell {...cell.getCellProps()} key={cell.getCellProps().key}>
               {cell.render("Cell")}
             </HvTableCell>
           ))}

--- a/packages/core/src/Table/stories/TableRenderers/TextColumnRenderer.tsx
+++ b/packages/core/src/Table/stories/TableRenderers/TextColumnRenderer.tsx
@@ -54,13 +54,14 @@ export const TextColumnRenderer = () => {
   );
 
   const rowRenderer = (pages: HvRowInstance<NewRendererEntry, string>[]) => {
-    return pages.map((row, index) => {
+    return pages.map((row, i) => {
       prepareRow(row);
+      const { key, ...rowProps } = row.getRowProps({ "aria-rowindex": i + 1 });
 
       return (
-        <HvTableRow {...row.getRowProps({ "aria-rowindex": index + 1 })}>
+        <HvTableRow key={key} {...rowProps}>
           {row.cells.map((cell) => (
-            <HvTableCell {...cell.getCellProps()}>
+            <HvTableCell {...cell.getCellProps()} key={cell.getCellProps().key}>
               {cell.render("Cell")}
             </HvTableCell>
           ))}

--- a/packages/core/src/Table/stories/TableSection/CompleteTableSection.tsx
+++ b/packages/core/src/Table/stories/TableSection/CompleteTableSection.tsx
@@ -91,7 +91,7 @@ export const CompleteTableSection = () => {
     return (
       <HvTableRow {...row.getRowProps()}>
         {row.cells.map((cell) => (
-          <HvTableCell {...cell.getCellProps()}>
+          <HvTableCell {...cell.getCellProps()} key={cell.getCellProps().key}>
             {cell.render("Cell")}
           </HvTableCell>
         ))}
@@ -116,9 +116,15 @@ export const CompleteTableSection = () => {
         <HvTable {...getTableProps()}>
           <HvTableHead>
             {headerGroups.map((headerGroup) => (
-              <HvTableRow {...headerGroup.getHeaderGroupProps()}>
+              <HvTableRow
+                {...headerGroup.getHeaderGroupProps()}
+                key={headerGroup.getHeaderGroupProps().key}
+              >
                 {headerGroup.headers.map((col) => (
-                  <HvTableHeader {...col.getHeaderProps()}>
+                  <HvTableHeader
+                    {...col.getHeaderProps()}
+                    key={col.getHeaderProps().key}
+                  >
                     {col.render("Header")}
                   </HvTableHeader>
                 ))}

--- a/packages/core/src/Table/stories/TableSection/PropsTableSection.tsx
+++ b/packages/core/src/Table/stories/TableSection/PropsTableSection.tsx
@@ -75,7 +75,7 @@ export const PropsTableSection = () => {
     return (
       <HvTableRow {...row.getRowProps()}>
         {row.cells.map((cell) => (
-          <HvTableCell {...cell.getCellProps()}>
+          <HvTableCell {...cell.getCellProps()} key={cell.getCellProps().key}>
             {cell.render("Cell")}
           </HvTableCell>
         ))}
@@ -95,9 +95,15 @@ export const PropsTableSection = () => {
         <HvTable {...getTableProps()}>
           <HvTableHead>
             {headerGroups.map((headerGroup) => (
-              <HvTableRow {...headerGroup.getHeaderGroupProps()}>
+              <HvTableRow
+                {...headerGroup.getHeaderGroupProps()}
+                key={headerGroup.getHeaderGroupProps().key}
+              >
                 {headerGroup.headers.map((col) => (
-                  <HvTableHeader {...col.getHeaderProps()}>
+                  <HvTableHeader
+                    {...col.getHeaderProps()}
+                    key={col.getHeaderProps().key}
+                  >
                     {col.render("Header")}
                   </HvTableHeader>
                 ))}

--- a/packages/core/src/Table/stories/TableSection/SimpleTableSection.tsx
+++ b/packages/core/src/Table/stories/TableSection/SimpleTableSection.tsx
@@ -52,7 +52,7 @@ export const SimpleTableSection = () => {
     return (
       <HvTableRow {...row.getRowProps()}>
         {row.cells.map((cell) => (
-          <HvTableCell {...cell.getCellProps()}>
+          <HvTableCell {...cell.getCellProps()} key={cell.getCellProps().key}>
             {cell.render("Cell")}
           </HvTableCell>
         ))}
@@ -66,9 +66,15 @@ export const SimpleTableSection = () => {
         <HvTable {...getTableProps()}>
           <HvTableHead>
             {headerGroups.map((headerGroup) => (
-              <HvTableRow {...headerGroup.getHeaderGroupProps()}>
+              <HvTableRow
+                {...headerGroup.getHeaderGroupProps()}
+                key={headerGroup.getHeaderGroupProps().key}
+              >
                 {headerGroup.headers.map((col) => (
-                  <HvTableHeader {...col.getHeaderProps()}>
+                  <HvTableHeader
+                    {...col.getHeaderProps()}
+                    key={col.getHeaderProps().key}
+                  >
                     {col.render("Header")}
                   </HvTableHeader>
                 ))}

--- a/packages/core/src/Table/stories/TableSection/TableEditable.tsx
+++ b/packages/core/src/Table/stories/TableSection/TableEditable.tsx
@@ -617,7 +617,7 @@ const Table = <T extends Data>({
     const formId = `edit-row-${row.original.id}`;
 
     return (
-      <Fragment key={`editable_row_group_${row?.original.id}`}>
+      <Fragment key={formId}>
         <HvTableRow
           className={classes.tableRowEditable}
           {...row?.getRowProps()}
@@ -625,6 +625,7 @@ const Table = <T extends Data>({
           {row.cells.map((cell) => (
             <HvTableCell
               {...cell.getCellProps()}
+              key={cell.getCellProps().key}
               style={{ borderBottom: `1px solid ${theme.colors.atmo4}` }}
             >
               {cell.render("Cell")}
@@ -740,7 +741,7 @@ const Table = <T extends Data>({
     ) : (
       <HvTableRow {...row.getRowProps()}>
         {row.cells.map((cell) => (
-          <HvTableCell {...cell.getCellProps()}>
+          <HvTableCell {...cell.getCellProps()} key={cell.getCellProps().key}>
             <HvOverflowTooltip data={cell.render("Cell")} />
           </HvTableCell>
         ))}
@@ -755,10 +756,14 @@ const Table = <T extends Data>({
           <HvTable {...getTableProps()} className={classes.tableRoot}>
             <HvTableHead>
               {headerGroups.map((headerGroup) => (
-                <HvTableRow {...headerGroup.getHeaderGroupProps()}>
+                <HvTableRow
+                  {...headerGroup.getHeaderGroupProps()}
+                  key={headerGroup.getHeaderGroupProps().key}
+                >
                   {headerGroup.headers.map((col) => (
                     <HvTableHeader
                       {...col.getHeaderProps()}
+                      key={col.getHeaderProps().key}
                       aria-hidden={col.variant === "actions" ? true : undefined}
                     >
                       {col.render("Header")}

--- a/packages/core/src/Table/stories/TableSection/TableFilter.tsx
+++ b/packages/core/src/Table/stories/TableSection/TableFilter.tsx
@@ -200,7 +200,7 @@ export const TableFilter = () => {
     return (
       <HvTableRow {...row.getRowProps()}>
         {row.cells.map((cell) => (
-          <HvTableCell {...cell.getCellProps()}>
+          <HvTableCell {...cell.getCellProps()} key={cell.getCellProps().key}>
             {cell.render("Cell")}
           </HvTableCell>
         ))}
@@ -302,9 +302,15 @@ export const TableFilter = () => {
           <HvTable {...getTableProps()}>
             <HvTableHead>
               {headerGroups.map((headerGroup) => (
-                <HvTableRow {...headerGroup.getHeaderGroupProps()}>
+                <HvTableRow
+                  {...headerGroup.getHeaderGroupProps()}
+                  key={headerGroup.getHeaderGroupProps().key}
+                >
                   {headerGroup.headers.map((col) => (
-                    <HvTableHeader {...col.getHeaderProps()}>
+                    <HvTableHeader
+                      {...col.getHeaderProps()}
+                      key={col.getHeaderProps().key}
+                    >
                       {col.render("Header")}
                     </HvTableHeader>
                   ))}

--- a/packages/core/src/Table/stories/TableSection/TableSettings.tsx
+++ b/packages/core/src/Table/stories/TableSection/TableSettings.tsx
@@ -478,11 +478,14 @@ export const TableSettings = () => {
 
     return (
       <HvTableRow {...row.getRowProps()}>
-        {row.cells.map((cell) => (
-          <HvTableCell {...cell.getCellProps()}>
-            {cell.render("Cell")}
-          </HvTableCell>
-        ))}
+        {row.cells.map((cell) => {
+          const { key, ...cellProps } = cell.getCellProps();
+          return (
+            <HvTableCell key={key} {...cellProps}>
+              {cell.render("Cell")}
+            </HvTableCell>
+          );
+        })}
       </HvTableRow>
     );
   };
@@ -543,9 +546,15 @@ export const TableSettings = () => {
         <HvTable {...getTableProps()}>
           <HvTableHead>
             {headerGroups.map((headerGroup) => (
-              <HvTableRow {...headerGroup.getHeaderGroupProps()}>
+              <HvTableRow
+                {...headerGroup.getHeaderGroupProps()}
+                key={headerGroup.getHeaderGroupProps().key}
+              >
                 {headerGroup.headers.map((col) => (
-                  <HvTableHeader {...col.getHeaderProps()}>
+                  <HvTableHeader
+                    {...col.getHeaderProps()}
+                    key={col.getHeaderProps().key}
+                  >
                     {col.render("Header")}
                   </HvTableHeader>
                 ))}
@@ -553,7 +562,7 @@ export const TableSettings = () => {
             ))}
           </HvTableHead>
           <HvTableBody {...getTableBodyProps()}>
-            {pageSize && [...Array(pageSize).keys()].map(renderTableRow)}
+            {[...Array(pageSize).keys()].map(renderTableRow)}
           </HvTableBody>
         </HvTable>
       </HvTableContainer>

--- a/packages/core/src/Tag/stories/Selectable.tsx
+++ b/packages/core/src/Tag/stories/Selectable.tsx
@@ -37,8 +37,9 @@ export const Selectable = () => {
       })}
     >
       <div className={css({ display: "flex", gap: theme.space.sm })}>
-        {tags.map((tag) => (
+        {tags.map((tag, i) => (
           <HvTag
+            key={`${tag.label}-${i}`}
             label={tag.label}
             color={tag.bgColor}
             selectable

--- a/packages/core/src/Tag/stories/SelectableControlled.tsx
+++ b/packages/core/src/Tag/stories/SelectableControlled.tsx
@@ -37,8 +37,9 @@ export const SelectableControlled = () => {
       })}
     >
       <div className={css({ display: "flex", gap: theme.space.sm })}>
-        {tags.map((tag) => (
+        {tags.map((tag, i) => (
           <HvTag
+            key={`${tag.label}-${i}`}
             label={tag.label}
             color={tag.bgColor}
             selectable

--- a/packages/lab/src/Dashboard/Dashboard.stories.tsx
+++ b/packages/lab/src/Dashboard/Dashboard.stories.tsx
@@ -135,7 +135,9 @@ export const DataDriven: StoryObj<HvDashboardProps> = {
             const Component = componentMap[type];
 
             if (!Component) {
-              return <div>❌ Cannot render {type} dashboard item</div>;
+              return (
+                <div key={item.id}>❌ Cannot render {type} dashboard item</div>
+              );
             }
 
             return (


### PR DESCRIPTION
Spreading key is discouraged and there's a React warning since `v18.3` https://github.com/facebook/react/pull/25697
[`react/jsx-key`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-key.md#rule-details) rule covers this