### PR TITLE
fix: multi button and button Pentaho theme styles

### DIFF
--- a/packages/styles/src/themes/pentahoPlus.ts
+++ b/packages/styles/src/themes/pentahoPlus.ts
@@ -370,10 +370,6 @@ const pentahoPlus = makeTheme((theme) => ({
           },
         },
         disabled: {
-          backgroundColor: "#E2E8F0",
-          "&:hover": {
-            backgroundColor: "#E2E8F0",
-          },
           "&:active": {
             boxShadow: "none",
           },
@@ -392,10 +388,10 @@ const pentahoPlus = makeTheme((theme) => ({
           backgroundColor: theme.colors.atmo1,
           boxShadow: theme.colors.shadow,
           "&.HvButton-disabled": {
-            backgroundColor: "#E2E8F0",
+            backgroundColor: theme.colors.atmo3,
             boxShadow: "none",
             "&:hover": {
-              backgroundColor: "#E2E8F0",
+              backgroundColor: theme.colors.atmo3,
             },
             "&:active": {
               boxShadow: "none",

--- a/packages/styles/src/themes/pentahoPlus.ts
+++ b/packages/styles/src/themes/pentahoPlus.ts
@@ -458,6 +458,10 @@ const pentahoPlus = makeTheme((theme) => ({
             },
           },
         },
+        splitGroup: {
+          background: "transparent",
+        },
+        splitGroupDisabled: { background: "transparent" },
       },
     },
   } satisfies Record<string, Record<string, any> | { classes?: CSSProperties }>,

--- a/packages/styles/src/themes/pentahoPlus.ts
+++ b/packages/styles/src/themes/pentahoPlus.ts
@@ -406,7 +406,7 @@ const pentahoPlus = makeTheme((theme) => ({
           borderRadius: 20,
           "& button.HvMultiButton-button": {
             border: "none",
-            background: "transparent",
+            backgroundColor: "transparent",
             "&.HvMultiButton-firstButton": {
               borderRadius: "20px 0 0 20px",
             },
@@ -417,14 +417,14 @@ const pentahoPlus = makeTheme((theme) => ({
               borderRadius: 20,
               border: "none",
               color: theme.colors.primary,
-              background: theme.colors.atmo1,
+              backgroundColor: theme.colors.atmo1,
               "&:hover": {
                 "&:not(:disabled)": {
                   border: "none",
                 },
                 "&:disabled": {
                   border: "none",
-                  background: theme.colors.atmo1,
+                  backgroundColor: theme.colors.atmo1,
                 },
               },
               "&:disabled": {
@@ -444,7 +444,7 @@ const pentahoPlus = makeTheme((theme) => ({
           borderRadius: 20,
           "& button.HvMultiButton-button": {
             border: "none",
-            background: "transparent",
+            backgroundColor: "transparent",
             "&.HvMultiButton-firstButton": {
               borderRadius: "20px 0 0 20px",
             },
@@ -455,7 +455,7 @@ const pentahoPlus = makeTheme((theme) => ({
               borderRadius: 20,
               border: "none",
               color: theme.colors.primary,
-              background: theme.colors.atmo1,
+              backgroundColor: theme.colors.atmo1,
             },
             "&:disabled": {
               border: "none",
@@ -463,9 +463,9 @@ const pentahoPlus = makeTheme((theme) => ({
           },
         },
         splitGroup: {
-          background: "transparent",
+          backgroundColor: "transparent",
         },
-        splitGroupDisabled: { background: "transparent" },
+        splitGroupDisabled: { backgroundColor: "transparent" },
       },
     },
   } satisfies Record<string, Record<string, any> | { classes?: CSSProperties }>,

--- a/packages/styles/src/themes/pentahoPlus.ts
+++ b/packages/styles/src/themes/pentahoPlus.ts
@@ -403,12 +403,10 @@ const pentahoPlus = makeTheme((theme) => ({
     HvMultiButton: {
       classes: {
         multiple: {
-          backgroundColor: "#EEEEEE",
-          color: "#999999",
           borderRadius: 20,
           "& button.HvMultiButton-button": {
             border: "none",
-            backgroundColor: "transparent",
+            background: "transparent",
             "&.HvMultiButton-firstButton": {
               borderRadius: "20px 0 0 20px",
             },
@@ -419,7 +417,19 @@ const pentahoPlus = makeTheme((theme) => ({
               borderRadius: 20,
               border: "none",
               color: theme.colors.primary,
-              backgroundColor: theme.colors.atmo1,
+              background: theme.colors.atmo1,
+              "&:hover": {
+                "&:not(:disabled)": {
+                  border: "none",
+                },
+                "&:disabled": {
+                  border: "none",
+                  background: theme.colors.atmo1,
+                },
+              },
+              "&:disabled": {
+                border: "none",
+              },
             },
             "&:disabled": {
               border: "none",
@@ -431,12 +441,10 @@ const pentahoPlus = makeTheme((theme) => ({
           },
         },
         vertical: {
-          backgroundColor: "#EEEEEE",
-          color: "#999999",
           borderRadius: 20,
           "& button.HvMultiButton-button": {
             border: "none",
-            backgroundColor: "transparent",
+            background: "transparent",
             "&.HvMultiButton-firstButton": {
               borderRadius: "20px 0 0 20px",
             },
@@ -447,7 +455,7 @@ const pentahoPlus = makeTheme((theme) => ({
               borderRadius: 20,
               border: "none",
               color: theme.colors.primary,
-              backgroundColor: theme.colors.atmo1,
+              background: theme.colors.atmo1,
             },
             "&:disabled": {
               border: "none",


### PR DESCRIPTION
- Multi button styles fixed:
   - Split button
   - Hover
   - Dark mode

https://github.com/lumada-design/hv-uikit-react/assets/43220251/d56fc1b6-3850-457c-ad8f-5a16b38f1c06


- Button styles fixed:
   - Disabled in dark mode

![Screenshot 2024-06-20 at 17 49 53](https://github.com/lumada-design/hv-uikit-react/assets/43220251/ee5245be-2065-4806-862c-6714f5231f84)

