### PR TITLE
docs: fix prepareRow calls

### DIFF
--- a/apps/app/src/pages/Flow/DashboardPreview/Renderers/Table.tsx
+++ b/apps/app/src/pages/Flow/DashboardPreview/Renderers/Table.tsx
@@ -148,8 +148,8 @@ export const Table = ({
           <HvTableBody {...getTableBodyProps()}>
             {page.length > 0 ? (
               page.map((row) => {
-                const { key, ...rowProps } = row.getRowProps();
                 prepareRow(row);
+                const { key, ...rowProps } = row.getRowProps();
 
                 return (
                   <HvTableRow key={key} {...rowProps}>

--- a/packages/cli/src/templates/AssetInventory/ListView.tsx
+++ b/packages/cli/src/templates/AssetInventory/ListView.tsx
@@ -32,8 +32,8 @@ export const ListView = ({ id, instance, columns }: ListViewProps) => {
         </HvTableHead>
         <HvTableBody withNavigation {...instance.getTableBodyProps()}>
           {instance.page.map((row) => {
-            const { key, ...rowProps } = row.getRowProps();
             instance.prepareRow(row);
+            const { key, ...rowProps } = row.getRowProps();
             return (
               <HvTableRow key={key} {...rowProps}>
                 {row.cells.map((cell) => {

--- a/packages/cli/src/templates/DetailsView/Table.tsx
+++ b/packages/cli/src/templates/DetailsView/Table.tsx
@@ -71,8 +71,8 @@ export const Table = ({ modelId }: TableProps) => {
           </HvTableHead>
           <HvTableBody {...instance.getTableBodyProps()}>
             {instance.page.map((row) => {
-              const { key, ...rowProps } = row.getRowProps();
               instance.prepareRow(row);
+              const { key, ...rowProps } = row.getRowProps();
               return (
                 <HvTableRow key={key} {...rowProps}>
                   {row.cells.map((cell) => {

--- a/packages/cli/src/templates/ListView/Table.tsx
+++ b/packages/cli/src/templates/ListView/Table.tsx
@@ -33,8 +33,8 @@ export const Table = ({ instance, id }: TableProps) => {
         </HvTableHead>
         <HvTableBody withNavigation {...instance.getTableBodyProps()}>
           {instance.page.map((row) => {
-            const { key, ...rowProps } = row.getRowProps();
             instance.prepareRow(row);
+            const { key, ...rowProps } = row.getRowProps();
             return (
               <HvTableRow key={key} {...rowProps}>
                 {row.cells.map((cell) => {


### PR DESCRIPTION
`prepareRow` must come before `row.getRowProps()`

caused by #4184