### PR TITLE
fix(BottomPanel): tab title overflow

### DIFF
--- a/docs/templates/Canvas.stories.tsx
+++ b/docs/templates/Canvas.stories.tsx
@@ -1,5 +1,6 @@
 import { css } from "@emotion/css";
 import { StoryObj } from "@storybook/react";
+import { userEvent, within } from "@storybook/test";
 import {
   canvasSidePanelClasses,
   canvasToolbarClasses,
@@ -31,6 +32,14 @@ export const Main: StoryObj = {
         code: CanvasRaw,
       },
     },
+    // Enables Chromatic snapshot
+    chromatic: { disableSnapshot: false, delay: 5000 },
+  },
+  // For visual testing
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const button = canvas.getByRole("button", { name: /Click to Add Nodes/i });
+    await userEvent.click(button);
   },
   decorators: [(Story) => <div className={classes.root}>{Story()}</div>],
   render: () => <Canvas />,

--- a/docs/tests/BottomPanel.stories.tsx
+++ b/docs/tests/BottomPanel.stories.tsx
@@ -1,0 +1,145 @@
+import { useState } from "react";
+import { css } from "@emotion/css";
+import { StoryObj } from "@storybook/react";
+import { HvButton, theme } from "@hitachivantara/uikit-react-core";
+import { Favorite, Heart } from "@hitachivantara/uikit-react-icons";
+import {
+  HvCanvasBottomPanel,
+  HvCanvasBottomPanelProps,
+} from "@hitachivantara/uikit-react-pentaho";
+
+// Used for Playwright and Chromatic tests
+export default {
+  title: "Tests/Bottom Panel",
+  parameters: {
+    // Enables Chromatic snapshot
+    chromatic: { disableSnapshot: false, delay: 5000 },
+  },
+};
+
+const tabs: HvCanvasBottomPanelProps["tabs"] = [
+  {
+    id: 0,
+    title: (overflowing) => (overflowing ? "Tab 1 Overflowing" : "Tab 1"),
+  },
+  {
+    id: 1,
+    title: "Tab 2",
+  },
+];
+
+const classes = {
+  root: css({ display: "flex", flexDirection: "column", gap: theme.space.sm }),
+  buttons: css({ display: "flex", gap: theme.space.sm }),
+  panel: css({ position: "relative" }),
+};
+
+const leftActions = [
+  { id: "action1", label: "Action 1", icon: <Favorite /> },
+  { id: "action2", label: "Action 2", icon: <Favorite /> },
+];
+const rightActions = [
+  { id: "action3", label: "Action 3", icon: <Heart /> },
+  { id: "action4", label: "Action 4", icon: <Heart /> },
+  { id: "action5", label: "Action 5", icon: <Heart /> },
+];
+
+export const Main: StoryObj = {
+  render: () => {
+    const [minimize, setMinimize] = useState(false);
+    const [open, setOpen] = useState(true);
+    const [selectedTab, setSelectedTab] = useState(tabs[0].id);
+    const [extraOpen, setExtraOpen] = useState(true);
+
+    const handleAction: HvCanvasBottomPanelProps["onAction"] = (
+      event,
+      action,
+      tabId,
+    ) => alert(`You clicked action ${action.label} for ${tabId}.`);
+
+    return (
+      <div className={classes.root}>
+        <div className={classes.buttons}>
+          <HvButton onClick={() => setOpen((prev) => !prev)}>
+            Toggle Open
+          </HvButton>
+          <HvButton onClick={() => setMinimize((prev) => !prev)}>
+            Toggle Minimize
+          </HvButton>
+          <HvButton onClick={() => setExtraOpen((prev) => !prev)}>
+            Toggle Extra Tests
+          </HvButton>
+        </div>
+        <HvCanvasBottomPanel
+          open={open}
+          className={classes.panel}
+          tabs={tabs}
+          leftActions={leftActions}
+          rightActions={rightActions}
+          overflowActions={[...leftActions, ...rightActions]}
+          onAction={handleAction}
+          minimize={minimize}
+          selectedTabId={selectedTab}
+          onTabChange={(event, id) => setSelectedTab(id as number)}
+        >
+          Content
+        </HvCanvasBottomPanel>
+
+        {extraOpen && (
+          <>
+            <HvCanvasBottomPanel
+              open
+              className={classes.panel}
+              tabs={tabs}
+              leftActions={[leftActions[0]]}
+              rightActions={[rightActions[0], rightActions[1]]}
+            >
+              Content
+            </HvCanvasBottomPanel>
+            <br />
+            <HvCanvasBottomPanel
+              open
+              className={classes.panel}
+              tabs={[
+                {
+                  id: 1,
+                  title: "Tab 2",
+                },
+              ]}
+              leftActions={[leftActions[0]]}
+              rightActions={[rightActions[0], rightActions[1]]}
+            >
+              Content
+            </HvCanvasBottomPanel>
+            <HvCanvasBottomPanel
+              open
+              minimize
+              className={classes.panel}
+              tabs={tabs}
+              leftActions={[leftActions[0]]}
+              rightActions={[rightActions[0], rightActions[1]]}
+            >
+              Content
+            </HvCanvasBottomPanel>
+            <br />
+            <HvCanvasBottomPanel
+              open
+              minimize
+              className={classes.panel}
+              tabs={[
+                {
+                  id: 1,
+                  title: "Tab 2",
+                },
+              ]}
+              leftActions={[leftActions[0]]}
+              rightActions={[rightActions[0], rightActions[1]]}
+            >
+              Content
+            </HvCanvasBottomPanel>
+          </>
+        )}
+      </div>
+    );
+  },
+};

