### PR TITLE
fix: enable using measures with the same field but with different aggregation functions

### DIFF
--- a/packages/viz/src/BarChart/BarChart.tsx
+++ b/packages/viz/src/BarChart/BarChart.tsx
@@ -83,7 +83,7 @@ export const HvBarChart = forwardRef<ReactECharts, HvBarChartProps>(
       ...others
     } = props;
 
-    const chartData = useData({
+    const { data: chartData, mapping: measuresMapping } = useData({
       data,
       groupBy,
       sortBy,
@@ -114,7 +114,7 @@ export const HvBarChart = forwardRef<ReactECharts, HvBarChartProps>(
       type: "bar",
       data: chartData,
       groupBy,
-      measures,
+      measuresMapping,
       stack,
       nameFormatter: seriesNameFormatter,
       horizontal,
@@ -129,7 +129,7 @@ export const HvBarChart = forwardRef<ReactECharts, HvBarChartProps>(
     const chartTooltip = useTooltip({
       ...tooltip,
       trigger: "axis",
-      measures,
+      measuresMapping,
       classes,
       horizontal,
     });

--- a/packages/viz/src/ConfusionMatrix/ConfusionMatrix.tsx
+++ b/packages/viz/src/ConfusionMatrix/ConfusionMatrix.tsx
@@ -116,7 +116,7 @@ export const HvConfusionMatrix = forwardRef<
 
   const groupByKey = getGroupKey(groupBy);
 
-  const chartData = useData({
+  const { data: chartData } = useData({
     data: dataProp,
     groupBy,
     measures: [measure],

--- a/packages/viz/src/DonutChart/DonutChart.tsx
+++ b/packages/viz/src/DonutChart/DonutChart.tsx
@@ -69,7 +69,13 @@ export const HvDonutChart = forwardRef<ReactECharts, HvDonutChartProps>(
       ...others
     } = props;
 
-    const chartData = useData({ data, groupBy, measures, sortBy, filters });
+    const { data: chartData, mapping: measuresMapping } = useData({
+      data,
+      groupBy,
+      measures,
+      sortBy,
+      filters,
+    });
 
     const chartDataset = useDataset(chartData);
 
@@ -77,7 +83,7 @@ export const HvDonutChart = forwardRef<ReactECharts, HvDonutChartProps>(
       type: "pie",
       data: chartData,
       groupBy,
-      measures,
+      measuresMapping,
       radius: type === "thin" ? ["65%", "70%"] : ["55%", "70%"],
     });
 
@@ -91,7 +97,7 @@ export const HvDonutChart = forwardRef<ReactECharts, HvDonutChartProps>(
 
     const chartTooltip = useTooltip({
       ...tooltip,
-      measures,
+      measuresMapping,
       classes,
       nameFormatter: slicesNameFormatter,
     });

--- a/packages/viz/src/LineChart/LineChart.stories.tsx
+++ b/packages/viz/src/LineChart/LineChart.stories.tsx
@@ -129,6 +129,61 @@ export const WithArea: StoryObj<HvLineChartProps> = {
   },
 };
 
+export const AggregationFunction: StoryObj<HvLineChartProps> = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "By default all the values for a measure are aggregated using the `sum` function. However, this can be changed depending on your needs.",
+      },
+    },
+  },
+  render: () => {
+    const format: HvLineChartProps["seriesNameFormatter"] = (value) => {
+      const parts = value?.split("_");
+      if (parts && parts?.length > 1) return `${parts[0]} (minimum)`;
+      return value || "";
+    };
+
+    return (
+      <HvLineChart
+        data={{
+          Year: [
+            "2020",
+            "2021",
+            "2022",
+            "2023",
+            "2020",
+            "2021",
+            "2022",
+            "2023",
+            "2020",
+            "2021",
+            "2022",
+            "2023",
+          ],
+          "Global Sales": [
+            5929, 2393, 1590, 7817, 4749, 1702, 2381, 2909, 6732, 3098, 2119,
+            2146,
+          ],
+        }}
+        groupBy="Year"
+        measures={[
+          {
+            field: "Global Sales",
+            area: true,
+          },
+          {
+            field: "Global Sales",
+            agg: "min",
+          },
+        ]}
+        seriesNameFormatter={format}
+      />
+    );
+  },
+};
+
 export const MultipleLinesChart: StoryObj<HvLineChartProps> = {
   parameters: {
     docs: {

--- a/packages/viz/src/LineChart/LineChart.tsx
+++ b/packages/viz/src/LineChart/LineChart.tsx
@@ -90,7 +90,7 @@ export const HvLineChart = forwardRef<ReactECharts, HvLineChartProps>(
       ...others
     } = props;
 
-    const chartData = useData({
+    const { data: chartData, mapping: measuresMapping } = useData({
       data,
       groupBy,
       measures,
@@ -117,7 +117,7 @@ export const HvLineChart = forwardRef<ReactECharts, HvLineChartProps>(
       type: "line",
       data: chartData,
       groupBy,
-      measures,
+      measuresMapping,
       area,
       areaOpacity,
       emptyCellMode,
@@ -133,7 +133,7 @@ export const HvLineChart = forwardRef<ReactECharts, HvLineChartProps>(
     const chartTooltip = useTooltip({
       ...tooltip,
       trigger: "axis",
-      measures,
+      measuresMapping,
       classes,
     });
 

--- a/packages/viz/src/ScatterPlot/ScatterPlot.tsx
+++ b/packages/viz/src/ScatterPlot/ScatterPlot.tsx
@@ -80,7 +80,7 @@ export const HvScatterPlot = forwardRef<ReactECharts, HvScatterPlotProps>(
       ...others
     } = props;
 
-    const chartData = useData({
+    const { data: chartData, mapping: measuresMapping } = useData({
       data,
       groupBy,
       measures,
@@ -107,7 +107,7 @@ export const HvScatterPlot = forwardRef<ReactECharts, HvScatterPlotProps>(
       type: "scatter",
       data: chartData,
       groupBy,
-      measures,
+      measuresMapping,
       nameFormatter: seriesNameFormatter,
     });
 
@@ -119,7 +119,7 @@ export const HvScatterPlot = forwardRef<ReactECharts, HvScatterPlotProps>(
     const chartTooltip = useTooltip({
       ...tooltip,
       trigger: "axis",
-      measures,
+      measuresMapping,
       classes,
     });
 

--- a/packages/viz/src/hooks/tooltip/useTooltip.tsx
+++ b/packages/viz/src/hooks/tooltip/useTooltip.tsx
@@ -1,16 +1,9 @@
 import { useCallback, useMemo } from "react";
-import { Arrayable, ExtractNames } from "@hitachivantara/uikit-react-core";
+import { ExtractNames } from "@hitachivantara/uikit-react-core";
 
-import {
-  HvBarChartMeasures,
-  HvChartTooltip,
-  HvChartTooltipParams,
-  HvDonutChartMeasure,
-  HvLineChartMeasures,
-  HvScatterPlotMeasure,
-} from "../../types";
+import { HvChartTooltip, HvChartTooltipParams } from "../../types";
 import { HvEChartsOption } from "../../types/common";
-import { getMeasure } from "../../utils";
+import { getMeasure, SingleMeasure } from "../../utils";
 import { useClasses } from "./styles";
 
 export type HvChartTooltipClasses = ExtractNames<typeof useClasses>;
@@ -27,9 +20,7 @@ interface EChartsTooltipParams {
 }
 
 interface HvTooltipHookProps {
-  measures?:
-    | Arrayable<HvLineChartMeasures | HvBarChartMeasures | HvScatterPlotMeasure>
-    | HvDonutChartMeasure;
+  measuresMapping?: Record<string, SingleMeasure>;
   trigger?: "item" | "axis";
   classes?: HvChartTooltipClasses;
   horizontal?: boolean;
@@ -42,7 +33,7 @@ interface HvTooltipHookProps {
 }
 
 export const useTooltip = ({
-  measures = [],
+  measuresMapping = {},
   classes,
   component,
   show = true,
@@ -80,7 +71,7 @@ export const useTooltip = ({
             : horizontal
               ? params[0].dimensionNames[params[0].encode.x[0]]
               : params[0].dimensionNames[params[0].encode.y[0]],
-          measures,
+          measuresMapping,
         );
 
         const value =
@@ -125,7 +116,7 @@ export const useTooltip = ({
                     : horizontal
                       ? s.dimensionNames[s.encode.x[0]]
                       : s.dimensionNames[s.encode.y[0]],
-                  measures,
+                  measuresMapping,
                 );
 
                 const value =
@@ -136,7 +127,7 @@ export const useTooltip = ({
                       : s.value[s.encode.y[0]];
 
                 const formattedValue =
-                  typeof measure !== "string" && measure.valueFormatter
+                  typeof measure !== "string" && measure?.valueFormatter
                     ? measure.valueFormatter(value)
                     : valueFormatter
                       ? valueFormatter(value)
@@ -167,7 +158,7 @@ export const useTooltip = ({
       hvClasses,
       horizontal,
       type,
-      measures,
+      measuresMapping,
       nameFormatter,
       titleFormatter,
       valueFormatter,

--- a/packages/viz/src/hooks/useSeries.tsx
+++ b/packages/viz/src/hooks/useSeries.tsx
@@ -6,14 +6,8 @@ import {
   PieSeriesOption,
   ScatterSeriesOption,
 } from "echarts/charts";
-import { Arrayable } from "@hitachivantara/uikit-react-core";
 
-import {
-  HvBarChartMeasures,
-  HvChartEmptyCellMode,
-  HvDonutChartMeasure,
-  HvLineChartMeasures,
-} from "../types";
+import { HvChartEmptyCellMode } from "../types";
 import {
   HvAxisChartCommonProps,
   HvChartCommonProps,
@@ -21,19 +15,16 @@ import {
 } from "../types/common";
 import {
   BarFullMeasure,
-  HvScatterPlotMeasure,
   LineFullMeasure,
   ScatterPlotMeasure,
 } from "../types/measures";
-import { getGroupKey, getMeasure } from "../utils";
+import { getGroupKey, getMeasure, SingleMeasure } from "../utils";
 
 interface HvSeriesHookProps {
   type: "line" | "bar" | "pie" | "scatter" | "treemap";
   data: internal.ColumnTable;
   groupBy: HvChartCommonProps["groupBy"];
-  measures:
-    | Arrayable<HvLineChartMeasures | HvBarChartMeasures | HvScatterPlotMeasure>
-    | HvDonutChartMeasure;
+  measuresMapping: Record<string, SingleMeasure>;
   area?: boolean;
   areaOpacity?: number;
   emptyCellMode?: HvChartEmptyCellMode;
@@ -47,14 +38,14 @@ export const useSeries = ({
   groupBy,
   type,
   data,
-  measures,
+  measuresMapping,
   nameFormatter,
   stack,
+  emptyCellMode,
+  radius,
   horizontal = false,
   area = false,
   areaOpacity = 0.5,
-  emptyCellMode,
-  radius,
 }: HvSeriesHookProps) => {
   const groupByKey = getGroupKey(groupBy);
 
@@ -65,13 +56,8 @@ export const useSeries = ({
       series: data
         .columnNames()
         .filter((c) => c !== groupByKey)
-        .map<
-          | LineSeriesOption
-          | BarSeriesOption
-          | PieSeriesOption
-          | ScatterSeriesOption
-        >((c) => {
-          const measure = getMeasure(c, measures);
+        .map((c) => {
+          const measure = getMeasure(c, measuresMapping);
 
           let pieOps: PieSeriesOption = {};
           let lineOps: LineSeriesOption = {};
@@ -193,17 +179,13 @@ export const useSeries = ({
             ...barOps,
             ...lineOps,
             ...scatterOps,
-          } as
-            | LineSeriesOption
-            | BarSeriesOption
-            | PieSeriesOption
-            | ScatterSeriesOption;
+          };
         }),
     };
   }, [
     data,
     groupByKey,
-    measures,
+    measuresMapping,
     type,
     nameFormatter,
     radius,


### PR DESCRIPTION
- It's now possible to use measures with the same field but with different aggregation functions: pairs field/aggregation functions are now unique instead of only fields. 