### PR TITLE
ci(release): change to bi-weekly releases

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -48,17 +48,3 @@ jobs:
                 }
               ]
             }
-
-  release:
-    name: Release
-    if: github.event_name == 'schedule' && !contains(github.event.head_commit.message, '${ RELEASE_COMMIT_MESSAGE }')
-    needs: [tests, visual-tests]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Trigger Release
-        # repo scope personal token is required to generate a dispatch event
-        run: |
-          curl -X POST \
-            https://api.github.com/repos/${{ github.repository }}/dispatches \
-            -H 'Authorization: token ${{ secrets.GITHUB_TOKEN }}' \
-            -d '{"event_type": "release"}'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,13 +1,24 @@
 name: Release
 
 on:
-  repository_dispatch:
-    types: [release]
+  schedule:
+    - cron: "0 5 * * 1,4" # at 05:00 on monday,thursday
   workflow_dispatch:
 
 jobs:
+  tests:
+    name: Tests
+    uses: ./.github/workflows/tests.yml
+    secrets: inherit
+
+  visual-tests:
+    name: Visual Tests
+    uses: ./.github/workflows/tests-visual.yml
+    secrets: inherit
+
   publish:
-    name: Publish
+    name: Publish Packages
+    needs: [tests, visual-tests]
     runs-on: ubuntu-latest
 
     env:


### PR DESCRIPTION
- Change releases to run automatically mondays & thursdays at 05:00
  - We might want to eventually change this to weekly + manual, but let's run with this for now
  - The Nightly workflow doesn't make much sense anymore (all checks run on PR). We might want to eventually disable or rework it

