### PR TITLE
chore: move to ESM packages

### DIFF
--- a/.config/vite.config.ts
+++ b/.config/vite.config.ts
@@ -1,8 +1,13 @@
-import { resolve } from "node:path";
+import { createRequire } from "node:module";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
 import dts from "vite-plugin-dts";
 import tsconfigPaths from "vite-tsconfig-paths";
+
+const require = createRequire(import.meta.url);
+const __dirname = dirname(fileURLToPath(import.meta.url));
 
 const pkg = require(resolve(process.cwd(), "package.json"));
 

--- a/.prettierrc
+++ b/.prettierrc
@@ -15,5 +15,5 @@
     "",
     "^[./]"
   ],
-  "importOrderTypeScriptVersion": "4.9.5"
+  "importOrderTypeScriptVersion": "5.5.4"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -145,19 +145,6 @@
         "vite-tsconfig-paths": "^4.2.2"
       }
     },
-    "apps/app/node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-      "dev": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
-      }
-    },
     "apps/docs": {
       "name": "uikit-docs",
       "dependencies": {
@@ -180,19 +167,6 @@
         "@types/react-dom": "^18.2.17",
         "string-replace-loader": "^3.1.0",
         "typescript": "^5.5.4"
-      }
-    },
-    "apps/docs/node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-      "dev": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
       }
     },
     "node_modules/@75lb/deep-merge": {
@@ -8447,9 +8421,9 @@
       }
     },
     "node_modules/@storybook/core/node_modules/@types/node": {
-      "version": "18.19.42",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.42.tgz",
-      "integrity": "sha512-d2ZFc/3lnK2YCYhos8iaNIYu9Vfhr92nHiyJHRltXWjXUBjEE+A4I58Tdbnw4VhggSW+2j5y5gTrLs4biNnubg==",
+      "version": "18.19.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.43.tgz",
+      "integrity": "sha512-Mw/YlgXnyJdEwLoFv2dpuJaDFriX+Pc+0qOBJ57jC1H6cDxIj2xc5yUrdtArDVG0m+KV6622a4p2tenEqB3C/g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8650,9 +8624,9 @@
       }
     },
     "node_modules/@storybook/react/node_modules/@types/node": {
-      "version": "18.19.42",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.42.tgz",
-      "integrity": "sha512-d2ZFc/3lnK2YCYhos8iaNIYu9Vfhr92nHiyJHRltXWjXUBjEE+A4I58Tdbnw4VhggSW+2j5y5gTrLs4biNnubg==",
+      "version": "18.19.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.43.tgz",
+      "integrity": "sha512-Mw/YlgXnyJdEwLoFv2dpuJaDFriX+Pc+0qOBJ57jC1H6cDxIj2xc5yUrdtArDVG0m+KV6622a4p2tenEqB3C/g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10051,9 +10025,9 @@
       "integrity": "sha512-nG96G3Wp6acyAgJqGasjODb+acrI7KltPiRxzHPXnP3NgI28bpQDRv53olbqGXbfcgF5aiiHmO3xpwEpS5Ld9g=="
     },
     "node_modules/@types/node": {
-      "version": "20.14.13",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.13.tgz",
-      "integrity": "sha512-+bHoGiZb8UiQ0+WEtmph2IWQCjIqg8MDZMAV+ppRRhUZnquF5mQkP/9vpSwJClEiSM/C7fZZExPzfU0vJTyp8w==",
+      "version": "20.14.14",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.14.tgz",
+      "integrity": "sha512-d64f00982fS9YoOgJkAMolK7MN8Iq3TDdVjchbYHdEmjth/DHowx82GnoA+tVUAN+7vxfYUgAzi+JXbKNd2SDQ==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~5.26.4"
@@ -39598,8 +39572,7 @@
         "recursive-readdir": "^2.2.3",
         "svgo": "^3.1.0",
         "tsx": "^4.6.2",
-        "vite": "^5.1.0",
-        "yargs": "^17.7.2"
+        "vite": "^5.1.0"
       },
       "peerDependencies": {
         "@emotion/react": "^11.11.1",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "hv-uikit-react",
+  "type": "module",
   "private": true,
   "description": "The React component library for the Next Design System.",
   "homepage": "https://github.com/lumada-design/hv-uikit-react",

--- a/packages/code-editor/package.json
+++ b/packages/code-editor/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@hitachivantara/uikit-react-code-editor",
   "version": "5.2.180",
+  "type": "module",
   "private": false,
   "author": "Hitachi Vantara UI Kit Team",
   "description": "A wrapper to the React Monaco editor (https://github.com/react-monaco-editor/react-monaco-editor) using the Hitachi Vantara's Design System styles.",
@@ -66,7 +67,8 @@
     "withoutPublish": true,
     "tempDir": "package",
     "fields": [
-      "main"
+      "main",
+      "type"
     ],
     "files": [
       "tsconfig.json"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@hitachivantara/uikit-react-core",
   "version": "5.66.14",
+  "type": "module",
   "private": false,
   "author": "Hitachi Vantara UI Kit Team",
   "description": "Core React components for the NEXT Design System.",
@@ -93,7 +94,8 @@
     "withoutPublish": true,
     "tempDir": "package",
     "fields": [
-      "main"
+      "main",
+      "type"
     ],
     "files": [
       "tsconfig.json"

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@hitachivantara/uikit-react-icons",
   "version": "5.10.5",
+  "type": "module",
   "private": false,
   "author": "Hitachi Vantara UI Kit Team",
   "description": "NEXT Design System icons packaged as a set of React components.",
@@ -30,8 +31,8 @@
     "optimize": "svgo -r -f assets assets",
     "preconvert": "npx rimraf src",
     "convert": "run-s convert:*",
-    "convert:svg": "tsx scripts/svgToReact.ts dir --input assets --output src",
-    "convert:sprites": "tsx scripts/svgToSprite.ts dir --input assets --output sprites",
+    "convert:svg": "tsx scripts/svgToReact.ts",
+    "convert:sprites": "tsx scripts/svgToSprite.ts",
     "convert:copy": "npx cpy \"lib/*\" \"src\"",
     "clean": "npx rimraf dist src sprites package",
     "prepare": "npm run convert",
@@ -58,8 +59,7 @@
     "recursive-readdir": "^2.2.3",
     "svgo": "^3.1.0",
     "tsx": "^4.6.2",
-    "vite": "^5.1.0",
-    "yargs": "^17.7.2"
+    "vite": "^5.1.0"
   },
   "files": [
     "dist"
@@ -81,7 +81,8 @@
     "withoutPublish": true,
     "tempDir": "package",
     "fields": [
-      "main"
+      "main",
+      "type"
     ],
     "files": [
       "tsconfig.json"

--- a/packages/icons/scripts/svgToReact.ts
+++ b/packages/icons/scripts/svgToReact.ts
@@ -2,26 +2,13 @@
 import fs from "node:fs";
 import path from "node:path";
 import { transform } from "@svgr/core";
-import recursive from "recursive-readdir";
-import yargs from "yargs";
 
 import { generateComponent } from "./generateComponent";
 import { extractColors, extractSize, replaceFill } from "./utils";
 
-// Argument setup
-const args = yargs // reading arguments from the command line
-  .option("output", { alias: "o" })
-  .option("input", { alias: "i" })
-  .option("rm-style", { default: false }).argv as any;
-
 // Resolve arguments
-const firstArg = args._[0];
-const secondArgs = args._[1] || "MyComponent";
-const inputPath = args.input;
-const outputPath = args.output as string;
-
-// Bootstrap base variables
-const svg = `./${firstArg}.svg`; // append the file extension
+const inputPath = "assets";
+const outputPath = "src";
 
 const componentOutputFolder = outputPath
   ? path.resolve(process.cwd(), outputPath)
@@ -151,16 +138,6 @@ const processFile = (file: string, subFolder = ".", depth = 0) => {
   }
 };
 
-const runUtilForAllInDir = () => {
-  recursive(`${process.cwd()}/${inputPath}`, (err, files) => {
-    if (err) {
-      console.log(err);
-      return;
-    } // Get out early if not found
-    files.forEach((file) => processFile(file));
-  });
-};
-
 const runUtilForJustFilesInDir = (
   folder: string,
   subFolder = ".",
@@ -193,10 +170,4 @@ fs.mkdir(outputPath, { recursive: true }, (err) => {
 
 fs.writeFile(path.resolve(process.cwd(), outputPath, `index.ts`), "", () => {});
 
-// Main entry point
-if (firstArg === "dir") {
-  if (secondArgs === "flatten") runUtilForAllInDir();
-  else runUtilForJustFilesInDir(`${process.cwd()}/${inputPath}`);
-} else {
-  runUtil(svg, secondArgs);
-}
+runUtilForJustFilesInDir(`${process.cwd()}/${inputPath}`);

--- a/packages/icons/scripts/svgToSprite.ts
+++ b/packages/icons/scripts/svgToSprite.ts
@@ -2,20 +2,13 @@
 import fs from "node:fs";
 import path from "node:path";
 import recursive from "recursive-readdir";
-import yargs from "yargs";
 
 import { generateSymbol } from "./generateSymbol";
 import { extractColors, replaceFill } from "./utils";
 
-// Argument setup
-const args = yargs // reading arguments from the command line
-  .option("output", { alias: "o" })
-  .option("input", { alias: "i" }).argv as any;
-
 // Resolve arguments
-const firstArg = args._[0];
-const inputPath = args.input as string;
-const outputPath = args.output as string;
+const inputPath = "assets";
+const outputPath = "sprites";
 
 const outputFolder = outputPath
   ? path.resolve(process.cwd(), outputPath)
@@ -55,11 +48,7 @@ fs.mkdir(outputFolder, { recursive: true }, (err) => {
 
 // Create a sprite for each group of SVG files
 (async () => {
-  const svgPathsByGroup =
-    firstArg === "dir"
-      ? await getSvgPathsByGroup(inputPath)
-      : { icons: [inputPath] };
-
+  const svgPathsByGroup = await getSvgPathsByGroup(inputPath);
   for (const groupName in svgPathsByGroup) {
     if (Object.hasOwn(svgPathsByGroup, groupName)) {
       const svgPaths = svgPathsByGroup[groupName];

--- a/packages/lab/package.json
+++ b/packages/lab/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@hitachivantara/uikit-react-lab",
   "version": "5.37.4",
+  "type": "module",
   "private": false,
   "author": "Hitachi Vantara UI Kit Team",
   "description": "Contributed React components for the NEXT UI Kit.",
@@ -81,7 +82,8 @@
     "withoutPublish": true,
     "tempDir": "package",
     "fields": [
-      "main"
+      "main",
+      "type"
     ],
     "files": [
       "tsconfig.json"

--- a/packages/pentaho/package.json
+++ b/packages/pentaho/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@hitachivantara/uikit-react-pentaho",
   "version": "0.3.0",
+  "type": "module",
   "private": false,
   "author": "Hitachi Vantara UI Kit Team",
   "description": "UI Kit Pentaho+ React components.",
@@ -72,7 +73,8 @@
     "withoutPublish": true,
     "tempDir": "package",
     "fields": [
-      "main"
+      "main",
+      "type"
     ],
     "files": [
       "tsconfig.json"

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@hitachivantara/uikit-react-shared",
   "version": "5.1.45",
+  "type": "module",
   "private": false,
   "author": "Hitachi Vantara UI Kit Team",
   "description": "Shared React contexts for the NEXT UI Kit.",
@@ -68,7 +69,8 @@
     "withoutPublish": true,
     "tempDir": "package",
     "fields": [
-      "main"
+      "main",
+      "type"
     ],
     "files": [
       "tsconfig.json"

--- a/packages/styles/package.json
+++ b/packages/styles/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@hitachivantara/uikit-styles",
   "version": "5.31.0",
+  "type": "module",
   "private": false,
   "author": "Hitachi Vantara UI Kit Team",
   "description": "UI Kit styling solution for the Next Design System.",
@@ -54,7 +55,8 @@
     "withoutPublish": true,
     "tempDir": "package",
     "fields": [
-      "main"
+      "main",
+      "type"
     ],
     "files": [
       "tsconfig.json"

--- a/packages/uno-preset/package.json
+++ b/packages/uno-preset/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@hitachivantara/uikit-uno-preset",
   "version": "0.2.25",
+  "type": "module",
   "private": false,
   "author": "Hitachi Vantara UI Kit Team",
   "description": "UI Kit UnoCSS preset with the NEXT theme.",
@@ -63,7 +64,8 @@
     "withoutPublish": true,
     "tempDir": "package",
     "fields": [
-      "main"
+      "main",
+      "type"
     ],
     "files": [
       "tsconfig.json"

--- a/packages/viz/package.json
+++ b/packages/viz/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@hitachivantara/uikit-react-viz",
   "version": "5.13.12",
+  "type": "module",
   "private": false,
   "author": "Hitachi Vantara UI Kit Team",
   "description": "Contributed React visualization components for the NEXT UI Kit.",
@@ -71,7 +72,8 @@
     "withoutPublish": true,
     "tempDir": "package",
     "fields": [
-      "main"
+      "main",
+      "type"
     ],
     "files": [
       "tsconfig.json"

--- a/scripts/flow-styles.js
+++ b/scripts/flow-styles.js
@@ -1,8 +1,9 @@
-/* eslint-disable import/no-extraneous-dependencies */
-/* eslint-disable no-console */
-const { execSync } = require("node:child_process");
-const fs = require("node:fs");
-const path = require("node:path");
+import { execSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const getReactFlowStyles = () => {
   try {
@@ -10,11 +11,11 @@ const getReactFlowStyles = () => {
 
     const reactFlowFile = path.resolve(
       __dirname,
-      "../../node_modules/reactflow/dist/style.css",
+      "../node_modules/reactflow/dist/style.css",
     );
     const filePath = path.resolve(
       __dirname,
-      "../../packages/lab/src/components/Flow/base.ts",
+      "../packages/lab/src/Flow/base.ts",
     );
 
     // Get styles

--- a/scripts/storybook-title.js
+++ b/scripts/storybook-title.js
@@ -1,6 +1,8 @@
-/* eslint-disable no-console */
-const fs = require("node:fs");
-const path = require("node:path");
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const fixTitle = (filePath, title) => {
   const data = fs.readFileSync(filePath, "utf-8");
@@ -17,7 +19,7 @@ const fixStorybookTitle = () => {
     console.log("⏳ Fixing Storybook title.");
 
     const title = "NEXT UI Kit";
-    const storybookDist = path.resolve(__dirname, "../../dist");
+    const storybookDist = path.resolve(__dirname, "../dist");
     const htmlFile = `${storybookDist}/index.html`;
     const iframeFile = `${storybookDist}/iframe.html`;
 


### PR DESCRIPTION
- chore(deps): align ts versions (prettier plugin, app, docs)
- build(icons): remove icons CLI behaviour & `yargs` dependency
- move project from CJS to ESM (add `type: "module"`), as [Vite CJS build is deprecated](https://vitejs.dev/guide/troubleshooting.html#vite-cjs-node-api-deprecated)
  - `type` is removed by `clean-publish` so this change has no effect on users

 ```
The CJS build of Vite's Node API is deprecated. See https://vitejs.dev/guide/troubleshooting.html#vite-cjs-node-api-deprecated for more details.
```
