### PR TITLE
fix(HvInlineEditor): typescript attribute recognition

### DIFF
--- a/packages/core/src/InlineEditor/InlineEditor.stories.tsx
+++ b/packages/core/src/InlineEditor/InlineEditor.stories.tsx
@@ -5,6 +5,7 @@ import {
   HvGrid,
   HvInlineEditor,
   HvInlineEditorProps,
+  HvInput,
   HvTypographyVariants,
 } from "@hitachivantara/uikit-react-core";
 
@@ -14,18 +15,18 @@ const meta: Meta<HvInlineEditorProps> = {
 };
 export default meta;
 
-export const Main: StoryObj<HvInlineEditorProps> = {
+export const Main: StoryObj<typeof HvInlineEditor<typeof HvInput>> = {
   args: {
     showIcon: false,
     variant: "body",
-  } as any,
+  },
   argTypes: {
     classes: { control: { disable: true } },
   },
   render: (args) => {
     return (
       <div style={{ width: 300 }}>
-        <HvInlineEditor {...(args as HvInlineEditorProps)} />
+        <HvInlineEditor {...args} />
       </div>
     );
   },

--- a/packages/core/src/InlineEditor/InlineEditor.stories.tsx
+++ b/packages/core/src/InlineEditor/InlineEditor.stories.tsx
@@ -4,17 +4,17 @@ import {
   HvContainer,
   HvGrid,
   HvInlineEditor,
-  HvInlineEditorProps,
+  HvInput,
   HvTypographyVariants,
 } from "@hitachivantara/uikit-react-core";
 
-const meta: Meta<typeof HvInlineEditor> = {
+const meta: Meta<typeof HvInlineEditor<typeof HvInput>> = {
   title: "Components/Inline Editor",
   component: HvInlineEditor,
 };
 export default meta;
 
-export const Main: StoryObj<HvInlineEditorProps> = {
+export const Main: StoryObj<typeof HvInlineEditor> = {
   args: {
     showIcon: false,
     variant: "body",
@@ -31,7 +31,7 @@ export const Main: StoryObj<HvInlineEditorProps> = {
   },
 };
 
-export const Disabled: StoryObj<HvInlineEditorProps> = {
+export const Disabled: StoryObj<typeof HvInlineEditor<typeof HvInput>> = {
   render: () => {
     return (
       <div style={{ width: 300 }}>

--- a/packages/core/src/InlineEditor/InlineEditor.stories.tsx
+++ b/packages/core/src/InlineEditor/InlineEditor.stories.tsx
@@ -4,34 +4,34 @@ import {
   HvContainer,
   HvGrid,
   HvInlineEditor,
-  HvInput,
+  HvInlineEditorProps,
   HvTypographyVariants,
 } from "@hitachivantara/uikit-react-core";
 
-const meta: Meta<typeof HvInlineEditor<typeof HvInput>> = {
+const meta: Meta<HvInlineEditorProps> = {
   title: "Components/Inline Editor",
   component: HvInlineEditor,
 };
 export default meta;
 
-export const Main: StoryObj<typeof HvInlineEditor> = {
+export const Main: StoryObj<HvInlineEditorProps> = {
   args: {
     showIcon: false,
     variant: "body",
-  },
+  } as any,
   argTypes: {
     classes: { control: { disable: true } },
   },
   render: (args) => {
     return (
       <div style={{ width: 300 }}>
-        <HvInlineEditor {...args} />
+        <HvInlineEditor {...(args as HvInlineEditorProps)} />
       </div>
     );
   },
 };
 
-export const Disabled: StoryObj<typeof HvInlineEditor<typeof HvInput>> = {
+export const Disabled: StoryObj<HvInlineEditorProps> = {
   render: () => {
     return (
       <div style={{ width: 300 }}>

--- a/packages/core/src/InlineEditor/InlineEditor.tsx
+++ b/packages/core/src/InlineEditor/InlineEditor.tsx
@@ -6,7 +6,7 @@ import { useControlled } from "../hooks/useControlled";
 import { useDefaultProps } from "../hooks/useDefaultProps";
 import { useTheme } from "../hooks/useTheme";
 import { HvInput, HvInputProps } from "../Input";
-import { HvBaseProps } from "../types/generic";
+import { fixedForwardRef, HvBaseProps, PolymorphicRef } from "../types/generic";
 import {
   HvTypography,
   HvTypographyProps,
@@ -20,8 +20,9 @@ export { staticClasses as inlineEditorClasses };
 
 export type HvInlineEditorClasses = ExtractNames<typeof useClasses>;
 
-export interface HvInlineEditorProps<T extends React.ElementType>
-  extends HvBaseProps<HTMLDivElement, "onBlur" | "onChange"> {
+export interface HvInlineEditorProps<
+  C extends React.ElementType = typeof HvInput,
+> extends HvBaseProps<HTMLDivElement, "onBlur" | "onChange"> {
   /** The value of the form element. */
   value?: string;
   /** The default value of the form element. */
@@ -29,7 +30,7 @@ export interface HvInlineEditorProps<T extends React.ElementType>
   /** Whether the Edit icon should always be visible */
   showIcon?: boolean;
   /** Component to use as the input. The component "inherit" from `HvBaseInput` (such as `HvInput` or `HvTextArea`) */
-  component?: T;
+  component?: C;
   /** Variant of the HvTypography to display */
   variant?: HvTypographyVariants;
   /** Called when the input is blurred. */
@@ -55,10 +56,13 @@ export interface HvInlineEditorProps<T extends React.ElementType>
  * An Inline Editor allows the user to edit a record without making a major switch
  * between viewing and editing, making it an efficient method of updating a record.
  */
-export const HvInlineEditor = <T extends React.ElementType>(
-  props: HvInlineEditorProps<T> &
-    Omit<React.ComponentProps<T>, keyof HvInlineEditorProps<T>>,
-) => {
+export const HvInlineEditor = fixedForwardRef(function HvInlineEditor<
+  C extends React.ElementType = typeof HvInput,
+>(
+  props: HvInlineEditorProps<C> &
+    Omit<React.ComponentProps<C>, keyof HvInlineEditorProps<C>>,
+  ref: PolymorphicRef<C>,
+) {
   const {
     className,
     classes: classesProp,
@@ -93,7 +97,7 @@ export const HvInlineEditor = <T extends React.ElementType>(
       input.focus();
       input.select();
     }
-  }, [editMode]);
+  }, [editMode, inputRef]);
 
   const handleClick = () => {
     setEditMode(true);
@@ -125,6 +129,7 @@ export const HvInlineEditor = <T extends React.ElementType>(
     <div className={cx(classes.root, className)}>
       {editMode && !disabled ? (
         <InputComponent
+          ref={ref}
           inputRef={inputRef}
           classes={{
             root: classes.inputRoot,
@@ -174,4 +179,4 @@ export const HvInlineEditor = <T extends React.ElementType>(
       )}
     </div>
   );
-};
+});

--- a/packages/core/src/InlineEditor/InlineEditor.tsx
+++ b/packages/core/src/InlineEditor/InlineEditor.tsx
@@ -1,4 +1,4 @@
-import { useLayoutEffect, useRef, useState } from "react";
+import React, { useLayoutEffect, useRef, useState } from "react";
 import { Edit } from "@hitachivantara/uikit-react-icons";
 
 import { HvButton, HvButtonProps } from "../Button";
@@ -20,7 +20,7 @@ export { staticClasses as inlineEditorClasses };
 
 export type HvInlineEditorClasses = ExtractNames<typeof useClasses>;
 
-export interface HvInlineEditorProps
+export interface HvInlineEditorProps<T extends React.ElementType>
   extends HvBaseProps<HTMLDivElement, "onBlur" | "onChange"> {
   /** The value of the form element. */
   value?: string;
@@ -29,7 +29,7 @@ export interface HvInlineEditorProps
   /** Whether the Edit icon should always be visible */
   showIcon?: boolean;
   /** Component to use as the input. The component "inherit" from `HvBaseInput` (such as `HvInput` or `HvTextArea`) */
-  component?: React.ElementType;
+  component?: T;
   /** Variant of the HvTypography to display */
   variant?: HvTypographyVariants;
   /** Called when the input is blurred. */
@@ -55,7 +55,10 @@ export interface HvInlineEditorProps
  * An Inline Editor allows the user to edit a record without making a major switch
  * between viewing and editing, making it an efficient method of updating a record.
  */
-export const HvInlineEditor = (props: HvInlineEditorProps) => {
+export const HvInlineEditor = <T extends React.ElementType>(
+  props: HvInlineEditorProps<T> &
+    Omit<React.ComponentProps<T>, keyof HvInlineEditorProps<T>>,
+) => {
   const {
     className,
     classes: classesProp,

--- a/packages/core/src/InlineEditor/InlineEditor.tsx
+++ b/packages/core/src/InlineEditor/InlineEditor.tsx
@@ -97,7 +97,7 @@ export const HvInlineEditor = fixedForwardRef(function HvInlineEditor<
       input.focus();
       input.select();
     }
-  }, [editMode, inputRef]);
+  }, [editMode]);
 
   const handleClick = () => {
     setEditMode(true);

--- a/packages/core/src/InlineEditor/InlineEditor.tsx
+++ b/packages/core/src/InlineEditor/InlineEditor.tsx
@@ -6,7 +6,11 @@ import { useControlled } from "../hooks/useControlled";
 import { useDefaultProps } from "../hooks/useDefaultProps";
 import { useTheme } from "../hooks/useTheme";
 import { HvInput, HvInputProps } from "../Input";
-import { fixedForwardRef, HvBaseProps, PolymorphicRef } from "../types/generic";
+import {
+  fixedForwardRef,
+  PolymorphicComponentRef,
+  PolymorphicRef,
+} from "../types/generic";
 import {
   HvTypography,
   HvTypographyProps,
@@ -20,37 +24,37 @@ export { staticClasses as inlineEditorClasses };
 
 export type HvInlineEditorClasses = ExtractNames<typeof useClasses>;
 
-export interface HvInlineEditorProps<
-  C extends React.ElementType = typeof HvInput,
-> extends HvBaseProps<HTMLDivElement, "onBlur" | "onChange"> {
-  /** The value of the form element. */
-  value?: string;
-  /** The default value of the form element. */
-  defaultValue?: string;
-  /** Whether the Edit icon should always be visible */
-  showIcon?: boolean;
-  /** Component to use as the input. The component "inherit" from `HvBaseInput` (such as `HvInput` or `HvTextArea`) */
-  component?: C;
-  /** Variant of the HvTypography to display */
-  variant?: HvTypographyVariants;
-  /** Called when the input is blurred. */
-  onBlur?: (
-    event: React.FocusEvent<HTMLTextAreaElement | HTMLInputElement>,
-    value: string,
-  ) => void;
-  /** Called when the input value changes. */
-  onChange?: (event: React.SyntheticEvent, value: string) => void;
-  /** Props passed to the HvButton component */
-  buttonProps?: HvButtonProps;
-  /** Props passed to the HvTypography text component */
-  typographyProps?: HvTypographyProps;
-  /** Whether the editor is disabled or not. */
-  disabled?: boolean;
-  /** A Jss Object used to override or extend the styles applied to the empty state component. */
-  classes?: HvInlineEditorClasses;
-  /** The placeholder value of the input. */
-  placeholder?: string;
-}
+export type HvInlineEditorProps<C extends React.ElementType = typeof HvInput> =
+  PolymorphicComponentRef<
+    C,
+    {
+      /** The value of the form element. */
+      value?: string;
+      /** The default value of the form element. */
+      defaultValue?: string;
+      /** Whether the Edit icon should always be visible */
+      showIcon?: boolean;
+      /** Variant of the HvTypography to display */
+      variant?: HvTypographyVariants;
+      /** Called when the input is blurred. */
+      onBlur?: (
+        event: React.FocusEvent<HTMLTextAreaElement | HTMLInputElement>,
+        value: string,
+      ) => void;
+      /** Called when the input value changes. */
+      onChange?: (event: React.SyntheticEvent, value: string) => void;
+      /** Props passed to the HvButton component */
+      buttonProps?: HvButtonProps;
+      /** Props passed to the HvTypography text component */
+      typographyProps?: HvTypographyProps;
+      /** Whether the editor is disabled or not. */
+      disabled?: boolean;
+      /** A Jss Object used to override or extend the styles applied to the empty state component. */
+      classes?: HvInlineEditorClasses;
+      /** The placeholder value of the input. */
+      placeholder?: string;
+    }
+  >;
 
 /**
  * An Inline Editor allows the user to edit a record without making a major switch
@@ -58,11 +62,7 @@ export interface HvInlineEditorProps<
  */
 export const HvInlineEditor = fixedForwardRef(function HvInlineEditor<
   C extends React.ElementType = typeof HvInput,
->(
-  props: HvInlineEditorProps<C> &
-    Omit<React.ComponentProps<C>, keyof HvInlineEditorProps<C>>,
-  ref: PolymorphicRef<C>,
-) {
+>(props: HvInlineEditorProps<C>, ref: PolymorphicRef<C>) {
   const {
     className,
     classes: classesProp,


### PR DESCRIPTION
previously when using `HvInlineEditor` the spread attributes were not correctly recognized correctly so attributes of `HvInput` like `disableClear` would show as error with typescript. This intends to fix it even when you change the component.