### PR TITLE
fix: viz legend position

### DIFF
--- a/packages/viz/src/hooks/useLegend.tsx
+++ b/packages/viz/src/hooks/useLegend.tsx
@@ -22,12 +22,10 @@ export const useLegend = ({
   direction = "horizontal",
 }: HvLegendHookProps) => {
   const option = useMemo<Pick<HvEChartsOption, "legend">>(() => {
-    const position: Record<string, string> = { y: positionProp?.y ?? "top" };
-    if (positionProp?.x != null && positionProp?.x !== "center") {
-      position[positionProp.x] = positionProp.x;
-    } else {
-      position.x = "center";
-    }
+    const position: Record<string, string> = {
+      y: positionProp?.y ?? "top",
+      x: positionProp?.x ?? "center",
+    };
 
     return {
       legend: {


### PR DESCRIPTION
Fixes going from:

![Screenshot 2024-05-27 at 18 01 12](https://github.com/lumada-design/hv-uikit-react/assets/43220251/930cbf1f-7971-45df-9f44-018cdb02a1a7)

to:

![Screenshot 2024-05-27 at 18 01 05](https://github.com/lumada-design/hv-uikit-react/assets/43220251/3da20329-118d-4123-8c03-e5499dbe4bc3)

when:

```
legend={{
          position: {
            x: "right",
          },
        }}
```

The legend orientation should have stayed horizontal and not vertical.
