### PR TITLE
fix: dropdown menu, split/multi button, and select for Pentaho theme

### DIFF
--- a/packages/core/src/BaseDropdown/BaseDropdownContext/BaseDropdownContext.tsx
+++ b/packages/core/src/BaseDropdown/BaseDropdownContext/BaseDropdownContext.tsx
@@ -1,10 +1,24 @@
-import React from "react";
+import { createContext, Dispatch, SetStateAction, useContext } from "react";
+import { usePopper } from "react-popper";
 
-const BaseDropdownContext = React.createContext<{
+interface BaseDropdownValue {
   width?: number;
   height?: number;
-}>({});
+  popperPlacement?: string;
+  popper?: ReturnType<typeof usePopper>;
+  referenceElement: HTMLElement | null;
+  setReferenceElement?: Dispatch<SetStateAction<HTMLElement | null>>;
+  popperElement: HTMLElement | null;
+  setPopperElement?: Dispatch<SetStateAction<HTMLElement | null>>;
+}
+
+const BaseDropdownContext = createContext<BaseDropdownValue>({
+  referenceElement: null,
+  popperElement: null,
+});
 
 BaseDropdownContext.displayName = "BaseDropdownContext";
+
+export const useBaseDropdownContext = () => useContext(BaseDropdownContext);
 
 export default BaseDropdownContext;

