### PR TITLE
ci: fix pr-close, disable nextra, enable SB, rename tests workflow

### DIFF
--- a/.github/actions/build-artifacts/action.yml
+++ b/.github/actions/build-artifacts/action.yml
@@ -38,10 +38,12 @@ runs:
 
     # Bypassing Jekyll processing on GitHub Pages by adding .nojekyll to read folders that start with an underscore
     - name: Build Nextra Docs
+      if: ${{ false }}
       run: npm run build:nextra && touch ${{ github.workspace }}/apps/docs/out/.nojekyll
       shell: bash
 
     - name: Archive Nextra Docs
+      if: ${{ false }}
       uses: actions/upload-artifact@v4
       with:
         name: nextra-docs

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -42,8 +42,8 @@ jobs:
             artifact: "documentation"
           - folder: "uikit-app"
             artifact: "app"
-          - folder: "uikit-docs"
-            artifact: "nextra-docs"
+          #- folder: "uikit-docs"
+          #  artifact: "nextra-docs"
 
     steps:
       - name: Checkout

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -10,9 +10,9 @@ env:
   RUN_URL: https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}
 
 jobs:
-  static-checks:
-    name: Static Checks
-    uses: ./.github/workflows/static-checks.yml
+  tests:
+    name: Tests
+    uses: ./.github/workflows/tests.yml
     secrets: inherit
 
   visual-tests:
@@ -22,7 +22,7 @@ jobs:
 
   notify-fail:
     name: Notify Fail
-    needs: [static-checks, visual-tests]
+    needs: [tests, visual-tests]
     if: failure()
     runs-on: ubuntu-latest
 
@@ -52,7 +52,7 @@ jobs:
   release:
     name: Release
     if: github.event_name == 'schedule' && !contains(github.event.head_commit.message, '${ RELEASE_COMMIT_MESSAGE }')
-    needs: [static-checks, visual-tests]
+    needs: [tests, visual-tests]
     runs-on: ubuntu-latest
     steps:
       - name: Trigger Release

--- a/.github/workflows/pr-close.yml
+++ b/.github/workflows/pr-close.yml
@@ -34,9 +34,9 @@ jobs:
           cd ${{ github.workspace }}/gh-docs
           git config --global user.name 'github-actions[bot]'
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'
-          git rm -r ${APP_PUBLISH_FOLDER}
-          git rm -r ${NEXTRA_PUBLISH_FOLDER}
-          git rm -r ${STORYBOOK_PUBLISH_FOLDER}
+          git rm -r --ignore-unmatch ${APP_PUBLISH_FOLDER}
+          git rm -r --ignore-unmatch ${NEXTRA_PUBLISH_FOLDER}
+          git rm -r --ignore-unmatch ${STORYBOOK_PUBLISH_FOLDER}
           git commit -m "${PUBLISH_MESSAGE}"
           git push
 
@@ -49,6 +49,7 @@ jobs:
           desc: Deployment for Stroybook documentation was pruned
 
       - name: Prune Deployment for Nextra Documentation
+        if: ${{ false }}
         uses: bobheadxi/deployments@v1
         with:
           step: deactivate-env

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -30,4 +30,3 @@ jobs:
     secrets: inherit
     with:
       publish-folder: pr-${{ github.event.number }}
-      publish-storybook: false

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -11,10 +11,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  static-checks:
-    name: Static Checks
-    uses: ./.github/workflows/static-checks.yml
-
   visual-tests:
     name: Visual Tests
     uses: ./.github/workflows/tests-visual.yml
@@ -23,6 +19,10 @@ jobs:
     secrets: inherit
     with:
       batch-id: pr-${{ github.event.number }}
+
+  tests:
+    name: Tests
+    uses: ./.github/workflows/tests.yml
 
   artifacts:
     name: Artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 18
 
       - name: Fetch git tags
         run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -74,13 +74,9 @@ jobs:
         with:
           node-version: 18
 
-      # ==========================
-      # code-editor (npm package)
-      # ==========================
-
       # Install dependencies inside each package so blackduck can scan them
       # To do this we need to remove the package.json and package-lock.json from the root
-      - name: Prepare packages for Blackduck scan
+      - name: Prepare package for Blackduck scan
         uses: lumada-common-services/gh-composite-actions@1.9.0
         with:
           command: |

--- a/.github/workflows/tests-playwright.yml
+++ b/.github/workflows/tests-playwright.yml
@@ -1,20 +1,17 @@
-name: Playwright tests
+name: Playwright Tests
 
 on:
   workflow_dispatch:
   workflow_call:
 
-env:
-  PUBLISH_FOLDER: ${{ inputs.publish-folder || github.ref_name }}
-
 jobs:
-  run-playwright-tests:
-    name: Playwright Tests
+  tests:
+    name: Run Tests
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        PROJECT: ["chromium", "chrome", "msedge", "firefox", "webkit"]
+        PROJECT: ["chrome", "firefox"]
 
     steps:
       - name: Checkout

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,4 @@
-name: Checks
+name: Tests
 
 on:
   workflow_dispatch:
@@ -9,7 +9,7 @@ env:
 
 jobs:
   checks:
-    name: Static Tests
+    name: Static Checks
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
- Fix [PR-Close workflow failing](https://github.com/lumada-design/hv-uikit-react/actions/workflows/pr-close.yml) trying to clean directories that might not exist
- Enable Storybook deployments, as we can't always rely on Chromatic deployments
- Disable Nextra deployment, (for now) as development is on-hold indefinitely
- Disable Playwright tests (just `HvFlow` for now) in flaky `webkit` and redundant (chrome-like) `msedge` and `chromium`
- Rename `static-tests` to `tests` as many aren't static tests
- Misc alignments
  - use `node@18`
  - sort Chromatic PR run to the top