### PR TITLE
ci(release): add custom GitHub releases

### DIFF
--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -1,5 +1,10 @@
 name: Dependencies
 description: Install UI Kit dependencies
+inputs:
+  install:
+    description: "Whether to npm install dependencies"
+    required: false
+    default: "true"
 
 runs:
   using: "composite"
@@ -10,6 +15,7 @@ runs:
         node-version: 18
 
     - name: Install dependencies
+      if: ${{ inputs.install == 'true' }}
       # ensure dev dependencies are installed
       run: npm ci --include=dev
       shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,10 +82,44 @@ jobs:
     uses: ./.github/workflows/security.yml
     secrets: inherit
 
+  publish-github:
+    name: Publish GitHub Release
+    needs: [publish]
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: "0"
+          fetch-tags: true
+
+      - name: Publish Setup
+        run: |
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+
+      - name: Install Dependencies
+        uses: ./.github/actions/install-dependencies
+        with:
+          install: false
+
+      - name: Tag Release
+        # Tag according to core's version, erroring (expectedly) when no new version
+        run: |
+          VERSION=v$(npm pkg get version -w @hitachivantara/uikit-react-core | sed -n 's/.*"@hitachivantara\/uikit-react-core": "\(.*\)".*/\1/p')
+          git tag -a $VERSION -m "Version $VERSION"
+          git push --tags
+
+      - name: Create GitHub Release
+        run: npx changelogithub@0.13
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   notify-release:
     name: Notify release
     runs-on: ubuntu-latest
-    needs: [publish-documentation]
+    needs: [publish-github]
 
     env:
       DOCUMENTATION_URL: https://${{ github.repository_owner }}.github.io/uikit/${{ github.ref_name }}/
@@ -105,6 +139,13 @@ jobs:
               branch: "${{ github.ref_name }}"
             })
 
+            const tags = await github.repos.listTags({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              per_page: 1
+            });
+            const latestTag = tags.data[0].name;
+
             const commitMessage = branch.data.commit.commit.message
             const slackMessage = commitMessage.replace('chore(release): publish', '')
               .replace(/\n/g, "\\n")
@@ -113,6 +154,7 @@ jobs:
               .replace(/\f/g, "\\f")
               
             core.exportVariable("SLACK_MESSAGE", slackMessage)
+            core.exportVariable("LATEST_TAG", latestTag)
 
       - name: Notify release
         uses: hbfernandes/slack-action@1.0
@@ -126,8 +168,8 @@ jobs:
               "attachments": [
                 {
                   "mrkdwn_in": ["text"],
-                  "author_name": "New UI-Kit artifacts are available",
-                  "title": "More details https://github.com/${{github.repository}}/releases",
+                  "author_name": "New UI-Kit Release is available",
+                  "title": "https://github.com/${{github.repository}}/releases/${{env.LATEST_TAG}}",
                   "text": "${{env.SLACK_MESSAGE}}",
                   "footer": "${{env.DOCUMENTATION_URL}}"
                 }

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -40,10 +40,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install Node.js
-        uses: actions/setup-node@v4
+      - name: Install Dependencies
+        uses: ./.github/actions/install-dependencies
         with:
-          node-version: 18
+          install: false
 
       - name: Request Citadel scan
         run: .github/scripts/citadel-request.mjs
@@ -69,10 +69,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install Node.js
-        uses: actions/setup-node@v4
+      - name: Install Dependencies
+        uses: ./.github/actions/install-dependencies
         with:
-          node-version: 18
+          install: false
 
       # Install dependencies inside each package so blackduck can scan them
       # To do this we need to remove the package.json and package-lock.json from the root

--- a/lerna.json
+++ b/lerna.json
@@ -14,7 +14,6 @@
       "preid": "next",
       "message": "chore(release): publish",
       "conventionalCommits": true,
-      "createRelease": "github",
       "contents": "package"
     }
   }


### PR DESCRIPTION
Add custom GitHub Releases using [changelogithub](https://github.com/antfu/changelogithub)

- Disable `lerna` GitHub Releases generation (`createRelease`)
- Generate GitHub releases with [changelogithub](https://github.com/antfu/changelogithub)
  - version is picked up from core package
  - example:

![image](https://github.com/user-attachments/assets/1aa5b83a-389f-49ee-9aef-e36be900a056)
