### PR TITLE
feat(component): add HvLunara - toggleable button group

### DIFF
--- a/packages/lab/src/HvLunara/HvLunara.stories.tsx
+++ b/packages/lab/src/HvLunara/HvLunara.stories.tsx
@@ -1,0 +1,269 @@
+import { useState } from "react";
+import { Meta, StoryObj } from "@storybook/react";
+import {
+  HvButton,
+  HvRadio,
+  HvRadioGroup,
+  HvSwitch,
+  HvTypography,
+} from "@hitachivantara/uikit-react-core";
+import { Email, Phone } from "@hitachivantara/uikit-react-icons";
+
+import { HvLunara, HvLunaraProps } from "./HvLunara";
+
+// Main
+const meta: Meta<typeof HvLunara> = {
+  title: "Lab/HvLunara/HvLunara",
+  component: HvLunara,
+};
+export default meta;
+
+export const Main: StoryObj<HvLunaraProps> = {
+  args: {
+    label: "Shortcuts",
+    options: [
+      { item: "Download", callback: () => alert("Clicked Download Button") },
+      { item: "Like", callback: () => alert("Clicked Like Button") },
+      { item: "Share", callback: () => alert("Clicked Share Button") },
+    ],
+  },
+  render: (args) => {
+    return <HvLunara {...args} />;
+  },
+};
+
+// Icons as Buttons
+export const IconButton: StoryObj<HvLunaraProps> = {
+  args: {
+    position: "top-right",
+    label: "Contact Us",
+    options: [
+      {
+        item: (
+          <>
+            <Phone
+              aria-label="call"
+              color="black"
+              style={{ width: 20, height: 21 }}
+            />{" "}
+            &nbsp;<span>Call</span>
+          </>
+        ),
+        callback: () => alert("Clicked Call Button"),
+      },
+      {
+        item: (
+          <>
+            <Email
+              aria-label="call"
+              color="black"
+              style={{ width: 20, height: 21 }}
+            />{" "}
+            &nbsp;<span>Email</span>
+          </>
+        ),
+        callback: () => alert("Clicked Email Button"),
+      },
+    ],
+  },
+  render: (args) => {
+    return <HvLunara {...args} />;
+  },
+};
+
+// Disabled
+export const DisabledButton: StoryObj<HvLunaraProps> = {
+  args: {
+    position: "top-right",
+    label: "Contact Us",
+    options: [
+      {
+        item: (
+          <>
+            <Phone
+              aria-label="call"
+              color="black"
+              style={{ width: 20, height: 21 }}
+            />{" "}
+            &nbsp;<span>Call</span>
+          </>
+        ),
+        callback: () => alert("Clicked Call Button"),
+        disabled: true,
+      },
+      {
+        item: "Email",
+        callback: () => alert("Clicked Email Button"),
+        disabled: true,
+      },
+    ],
+  },
+  render: (args) => {
+    return <HvLunara {...args} />;
+  },
+};
+
+// Variants
+export const Variants: StoryObj<HvLunaraProps> = {
+  args: {
+    label: "Resources",
+    position: "top-right" as HvLunaraProps["position"],
+    options: [
+      {
+        item: "Hitachi",
+        callback: () => {
+          alert("Clicked Hitachi Button");
+        },
+      },
+      {
+        item: "External",
+        callback: () => {
+          "Clicked External Button";
+        },
+      },
+    ],
+  },
+  render: (args) => {
+    const variants = {
+      primary: "top-right",
+      secondary: "center-right",
+      light: "bottom-right",
+    };
+    return (
+      <>
+        {Object.entries(variants).map(([variant, position]) => (
+          <HvLunara
+            key={variant}
+            variant={variant as HvLunaraProps["variant"]}
+            position={position as HvLunaraProps["position"]}
+            {...args}
+          />
+        ))}
+      </>
+    );
+  },
+};
+
+// Controlled
+export const Controlled: StoryObj<HvLunaraProps> = {
+  args: {
+    label: "Menu",
+    position: "top-right" as HvLunaraProps["position"],
+    options: [
+      { item: "Home", callback: () => alert("Navigating to Home") },
+      { item: "Services", callback: () => alert("Navigating to Services") },
+      {
+        item: "Our Offerings",
+        callback: () => alert("Navigating to Our Offerings"),
+      },
+      {
+        item: "Our Policies",
+        callback: () => alert("Navigating to Policies"),
+      },
+    ],
+  },
+  render: (args) => {
+    const [value, setValue] = useState<HvLunaraProps["variant"]>("light");
+    const [outline, setOutline] = useState<HvLunaraProps["outline"]>(false);
+    const [btnRadius, setbtnRadius] =
+      useState<HvLunaraProps["btnRadius"]>("round");
+    const variants = ["light", "dark", "primary", "secondary"];
+    const btnVariants = ["base", "round", "full", "none"];
+    return (
+      <div style={{ display: "inline-flex", gap: 100, margin: 20 }}>
+        <div>
+          <HvTypography variant="mTitle">Variants</HvTypography>
+          <br />
+          {variants.map((item) => {
+            return (
+              <div key={item}>
+                <HvButton
+                  onClick={() => setValue(item as HvLunaraProps["variant"])}
+                  variant={value === item ? "positive" : "primary"}
+                >
+                  {item}
+                </HvButton>
+                <br />
+                <br />
+              </div>
+            );
+          })}
+        </div>
+        <div>
+          <HvSwitch
+            label="Outline"
+            value="off"
+            onChange={() => setOutline(!outline)}
+          />
+        </div>
+        <div>
+          <HvRadioGroup label="Button Radius">
+            {btnVariants.map((item) => {
+              return (
+                <HvRadio
+                  key={item}
+                  label={item}
+                  value={item}
+                  onChange={() =>
+                    setbtnRadius(item as HvLunaraProps["btnRadius"])
+                  }
+                  checked={btnRadius === item}
+                />
+              );
+            })}
+          </HvRadioGroup>
+        </div>
+        <HvLunara
+          variant={value}
+          btnRadius={btnRadius}
+          outline={outline}
+          {...args}
+        />
+      </div>
+    );
+  },
+};
+
+// Positional
+export const Positions: StoryObj<HvLunaraProps> = {
+  args: {
+    label: "Menu",
+    options: [
+      {
+        item: "Home",
+        callback: () => {
+          alert("Clicked home Button");
+        },
+      },
+      {
+        item: "Products",
+        callback: () => {
+          alert("Clicked Products Button");
+        },
+      },
+    ],
+  },
+  render: (args) => {
+    const position = [
+      "top-left",
+      "top-right",
+      "center-left",
+      "center-right",
+      "bottom-left",
+      "bottom-right",
+    ];
+    return (
+      <div>
+        {position.map((pos) => {
+          return (
+            <HvLunara
+              key={pos}
+              position={pos as HvLunaraProps["position"]}
+              {...args}
+            />
+          );
+        })}
+      </div>
+    );
+  },
+};

