### PR TITLE
fix: drag and drop with keyboard for tree view panel in canvas template

### DIFF
--- a/packages/core/src/TreeView/TreeItem/TreeItem.tsx
+++ b/packages/core/src/TreeView/TreeItem/TreeItem.tsx
@@ -67,6 +67,8 @@ export interface HvTreeItemProps extends React.HTMLAttributes<HTMLElement> {
   TransitionComponent?: React.JSXElementConstructor<TransitionProps>;
   /** Props applied to the transition component */
   TransitionProps?: TransitionProps;
+  /** Whether to disable the following default behavior: when the item is focused, the focus is placed on the tree root. @default `false` */
+  disableTreeFocus?: boolean;
 }
 
 export const HvTreeItem = forwardRef<HTMLLIElement, HvTreeItemProps>(
@@ -86,6 +88,7 @@ export const HvTreeItem = forwardRef<HTMLLIElement, HvTreeItemProps>(
       ContentComponent: Component = DefaultContent,
       TransitionProps: transitionProps,
       ContentProps: contentProps,
+      disableTreeFocus = false,
       ...others
     } = useDefaultProps("HvTreeItem", props);
     const { classes, cx } = useClasses(classesProp);
@@ -157,7 +160,7 @@ export const HvTreeItem = forwardRef<HTMLLIElement, HvTreeItemProps>(
 
     const handleFocus = (event: React.FocusEvent<HTMLLIElement>) => {
       // DOM focus stays on the tree which manages focus with aria-activedescendant
-      if (event.target === event.currentTarget) {
+      if (event.target === event.currentTarget && !disableTreeFocus) {
         const rootElement: any =
           typeof event.target.getRootNode === "function"
             ? event.target.getRootNode()


### PR DESCRIPTION
In [this PR](https://github.com/lumada-design/hv-uikit-react/pull/4227), the Canvas template was created. However, drag and drop with keyboard was not implemented for the tree view panel as it wasn’t working OOTB. This PR implements the missing drag and drop keyboard feature for the template.