--- a/packages/core/src/Button/Button.styles.ts
+++ b/packages/core/src/Button/Button.styles.ts
@@ -25,7 +25,7 @@ export const { staticClasses, useClasses } = createClasses("HvButton", {
     // Default button - no size specified
     fontFamily: theme.fontFamily.body,
     ...theme.typography.label,
-    height: "32px",
+    height: "var(--HvButton-height)",
     border: "1px solid currentcolor",
     borderRadius: theme.radii.base,
     padding: theme.spacing(0, "sm"),

--- a/packages/core/src/Button/Button.tsx
+++ b/packages/core/src/Button/Button.tsx
@@ -109,6 +109,7 @@ export const HvButton = fixedForwardRef(function HvButton<
     onClick: onClickProp,
     onMouseDown: onMouseDownProp,
     selected,
+    style,
     ...others
   } = useDefaultProps("HvButton", props);
   const { classes, css, cx } = useClasses(classesProp);
@@ -139,22 +140,31 @@ export const HvButton = fixedForwardRef(function HvButton<
     return result.map((x) => x.toLowerCase());
   }, [variant]);
 
+  const sizeStyles = useMemo(
+    () =>
+      size ? (icon ? getIconSizeStyles(size) : getSizeStyles(size)) : undefined,
+    [size, icon],
+  );
+
   return (
     <Component
       ref={ref}
+      style={{
+        ...style,
+        "--HvButton-height": sizeStyles ? sizeStyles.height : "32px",
+      }}
       className={cx(
         classes.root,
         type && classes[type],
         color && css(getColoringStyle(color, type)),
         classes[variant], // Placed after type and color CSS for DS3 override
-        size && !icon && css(getSizeStyles(size)),
         radius && css(getRadiusStyles(radius)),
         overrideIconColors && css(getOverrideColors()),
         {
           [classes.icon]: icon,
           [classes.disabled]: disabled,
         },
-        size && icon && css(getIconSizeStyles(size)),
+        sizeStyles && css(sizeStyles),
         className,
       )}
       onClick={handleClick}

--- a/packages/core/src/Calendar/SingleCalendar/SingleCalendar.styles.tsx
+++ b/packages/core/src/Calendar/SingleCalendar/SingleCalendar.styles.tsx
@@ -4,7 +4,6 @@ import { createClasses } from "../../utils/classes";
 
 export const { staticClasses, useClasses } = createClasses("HvSingleCalendar", {
   calendarContainer: {
-    backgroundColor: theme.colors.atmo1,
     width: "318px",
     minHeight: "440px",
     position: "relative",

--- a/packages/core/src/ColorPicker/ColorPicker.styles.tsx
+++ b/packages/core/src/ColorPicker/ColorPicker.styles.tsx
@@ -27,6 +27,7 @@ export const { staticClasses, useClasses } = createClasses("HvColorPicker", {
     display: "flex",
     justifyContent: "center",
     padding: "16px",
+    backgroundColor: "transparent",
   },
   colorPicker: {
     width: "232px",

--- a/packages/core/src/DropDownMenu/DropDownMenu.styles.tsx
+++ b/packages/core/src/DropDownMenu/DropDownMenu.styles.tsx
@@ -13,6 +13,8 @@ export const { staticClasses, useClasses } = createClasses("HvDropDownMenu", {
   iconSelected: {
     boxShadow: theme.colors.shadow,
   },
-  menuListRoot: {},
+  menuListRoot: {
+    backgroundColor: "transparent",
+  },
   menuList: {},
 });

--- a/packages/core/src/DropDownMenu/DropDownMenu.tsx
+++ b/packages/core/src/DropDownMenu/DropDownMenu.tsx
@@ -1,9 +1,11 @@
-import { ChangeEvent, useMemo } from "react";
+import { ChangeEvent, forwardRef, useMemo } from "react";
+import { Placement } from "@popperjs/core";
 import { MoreOptionsVertical } from "@hitachivantara/uikit-react-icons";
 
 import { HvBaseDropdown, HvBaseDropdownProps } from "../BaseDropdown";
+import { useBaseDropdownContext } from "../BaseDropdown/BaseDropdownContext/BaseDropdownContext";
 import { HvButtonSize, HvButtonVariant } from "../Button";
-import { HvDropdownButton } from "../DropdownButton";
+import { HvDropdownButton, HvDropdownButtonProps } from "../DropdownButton";
 import { useControlled } from "../hooks/useControlled";
 import { useDefaultProps } from "../hooks/useDefaultProps";
 import { useUniqueId } from "../hooks/useUniqueId";
@@ -65,6 +67,29 @@ export interface HvDropDownMenuProps
   /** A Jss Object used to override or extend the styles applied to the component. */
   classes?: HvDropDownMenuClasses;
 }
+
+const HeaderComponent = forwardRef<HTMLButtonElement, HvDropdownButtonProps>(
+  (props, ref) => {
+    const { open, children, ...others } = props;
+
+    const { popperPlacement } = useBaseDropdownContext();
+
+    return (
+      <HvDropdownButton
+        icon
+        ref={ref}
+        open={open}
+        aria-expanded={open}
+        aria-label="Dropdown menu" // TODO - translate
+        aria-haspopup="menu"
+        placement={popperPlacement as Placement}
+        {...others}
+      >
+        {children}
+      </HvDropdownButton>
+    );
+  },
+);
 
 /**
  * A dropdown menu is a graphical control element, similar to a list box, that allows the user to choose a value from a list.
@@ -131,7 +156,7 @@ export const HvDropDownMenu = (props: HvDropDownMenuProps) => {
       }}
       expanded={open && !disabled}
       component={
-        <HvDropdownButton
+        <HeaderComponent
           id={setId(id, "icon-button")}
           disabled={disabled}
           className={cx(classes.icon, {
@@ -140,13 +165,9 @@ export const HvDropDownMenu = (props: HvDropDownMenuProps) => {
           size={size}
           variant={variant ?? category}
           open={open}
-          aria-expanded={open}
-          aria-label="Dropdown menu" // TODO - translate
-          aria-haspopup="menu"
-          icon
         >
           {icon || <MoreOptionsVertical role="presentation" />}
-        </HvDropdownButton>
+        </HeaderComponent>
       }
       placement={placement}
       variableWidth

--- a/packages/core/src/Dropdown/List/List.tsx
+++ b/packages/core/src/Dropdown/List/List.tsx
@@ -1,8 +1,8 @@
-import { useContext, useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { theme } from "@hitachivantara/uikit-styles";
 
 import { HvActionBar } from "../../ActionBar";
-import BaseDropdownContext from "../../BaseDropdown/BaseDropdownContext";
+import { useBaseDropdownContext } from "../../BaseDropdown/BaseDropdownContext/BaseDropdownContext";
 import { HvButton } from "../../Button";
 import { HvCheckBox } from "../../CheckBox";
 import { useDefaultProps } from "../../hooks/useDefaultProps";
@@ -135,7 +135,7 @@ export const HvDropdownList = (props: HvDropdownListProps) => {
   const [list, setList] = useState<HvListValue[]>(clone(values));
   const [allSelected, setAllSelected] = useState<boolean>(false);
   const [anySelected, setAnySelected] = useState<boolean>(false);
-  const { width, height } = useContext(BaseDropdownContext);
+  const { width, height } = useBaseDropdownContext();
 
   const hasChanges = useMemo(() => {
     return String(getSelectedIds(values)) !== String(getSelectedIds(list));

--- a/packages/core/src/MultiButton/MultiButton.styles.tsx
+++ b/packages/core/src/MultiButton/MultiButton.styles.tsx
@@ -144,9 +144,6 @@ export const { staticClasses, useClasses } = createClasses("HvMultiButton", {
   vertical: {
     flexDirection: "column",
     height: "auto",
-    btnSecondary: {
-      flex: "1 1 20px",
-    },
     "& button$button": {
       minWidth: 32,
       width: "100%",

--- a/packages/core/src/TimePicker/TimePicker.styles.ts
+++ b/packages/core/src/TimePicker/TimePicker.styles.ts
@@ -38,7 +38,6 @@ export const { useClasses, staticClasses } = createClasses("HvTimePicker", {
   icon: {},
 
   timePopperContainer: {
-    backgroundColor: theme.colors.atmo1,
     zIndex: 10,
     display: "flex",
     flexDirection: "row",

--- a/packages/styles/src/themes/pentahoPlus.ts
+++ b/packages/styles/src/themes/pentahoPlus.ts
@@ -384,7 +384,7 @@ const pentahoPlus = makeTheme((theme) => ({
           },
         },
         subtle: {
-          border: "none",
+          borderColor: "transparent",
           backgroundColor: theme.colors.atmo1,
           boxShadow: theme.colors.shadow,
           "&.HvButton-disabled": {
@@ -466,6 +466,18 @@ const pentahoPlus = makeTheme((theme) => ({
           backgroundColor: "transparent",
         },
         splitGroupDisabled: { backgroundColor: "transparent" },
+      },
+    },
+    HvDropdownButton: {
+      classes: {
+        openUp: {
+          borderRadius:
+            "0px 0px calc(var(--HvButton-height) / 2) calc(var(--HvButton-height) / 2)",
+        },
+        openDown: {
+          borderRadius:
+            "calc(var(--HvButton-height) / 2) calc(var(--HvButton-height) / 2) 0px 0px",
+        },
       },
     },
   } satisfies Record<string, Record<string, any> | { classes?: CSSProperties }>,

--- a/packages/styles/src/themes/pentahoPlus.ts
+++ b/packages/styles/src/themes/pentahoPlus.ts
@@ -464,8 +464,35 @@ const pentahoPlus = makeTheme((theme) => ({
         },
         splitGroup: {
           backgroundColor: "transparent",
+          // Button
+          "& button.HvMultiButton-button": {
+            "&.HvMultiButton-firstButton": {
+              "& + div.HvMultiButton-splitContainer": {
+                marginLeft: 0,
+              },
+            },
+          },
+          // Dropdown Menu
+          "& .HvDropDownMenu-root": {
+            "&:has(.HvMultiButton-firstButton)": {
+              "& + div.HvMultiButton-splitContainer": {
+                marginRight: -1,
+              },
+            },
+          },
+          "& .HvMultiButton-button.HvMultiButton-firstButton > button": {
+            marginRight: -1,
+          },
+          "& .HvMultiButton-button.HvMultiButton-lastButton > button": {
+            marginLeft: -1,
+          },
         },
         splitGroupDisabled: { backgroundColor: "transparent" },
+        splitContainer: {
+          width: 1,
+          zIndex: theme.zIndices.docked,
+          "&&": { backgroundColor: "transparent" },
+        },
       },
     },
     HvDropdownButton: {

--- a/packages/styles/src/themes/pentahoPlus.ts
+++ b/packages/styles/src/themes/pentahoPlus.ts
@@ -403,62 +403,94 @@ const pentahoPlus = makeTheme((theme) => ({
     HvMultiButton: {
       classes: {
         multiple: {
-          borderRadius: 20,
+          borderRadius: theme.radii.full,
           "& button.HvMultiButton-button": {
-            border: "none",
-            backgroundColor: "transparent",
+            borderColor: "transparent",
             "&.HvMultiButton-firstButton": {
-              borderRadius: "20px 0 0 20px",
+              borderColor: "transparent",
+              borderRadius: `${theme.radii.full} 0 0 ${theme.radii.full}`,
+              "&:disabled": {
+                borderColor: "transparent",
+                "&:hover": {
+                  borderColor: "transparent",
+                },
+              },
             },
             "&.HvMultiButton-lastButton": {
-              borderRadius: "0 20px 20px 0",
+              borderColor: "transparent",
+              borderRadius: `0 ${theme.radii.full} ${theme.radii.full} 0`,
+              "&:disabled": {
+                borderColor: "transparent",
+                "&:hover": {
+                  borderColor: "transparent",
+                },
+              },
             },
             "&.HvMultiButton-selected": {
-              borderRadius: 20,
-              border: "none",
+              borderRadius: theme.radii.full,
+              borderColor: "transparent",
               color: theme.colors.primary,
               backgroundColor: theme.colors.atmo1,
               "&:hover": {
                 "&:not(:disabled)": {
-                  border: "none",
+                  borderColor: "transparent",
                 },
                 "&:disabled": {
-                  border: "none",
-                  backgroundColor: theme.colors.atmo1,
+                  borderColor: "transparent",
                 },
               },
               "&:disabled": {
-                border: "none",
+                borderColor: "transparent",
               },
             },
             "&:disabled": {
-              border: "none",
+              borderColor: "transparent",
               "&:hover": {
-                border: "none",
-                backgroundColor: "transparent",
+                borderColor: "transparent",
               },
+            },
+            "&:not(.HvMultiButton-firstButton)": {
+              marginLeft: 0,
             },
           },
         },
         vertical: {
-          borderRadius: 20,
+          borderRadius: theme.radii.full,
           "& button.HvMultiButton-button": {
-            border: "none",
-            backgroundColor: "transparent",
+            borderRadius: theme.radii.full,
+            borderColor: "transparent",
             "&.HvMultiButton-firstButton": {
-              borderRadius: "20px 0 0 20px",
+              borderRadius: theme.radii.full,
+              borderColor: "transparent",
+              "&:disabled": {
+                borderColor: "transparent",
+                "&:hover": { borderColor: "transparent" },
+              },
             },
             "&.HvMultiButton-lastButton": {
-              borderRadius: "0 20px 20px 0",
+              borderRadius: theme.radii.full,
+              borderColor: "transparent",
+              "&:disabled": {
+                borderColor: "transparent",
+                "&:hover": { borderColor: "transparent" },
+              },
             },
             "&.HvMultiButton-selected": {
-              borderRadius: 20,
-              border: "none",
+              borderRadius: theme.radii.full,
+              borderColor: "transparent",
               color: theme.colors.primary,
               backgroundColor: theme.colors.atmo1,
+              "&:disabled": {
+                borderColor: "transparent",
+                "&:hover": { borderColor: "transparent" },
+              },
             },
             "&:disabled": {
-              border: "none",
+              borderColor: "transparent",
+              "&:hover": { borderColor: "transparent" },
+            },
+            "&:not(.HvMultiButton-firstButton)": {
+              marginTop: 0,
             },
           },
         },


### PR DESCRIPTION
The following styling problems with the Pentaho theme were fixed:
- **Select**: wrong border radius when expanded
- **Split button**: problems with split container when hovered (disappearing)
- **Multi button**: `variant` prop not working properly
- **Dropdown menu**: wrong border radius when expanded
- **Dropdown menu, color picker, date picker and time picker**: background color overflowing rounded corners

Also:

- `HvBaseDropdown` was refactored in order to wrap the root component with the provider: this change was needed for `HvDropdownButton` to know the placement

ℹ️ The multi button looks still a bit weird, but since we don't have specs it's normal. 