--- a/packages/lab/src/HvLunara/HvLunara.styles.tsx
+++ b/packages/lab/src/HvLunara/HvLunara.styles.tsx
@@ -1,0 +1,252 @@
+import { createClasses } from "@hitachivantara/uikit-react-core";
+import { theme } from "@hitachivantara/uikit-styles";
+
+export const { staticClasses, useClasses } = createClasses("HvLunara", {
+  // Root Container styling
+  root: {
+    position: "fixed",
+    display: "flex",
+    width: "fit-content",
+    maxWidth: 600,
+    fontFamily: theme.fontFamily.body,
+    gap: theme.spacing("xs"),
+    "&$right": {
+      flexDirection: "row-reverse",
+    },
+    zIndex: theme.zIndices.toast,
+  },
+
+  // Positioning of element
+  "top-left": {
+    top: "10%",
+    left: "0",
+  },
+  "bottom-left": {
+    bottom: "15%",
+    left: "0",
+    transform: "translate(0,100%)",
+  },
+  "top-right": {
+    top: "10%",
+    right: "0",
+  },
+  "bottom-right": {
+    bottom: "15%",
+    right: "0",
+    transform: "translate(0,100%)",
+  },
+  "center-left": {
+    top: "50%",
+    left: "0",
+  },
+  "center-right": {
+    top: "50%",
+    right: "0",
+  },
+
+  // UL component styles
+  uList: {
+    display: "flex",
+    opacity: 0,
+    visibility: "hidden",
+    margin: 0,
+    padding: theme.spacing("xs"),
+    gap: theme.spacing("xs"),
+    flexWrap: "wrap",
+    "&$expanded": {
+      visibility: "visible",
+      opacity: 1,
+      transition: "opacity 1s ease-in-out",
+    },
+    "&$right": {
+      flexDirection: "row-reverse",
+    },
+  },
+  // list items styling
+  listItem: {
+    display: "inline-flex",
+    flexGrow: 1,
+    height: "fit-content",
+    justifyContent: "center",
+    alignItems: "center",
+    padding: theme.spacing("xs"),
+    cursor: "pointer",
+  },
+
+  expanded: {},
+  right: {},
+  outline: {},
+  active: {},
+  labelParent: {
+    height: "fit-content",
+    padding: theme.spacing("xs"),
+    cursor: "pointer",
+  },
+  activeUlist: {},
+  bgcolor: {},
+  disabled: {},
+
+  // Theme variants of component i.e primary, secondary, light and dark
+  primary: {
+    "&$bgcolor": {
+      backgroundColor: theme.colors.cat3_40,
+    },
+    color: theme.colors.base_dark,
+    "&:hover": {
+      background: theme.colors.cat3_20,
+    },
+    "&$labelParent": {
+      background: theme.colors.cat3_40,
+      boxShadow: `0px 1px 6px ${theme.colors.secondary_60}`,
+    },
+    "&$activeUlist": {
+      background: theme.colors.base_light,
+      boxShadow: `0px 1px 6px ${theme.colors.secondary_60}`,
+    },
+    "&$outline": {
+      border: `0.5px solid ${theme.colors.cat3_160}`,
+    },
+    "&$active": {
+      background: theme.colors.base_light,
+      color: theme.colors.brand,
+    },
+    "&$disabled": {
+      opacity: 0.7,
+      color: theme.colors.secondary,
+      background: theme.colors.atmo3,
+      pointerEvents: "none",
+      cursor: "not-allowed",
+    },
+  },
+
+  secondary: {
+    "&$bgcolor": {
+      backgroundColor: theme.colors.cat1_40,
+    },
+    color: theme.colors.base_dark,
+    "&:hover": {
+      background: theme.colors.cat1_20,
+    },
+    "&$outline": {
+      border: `0.5px solid ${theme.colors.cat4_140}`,
+    },
+    "&$labelParent": {
+      background: theme.colors.cat1_40,
+      boxShadow: `0 1px 6px ${theme.colors.secondary_60}`,
+      border: `0.5px solid ${theme.colors.atmo3}`,
+      cursor: "pointer",
+    },
+    "&$activeUlist": {
+      background: theme.colors.base_light,
+      boxShadow: `0 1px 6px ${theme.colors.secondary_60}`,
+      border: `0.5px solid ${theme.colors.atmo3}`,
+    },
+    "&$active": {
+      background: theme.colors.base_light,
+      color: theme.colors.brand,
+    },
+    "&$disabled": {
+      opacity: 0.7,
+      color: theme.colors.secondary,
+      background: theme.colors.atmo3,
+      pointerEvents: "none",
+      cursor: "not-allowed",
+    },
+  },
+
+  light: {
+    "&$bgcolor": {
+      backgroundColor: theme.colors.atmo4,
+    },
+    "&:hover": {
+      background: theme.colors.atmo3,
+    },
+    "&$outline": {
+      border: `0.5px solid ${theme.colors.base_dark}`,
+    },
+    "&$labelParent": {
+      background: theme.colors.atmo1,
+      boxShadow: `0 1px 6px ${theme.colors.secondary_60}`,
+    },
+    "&$activeUlist": {
+      background: theme.colors.atmo1,
+      boxShadow: `0 1px 6px ${theme.colors.secondary_60}`,
+    },
+    "&$active": {
+      color: theme.colors.base_light,
+      background: theme.colors.negative_120,
+    },
+    "&$disabled": {
+      opacity: 0.7,
+      color: theme.colors.secondary,
+      background: theme.colors.atmo3,
+      pointerEvents: "none",
+      cursor: "not-allowed",
+    },
+  },
+
+  // radius classes
+  box: {},
+
+  base: {
+    borderRadius: theme.radii.base,
+    "&$box": {
+      borderRadius: theme.radii.base,
+    },
+  },
+  round: {
+    borderRadius: theme.radii.round,
+    "&$box": {
+      borderRadius: theme.radii.round,
+    },
+  },
+  full: {
+    borderRadius: theme.radii.full,
+    "&$box": {
+      borderRadius: 30,
+    },
+  },
+  none: {},
+
+  // font size and spacing
+  sm: {
+    fontSize: theme.fontSizes.sm,
+  },
+  lg: {
+    fontSize: theme.fontSizes.lg,
+    padding: theme.spacing("sm"),
+  },
+  xs: {
+    fontSize: theme.fontSizes.xs,
+    padding: theme.spacing("xs"),
+  },
+
+  // label variants classes
+  bold: {
+    fontWeight: theme.fontWeights.bold,
+  },
+  italic: {
+    fontStyle: "italic",
+  },
+  underlined: {
+    textDecoration: "underline",
+  },
+  "bold-italic": {
+    fontWeight: theme.fontWeights.bold,
+    fontStyle: "italic",
+  },
+  "bold-underlined": {
+    fontWeight: theme.fontWeights.bold,
+    textDecoration: "underline",
+  },
+  "italic-underlined": {
+    fontStyle: "italic",
+    textDecoration: "underline",
+  },
+  "bold-italic-underlined": {
+    fontWeight: theme.fontWeights.bold,
+    fontStyle: "italic",
+    textDecoration: "underline",
+  },
+  normal: {},
+});