--- a/packages/cli/src/templates/Canvas/Table.tsx
+++ b/packages/cli/src/templates/Canvas/Table.tsx
@@ -147,7 +147,7 @@ export const DataTable = ({ id }: DataTableProps) => {
     prepareRow(row);
 
     return (
-      <HvTableRow {...row.getRowProps()}>
+      <HvTableRow {...row.getRowProps()} key={row.getRowProps().key}>
         {row.cells.map((cell) => (
           <HvTableCell {...cell.getCellProps()} key={cell.getCellProps().key}>
             {cell.render("Cell")}

--- a/packages/cli/src/templates/Canvas/index.tsx
+++ b/packages/cli/src/templates/Canvas/index.tsx
@@ -86,19 +86,17 @@ const Page = () => {
   const { selectedTable, openedTables, setOpenedTables, setSelectedTable } =
     useCanvasContext();
 
-  const bottomTabs = useMemo(
+  const bottomTabs: HvCanvasBottomPanelProps["tabs"] = useMemo(
     () =>
       openedTables?.map((table) => ({
         id: table.id,
-        title: (
+        title: (overflowing) => (
           <div className={classes.titleRoot}>
-            <Table />
-            <div className={classes.titleContainer}>
-              <HvOverflowTooltip data={table.label} />
-            </div>
+            {!overflowing && <Table />}
+            <HvOverflowTooltip data={table.label} />
           </div>
         ),
-      })),
+      })) ?? [],
     [openedTables],
   );
 
@@ -180,6 +178,33 @@ const Page = () => {
     [bottomTabs, openedTables],
   );
 
+  const leftActions = [
+    {
+      id: "toggle",
+      label: minimize ? "Maximize" : "Minimize",
+      icon: (
+        <DropUpXS
+          iconSize="XS"
+          style={{ rotate: !minimize ? "180deg" : undefined }}
+          className={classes.toggleIcon}
+        />
+      ),
+    },
+  ];
+
+  const rightActions = [
+    {
+      id: "fullscreen",
+      label: "Fullscreen",
+      icon: <Fullscreen iconSize="XS" />,
+    },
+    {
+      id: "close",
+      label: "Close",
+      icon: <Close iconSize="XS" />,
+    },
+  ];
+
   return (
     <div className={classes.root}>
       <HvFlow
@@ -234,40 +259,22 @@ const Page = () => {
           Execute
         </HvButton>
       </HvCanvasToolbar>
-      {bottomTabs && bottomPanelOpen && (
+      {bottomTabs.length > 0 && bottomPanelOpen && (
         <HvCanvasBottomPanel
           className={cx({
             [classes.fullWidth]: !sidePanelOpen,
             [classes.minWidth]: sidePanelOpen,
           })}
+          classes={{
+            rightActions: classes.rightActions,
+          }}
           open={bottomPanelOpen}
           minimize={minimize}
           tabs={bottomTabs}
-          tab={selectedTable}
-          leftActions={[
-            {
-              id: "toggle",
-              label: minimize ? "Maximize" : "Minimize",
-              icon: (
-                <DropUpXS
-                  style={{ rotate: !minimize ? "180deg" : undefined }}
-                  className={classes.toggleIcon}
-                />
-              ),
-            },
-          ]}
-          rightActions={[
-            {
-              id: "fullscreen",
-              label: "Fullscreen",
-              icon: <Fullscreen />,
-            },
-            {
-              id: "close",
-              label: "Close",
-              icon: <Close />,
-            },
-          ]}
+          selectedTabId={selectedTable}
+          leftActions={leftActions}
+          rightActions={rightActions}
+          overflowActions={[...leftActions, ...rightActions]}
           onTabChange={handleChangeTab}
           onAction={handleAction}
         >
@@ -282,7 +289,9 @@ const Page = () => {
           onClose={() => setFullscreen((prev) => !prev)}
         >
           <HvDialogTitle className={classes.dialogTitle}>
-            {bottomTabs?.find((x) => x.id === selectedTable)?.title}
+            {(
+              bottomTabs?.find((x) => x.id === selectedTable)?.title as Function
+            )(false)}
           </HvDialogTitle>
           <HvDialogContent>
             <DataTable id={selectedTable} />

--- a/packages/cli/src/templates/Canvas/styles.tsx
+++ b/packages/cli/src/templates/Canvas/styles.tsx
@@ -1,5 +1,5 @@
 import { css } from "@emotion/css";
-import { theme } from "@hitachivantara/uikit-react-core";
+import { actionsGenericClasses, theme } from "@hitachivantara/uikit-react-core";
 
 export const classes = {
   flow: css({
@@ -37,10 +37,6 @@ export const classes = {
     height: `calc(100% - ${theme.header.height} - ${theme.header.secondLevelHeight})`,
   }),
   toggleIcon: css({ transition: "rotate 0.2s ease" }),
-  titleContainer: css({
-    display: "flex",
-    width: "100%",
-  }),
   titleRoot: css({
     display: "flex",
     width: "100%",
@@ -49,5 +45,10 @@ export const classes = {
   dialogTitle: css({
     ...theme.typography.label,
     "& div > div": { margin: 0, padding: 0 },
+  }),
+  rightActions: css({
+    [`& .${actionsGenericClasses.button}:not(:last-child)`]: {
+      marginRight: 0,
+    },
   }),
 };

--- a/packages/pentaho/src/Canvas/BottomPanel/BottomPanel.spec.tsx
+++ b/packages/pentaho/src/Canvas/BottomPanel/BottomPanel.spec.tsx
@@ -1,0 +1,188 @@
+import { expect, test, type Page } from "@playwright/test";
+
+// Playwright tests were added because unit tests were not working properly since the
+// component's layout changes according with the screen width
+
+const hideExtraTests = async (page: Page) => {
+  const btn = page.getByRole("button", { name: "Toggle Extra Tests" });
+  await btn.click();
+};
+
+const goToControlledSample = async (page: Page) => {
+  page.goto("./iframe.html?args=&id=tests-bottom-panel--main&viewMode=story");
+  await hideExtraTests(page);
+};
+
+const goToUncontrolledSample = async (page: Page) =>
+  page.goto(
+    "./iframe.html?args=&id=pentaho-canvas-bottom-panel--main&viewMode=story",
+  );
+
+test.beforeEach(async ({ page }) => {
+  page.setViewportSize({ width: 800, height: 500 });
+});
+
+test("opens and closes by controlling the component and renders correctly when closed", async ({
+  page,
+}) => {
+  await goToControlledSample(page);
+
+  // Close panel
+  const toggleBtn = page.getByRole("button", { name: "Toggle Open" });
+  await toggleBtn.click();
+
+  const tabList = page.getByRole("tablist");
+  const tabPanel = page.getByRole("tabpanel");
+  await expect(tabList).toBeHidden();
+  await expect(tabPanel).toBeHidden();
+});
+
+test("renders correctly when opened", async ({ page }) => {
+  await goToControlledSample(page);
+
+  const tabList = page.getByRole("tablist");
+  const tabPanel = page.getByRole("tabpanel");
+  const selectedTab = page.getByRole("tab", { selected: true });
+  await expect(tabList).toBeVisible();
+  await expect(tabPanel).toBeVisible();
+  await expect(tabPanel).toContainText("Content");
+  await expect(selectedTab).toContainText("Tab 1");
+  expect(await page.getByRole("tab", { selected: false }).all()).toHaveLength(
+    1,
+  );
+  expect(await page.getByRole("tab").all()).toHaveLength(2);
+  expect(await page.getByRole("tab").allTextContents()).toEqual([
+    "Tab 1",
+    "Tab 2",
+  ]);
+});
+
+test("minimizes and maximizes the tabs by controlling the component", async ({
+  page,
+}) => {
+  await goToControlledSample(page);
+
+  let tabList = page.getByRole("tablist");
+  let tabPanel = page.getByRole("tabpanel");
+  await expect(tabList).toBeVisible();
+  await expect(tabPanel).toBeVisible();
+
+  // Minimize tabs
+  const minimizeBtn = page.getByRole("button", { name: "Toggle Minimize" });
+  await minimizeBtn.click();
+
+  tabList = page.getByRole("tablist");
+  tabPanel = page.getByRole("tabpanel");
+  await expect(tabList).toBeVisible();
+  await expect(tabPanel).toBeHidden();
+});
+
+test("renders the correct number of right and left actions", async ({
+  page,
+}) => {
+  await goToControlledSample(page);
+
+  expect(
+    await page.getByRole("button", { name: "Dropdown menu" }).all(),
+  ).toHaveLength(4);
+  expect(
+    await page.getByRole("button", { name: "Action 1" }).all(),
+  ).toHaveLength(2);
+  expect(
+    await page.getByRole("button", { name: "Action 3" }).all(),
+  ).toHaveLength(2);
+  expect(
+    await page.getByRole("button", { name: "Action 4" }).all(),
+  ).toHaveLength(2);
+
+  // Click left action for first tab
+  const leftDropdownMenu = page
+    .getByRole("button", { name: "Dropdown menu" })
+    .first();
+  await leftDropdownMenu.click();
+  const leftMenu = page.getByRole("menu");
+  await expect(leftMenu).toBeVisible();
+  expect(await page.getByRole("menuitem").all()).toHaveLength(1);
+  expect(await page.getByRole("menuitem").allTextContents()).toEqual([
+    "Action 2",
+  ]);
+
+  // Click right action for first tab
+  const rightDropdownMenu = page
+    .getByRole("button", { name: "Dropdown menu" })
+    .nth(1);
+  await rightDropdownMenu.click();
+  const rightMenu = page.getByRole("menu");
+  await expect(rightMenu).toBeVisible();
+  expect(await page.getByRole("menuitem").all()).toHaveLength(1);
+  expect(await page.getByRole("menuitem").allTextContents()).toEqual([
+    "Action 5",
+  ]);
+});
+
+test("switches the selected tab when controlled", async ({ page }) => {
+  await goToControlledSample(page);
+
+  let selectedTab = page.getByRole("tab", { selected: true });
+  let unSelectedTab = page.getByRole("tab", { selected: false });
+  await expect(selectedTab).toContainText("Tab 1");
+  await expect(unSelectedTab).toContainText("Tab 2");
+
+  await unSelectedTab.click();
+
+  selectedTab = page.getByRole("tab", { selected: true });
+  unSelectedTab = page.getByRole("tab", { selected: false });
+  await expect(selectedTab).toContainText("Tab 2");
+  await expect(unSelectedTab).toContainText("Tab 1");
+});
+
+test("switches the selected tab when uncontrolled", async ({ page }) => {
+  await goToUncontrolledSample(page);
+
+  let selectedTab = page.getByRole("tab", { selected: true });
+  let unSelectedTab = page.getByRole("tab", { selected: false });
+  await expect(selectedTab).toContainText("Tab 1");
+  await expect(unSelectedTab).toContainText("Tab 2");
+
+  await unSelectedTab.click();
+
+  selectedTab = page.getByRole("tab", { selected: true });
+  unSelectedTab = page.getByRole("tab", { selected: false });
+  await expect(selectedTab).toContainText("Tab 2");
+  await expect(unSelectedTab).toContainText("Tab 1");
+});
+
+test("render overflow actions when the tab content is overflowing", async ({
+  page,
+}) => {
+  // Change viewport
+  page.setViewportSize({ width: 200, height: 500 });
+
+  await goToControlledSample(page);
+
+  // Open panel
+  const toggleBtn = page.getByRole("button", { name: "Toggle Open" });
+  await toggleBtn.click();
+
+  const selectedTab = page.getByRole("tab", { selected: true });
+  await expect(selectedTab).toContainText("Tab 1 Overflowing");
+  expect(
+    await page.getByRole("button", { name: "Dropdown menu" }).all(),
+  ).toHaveLength(2);
+
+  // Click action for first tab
+  const dropdownMenu = page
+    .getByRole("button", { name: "Dropdown menu" })
+    .first();
+  await dropdownMenu.click();
+  const menu = page.getByRole("menu");
+  await expect(menu).toBeVisible();
+  expect(await page.getByRole("menuitem").all()).toHaveLength(5);
+  expect(await page.getByRole("menuitem").allTextContents()).toEqual([
+    "Action 1",
+    "Action 2",
+    "Action 3",
+    "Action 4",
+    "Action 5",
+  ]);
+});

--- a/packages/pentaho/src/Canvas/BottomPanel/BottomPanel.stories.tsx
+++ b/packages/pentaho/src/Canvas/BottomPanel/BottomPanel.stories.tsx
@@ -18,7 +18,7 @@ export const Main: StoryObj<HvCanvasBottomPanelProps> = {
   argTypes: {
     tabs: { control: { disable: true } },
     classes: { control: { disable: true } },
-    tab: { control: { disable: true } },
+    selectedTabId: { control: { disable: true } },
     leftActions: { control: { disable: true } },
     rightActions: { control: { disable: true } },
   },

--- a/packages/pentaho/src/Canvas/BottomPanel/BottomPanel.styles.tsx
+++ b/packages/pentaho/src/Canvas/BottomPanel/BottomPanel.styles.tsx
@@ -1,4 +1,8 @@
-import { createClasses, theme } from "@hitachivantara/uikit-react-core";
+import {
+  buttonClasses,
+  createClasses,
+  theme,
+} from "@hitachivantara/uikit-react-core";
 
 export const { staticClasses, useClasses } = createClasses(
   "HvCanvasBottomPanel",
@@ -33,12 +37,7 @@ export const { staticClasses, useClasses } = createClasses(
         right: `calc(100% - var(--right) + ${theme.space.xs})`,
       },
     },
-    overflowing: {
-      "& $tabTitle": {
-        paddingLeft: theme.space.sm,
-        paddingRight: theme.space.sm,
-      },
-    },
+    overflowing: {},
     tab: {
       display: "flex",
       alignItems: "center",
@@ -49,8 +48,8 @@ export const { staticClasses, useClasses } = createClasses(
       display: "flex",
       width: "100%",
       padding: theme.space.sm,
-      paddingLeft: `calc(var(--left-actions-width) + ${theme.space.xs})`,
-      paddingRight: `calc(var(--right-actions-width) + ${theme.space.xs})`,
+      paddingLeft: "var(--left-actions-width)",
+      paddingRight: "var(--right-actions-width)",
     },
     tabsRoot: {
       position: "relative",
@@ -64,6 +63,18 @@ export const { staticClasses, useClasses } = createClasses(
       position: "absolute",
       right: theme.space.xs,
       top: 8,
+    },
+    actionsDisabled: {
+      pointerEvents: "none",
+      [`&& .${buttonClasses.disabled}`]: {
+        pointerEvents: "none",
+        backgroundColor: "transparent",
+        borderColor: "transparent",
+        ":hover": {
+          backgroundColor: "transparent",
+          borderColor: "transparent",
+        },
+      },
     },
     content: { borderTopRightRadius: "var(--right-border-radius)" },
   },

--- a/packages/pentaho/src/Canvas/BottomPanel/BottomPanel.test.tsx
+++ b/packages/pentaho/src/Canvas/BottomPanel/BottomPanel.test.tsx
@@ -1,9 +1,7 @@
-import { useState } from "react";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, it, vi } from "vitest";
-import { HvButton } from "@hitachivantara/uikit-react-core";
-import { Close, DropUpXS } from "@hitachivantara/uikit-react-icons";
+import { Close } from "@hitachivantara/uikit-react-icons";
 
 import { HvCanvasBottomPanel, HvCanvasBottomPanelProps } from "./BottomPanel";
 
@@ -20,106 +18,21 @@ const panelTabs = [
 
 const renderSimplePanel = (props?: Partial<HvCanvasBottomPanelProps>) =>
   render(
-    <HvCanvasBottomPanel {...props} tabs={panelTabs}>
+    <HvCanvasBottomPanel
+      open
+      tabs={panelTabs}
+      overflowActions={[{ id: "action", label: "Action", icon: <Close /> }]}
+      {...props}
+    >
       Content
     </HvCanvasBottomPanel>,
   );
 
-const ControlledOpen = () => {
-  const [open, setOpen] = useState(false);
-  return (
-    <>
-      <HvButton onClick={() => setOpen((prev) => !prev)}>Toggle</HvButton>
-      <HvCanvasBottomPanel tabs={panelTabs} open={open}>
-        Content
-      </HvCanvasBottomPanel>
-    </>
-  );
-};
-
-const ControlledTab = (props?: Partial<HvCanvasBottomPanelProps>) => {
-  const [tab, setTab] = useState(panelTabs[1].id);
-  return (
-    <HvCanvasBottomPanel
-      {...props}
-      tabs={panelTabs}
-      tab={tab}
-      onTabChange={(e, id) => {
-        setTab(id as number);
-        props?.onTabChange?.(e, id);
-      }}
-    >
-      Content
-    </HvCanvasBottomPanel>
-  );
-};
-
-const ControlledMinimize = (props?: Partial<HvCanvasBottomPanelProps>) => {
-  const [minimize, setMinimize] = useState(false);
-  return (
-    <>
-      <HvButton onClick={() => setMinimize((prev) => !prev)}>Toggle</HvButton>
-      <HvCanvasBottomPanel {...props} tabs={panelTabs} minimize={minimize}>
-        Content
-      </HvCanvasBottomPanel>
-    </>
-  );
-};
-
-const expectPanelOpened = () => {
-  const tablist = screen.getByRole("tablist");
-  const tabs = screen.getAllByRole("tab");
-  const tabPanel = screen.getByRole("tabpanel");
-  expect(tabs).toHaveLength(panelTabs.length);
-  expect(tabs.map((tab) => tab.textContent)).toEqual(["Tab 1", "Tab 2"]);
-  expect(screen.getByRole("tab", { selected: true })).toHaveTextContent(
-    "Tab 1",
-  );
-  expect(screen.getAllByRole("tab", { selected: false })).toHaveLength(1);
-  expect(tablist).toBeInTheDocument();
-  expect(tabPanel).toBeInTheDocument();
-  expect(tabPanel).toHaveTextContent("Content");
-};
-
-const expectPanelClosed = () => {
-  const tablist = screen.queryByRole("tablist");
-  const tabPanel = screen.queryByRole("tabpanel");
-  expect(tablist).toBeNull();
-  expect(tabPanel).toBeNull();
-};
-
 describe("CanvasBottomPanel", () => {
-  it("renders all components when opened", () => {
-    renderSimplePanel({
-      open: true,
-      leftActions: [{ id: "minimize", label: "Minimize", icon: <DropUpXS /> }],
-      rightActions: [{ id: "close", label: "Close", icon: <Close /> }],
-    });
-    expectPanelOpened();
-    const leftActions = screen.getAllByRole("button", { name: "Minimize" });
-    const rightActions = screen.getAllByRole("button", { name: "Close" });
-    expect(leftActions).toHaveLength(panelTabs.length);
-    expect(rightActions).toHaveLength(panelTabs.length);
-  });
-
-  it("is closed by default", () => {
-    renderSimplePanel();
-    expectPanelClosed();
-  });
-
-  it("closes and opens by controlling the component", async () => {
-    const user = userEvent.setup();
-    render(<ControlledOpen />);
-    expectPanelClosed();
-    const toggle = screen.getByRole("button", { name: "Toggle" });
-    await user.click(toggle);
-    expectPanelOpened();
-  });
-
-  it("switches the selected tab and onTabChange is triggered when uncontrolled", async () => {
+  it("triggers onTabChange when changing the selected tab", async () => {
     const user = userEvent.setup();
     const clickMock = vi.fn();
-    renderSimplePanel({ open: true, onTabChange: clickMock });
+    renderSimplePanel({ onTabChange: clickMock });
 
     const tabs = screen.getAllByRole("tab");
     expect(screen.getByRole("tab", { selected: true })).toHaveTextContent(
@@ -131,90 +44,20 @@ describe("CanvasBottomPanel", () => {
       "Tab 2",
     );
     expect(screen.getAllByRole("tab", { selected: false })).toHaveLength(1);
-    expect(clickMock).toHaveBeenCalled();
+    expect(clickMock).toHaveBeenCalledTimes(1);
   });
 
-  it("switches the selected tab and onTabChange is triggered when controlled", async () => {
+  it("triggers onAction when an action is clicked", async () => {
     const user = userEvent.setup();
     const clickMock = vi.fn();
-    render(<ControlledTab open onTabChange={clickMock} />);
+    renderSimplePanel({ onAction: clickMock });
 
-    const tabs = screen.getAllByRole("tab");
-    expect(screen.getByRole("tab", { selected: true })).toHaveTextContent(
-      "Tab 2",
-    );
-    expect(screen.getAllByRole("tab", { selected: false })).toHaveLength(1);
-    await user.click(tabs[0]);
-    expect(screen.getByRole("tab", { selected: true })).toHaveTextContent(
-      "Tab 1",
-    );
-    expect(screen.getAllByRole("tab", { selected: false })).toHaveLength(1);
-    expect(clickMock).toHaveBeenCalled();
-  });
-
-  it("minimizes and maximizes the tabs by controlling the component", async () => {
-    const user = userEvent.setup();
-    render(<ControlledMinimize open />);
-
-    const toggle = screen.getByRole("button", { name: "Toggle" });
-    const tablist = screen.getByRole("tablist");
-    const tabs = screen.getAllByRole("tab");
-    const tabPanel = screen.queryByRole("tabpanel");
-    expect(tablist).toBeInTheDocument();
-    expect(tabs).toHaveLength(panelTabs.length);
-    expect(tabPanel).toBeInTheDocument();
-
-    await user.click(toggle);
-
-    expect(tablist).toBeInTheDocument();
-    expect(tabs).toHaveLength(panelTabs.length);
-    expect(tabPanel).not.toBeVisible();
-  });
-
-  it("renders the correct number of actions and onAction is triggered", async () => {
-    const user = userEvent.setup();
-    const clickMock = vi.fn();
-    renderSimplePanel({
-      open: true,
-      onAction: clickMock,
-      leftActions: [
-        { id: "action4", label: "Action4", icon: <DropUpXS /> },
-        { id: "action5", label: "Action4", icon: <DropUpXS /> },
-      ],
-      rightActions: [
-        { id: "action1", label: "Action1", icon: <Close /> },
-        { id: "action2", label: "Action2", icon: <Close /> },
-        { id: "action3", label: "Action3", icon: <Close /> },
-      ],
-    });
-
-    const dropdownMenus = screen.getAllByRole("button", {
+    const dropdownMenu = screen.getAllByRole("button", {
       name: "Dropdown menu",
     });
-    const action4Btns = screen.getAllByRole("button", { name: "Action4" });
-    const action1Btns = screen.getAllByRole("button", { name: "Action1" });
-    const action2Btns = screen.getAllByRole("button", { name: "Action2" });
-    expect(dropdownMenus).toHaveLength(panelTabs.length * 2);
-    expect(action4Btns).toHaveLength(panelTabs.length);
-    expect(action1Btns).toHaveLength(panelTabs.length);
-    expect(action2Btns).toHaveLength(panelTabs.length);
-
-    // Click left action for first tab
-    await user.click(dropdownMenus[0]);
-    const leftMenu = screen.getByRole("menu");
-    const leftMenuItems = screen.getAllByRole("menuitem");
-    expect(leftMenu).toBeInTheDocument();
-    expect(leftMenuItems).toHaveLength(1);
-    await user.click(leftMenuItems[0]);
-    expect(clickMock).toHaveBeenCalled();
-
-    // Click right action for first tab
-    await user.click(dropdownMenus[1]);
-    const rightMenu = screen.getByRole("menu");
-    const rightMenuItems = screen.getAllByRole("menuitem");
-    expect(rightMenu).toBeInTheDocument();
-    expect(rightMenuItems).toHaveLength(1);
-    await user.click(rightMenuItems[0]);
-    expect(clickMock).toHaveBeenCalledTimes(2);
+    await user.click(dropdownMenu[0]);
+    const menuItem = screen.getByRole("menuitem", { name: "Action" });
+    await user.click(menuItem);
+    expect(clickMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/pentaho/src/Canvas/BottomPanel/BottomPanel.tsx
+++ b/packages/pentaho/src/Canvas/BottomPanel/BottomPanel.tsx
@@ -7,6 +7,7 @@ import {
   HvActionsGenericProps,
   HvBaseProps,
   HvPanel,
+  theme,
   useControlled,
   useDefaultProps,
   useUniqueId,
@@ -28,20 +29,33 @@ export interface HvCanvasBottomPanelProps extends HvBaseProps {
   /** List of tabs visible on the panel. */
   tabs: {
     id: string | number;
-    title: React.ReactNode;
+    title: React.ReactNode | ((overflowing: boolean) => React.ReactNode);
   }[];
   /** Id of the selected tab if it needs to be controlled. */
-  tab?: string | number;
+  selectedTabId?: string | number;
   /** Callback triggered when a tab changes/is clicked. */
   onTabChange?: (
     event: React.SyntheticEvent | null,
     tabId: string | number | null,
   ) => void;
-  /** Actions to be rendered in the left side of a tab. If more than one action is provided, a dropdown menu will be used. */
+  /**
+   * Actions to be rendered in the left side of a tab.
+   * If more than one action is provided, a dropdown menu will be used.
+   * These actions are not shown when the tab content is overflowing.
+   */
   leftActions?: HvActionsGenericProps["actions"];
-  /** Actions to be rendered in the right side of a tab.If more than two actions are provided, a dropdown menu will be used to add the remaining actions. */
+  /**
+   * Actions to be rendered in the right side of a tab.
+   * If more than two actions are provided, a dropdown menu will be used to display the remaining actions.
+   * These actions are not shown when the tab content is overflowing.
+   */
   rightActions?: HvActionsGenericProps["actions"];
-  /** Callback triggered when a right or left action is clicked. */
+  /**
+   * Actions to be rendered in the right side of a tab when the tab content is overflowing.
+   * These actions will replace both `leftActions` and `rightActions`.
+   */
+  overflowActions?: HvActionsGenericProps["actions"];
+  /** Callback triggered when an action is clicked. */
   onAction?: (
     event: React.SyntheticEvent,
     action: HvActionGeneric,
@@ -67,7 +81,8 @@ export const HvCanvasBottomPanel = forwardRef<
     minimize,
     leftActions,
     rightActions,
-    tab: tabProp,
+    overflowActions,
+    selectedTabId: selectedTabIdProp,
     classes: classesProp,
     onTabChange,
     onAction,
@@ -108,12 +123,16 @@ export const HvCanvasBottomPanel = forwardRef<
     });
 
   const overflowing = useMemo(() => {
-    const scrollWidth = tabRef.current?.scrollWidth ?? 0;
-    return scrollWidth - tabWidth >= 1;
-  }, [tabRef, tabWidth]);
+    const availableWidth =
+      tabWidth -
+      (leftActions ? leftActionWidth : 0) -
+      (rightActions ? rightActionWidth : 0);
+
+    return availableWidth < 60;
+  }, [leftActionWidth, leftActions, rightActionWidth, rightActions, tabWidth]);
 
   const [selectedTab, setSelectedTab] = useControlled<string | number | null>(
-    tabProp,
+    selectedTabIdProp,
     tabs[0].id,
   );
 
@@ -145,8 +164,14 @@ export const HvCanvasBottomPanel = forwardRef<
         <HvCanvasPanelTabs
           style={{
             // @ts-ignore
-            "--left-actions-width": `${leftActionWidth}px`,
-            "--right-actions-width": `${rightActionWidth}px`,
+            "--left-actions-width":
+              overflowing || !leftActions
+                ? theme.space.sm
+                : `calc(${leftActionWidth}px + ${theme.space.xs})`,
+            "--right-actions-width":
+              !rightActions || (overflowing && !overflowActions)
+                ? theme.space.sm
+                : `calc(${overflowing ? 32 : rightActionWidth}px + ${theme.space.xs})`,
           }}
           onChange={handleTabChange}
           value={selectedTab}
@@ -158,13 +183,18 @@ export const HvCanvasBottomPanel = forwardRef<
               id={`${id}-${tab.id}`}
               value={tab.id}
               className={classes.tab}
+              tabIndex={0}
             >
-              <div className={classes.tabTitle}>{tab.title}</div>
+              <div className={classes.tabTitle}>
+                {typeof tab.title === "function"
+                  ? tab.title(overflowing)
+                  : tab.title}
+              </div>
             </HvCanvasPanelTab>
           ))}
         </HvCanvasPanelTabs>
-        {/* For accessibility purposes, these buttons cannot be children of a tablist so they are rendered as HvCanvasPanelTabs sibling. */}
-        {(leftActions || rightActions) && !overflowing
+        {/* For accessibility purposes, these buttons cannot be children of a tablist so they are rendered as HvCanvasTabs sibling. */}
+        {leftActions || rightActions || overflowActions
           ? tabs.map((tab, index) => {
               const btnsDisabled = selectedTab !== tab.id && !minimize;
               return (
@@ -177,8 +207,13 @@ export const HvCanvasBottomPanel = forwardRef<
                     "--left": `calc(${index} * var(--tab-width))`,
                   }}
                 >
-                  {leftActions && (
-                    <div ref={leftActionRef} className={classes.leftActions}>
+                  {leftActions && !overflowing && (
+                    <div
+                      ref={leftActionRef}
+                      className={cx(classes.leftActions, {
+                        [classes.actionsDisabled]: btnsDisabled,
+                      })}
+                    >
                       <HvActionsGeneric
                         maxVisibleActions={1}
                         actions={leftActions}
@@ -191,11 +226,34 @@ export const HvCanvasBottomPanel = forwardRef<
                       />
                     </div>
                   )}
-                  {rightActions && (
-                    <div ref={rightActionRef} className={classes.rightActions}>
+                  {rightActions && !overflowing && (
+                    <div
+                      ref={rightActionRef}
+                      className={cx(classes.rightActions, {
+                        [classes.actionsDisabled]: btnsDisabled,
+                      })}
+                    >
                       <HvActionsGeneric
                         maxVisibleActions={2}
                         actions={rightActions}
+                        disabled={btnsDisabled}
+                        onAction={(event, action) =>
+                          onAction?.(event, action, tab.id)
+                        }
+                        variant="secondaryGhost"
+                        iconOnly
+                      />
+                    </div>
+                  )}
+                  {overflowActions && overflowing && (
+                    <div
+                      className={cx(classes.rightActions, {
+                        [classes.actionsDisabled]: btnsDisabled,
+                      })}
+                    >
+                      <HvActionsGeneric
+                        maxVisibleActions={0}
+                        actions={overflowActions}
                         disabled={btnsDisabled}
                         onAction={(event, action) =>
                           onAction?.(event, action, tab.id)


### PR DESCRIPTION
- `HvCanvasBottomPanel` component updates:
   - tabs title layout improved when content is overflowing (video below): `overflowActions` prop added
   - tests updated
   - `tab` prop renamed to `selectedTabId` (for consistency with the new toolbar tabs)
- Canvas template added to visual tests: to visually test the toolbar and side panel

https://github.com/user-attachments/assets/bd9f22ec-9dfe-4dab-8147-f472fdc79d38

