### PR TITLE
fix: `fixedForwardRef` types in typescript@4

### DIFF
--- a/packages/core/src/types/generic.ts
+++ b/packages/core/src/types/generic.ts
@@ -56,8 +56,9 @@ export type Arrayable<T> = T | T[];
 
 /** React.forwardRef with fixed type declarations */
 export function fixedForwardRef<T, P = {}>(
-  render: (props: P, ref: React.Ref<T>) => React.ReactNode,
-): (props: P & React.RefAttributes<T>) => React.ReactNode {
+  // TODO: change `React.ReactElement | null` to `React.ReactNode` in v6 (requires ts@5+)
+  render: (props: P, ref: React.Ref<T>) => React.ReactElement | null,
+): (props: P & React.RefAttributes<T>) => React.ReactElement | null {
   return forwardRef(render) as any;
 }
 


### PR DESCRIPTION
Using `React.ReactNode` in `typescript@4` will break, as `undefined` isn't a valid JSX element in v4:

![image](https://github.com/user-attachments/assets/7d7eb30d-9e83-4fc2-8bcf-b65ee4ad072e)