--- a/packages/lab/src/HvLunara/HvLunara.test.tsx
+++ b/packages/lab/src/HvLunara/HvLunara.test.tsx
@@ -1,0 +1,90 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { Phone } from "@hitachivantara/uikit-react-icons";
+
+import { HvLunara, LunaraItem } from "./HvLunara";
+
+describe("MyComponent", () => {
+  const options: LunaraItem[] = [
+    { item: "Option 1", callback: () => console.log("Option 1 clicked") },
+    { item: "Option 2", callback: () => console.log("Option 2 clicked") },
+  ];
+
+  // Rendering of Items with label button
+
+  it("renders label and options", async () => {
+    const { getByText, getByRole } = render(
+      <HvLunara label="Label" options={options} />,
+    );
+    expect(getByText("Label")).toBeInTheDocument();
+    fireEvent.click(getByRole("button"));
+    await waitFor(() => {
+      expect(screen.getByTestId("option-list")).toBeVisible();
+    });
+
+    expect(screen.getByText("Option 1")).toBeInTheDocument();
+    expect(screen.getByText("Option 2")).toBeInTheDocument();
+  });
+
+  // Invoke of callback functions
+
+  it("calls callback when option is clicked", () => {
+    const callback1 = vi.fn();
+    const callback2 = vi.fn();
+    const testOptions = [
+      { item: "Option 1", callback: callback1 },
+      { item: "Option 2", callback: callback2 },
+    ];
+    const { getByText } = render(
+      <HvLunara label="Label" options={testOptions} />,
+    );
+
+    fireEvent.click(getByText("Option 1"));
+    expect(callback1).toHaveBeenCalled();
+
+    fireEvent.click(getByText("Option 2"));
+    expect(callback2).toHaveBeenCalled();
+  });
+
+  // Expand and Collapse of List
+
+  it("expands and collapses options", async () => {
+    const { getByRole, queryByText } = render(
+      <HvLunara label="Label" options={options} />,
+    );
+    const labelButton = getByRole("button");
+
+    userEvent.click(labelButton);
+    await waitFor(() => {
+      expect(screen.getByTestId("option-list")).toBeVisible();
+    });
+    expect(queryByText("Option 1")).toBeVisible();
+    expect(queryByText("Option 2")).toBeVisible();
+
+    userEvent.click(labelButton);
+    await waitFor(() => {
+      expect(screen.getByTestId("option-list")).not.toBeVisible();
+    });
+    expect(queryByText("Option 1")).not.toBeVisible();
+    expect(queryByText("Option 2")).not.toBeVisible();
+  });
+
+  // Icon as one of the item
+
+  it("renders icon as one of the options", async () => {
+    const options2: LunaraItem[] = [
+      { item: "Option 1", callback: vi.fn() },
+      { item: <Phone aria-label="call" />, callback: vi.fn() },
+    ];
+    render(<HvLunara label="Label" options={options2} />);
+
+    fireEvent.click(screen.getByRole("button"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("option-list")).toBeVisible();
+    });
+    screen.debug();
+    expect(screen.getByTitle("call")).toBeInTheDocument();
+  });
+});

