### PR TITLE
fix: styles across components

### DIFF
--- a/apps/app/src/assets/HitachiLogo.tsx
+++ b/apps/app/src/assets/HitachiLogo.tsx
@@ -1,16 +1,10 @@
-import { theme } from "@hitachivantara/uikit-styles";
-
 export const HitachiLogo = ({ ...others }: React.SVGProps<SVGSVGElement>) => {
   return (
     <svg
-      x="0px"
-      y="0px"
+      role="img"
       viewBox="0 0 80 16"
-      xmlSpace="preserve"
-      width={80}
-      height={16}
-      style={{ width: 72, height: 20 }}
-      fill={theme.colors.secondary}
+      width={72}
+      fill="currentColor"
       {...others}
     >
       <title>Logo</title>

--- a/packages/cli/src/baselines/vite/src/assets/HitachiLogo.tsx
+++ b/packages/cli/src/baselines/vite/src/assets/HitachiLogo.tsx
@@ -1,18 +1,13 @@
-import { theme } from "@hitachivantara/uikit-styles";
-
-const HitachiLogo = (props: React.SVGAttributes<SVGElement>) => {
+export const HitachiLogo = ({ ...others }: React.SVGProps<SVGSVGElement>) => {
   return (
     <svg
-      x="0px"
-      y="0px"
+      role="img"
       viewBox="0 0 80 16"
-      xmlSpace="preserve"
-      width={80}
-      height={16}
-      style={{ width: 72, height: 20 }}
-      fill={theme.colors.secondary}
-      {...props}
+      width={72}
+      fill="currentColor"
+      {...others}
     >
+      <title>Logo</title>
       <path d="M63.6,2.5c0,0,0,4.8,0,4.7H70c0,0,0-4.7,0-4.7s3.1,0,3.1,0c0,0,0,11.8,0,11.9H70c0,0,0-5.2,0-5.2c0,0-6.3,0-6.3,0c0,0,0,5.2,0,5.2h-3.1c0,0,0-11.9,0-11.9C60.5,2.5,63.6,2.5,63.6,2.5z" />
       <path d="M33.9,2.5c0,0,0,2,0,2h-4.8v9.8h-3.1V4.5h-4.8v-2C21.1,2.5,33.9,2.5,33.9,2.5z" />
       <path d="M46,14.3c0,0-3.5,0-3.5,0l-1-2.6h-5.9c0,0-1,2.6-1,2.6h-3.5l5.5-11.9h3.8L46,14.3z M38.6,4.5l-2.2,5.4h4.4L38.6,4.5" />
@@ -30,5 +25,3 @@ const HitachiLogo = (props: React.SVGAttributes<SVGElement>) => {
     </svg>
   );
 };
-
-export default HitachiLogo;

--- a/packages/cli/src/baselines/vite/src/components/common/Header/Header.tsx
+++ b/packages/cli/src/baselines/vite/src/components/common/Header/Header.tsx
@@ -11,7 +11,7 @@ import {
   HvHeaderNavigationProps,
 } from "@hitachivantara/uikit-react-core";
 
-import HitachiLogo from "../../../assets/HitachiLogo";
+import { HitachiLogo } from "../../../assets/HitachiLogo";
 import { NavigationContext } from "../../../context/NavigationContext";
 // @ts-expect-error TODO
 import navigation from "../../../lib/navigation";

--- a/packages/core/src/AppSwitcher/Action/Action.styles.tsx
+++ b/packages/core/src/AppSwitcher/Action/Action.styles.tsx
@@ -9,7 +9,6 @@ export const { staticClasses, useClasses } = createClasses(
       width: "100%",
       maxWidth: 280,
       minHeight: 52,
-      marginRight: theme.space.sm,
     },
     icon: { display: "flex", minWidth: 40, justifyContent: "center" },
     iconUrl: { width: 32 },

--- a/packages/core/src/AppSwitcher/Action/Action.tsx
+++ b/packages/core/src/AppSwitcher/Action/Action.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useState } from "react";
 import { Info } from "@hitachivantara/uikit-react-icons";
-import { getColor, HvColorAny, theme } from "@hitachivantara/uikit-styles";
+import { getColor, HvColorAny } from "@hitachivantara/uikit-styles";
 
 import { HvAvatar } from "../../Avatar";
 import { useUniqueId } from "../../hooks/useUniqueId";
@@ -66,9 +66,10 @@ export const HvAppSwitcherAction = ({
   const { name, description, disabled, iconElement, iconUrl, url, target } =
     application;
 
-  const color = disabled
-    ? theme.colors.secondary_60
-    : getColor(application?.color, theme.colors.secondary);
+  const color = getColor(
+    disabled ? "secondary_60" : application?.color,
+    "secondary",
+  );
 
   const [validIconUrl, setValidIconUrl] = useState<boolean>(true);
 
@@ -122,48 +123,6 @@ export const HvAppSwitcherAction = ({
   const isLink = url != null;
   const descriptionElementId = useUniqueId(id);
 
-  const renderApplication = useCallback(
-    (children: React.ReactNode) => {
-      const typographyProps = {
-        className: classes.typography,
-        onClick: handleOnClick,
-        style: { borderColor: color },
-        "aria-label": name,
-        ...(description && { "aria-describedby": descriptionElementId }),
-      };
-
-      if (isLink) {
-        return (
-          <HvTypography
-            component="a"
-            href={url}
-            target={target || "_top"}
-            {...typographyProps}
-          >
-            {children}
-          </HvTypography>
-        );
-      }
-
-      return (
-        <HvTypography component="button" {...typographyProps}>
-          {children}
-        </HvTypography>
-      );
-    },
-    [
-      classes.typography,
-      color,
-      description,
-      descriptionElementId,
-      handleOnClick,
-      isLink,
-      name,
-      target,
-      url,
-    ],
-  );
-
   return (
     <HvListItem
       id={id}
@@ -177,37 +136,33 @@ export const HvAppSwitcherAction = ({
         className,
       )}
     >
-      {/* As HvTooltip don't have the id prop, is not possible to use the aria-labelledby to reference it.
-       In substitution is used the aria-label with the "title" value */}
-      {renderApplication(
-        <>
-          <div className={classes.icon}>{renderApplicationIcon()}</div>
+      <HvTypography
+        component="button"
+        className={classes.typography}
+        onClick={handleOnClick}
+        style={{ borderColor: color }}
+        aria-label={name}
+        {...(description && { "aria-describedby": descriptionElementId })}
+        {...(isLink && { component: "a", href: url, target: target || "_top" })}
+      >
+        <div className={classes.icon}>{renderApplicationIcon()}</div>
 
-          <HvOverflowTooltip
-            paragraphOverflow
-            className={classes.title}
-            placement="top-start"
-            data={name}
-            classes={{
-              tooltipAnchorParagraph: classes.titleAnchor,
-            }}
-          />
+        <HvOverflowTooltip
+          paragraphOverflow
+          className={classes.title}
+          placement="top-start"
+          data={name}
+          classes={{
+            tooltipAnchorParagraph: classes.titleAnchor,
+          }}
+        />
 
-          {description && (
-            <HvTooltip
-              disableFocusListener
-              disableTouchListener
-              title={description}
-            >
-              <Info
-                className={classes.iconInfo}
-                title={description}
-                id={descriptionElementId}
-              />
-            </HvTooltip>
-          )}
-        </>,
-      )}
+        {description && (
+          <HvTooltip title={description}>
+            <Info className={classes.iconInfo} id={descriptionElementId} />
+          </HvTooltip>
+        )}
+      </HvTypography>
     </HvListItem>
   );
 };

--- a/packages/core/src/AppSwitcher/AppSwitcher.styles.tsx
+++ b/packages/core/src/AppSwitcher/AppSwitcher.styles.tsx
@@ -6,14 +6,7 @@ export const { staticClasses, useClasses } = createClasses("HvAppSwitcher", {
   root: {
     display: "flex",
     flexDirection: "column",
-    backgroundColor: theme.colors.atmo1,
     overflow: "hidden",
-
-    // we need to play with the 4px because of the focus ring
-    // padding: `${theme.spacing(2) - 4}px 0 ${theme.spacing(2) - 4}px ${
-    //   theme.spacing(2) - 4
-    // }px`,
-    padding: theme.spacing("sm", 0, "sm", "sm"),
   },
   item: {},
   itemSelected: {},
@@ -28,22 +21,19 @@ export const { staticClasses, useClasses } = createClasses("HvAppSwitcher", {
     justifyContent: "flex-start",
 
     overflowY: "auto",
-
-    // We need to play with the 4px because of the focus ring
-    padding: "4px 0 4px 4px",
+    gap: theme.space.xs,
+    padding: 4,
+    margin: -4,
   },
   footerContainer: {
     display: "flex",
     alignItems: "center",
     marginTop: "auto",
     height: 52,
-
-    // We need to play with the 4px because of the focus ring
-    // padding: `${theme.hv.spacing.sm - 4}px ${theme.hv.spacing.sm + 4}px 4px 4px`,
-    padding: `${theme.space.sm} ${theme.space.sm} 4px 4px`,
+    paddingTop: theme.space.sm,
   },
   open: {
-    zIndex: "1200",
+    zIndex: theme.zIndices.overlay,
     position: "absolute",
     top: "50px",
     overflowX: "hidden",
@@ -52,16 +42,13 @@ export const { staticClasses, useClasses } = createClasses("HvAppSwitcher", {
   closed: { display: "none" },
   title: {
     minHeight: 36,
-
-    // we need to play with the 4px because of the focus ring
-    // padding: `4px ${theme.hv.spacing.sm}px ${theme.hv.spacing.sm - 4}px 4px`,
-    padding: `4px ${theme.space.sm} ${theme.space.sm} 4px`,
+    paddingBottom: theme.space.sm,
     ...theme.typography.label,
   },
   titleAnchor: {
     WebkitLineClamp: 2,
   },
-  single: { width: 320 },
-  dual: { width: 640 },
+  single: { width: 280 + 40 },
+  dual: { width: 560 + 40 },
   fluid: {},
 });

--- a/packages/core/src/AppSwitcher/AppSwitcher.tsx
+++ b/packages/core/src/AppSwitcher/AppSwitcher.tsx
@@ -3,6 +3,7 @@ import { useMemo } from "react";
 import { useDefaultProps } from "../hooks/useDefaultProps";
 import { HvListContainer } from "../ListContainer";
 import { HvOverflowTooltip } from "../OverflowTooltip";
+import { HvPanel } from "../Panel";
 import { HvBaseProps } from "../types/generic";
 import { HvTypography } from "../Typography";
 import { ExtractNames } from "../utils/classes";
@@ -88,7 +89,7 @@ export const HvAppSwitcher = (props: HvAppSwitcherProps) => {
   );
 
   return (
-    <div
+    <HvPanel
       className={cx(
         classes.root,
         classes[layout],
@@ -112,7 +113,11 @@ export const HvAppSwitcher = (props: HvAppSwitcherProps) => {
             }}
           />
         ))}
-      <HvListContainer disableGutters className={classes.actionsContainer}>
+      <HvListContainer
+        condensed
+        disableGutters
+        className={classes.actionsContainer}
+      >
         {panelActions}
       </HvListContainer>
       {footer && (
@@ -124,6 +129,6 @@ export const HvAppSwitcher = (props: HvAppSwitcherProps) => {
           {footer}
         </HvTypography>
       )}
-    </div>
+    </HvPanel>
   );
 };

--- a/packages/core/src/AvatarGroup/AvatarGroup.tsx
+++ b/packages/core/src/AvatarGroup/AvatarGroup.tsx
@@ -5,7 +5,7 @@ import { HvSize, theme } from "@hitachivantara/uikit-styles";
 import { HvAvatar } from "../Avatar/Avatar";
 import { useDefaultProps } from "../hooks/useDefaultProps";
 import { HvBaseProps } from "../types/generic";
-import { ExtractNames } from "../utils/classes";
+import { ExtractNames, mergeStyles } from "../utils/classes";
 import { staticClasses, useClasses } from "./AvatarGroup.styles";
 import { HvAvatarGroupProvider } from "./AvatarGroupContext";
 
@@ -167,14 +167,15 @@ export const HvAvatarGroup = forwardRef<HTMLDivElement, HvAvatarGroupProps>(
         className={cx(
           classes.root,
           classes[direction],
-          { [classes.highlight]: highlight },
-          { [classes.toBack]: toBack },
+          {
+            [classes.highlight]: highlight,
+            [classes.toBack]: toBack,
+          },
           className,
         )}
-        style={{
-          ["--spacing" as string]: `-${spacingValue}px`,
-          ...style,
-        }}
+        style={mergeStyles(style, {
+          "--spacing": `-${spacingValue}px`,
+        })}
         ref={ref}
         {...others}
       >

--- a/packages/core/src/BaseDropdown/BaseDropdown.styles.tsx
+++ b/packages/core/src/BaseDropdown/BaseDropdown.styles.tsx
@@ -48,6 +48,7 @@ export const { useClasses, staticClasses } = createClasses("HvBaseDropdown", {
   headerDisabled: {
     cursor: "not-allowed",
     pointerEvents: "none",
+    color: theme.colors.secondary_60,
     border: `1px solid ${theme.colors.secondary_60}`,
     background: theme.colors.atmo2,
     "&:hover": {
@@ -57,6 +58,7 @@ export const { useClasses, staticClasses } = createClasses("HvBaseDropdown", {
   headerReadOnly: {
     cursor: "not-allowed",
     pointerEvents: "none",
+    color: theme.colors.secondary_80,
     border: `1px solid ${theme.colors.secondary_60}`,
     background: theme.colors.atmo2,
     userSelect: "text",
@@ -79,16 +81,13 @@ export const { useClasses, staticClasses } = createClasses("HvBaseDropdown", {
     boxSizing: "border-box",
     paddingLeft: theme.space.xs,
     paddingRight: theme.sizes.sm,
+    color: "inherit",
   },
+  selectionDisabled: {},
   placeholder: {
     display: "block",
-    overflow: "hidden",
-    textOverflow: "ellipsis",
-    whiteSpace: "nowrap",
-    ...theme.typography.body,
     color: theme.colors.secondary_80,
   },
-  selectionDisabled: { color: theme.colors.secondary_60 },
   panel: {
     position: "relative",
 

--- a/packages/core/src/BaseDropdown/BaseDropdown.tsx
+++ b/packages/core/src/BaseDropdown/BaseDropdown.tsx
@@ -267,14 +267,13 @@ const BaseDropdown = forwardRef<
       ref={handleDropdownHeaderRef}
       {...dropdownHeaderProps}
     >
-      <div className={classes.selection}>
+      <div
+        className={cx(classes.selection, {
+          [classes.selectionDisabled]: disabled,
+        })}
+      >
         {placeholder && typeof placeholder === "string" ? (
-          <HvTypography
-            className={cx(classes.placeholder, {
-              [classes.selectionDisabled]: disabled,
-            })}
-            variant="body"
-          >
+          <HvTypography noWrap className={classes.placeholder}>
             {placeholder}
           </HvTypography>
         ) : (

--- a/packages/core/src/Card/Card.styles.tsx
+++ b/packages/core/src/Card/Card.styles.tsx
@@ -9,6 +9,7 @@ export const { staticClasses, useClasses } = createClasses("HvCard", {
     position: "relative",
     outline: `1px solid ${theme.colors.atmo4}`,
     borderRadius: `0px 0px ${theme.radii.round} ${theme.radii.round}`,
+    backgroundColor: "var(--bg-color)",
     "&:focus-visible": {
       ...outlineStyles,
     },
@@ -42,6 +43,8 @@ export const { staticClasses, useClasses } = createClasses("HvCard", {
     right: theme.space.xs,
   },
   semanticBar: {
+    backgroundColor: "var(--bar-color)",
+    height: "var(--bar-height)",
     width: "100%",
     top: -1,
     right: 0,

--- a/packages/core/src/Card/Card.tsx
+++ b/packages/core/src/Card/Card.tsx
@@ -1,13 +1,8 @@
-import {
-  getColor,
-  HvColor,
-  HvColorAny,
-  theme,
-} from "@hitachivantara/uikit-styles";
+import { getColor, HvColorAny } from "@hitachivantara/uikit-styles";
 
 import { useDefaultProps } from "../hooks/useDefaultProps";
 import { HvBaseProps } from "../types/generic";
-import { ExtractNames } from "../utils/classes";
+import { ExtractNames, mergeStyles } from "../utils/classes";
 import { staticClasses, useClasses } from "./Card.styles";
 
 export { staticClasses as cardClasses };
@@ -41,6 +36,7 @@ export interface HvCardProps extends HvBaseProps {
 export const HvCard = (props: HvCardProps) => {
   const {
     classes: classesProp,
+    style,
     className,
     children,
     icon,
@@ -51,16 +47,23 @@ export const HvCard = (props: HvCardProps) => {
     ...others
   } = useDefaultProps("HvCard", props);
 
-  const { classes, css, cx } = useClasses(classesProp);
+  const { classes, cx } = useClasses(classesProp);
+
+  const barColor =
+    (statusColor !== "sema0" && statusColor) ||
+    (selected && "secondary") ||
+    "atmo4";
 
   return (
     <div
+      style={mergeStyles(style, {
+        "--bg-color": getColor(bgcolor),
+        "--bar-height": `${selected ? 4 : 2}px`,
+        "--bar-color": getColor(barColor),
+      })}
       className={cx(
         "HvIsCardGridElement",
         classes.root,
-        css({
-          backgroundColor: getColor(bgcolor),
-        }),
         {
           [classes.selectable]: selectable,
           [classes.selected]: selected,
@@ -70,20 +73,7 @@ export const HvCard = (props: HvCardProps) => {
       {...others}
     >
       <div className={classes.semanticContainer}>
-        <div
-          className={cx(
-            css({
-              height: selected ? 4 : 2,
-              backgroundColor:
-                statusColor === "sema0"
-                  ? selected
-                    ? theme.colors.secondary
-                    : theme.colors.atmo4
-                  : theme.colors[statusColor as HvColor],
-            }),
-            classes.semanticBar,
-          )}
-        />
+        <div className={classes.semanticBar} />
         <div className={classes.icon}>{icon}</div>
       </div>
       {children}

--- a/packages/core/src/CheckBoxGroup/CheckBoxGroup.styles.tsx
+++ b/packages/core/src/CheckBoxGroup/CheckBoxGroup.styles.tsx
@@ -5,9 +5,8 @@ import { createClasses } from "../utils/classes";
 export const { staticClasses, useClasses } = createClasses("HvCheckBoxGroup", {
   root: {
     display: "inline-block",
-    padding: 4,
-    margin: -4,
-    overflow: "hidden",
+    overflow: "clip",
+    overflowClipMargin: 4,
     verticalAlign: "top",
   },
   label: { marginBottom: theme.space.xs },
@@ -26,10 +25,7 @@ export const { staticClasses, useClasses } = createClasses("HvCheckBoxGroup", {
   horizontal: {
     flexDirection: "row",
     flexWrap: "wrap",
-
-    "&>*:not(:first-of-type)": {
-      marginLeft: theme.space.sm,
-    },
+    gap: theme.space.sm,
   },
   invalid: {
     paddingBottom: theme.space.xs,

--- a/packages/core/src/DatePicker/DatePicker.styles.tsx
+++ b/packages/core/src/DatePicker/DatePicker.styles.tsx
@@ -41,13 +41,9 @@ export const { staticClasses, useClasses } = createClasses("HvDatePicker", {
       marginRight: theme.space.xs,
     },
   },
-  inputText: {
-    color: theme.colors.secondary_80,
-    overflow: "hidden",
-    textOverflow: "ellipsis",
-    whiteSpace: "nowrap",
-  },
+  inputText: {},
   dateText: {
-    color: theme.colors.secondary,
+    color: "inherit",
+    fontWeight: theme.typography.label.fontWeight,
   },
 });

--- a/packages/core/src/DatePicker/DatePicker.tsx
+++ b/packages/core/src/DatePicker/DatePicker.tsx
@@ -20,7 +20,6 @@ import { useControlled } from "../hooks/useControlled";
 import { useDefaultProps } from "../hooks/useDefaultProps";
 import { useLabels } from "../hooks/useLabels";
 import { useUniqueId } from "../hooks/useUniqueId";
-import { HvTypography } from "../Typography";
 import { ExtractNames } from "../utils/classes";
 import { setId } from "../utils/setId";
 import { useSavedState } from "../utils/useSavedState";
@@ -410,17 +409,8 @@ export const HvDatePicker = forwardRef<HTMLDivElement, HvDatePickerProps>(
       </HvActionBar>
     );
 
-    const renderInput = (dateString: string) => {
-      return (
-        <HvTypography
-          className={cx(classes.inputText, { [classes.dateText]: dateString })}
-          variant="label"
-        >
-          {dateString || placeholder || ""}
-        </HvTypography>
-      );
-    };
     const dateValue = rangeMode ? { startDate, endDate } : startDate;
+    const dateString = getDateLabel(dateValue, rangeMode, locale);
 
     const hasLabel = label != null;
     const hasDescription = description != null;
@@ -483,6 +473,9 @@ export const HvDatePicker = forwardRef<HTMLDivElement, HvDatePickerProps>(
             panel: classes.panel,
             header: cx({ [classes.dropdownHeaderInvalid]: isStateInvalid }),
             headerOpen: classes.dropdownHeaderOpen,
+            placeholder: cx(classes.inputText, {
+              [classes.dateText]: dateString,
+            }),
           }}
           readOnly={readOnly}
           disabled={disabled}
@@ -493,13 +486,8 @@ export const HvDatePicker = forwardRef<HTMLDivElement, HvDatePickerProps>(
           onToggle={handleToggle}
           onClickOutside={handleCalendarClose}
           onContainerCreation={focusOnContainer}
-          placeholder={renderInput(getDateLabel(dateValue, rangeMode, locale))}
-          adornment={
-            <Calendar
-              className={classes.icon}
-              color={disabled ? "secondary_80" : undefined}
-            />
-          }
+          placeholder={dateString || placeholder || ""}
+          adornment={<Calendar className={classes.icon} color="currentcolor" />}
           popperProps={{
             modifiers: [
               { name: "preventOverflow", enabled: escapeWithReference },

--- a/packages/core/src/DotPagination/DotPagination.styles.tsx
+++ b/packages/core/src/DotPagination/DotPagination.styles.tsx
@@ -9,13 +9,10 @@ export const { useClasses, staticClasses } = createClasses("HvDotPagination", {
   },
 
   horizontal: {
-    marginLeft: 0,
     width: "auto",
   },
 
-  radioRoot: {
-    marginLeft: theme.space.xs,
-  },
+  radioRoot: {},
 
   radio: {
     height: 16,

--- a/packages/core/src/DropdownButton/DropdownButton.styles.tsx
+++ b/packages/core/src/DropdownButton/DropdownButton.styles.tsx
@@ -50,7 +50,7 @@ export const { staticClasses, useClasses } = createClasses("HvDropdownButton", {
     color: "inherit",
     flex: 1,
     textAlign: "start",
-    overflow: "clip visible",
+    overflow: "auto",
     textOverflow: "ellipsis",
     whiteSpace: "nowrap",
   },

--- a/packages/core/src/FilterGroup/FilterContent/FilterContent.styles.tsx
+++ b/packages/core/src/FilterGroup/FilterContent/FilterContent.styles.tsx
@@ -36,13 +36,11 @@ export const { staticClasses, useClasses } = createClasses(name, {
   },
   leftSidePanel: {
     display: "inline-block",
-    width: `calc(50% - ${theme.space.sm} - ${theme.space.sm} + 8px)`,
-    height: `calc(100% - ${theme.space.sm} - ${theme.space.sm} + 8px)`,
+    width: "50%",
+    height: "100%",
     verticalAlign: "top",
     maxHeight: "calc(500px - 75px)",
     minHeight: "calc(370px - 75px)",
-    padding: 4,
-    margin: `calc(${theme.spacing("sm")} - 4px)`,
   },
   actionBar: {},
   space: {

--- a/packages/core/src/Header/Header.styles.tsx
+++ b/packages/core/src/Header/Header.styles.tsx
@@ -12,7 +12,6 @@ export const { staticClasses, useClasses } = createClasses("HvHeader", {
     boxSizing: "border-box",
     flexShrink: 0,
     zIndex: theme.zIndices.banner,
-    color: theme.colors.atmo1,
     boxShadow: theme.colors.shadow,
     borderTop: "none",
   },

--- a/packages/core/src/Header/assets/HitachiLogo.tsx
+++ b/packages/core/src/Header/assets/HitachiLogo.tsx
@@ -1,16 +1,10 @@
-import { theme } from "@hitachivantara/uikit-styles";
-
 export const HitachiLogo = ({ ...others }: React.SVGProps<SVGSVGElement>) => {
   return (
     <svg
-      x="0px"
-      y="0px"
+      role="img"
       viewBox="0 0 80 16"
-      xmlSpace="preserve"
-      width={80}
-      height={16}
-      style={{ width: 72, height: 20 }}
-      fill={theme.colors.secondary}
+      width={72}
+      fill="currentColor"
       {...others}
     >
       <title>Logo</title>

--- a/packages/core/src/ListContainer/ListContainer.styles.tsx
+++ b/packages/core/src/ListContainer/ListContainer.styles.tsx
@@ -1,5 +1,8 @@
 import { createClasses } from "../utils/classes";
 
 export const { staticClasses, useClasses } = createClasses("HvListContainer", {
-  root: {},
+  root: {
+    overflow: "clip",
+    overflowClipMargin: 4,
+  },
 });

--- a/packages/core/src/LoadingContainer/LoadingContainer.tsx
+++ b/packages/core/src/LoadingContainer/LoadingContainer.tsx
@@ -1,7 +1,7 @@
 import { useDefaultProps } from "../hooks/useDefaultProps";
 import { HvLoading, HvLoadingProps } from "../Loading";
 import { HvBaseProps } from "../types/generic";
-import { ExtractNames } from "../utils/classes";
+import { ExtractNames, mergeStyles } from "../utils/classes";
 import { staticClasses, useClasses } from "./LoadingContainer.styles";
 
 export { staticClasses as loadingContainerClasses };
@@ -52,7 +52,7 @@ export const HvLoadingContainer = (props: HvLoadingContainerProps) => {
         label={label}
         hidden={hidden}
         aria-label={ariaLabel}
-        style={opacity ? { ["--opacity" as string]: opacity } : undefined}
+        style={mergeStyles({}, { "--opacity": opacity })}
       />
       {children}
     </div>

--- a/packages/core/src/RadioGroup/RadioGroup.styles.tsx
+++ b/packages/core/src/RadioGroup/RadioGroup.styles.tsx
@@ -5,9 +5,8 @@ import { createClasses } from "../utils/classes";
 export const { staticClasses, useClasses } = createClasses("HvRadioGroup", {
   root: {
     display: "inline-block",
-    padding: 0,
-    margin: 0,
-    overflow: "hidden",
+    overflow: "clip",
+    overflowClipMargin: 4,
     verticalAlign: "top",
   },
   label: { marginBottom: theme.space.xs },
@@ -26,10 +25,7 @@ export const { staticClasses, useClasses } = createClasses("HvRadioGroup", {
   horizontal: {
     flexDirection: "row",
     flexWrap: "wrap",
-    "&>*:not(:first-of-type)": {
-      marginLeft: theme.space.sm,
-    },
-    width: `calc(100% + ${theme.space.sm})`, // Compensate the negative margin left which increases the width
+    gap: theme.space.sm,
   },
   invalid: {
     paddingBottom: theme.space.xs,

--- a/packages/core/src/Slider/SliderInput/SliderInput.tsx
+++ b/packages/core/src/Slider/SliderInput/SliderInput.tsx
@@ -87,7 +87,9 @@ export const HvSliderInput = ({
     <div className={cx(classes.inputRoot, className)} {...others}>
       {inputValues.map((value, index) => (
         <div key={setId(id, index)} className={classes.inputContainer}>
-          {index !== 0 && <Remove color={disabled ? ["atmo4"] : undefined} />}
+          {index !== 0 && (
+            <Remove color={disabled ? "secondary_60" : undefined} />
+          )}
           <HvInput
             id={setId(id, index)}
             aria-label={`${label}-${index}`}

--- a/packages/core/src/VerticalNavigation/TreeView/TreeViewItem.tsx
+++ b/packages/core/src/VerticalNavigation/TreeView/TreeViewItem.tsx
@@ -489,7 +489,7 @@ export const HvVerticalNavigationTreeViewItem = forwardRef(
               isOpen={isOpen}
               hasAnyChildWithData={hasAnyChildWithData}
               style={{
-                // @ts-ignore
+                // @ts-expect-error csstype doesn't support CSS vars
                 "--icon-margin-left": hasAnyChildWithData ? "auto" : "unset",
               }}
               className={classes.icon}

--- a/packages/core/src/utils/classes.ts
+++ b/packages/core/src/utils/classes.ts
@@ -3,3 +3,21 @@ export {
   createClasses,
   type ExtractNames,
 } from "@hitachivantara/uikit-react-shared";
+
+function stripNullish<T extends Record<string, unknown>>(obj: T) {
+  return Object.entries(obj).reduce<Record<string, unknown>>(
+    (acc, [key, value]) => {
+      if (value != null && value !== "") {
+        acc[key] = value;
+      }
+      return acc;
+    },
+    {},
+  );
+}
+
+/** @internal */
+export const mergeStyles = (
+  styleProp: React.CSSProperties | undefined,
+  styles: Record<string, any>,
+): React.CSSProperties => ({ ...stripNullish(styles), ...styleProp });

--- a/packages/lab/src/Flow/Sidebar/Sidebar.styles.tsx
+++ b/packages/lab/src/Flow/Sidebar/Sidebar.styles.tsx
@@ -7,7 +7,7 @@ export const { staticClasses, useClasses } = createClasses("HvFlowSidebar", {
     padding: theme.spacing("sm", "lg", "xs", "sm"),
   },
   contentContainer: { padding: theme.spacing(0, "lg", "sm", "lg") },
-  description: { color: theme.colors.secondary_60 },
+  description: { color: theme.colors.secondary_80 },
   searchRoot: {
     paddingTop: theme.space.sm,
     paddingBottom: theme.space.sm,


### PR DESCRIPTION
Fixes some styles inconsistencies in components, found by https://github.com/lumada-design/hv-uikit-react/pull/4192

- disabled/subtle text colors: components using BaseDropdown, FlowSidebar, etc.
- add `style` + CSS var utility
- `HitachiLogo` coloring
- ListContainer spacing & outline overflow