### PR TITLE
feat: add useBaseNode hook and demo nodes

### DIFF
--- a/packages/lab/src/Flow/Node/BaseNode.tsx
+++ b/packages/lab/src/Flow/Node/BaseNode.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { Handle, NodeProps, NodeToolbar, Position } from "reactflow";
 import {
   ExtractNames,
@@ -8,9 +7,8 @@ import {
   useLabels,
 } from "@hitachivantara/uikit-react-core";
 
-import { HvUseNodeProps, useHvNode } from "../hooks";
+import { HvUseNodeParams, useHvNode } from "../hooks";
 import {
-  HvFlowNodeAction,
   HvFlowNodeInput,
   HvFlowNodeInputGroup,
   HvFlowNodeOutput,
@@ -37,12 +35,10 @@ export const DEFAULT_LABELS = {
 
 export interface HvFlowBaseNodeProps<T = any>
   extends Omit<HvBaseProps, "id" | "color">,
-    Omit<HvUseNodeProps, "id">,
+    Omit<HvUseNodeParams, "id">,
     NodeProps<T> {
   /** Header items */
   headerItems?: React.ReactNode;
-  /** Node actions */
-  nodeActions?: HvFlowNodeAction[];
   /** The content of the node footer */
   footer?: React.ReactNode;
   /** Labels used on the node. */

--- a/packages/lab/src/Flow/hooks/index.ts
+++ b/packages/lab/src/Flow/hooks/index.ts
@@ -2,3 +2,4 @@ export * from "./useFlowNode";
 export * from "./useFlowContext";
 export * from "./useFlowNodeMeta";
 export * from "./useFlowInstance";
+export * from "./useNode";

--- a/packages/lab/src/Flow/hooks/useNode.tsx
+++ b/packages/lab/src/Flow/hooks/useNode.tsx
@@ -1,4 +1,10 @@
-import { isValidElement, useCallback, useMemo, useState } from "react";
+import {
+  isValidElement,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
 import { NodeToolbarProps } from "reactflow";
 import { uid } from "uid";
 import { useLabels } from "@hitachivantara/uikit-react-core";
@@ -27,7 +33,7 @@ const DEFAULT_LABELS = {
   duplicateActionLabel: "Duplicate",
 };
 
-export interface HvUseNodeProps {
+export interface HvUseNodeParams {
   id: string;
   /** Node group ID */
   groupId?: string;
@@ -51,7 +57,7 @@ export interface HvUseNodeProps {
   nodeToolbarProps?: NodeToolbarProps;
 }
 
-export function useHvNode(props: HvUseNodeProps) {
+export function useHvNode(props: HvUseNodeParams) {
   const {
     id,
     title: titleProp,
@@ -67,13 +73,11 @@ export function useHvNode(props: HvUseNodeProps) {
   } = props;
 
   const { registerNode, unregisterNode } = useNodeMetaRegistry();
-
   const labels = useLabels(DEFAULT_LABELS, labelsProps);
-
   const inputs = useMemo(() => identifyHandles(inputsProp), [inputsProp]);
-
+  const inputEdges = useFlowNodeInputEdges();
   const outputs = useMemo(() => identifyHandles(outputsProp), [outputsProp]);
-
+  const outputEdges = useFlowNodeOutputEdges();
   const { nodeGroups } = useFlowContext();
 
   const node = useFlowNode();
@@ -105,7 +109,7 @@ export function useHvNode(props: HvUseNodeProps) {
     [nodeToolbarProps, showActions],
   );
 
-  const nodeActions = useMemo(
+  const nodeActions = useMemo<HvFlowNodeAction[]>(
     () =>
       nodeActionsProp || [
         { id: "delete", label: labels?.deleteActionLabel, icon: <Delete /> },
@@ -118,7 +122,7 @@ export function useHvNode(props: HvUseNodeProps) {
     [labels?.deleteActionLabel, labels?.duplicateActionLabel, nodeActionsProp],
   );
 
-  useMemo(() => {
+  useEffect(() => {
     registerNode(id, {
       label: title || "",
       inputs,
@@ -126,9 +130,6 @@ export function useHvNode(props: HvUseNodeProps) {
     });
     return () => unregisterNode(id);
   }, [id, title, inputs, outputs, registerNode, unregisterNode]);
-
-  const inputEdges = useFlowNodeInputEdges();
-  const outputEdges = useFlowNodeOutputEdges();
 
   const handleDefaultAction = useCallback(
     (action: HvFlowNodeAction) => {
@@ -165,25 +166,45 @@ export function useHvNode(props: HvUseNodeProps) {
     [node, reactFlowInstance],
   );
 
-  return {
-    // state
-    id,
-    title,
-    icon,
-    color,
-    iconColor,
-    subtitle,
-    inputs,
-    inputEdges,
-    outputs,
-    outputEdges,
-    node,
-    nodeActions,
-    showActions,
-    // prop getters
-    getNodeToolbarProps,
-    // actions
-    toggleShowActions,
-    handleDefaultAction,
-  };
+  return useMemo(
+    () => ({
+      // state
+      id,
+      title,
+      icon,
+      color,
+      iconColor,
+      subtitle,
+      inputs,
+      inputEdges,
+      outputs,
+      outputEdges,
+      node,
+      nodeActions,
+      showActions,
+      // prop getters
+      getNodeToolbarProps,
+      // actions
+      toggleShowActions,
+      handleDefaultAction,
+    }),
+    [
+      id,
+      title,
+      icon,
+      color,
+      iconColor,
+      subtitle,
+      inputs,
+      inputEdges,
+      outputs,
+      outputEdges,
+      node,
+      nodeActions,
+      showActions,
+      getNodeToolbarProps,
+      toggleShowActions,
+      handleDefaultAction,
+    ],
+  );
 }

--- a/packages/lab/src/Flow/hooks/useNode.tsx
+++ b/packages/lab/src/Flow/hooks/useNode.tsx
@@ -1,0 +1,189 @@
+import { isValidElement, useCallback, useMemo, useState } from "react";
+import { NodeToolbarProps } from "reactflow";
+import { uid } from "uid";
+import { useLabels } from "@hitachivantara/uikit-react-core";
+import { Delete, Duplicate } from "@hitachivantara/uikit-react-icons";
+import { getColor, HvColorAny, theme } from "@hitachivantara/uikit-styles";
+
+import { useNodeMetaRegistry } from "../FlowContext/NodeMetaContext";
+import { identifyHandles } from "../Node/utils";
+import {
+  HvFlowNodeAction,
+  HvFlowNodeInput,
+  HvFlowNodeInputGroup,
+  HvFlowNodeOutput,
+  HvFlowNodeOutputGroup,
+} from "../types";
+import { useFlowContext } from "./useFlowContext";
+import { useFlowInstance } from "./useFlowInstance";
+import {
+  useFlowNode,
+  useFlowNodeInputEdges,
+  useFlowNodeOutputEdges,
+} from "./useFlowNode";
+
+const DEFAULT_LABELS = {
+  deleteActionLabel: "Delete",
+  duplicateActionLabel: "Duplicate",
+};
+
+export interface HvUseNodeProps {
+  id: string;
+  /** Node group ID */
+  groupId?: string;
+
+  title?: string;
+
+  subtitle?: string;
+
+  icon?: React.ReactNode;
+
+  color?: HvColorAny;
+  /** Node inputs */
+  inputs?: (HvFlowNodeInput | HvFlowNodeInputGroup)[];
+  /** Node outputs */
+  outputs?: (HvFlowNodeOutput | HvFlowNodeOutputGroup)[];
+  /** Node actions */
+  nodeActions?: HvFlowNodeAction[];
+  /** Labels used on the default actions. */
+  labels?: Partial<typeof DEFAULT_LABELS>;
+  /** Props for the NodeToolbar Component */
+  nodeToolbarProps?: NodeToolbarProps;
+}
+
+export function useHvNode(props: HvUseNodeProps) {
+  const {
+    id,
+    title: titleProp,
+    icon: iconProp,
+    color: colorProp,
+    subtitle: subtitleProp,
+    nodeActions: nodeActionsProp,
+    inputs: inputsProp,
+    outputs: outputsProp,
+    groupId,
+    labels: labelsProps,
+    nodeToolbarProps,
+  } = props;
+
+  const { registerNode, unregisterNode } = useNodeMetaRegistry();
+
+  const labels = useLabels(DEFAULT_LABELS, labelsProps);
+
+  const inputs = useMemo(() => identifyHandles(inputsProp), [inputsProp]);
+
+  const outputs = useMemo(() => identifyHandles(outputsProp), [outputsProp]);
+
+  const { nodeGroups } = useFlowContext();
+
+  const node = useFlowNode();
+
+  const reactFlowInstance = useFlowInstance();
+
+  const nodeGroup = (groupId && nodeGroups && nodeGroups[groupId]) || undefined;
+
+  const title = titleProp || nodeGroup?.label;
+  const icon = iconProp || nodeGroup?.icon;
+  const color = getColor(colorProp || nodeGroup?.color);
+  const iconColor = isValidElement(icon)
+    ? getColor(icon.props.color || "base_dark")
+    : getColor("base_dark");
+  const subtitle = subtitleProp || node?.data.nodeLabel;
+
+  const [showActions, setShowActions] = useState(false);
+
+  const toggleShowActions = useCallback(() => {
+    setShowActions(!showActions);
+  }, [showActions]);
+
+  const getNodeToolbarProps = useCallback(
+    () => ({
+      offset: 0,
+      isVisible: showActions,
+      ...nodeToolbarProps,
+    }),
+    [nodeToolbarProps, showActions],
+  );
+
+  const nodeActions = useMemo(
+    () =>
+      nodeActionsProp || [
+        { id: "delete", label: labels?.deleteActionLabel, icon: <Delete /> },
+        {
+          id: "duplicate",
+          label: labels?.duplicateActionLabel,
+          icon: <Duplicate />,
+        },
+      ],
+    [labels?.deleteActionLabel, labels?.duplicateActionLabel, nodeActionsProp],
+  );
+
+  useMemo(() => {
+    registerNode(id, {
+      label: title || "",
+      inputs,
+      outputs,
+    });
+    return () => unregisterNode(id);
+  }, [id, title, inputs, outputs, registerNode, unregisterNode]);
+
+  const inputEdges = useFlowNodeInputEdges();
+  const outputEdges = useFlowNodeOutputEdges();
+
+  const handleDefaultAction = useCallback(
+    (action: HvFlowNodeAction) => {
+      if (!node) return;
+
+      if (action.callback) {
+        action.callback(node);
+        return;
+      }
+
+      // built-in actions
+      switch (action.id) {
+        case "delete":
+          reactFlowInstance.deleteElements({ nodes: [node] });
+          break;
+        case "duplicate":
+          reactFlowInstance.addNodes([
+            {
+              ...node,
+              id: uid(),
+              position: {
+                x: node.position.x,
+                y: node.position.y + (node.height || 0) + 20,
+              },
+              selected: false,
+              zIndex: Number(theme.zIndices.overlay),
+            },
+          ]);
+          break;
+        default:
+          break;
+      }
+    },
+    [node, reactFlowInstance],
+  );
+
+  return {
+    // state
+    id,
+    title,
+    icon,
+    color,
+    iconColor,
+    subtitle,
+    inputs,
+    inputEdges,
+    outputs,
+    outputEdges,
+    node,
+    nodeActions,
+    showActions,
+    // prop getters
+    getNodeToolbarProps,
+    // actions
+    toggleShowActions,
+    handleDefaultAction,
+  };
+}

--- a/packages/lab/src/Flow/stories/BaseHook/IconEdge.tsx
+++ b/packages/lab/src/Flow/stories/BaseHook/IconEdge.tsx
@@ -1,0 +1,39 @@
+import {
+  BaseEdge,
+  EdgeLabelRenderer,
+  EdgeProps,
+  getBezierPath,
+} from "reactflow";
+import { Level0Good } from "@hitachivantara/uikit-react-icons";
+
+export const CustomEdge = (props: EdgeProps) => {
+  const { sourceX, sourceY, sourcePosition, targetX, targetY, targetPosition } =
+    props;
+
+  const [edgePath, labelX, labelY] = getBezierPath({
+    sourceX,
+    sourceY,
+    sourcePosition,
+    targetX,
+    targetY,
+    targetPosition,
+  });
+
+  return (
+    <>
+      <BaseEdge {...props} path={edgePath} />
+      <EdgeLabelRenderer>
+        <div
+          style={{
+            position: "absolute",
+            transform: `translate(-50%, -50%) translate(${labelX}px,${labelY}px)`,
+            fontSize: 12,
+            pointerEvents: "all",
+          }}
+        >
+          <Level0Good color="positive" />
+        </div>
+      </EdgeLabelRenderer>
+    </>
+  );
+};

--- a/packages/lab/src/Flow/stories/BaseHook/Node.tsx
+++ b/packages/lab/src/Flow/stories/BaseHook/Node.tsx
@@ -1,0 +1,148 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import { css, cx } from "@emotion/css";
+import { Handle, NodeToolbar, Position } from "reactflow";
+import { HvIconButton, HvTypography } from "@hitachivantara/uikit-react-core";
+import { Level0Good, Level2Average } from "@hitachivantara/uikit-react-icons";
+import { HvFlowNodeFC, HvFlowNodeProps } from "@hitachivantara/uikit-react-lab";
+import { theme } from "@hitachivantara/uikit-styles";
+
+import { useHvNode } from "../../hooks/useNode";
+import { isConnected, renderedIcon } from "../../Node/utils";
+
+const classes = {
+  root: css({
+    borderRadius: "25px",
+    backgroundColor: theme.colors.atmo1,
+    boxShadow: theme.colors.shadow,
+    borderWidth: "1px",
+    minWidth: "200px",
+    minHeight: "100px",
+  }),
+  content: css({
+    display: "flex",
+    flexDirection: "row",
+    alignItems: "center",
+    minHeight: "100px",
+    padding: theme.spacing("sm"),
+  }),
+  title: css({
+    color: theme.colors.base_dark,
+  }),
+  cornerIcon: css({
+    position: "absolute",
+    top: `calc(-30px + ${theme.space.sm})`,
+    right: `calc(-22px + ${theme.space.sm})`,
+  }),
+  contentIcon: css({
+    width: 48,
+    height: 48,
+    display: "flex",
+    justifyContent: "center",
+    alignItems: "center",
+    borderRadius: theme.radii.round,
+    marginRight: theme.space.xs,
+  }),
+  nodeToolbar: css({
+    backgroundColor: theme.colors.atmo1,
+    borderRadius: theme.radii.full,
+  }),
+  handle: css({
+    backgroundColor: theme.colors.secondary_80,
+    height: 10,
+    width: 10,
+  }),
+};
+
+export const Node: HvFlowNodeFC<any> = ({
+  id,
+  title: titleProp,
+  subtitle: subtitleProp,
+  groupId = "teapot",
+  color: colorProp,
+  icon: iconProp,
+  inputs: inputsProp,
+  outputs: outputsProp,
+}: HvFlowNodeProps<unknown>) => {
+  const {
+    toggleShowActions,
+    getNodeToolbarProps,
+    handleDefaultAction,
+    nodeActions,
+    title,
+    icon,
+    color,
+    subtitle,
+    showActions,
+    outputEdges,
+    inputs,
+    outputs,
+  } = useHvNode({
+    id,
+    title: titleProp,
+    subtitle: subtitleProp,
+    color: colorProp,
+    inputs: inputsProp,
+    outputs: outputsProp,
+    icon: iconProp,
+    groupId,
+  });
+  return (
+    <div
+      className={cx(
+        "nowheel",
+        classes.root,
+        css({ borderColor: showActions ? theme.colors.neutral : color }),
+      )}
+      onMouseEnter={toggleShowActions}
+      onMouseLeave={toggleShowActions}
+    >
+      <NodeToolbar className={classes.nodeToolbar} {...getNodeToolbarProps()}>
+        {nodeActions?.map((action) => (
+          <HvIconButton
+            key={action.id}
+            title={action.label}
+            onClick={() => handleDefaultAction(action)}
+          >
+            {renderedIcon(action.icon)}
+          </HvIconButton>
+        ))}
+      </NodeToolbar>
+      <div className={classes.cornerIcon}>
+        {isConnected(id, "source", "0", outputEdges) ? (
+          <Level0Good color="positive" />
+        ) : (
+          <Level2Average color="warning" />
+        )}
+      </div>
+      {inputs && inputs?.length > 0 && (
+        <Handle
+          className={classes.handle}
+          type="target"
+          position={Position.Left}
+          id="0"
+        />
+      )}
+      {outputs && outputs?.length > 0 && (
+        <Handle
+          className={classes.handle}
+          type="source"
+          position={Position.Right}
+          id="0"
+        />
+      )}
+      <div className={classes.content}>
+        <div
+          className={cx(classes.contentIcon, css({ backgroundColor: color }))}
+        >
+          {icon}
+        </div>
+        <div>
+          <HvTypography variant="title4" component="h2">
+            {title}
+          </HvTypography>
+          <HvTypography variant="caption1">{subtitle}</HvTypography>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/packages/lab/src/Flow/stories/BaseHook/index.tsx
+++ b/packages/lab/src/Flow/stories/BaseHook/index.tsx
@@ -1,0 +1,218 @@
+import { useState } from "react";
+import { restrictToWindowEdges } from "@dnd-kit/modifiers";
+import { css } from "@emotion/css";
+import {
+  HvButton,
+  HvGlobalActions,
+  HvIconButton,
+  HvTypography,
+  theme,
+  useTheme,
+} from "@hitachivantara/uikit-react-core";
+import {
+  Add,
+  Backwards,
+  Fail,
+  Leaf,
+  Teapot,
+  Water,
+} from "@hitachivantara/uikit-react-icons";
+import {
+  HvFlow,
+  HvFlowControls,
+  HvFlowEmpty,
+  HvFlowProps,
+  HvFlowSidebar,
+} from "@hitachivantara/uikit-react-lab";
+
+import { restrictToSample } from "../Base";
+import { LayoutsProvider } from "../Base/LayoutsContext";
+// The code for these utils are available here: https://github.com/lumada-design/hv-uikit-react/tree/master/packages/lab/src/components/Flow/stories/BaseHook
+import { CustomEdge } from "./IconEdge";
+import { Node } from "./Node";
+
+// Initial state
+const initialState = {
+  nodes: [
+    {
+      width: 250,
+      height: 365,
+      id: "1caf2381eaf",
+      position: { x: 194, y: -160 },
+      data: { nodeLabel: "Custom Label" },
+      type: "leaves",
+    },
+    {
+      width: 250,
+      height: 274,
+      id: "caf2381eaf3",
+      position: { x: 637, y: -367 },
+      data: { nodeLabel: "Custom Label" },
+      type: "teapot",
+    },
+  ],
+  edges: [
+    {
+      source: "1caf2381eaf",
+      sourceHandle: "0",
+      target: "caf2381eaf3",
+      targetHandle: "0",
+      id: "reactflow__edge-1caf2381eaf0-caf2381eaf30",
+      type: "iconEdge",
+    },
+  ],
+  viewport: { x: 150, y: 300, zoom: 0.6 },
+};
+
+const LeavesNode = (props) => (
+  <Node
+    groupId="leaves"
+    {...props}
+    outputs={[{ label: "outputs", provides: "leaves" }]}
+    inputs={[]}
+  />
+);
+
+const WaterNode = (props) => (
+  <Node
+    groupId="water"
+    {...props}
+    outputs={[{ label: "outputs", provides: "water" }]}
+    inputs={[]}
+  />
+);
+
+const TeapotNode = (props) => (
+  <Node
+    groupId="teapot"
+    {...props}
+    inputs={[{ label: "inputs", accepts: ["leaves", "water"] }]}
+    outputs={[{ label: "outputs", provides: "tea" }]}
+  />
+);
+
+const nodeGroups = {
+  leaves: {
+    label: "Tea Leaves",
+    color: "cat3",
+    icon: <Leaf />,
+    items: [{ nodeType: "leaves", label: "Green Tea" }],
+  },
+  teapot: {
+    label: "Teapot",
+    color: "cat2_40",
+    icon: <Teapot />,
+    items: [{ nodeType: "teapot", label: "Teapot" }],
+  },
+  water: {
+    label: "Water",
+    color: "cat1",
+    icon: <Water />,
+    items: [{ nodeType: "water", label: "Water" }],
+  },
+} satisfies HvFlowProps["nodeGroups"];
+
+export type NodeGroup = keyof typeof nodeGroups;
+
+export const nodeTypes: HvFlowProps["nodeTypes"] = {
+  leaves: LeavesNode,
+  teapot: TeapotNode,
+  water: WaterNode,
+} satisfies HvFlowProps["nodeTypes"];
+
+// Classes
+export const classes = {
+  root: css({ height: "100vh" }),
+  globalActions: css({ paddingBottom: theme.space.md }),
+  flow: css({
+    height: "calc(100% - 90px)",
+  }),
+};
+
+export const Flow = () => {
+  const { rootId } = useTheme();
+
+  const [open, setOpen] = useState(false);
+
+  const CustomAction = (
+    <div className={css({ display: "flex", flexDirection: "row" })}>
+      <HvTypography
+        link
+        component="a"
+        href="#"
+        onClick={(e) => {
+          e.preventDefault();
+          setOpen(true);
+        }}
+      >
+        Add nodes
+      </HvTypography>
+      <HvTypography>&nbsp;to start building your flow.</HvTypography>
+    </div>
+  );
+
+  return (
+    <div className={classes.root}>
+      <HvGlobalActions
+        className={classes.globalActions}
+        position="relative"
+        backButton={
+          <HvIconButton title="Back">
+            <Backwards />
+          </HvIconButton>
+        }
+        title="New Flow"
+      >
+        <HvButton
+          variant="primary"
+          startIcon={<Add />}
+          onClick={() => setOpen(true)}
+        >
+          Add Node
+        </HvButton>
+      </HvGlobalActions>
+      <div className={classes.flow}>
+        <HvFlow
+          nodes={initialState.nodes}
+          edges={initialState.edges}
+          edgeTypes={{ iconEdge: CustomEdge }}
+          nodeTypes={nodeTypes}
+          nodeGroups={nodeGroups}
+          defaultViewport={initialState.viewport}
+          sidebar={
+            <HvFlowSidebar
+              title="Add Node"
+              description="Please choose within the options below"
+              open={open}
+              onClose={() => setOpen(false)}
+              // Needed to fix storybook
+              dragOverlayProps={{
+                modifiers: [
+                  restrictToWindowEdges,
+                  (args) => restrictToSample(rootId || "", args),
+                ],
+              }}
+            />
+          }
+          // Keeping track of flow updates
+          onFlowChange={(nds, eds) =>
+            console.log("Flow updated: ", { nodes: nds, edges: eds })
+          }
+        >
+          <HvFlowControls />
+          <HvFlowEmpty
+            title="Empty Flow"
+            action={CustomAction}
+            icon={<Fail />}
+          />
+        </HvFlow>
+      </div>
+    </div>
+  );
+};
+
+export const BaseHook = () => (
+  <LayoutsProvider>
+    <Flow />
+  </LayoutsProvider>
+);

--- a/packages/lab/src/Flow/stories/Flow.stories.tsx
+++ b/packages/lab/src/Flow/stories/Flow.stories.tsx
@@ -9,6 +9,8 @@ import {
   HvFlowSidebar,
 } from "@hitachivantara/uikit-react-lab";
 
+import { BaseHook as BaseHookStory } from "./BaseHook";
+import BaseHookRaw from "./BaseHook?raw";
 import { CustomDrop as CustomDropStory } from "./CustomDrop";
 import CustomDropRaw from "./CustomDrop?raw";
 import { Dynamic as DynamicStory } from "./Dynamic";
@@ -174,4 +176,21 @@ export const InvalidFlow: StoryObj<HvFlowProps> = {
     },
   },
   render: () => <InvalidStory />,
+};
+
+export const BaseHook: StoryObj<HvFlowProps> = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "This sample demonstrate the use of the `useHvNode` hook to create a node with a custom look and feel",
+      },
+      source: {
+        code: BaseHookRaw,
+      },
+    },
+    // Enables Chromatic snapshot
+    chromatic: { disableSnapshot: false },
+  },
+  render: () => <BaseHookStory />,
 };


### PR DESCRIPTION
A useBaseNode hook (in lack of a better name) was created with the logic parts of `BaseNode` and `Node` leaving the visual implementation to the components that use it. 
To exemplify this some nodes were added and are present in the `Base Hook` story in the documentation:

A simpler `WebttleNode` that uses the `useBaseNode` hook and has a different visual (similar to the webttle use case).

A `DANode` that uses the `useBaseNode` hook instead of the `BaseNode` and `Node` components but keeps the same api.

A `AssetDA` and `MLModelDA` that use the `DANode` component to implement the `Asset` and `MLModel` nodes.

A `AssetWorkbench`  a node that uses the `useBaseNode` to implement a `Asset` node.

`AssetDA` and `AssetWorkbench` were created to compare the different approaches of using the hook. With `AssetDA` we still have a big and cumbersome api and end up with two different complex components `AssetDA` and `DANode` but they cover most use cases of that project. Meanwhile `AssetWorkbench` directly uses the hook is much more "readable" and easy to maintain.
