### PR TITLE
feat(QueryBuilder): prop added to disable default attribute validation

### DIFF
--- a/packages/core/src/QueryBuilder/Context.tsx
+++ b/packages/core/src/QueryBuilder/Context.tsx
@@ -330,6 +330,7 @@ export interface HvQueryBuilderContextValue {
   initialTouched: boolean;
   readOnly: boolean;
   disableConfirmation: boolean;
+  allowRepeatedAttributes?: boolean;
   renderers?: HvQueryBuilderRenderers;
   emptyRenderer?: string[];
 }
@@ -345,6 +346,7 @@ export const HvQueryBuilderContext = createContext<HvQueryBuilderContextValue>({
   labels: defaultLabels,
   initialTouched: false,
   disableConfirmation: false,
+  allowRepeatedAttributes: false,
   readOnly: false,
 });
 

--- a/packages/core/src/QueryBuilder/QueryBuilder.tsx
+++ b/packages/core/src/QueryBuilder/QueryBuilder.tsx
@@ -70,12 +70,19 @@ export interface HvQueryBuilderProps {
   renderers?: HvQueryBuilderRenderers;
   /** Whether to opt-out of the confirmation dialogs shown before removing rules and rule groups. @default false. */
   disableConfirmation?: boolean;
+  /**
+   * Whether to allow attributes to be repeated in AND conditions.
+   * By default an error is shown when the selected attribute already exists in an AND conditions.
+   * @default false
+   */
+  allowRepeatedAttributes?: boolean; // TODO - review in v6: should we even have this validation? if needed, we should review its behavior.
   /** A Jss Object used to override or extend the styles applied. */
   classes?: HvQueryBuilderClasses;
 }
 
 // TODO - v6
 // - "range", "Empty", and "IsNotEmpty" operators with internal/built-in logic
+// - review query builder validation
 
 // Notes:
 // Deep clone is needed throughout the component to avoid undesired mutations in props, state, and ref values
@@ -95,6 +102,7 @@ export const HvQueryBuilder = (props: HvQueryBuilderProps) => {
     defaultValue,
     onChange,
     disableConfirmation = false,
+    allowRepeatedAttributes = false,
     operators = defaultOperators,
     combinators = defaultCombinators,
     maxDepth = 1,
@@ -157,6 +165,7 @@ export const HvQueryBuilder = (props: HvQueryBuilderProps) => {
       readOnly,
       renderers,
       disableConfirmation,
+      allowRepeatedAttributes,
       emptyRenderer,
     }),
     [
@@ -170,6 +179,7 @@ export const HvQueryBuilder = (props: HvQueryBuilderProps) => {
       renderers,
       disableConfirmation,
       emptyRenderer,
+      allowRepeatedAttributes,
     ],
   );
 

--- a/packages/core/src/QueryBuilder/RuleGroup/RuleGroup.tsx
+++ b/packages/core/src/QueryBuilder/RuleGroup/RuleGroup.tsx
@@ -37,6 +37,7 @@ export const RuleGroup = ({
     labels,
     readOnly,
     disableConfirmation,
+    allowRepeatedAttributes,
   } = useQueryBuilderContext();
 
   const normalizedMaxDepth = maxDepth - 1;
@@ -159,20 +160,21 @@ export const RuleGroup = ({
               );
             }
 
-            const isInvalid =
-              combinator === "and" &&
-              rules.some((r, i) => {
-                if ("attribute" in r) {
-                  if (
-                    r.attribute === rule.attribute &&
-                    r.id !== rule.id &&
-                    i < index
-                  ) {
-                    return true;
+            const isInvalid = allowRepeatedAttributes
+              ? false
+              : combinator === "and" &&
+                rules.some((r, i) => {
+                  if ("attribute" in r) {
+                    if (
+                      r.attribute === rule.attribute &&
+                      r.id !== rule.id &&
+                      i < index
+                    ) {
+                      return true;
+                    }
                   }
-                }
-                return false;
-              });
+                  return false;
+                });
 
             return (
               <Rule


### PR DESCRIPTION
- `allowRepeatedAttributes ` prop added to disable the default attribute validation
   - From what I've tested, the validation only occurs at the UI level as shown in the video below (by changing the `status` of `HvDropdown`). Internally the query still updates.

https://github.com/lumada-design/hv-uikit-react/assets/43220251/3e339a44-2daf-4b3b-b75c-4b2945734afa