--- a/packages/lab/src/HvLunara/HvLunara.tsx
+++ b/packages/lab/src/HvLunara/HvLunara.tsx
@@ -1,0 +1,254 @@
+import { FC, HTMLAttributes, useCallback, useRef, useState } from "react";
+import {
+  ExtractNames,
+  HvBaseProps,
+  setId,
+  useClickOutside,
+  useDefaultProps,
+  useUniqueId,
+} from "@hitachivantara/uikit-react-core";
+
+import { staticClasses, useClasses } from "./HvLunara.styles";
+
+export { staticClasses as lunaraClasses };
+
+export type HvLunaraClasses = ExtractNames<typeof useClasses>;
+
+export type HorizontalPosition = "left" | "center" | "right";
+export type VerticalPosition = "top" | "center" | "bottom";
+
+export type LunaraItem = {
+  // If using icon as an Item, do specify aria-label attribute for Icon so that Item is read by the screen readers.
+  item: React.ReactNode;
+  callback: (() => () => void) | (() => void);
+  disabled?: boolean;
+};
+
+export interface HvLunaraProps extends HvBaseProps<HTMLDivElement, "children"> {
+  // Mandatory label
+  label: string;
+
+  // fontSizes
+  size?: "xs" | "sm" | "lg" | "none";
+
+  /* Variant is used to describe the theme of the component to be used, by default we have 4 themes which can be totally customized using containerProps, 
+  labelProps, classes and buttonProps and labelContainerProps. */
+  variant?: "primary" | "secondary" | "light";
+
+  // labelVariant is used to determine the variant of text which can be kept for label
+  labelVariant?:
+    | "bold"
+    | "italic"
+    | "underlined"
+    | "bold-italic"
+    | "bold-underlined"
+    | "italic-underlined"
+    | "bold-italic-underlined"
+    | "normal";
+
+  // cancelLabel determines the closing label or text
+  closingLabel?: string;
+
+  // btnRadius determines the inline listItems appearance taht acts as buttons
+  btnRadius?: "round" | "base" | "full" | "none";
+
+  // outline determines the border whther to be kept for the list item buttons or not
+  outline?: boolean;
+
+  // It determines the positioning of component in the viewport area.
+  position?: Exclude<
+    `${VerticalPosition}-${HorizontalPosition}`,
+    "center-center" | "top-center" | "bottom-center"
+  >;
+
+  /* For options which are listItems to our UL list and represented as inline-buttons, it should be passed as an array of objects wherein each object will consist of
+   item: string type and a callback function to implement the functionality associated with that listItem or button  */
+  options?: LunaraItem[];
+
+  // for customizing root container and adding other properties and attributes
+  containerProps?: HTMLAttributes<HTMLDivElement>;
+
+  // For customizing label or labelcontainer  and adding other properties and attributes
+  labelContainerProps?: HTMLAttributes<HTMLDivElement>;
+
+  // for customizing label and adding other properties and attributes
+  labelProps?: HTMLAttributes<HTMLDivElement>;
+
+  // For customizing list item and adding other props
+  buttonProps?: HTMLAttributes<HTMLLIElement>;
+
+  // For customizing Existing classes
+  classes?: HvLunaraClasses;
+}
+
+export const HvLunara: FC<HvLunaraProps> = (props) => {
+  const {
+    id: idProp,
+    size = "none",
+    classes: classesProps,
+    label,
+    outline,
+    className, // To add additional className to the root container
+    btnRadius = "round",
+    labelVariant = "bold",
+    position = "bottom-right",
+    variant = "light",
+    closingLabel,
+    containerProps,
+    labelContainerProps,
+    labelProps,
+    buttonProps,
+  } = useDefaultProps("HvLunara", props);
+
+  const labelRef = useRef<HTMLDivElement>(null!);
+  const listRef = useRef<HTMLUListElement | null>(null);
+  const rootRef = useRef<HTMLDivElement>(null!);
+  const [isExpanded, setIsExpanded] = useState<boolean>(false);
+  const check = position.split("-")[1] === "right";
+
+  const { classes, cx } = useClasses(classesProps);
+
+  const handleClick = (item: LunaraItem) => {
+    const result = item.callback();
+    if (typeof result === "function") {
+      result();
+    }
+  };
+
+  const handleListExpansion = useCallback(() => {
+    if (listRef.current) {
+      labelRef.current.textContent = !isExpanded
+        ? closingLabel ?? "Close"
+        : label;
+      setIsExpanded(!isExpanded);
+    }
+  }, [closingLabel, label, isExpanded]);
+
+  const handleClose = () => {
+    if (isExpanded) {
+      setIsExpanded(false);
+      labelRef.current.textContent = label;
+    }
+  };
+
+  const id = useUniqueId(idProp);
+  const lunaraLabelContainerId = setId(id, "labelContainer");
+  const lunaraLabelId = setId(id, "label");
+  const lunaraListId = setId(id, "list");
+
+  useClickOutside(rootRef, handleClose);
+
+  const { style: containerStyle, ...otherContainerProps } =
+    containerProps || {};
+
+  const { style: labelContainerStyle, ...otherLabelContainerProps } =
+    labelContainerProps || {};
+
+  const { style: labelStyle, ...otherLabelProps } = labelProps || {};
+
+  const { style: buttonStyle, ...otherButtonProps } = buttonProps || {};
+
+  const handleKeyDown = (
+    event: React.KeyboardEvent<HTMLDivElement | HTMLLIElement>,
+    item: LunaraItem | null,
+  ) => {
+    const { key, currentTarget } = event;
+    if (key === "Enter" || key === " ") {
+      if (currentTarget instanceof HTMLDivElement) {
+        handleListExpansion();
+      } else if (item) {
+        handleClick(item);
+      }
+    }
+  };
+
+  return (
+    <div
+      id={id}
+      className={cx(classes.root, classes[position], className, {
+        [classes.right]: check,
+      })}
+      style={{ ...containerStyle }}
+      {...otherContainerProps}
+      ref={rootRef}
+      role="presentation"
+    >
+      <div
+        id={lunaraLabelContainerId}
+        className={cx(
+          classes[variant],
+          classes.labelParent,
+          classes[labelVariant],
+          classes[btnRadius],
+          { [classes.active]: isExpanded },
+        )}
+        style={{ ...labelContainerStyle }}
+        {...otherLabelContainerProps}
+        role="button"
+        tabIndex={0}
+        aria-expanded={isExpanded}
+        aria-controls={lunaraListId}
+        aria-label={`${label} button`}
+        onClick={() => handleListExpansion()}
+        onKeyDown={(event) => handleKeyDown(event, null)}
+      >
+        <div
+          id={lunaraLabelId}
+          className={cx(classes.listItem, classes[size])}
+          style={{ ...labelStyle }}
+          {...otherLabelProps}
+          ref={labelRef}
+          role="none"
+        >
+          {label}
+        </div>
+      </div>
+
+      <ul
+        id={lunaraListId}
+        data-testid="option-list"
+        aria-labelledby={lunaraLabelId}
+        className={cx(
+          classes.uList,
+          classes.activeUlist,
+          classes[variant],
+          classes[btnRadius],
+          classes.box,
+          {
+            [classes.expanded]: isExpanded,
+            [classes.right]: check,
+          },
+        )}
+        ref={listRef}
+      >
+        {props?.options?.map((item, i) => {
+          return (
+            <li
+              key={i}
+              role="menuitem"
+              tabIndex={0}
+              className={cx(
+                classes.listItem,
+                classes[btnRadius],
+                classes[size],
+                classes[variant],
+                classes.bgcolor,
+                {
+                  [classes.outline]: outline,
+                  [classes.disabled]: item.disabled,
+                },
+              )}
+              style={{ ...buttonStyle }}
+              {...otherButtonProps}
+              onClick={() => handleClick(item)}
+              onKeyDown={(event) => handleKeyDown(event, item)}
+              aria-disabled={item.disabled ?? false}
+            >
+              {item.item}
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+};

--- a/packages/lab/src/HvLunara/index.ts
+++ b/packages/lab/src/HvLunara/index.ts
@@ -1,0 +1,1 @@
+export * from "./HvLunara";


### PR DESCRIPTION
**Problem Statement -** Frequently accessible features and actions available across either different pages or a page with much of functionalities can lead to inefficiencies in user workflow and can be frustrating. Few example includes,
1. Navigating to the pertinent features of the current page available on other pages.
2. Finding the functionalities if a page is long and scrollable.
3.  Accessing the Navigation bar Items if the page is scrollable and long.
[HvLunara.docx](https://github.com/user-attachments/files/15541553/HvLunara.docx)
 

**Solution -** HvLunara, customizable and easily accessible component that can be used to consolidate frequently used features from various pages into a single, easily navigable interface for the ease of use.