### PR TITLE
build: fix publish/build/clean scripts & update release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,9 +16,6 @@ jobs:
       RELEASE_TYPE: ${{ github.event.client_payload.type }}
       NPM_CONFIG_PROVENANCE: true
 
-    outputs:
-      published: ${{ steps.check-updates.outputs.published }}
-
     permissions:
       contents: write
       id-token: write
@@ -61,23 +58,20 @@ jobs:
           fi
 
       - name: Check if packages were updated
-        id: check-updates
         run: |
           if grep -q "lerna success published" publish_logs.txt; then
             echo "New packages were published"
-            echo "published=true" >> "$GITHUB_OUTPUT"
           elif grep -q "lerna Command failed" publish_logs.txt; then
             echo "lerna Command failed"
             exit 1
           else
             echo "No packages were updated"
-            echo "published=false" >> "$GITHUB_OUTPUT"
+            exit 1
           fi
 
-  publish-artifacts:
-    name: Publish Artifacts
+  publish-documentation:
+    name: Publish Documentation
     needs: [publish]
-    if: needs.publish.outputs.published == 'true'
     uses: ./.github/workflows/documentation.yml
     secrets: inherit
     with:
@@ -92,7 +86,7 @@ jobs:
   notify-release:
     name: Notify release
     runs-on: ubuntu-latest
-    needs: [publish-artifacts]
+    needs: [publish-documentation]
 
     env:
       DOCUMENTATION_URL: https://${{ github.repository_owner }}.github.io/uikit/${{ github.ref_name }}/

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -29,7 +29,7 @@
     "pretest": "node src/index.js create uikit-app -t Form,ListView",
     "test": "cd uikit-app",
     "posttest": "npx rimraf uikit-app",
-    "prepublishOnly": "run-s clean && npx clean-publish"
+    "prepublishOnly": "npm run clean && npx clean-publish"
   },
   "dependencies": {
     "chalk": "^5.2.0",

--- a/packages/pentaho/package.json
+++ b/packages/pentaho/package.json
@@ -30,7 +30,7 @@
     "coverage": "vitest run --coverage",
     "clean": "npx rimraf dist package",
     "typecheck": "tsc --noEmit",
-    "prepublishOnly": "run-s clean build && npx clean-publish"
+    "prepublishOnly": "npm run build && npx clean-publish"
   },
   "peerDependencies": {
     "@emotion/react": "^11.11.1",

--- a/packages/uno-preset/package.json
+++ b/packages/uno-preset/package.json
@@ -25,7 +25,7 @@
     "url": "https://github.com/lumada-design/hv-uikit-react/issues"
   },
   "scripts": {
-    "build": "vite build",
+    "build": "npm run clean && vite build",
     "clean": "npx rimraf dist package",
     "typecheck": "tsc --noEmit",
     "prepublishOnly": "npm run build && npx clean-publish"


### PR DESCRIPTION
- align and fix publish > build > clean scripts
  - `uno-preset` was missing a `clean`
- update `release.yml` workflow to fail if there are no artifacts to release for better visibility