### PR TITLE
feat(CodeEditor): IntelliSense support for XML

### DIFF
--- a/.storybook/vite.config.ts
+++ b/.storybook/vite.config.ts
@@ -5,5 +5,8 @@ import tsconfigPaths from "vite-tsconfig-paths";
 import { presetHv } from "@hitachivantara/uikit-uno-preset";
 
 export default defineConfig({
+  optimizeDeps: {
+    exclude: ["xmllint-wasm"],
+  },
   plugins: [react(), tsconfigPaths(), unoCSS({ presets: [presetHv()] })],
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -38279,6 +38279,14 @@
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true
     },
+    "node_modules/xmllint-wasm": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xmllint-wasm/-/xmllint-wasm-4.0.2.tgz",
+      "integrity": "sha512-tJxQzA9krv9gaQxYFJ/NVrpLf/wpWYPKjweCLMNbjooBTsW7/O26pyc3Pd0Lp0oTLUMFir/MEX3ybY/hhRjIpw==",
+      "engines": {
+        "node": ">=12.4.0"
+      }
+    },
     "node_modules/xtend": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
@@ -38524,7 +38532,8 @@
       "dependencies": {
         "@hitachivantara/uikit-react-shared": "^5.2.0",
         "@hitachivantara/uikit-styles": "^5.31.1",
-        "@monaco-editor/react": "^4.5.1"
+        "@monaco-editor/react": "^4.5.1",
+        "xmllint-wasm": "^4.0.2"
       },
       "devDependencies": {
         "@types/react": "^18.2.43",

--- a/packages/code-editor/package.json
+++ b/packages/code-editor/package.json
@@ -40,7 +40,8 @@
   "dependencies": {
     "@hitachivantara/uikit-react-shared": "^5.2.0",
     "@hitachivantara/uikit-styles": "^5.31.1",
-    "@monaco-editor/react": "^4.5.1"
+    "@monaco-editor/react": "^4.5.1",
+    "xmllint-wasm": "^4.0.2"
   },
   "devDependencies": {
     "@types/react": "^18.2.43",

--- a/packages/code-editor/src/CodeEditor/CodeEditor.stories.tsx
+++ b/packages/code-editor/src/CodeEditor/CodeEditor.stories.tsx
@@ -1,21 +1,13 @@
-import { useState } from "react";
-import { css } from "@emotion/css";
-import { Modal } from "@mui/material";
 import { Meta, StoryObj } from "@storybook/react";
 import {
   HvCodeEditor,
   HvCodeEditorProps,
 } from "@hitachivantara/uikit-react-code-editor";
-import {
-  HvIconButton,
-  HvTypography,
-  theme,
-} from "@hitachivantara/uikit-react-core";
-import {
-  Duplicate,
-  Fullscreen,
-  PopUp,
-} from "@hitachivantara/uikit-react-icons";
+
+import { MainStory } from "./stories/Main";
+import MainStoryRaw from "./stories/Main?raw";
+import { XmlStory } from "./stories/Xml";
+import XmlStoryRaw from "./stories/Xml?raw";
 
 const meta: Meta<typeof HvCodeEditor> = {
   title: "Widgets/Code Editor",
@@ -23,176 +15,15 @@ const meta: Meta<typeof HvCodeEditor> = {
 };
 export default meta;
 
-const Header = (props: {
-  fileName: string;
-  handleOpen: (value: boolean) => void;
-}) => {
-  const { fileName, handleOpen } = props;
-
-  const styles = {
-    headerItemsWrapper: css({
-      display: "flex",
-      alignItems: "center",
-    }),
-    codeEditorHeader: css({
-      height: 50,
-      border: `1px solid ${theme.colors.atmo4}`,
-      borderBottom: "none",
-      background: theme.colors.atmo1,
-      padding: theme.spacing("xs", "xs", "xs", "sm"),
-      display: "flex",
-      justifyContent: "space-between",
-    }),
-    codeEditorFileName: css({
-      margin: "5px 0px",
-    }),
-    codeEditorResetButton: css({
-      float: "right",
-    }),
-    paper: css({
-      position: "absolute",
-      width: "100%",
-      backgroundColor: "#FFF",
-      boxShadow:
-        "0px 3px 5px -1px rgba(0,0,0,0.2), 0px 5px 8px 0px rgba(0,0,0,0.14),0px 1px 14px 0px rgba(0,0,0,0.12)",
-    }),
-    buttonMargin: css({
-      marginLeft: theme.spacing("xs"),
-    }),
-  };
-
-  return (
-    <div className={styles.codeEditorHeader}>
-      <div className={styles.headerItemsWrapper}>
-        <HvTypography
-          className={styles.codeEditorFileName}
-          component="div"
-          variant="label"
-        >
-          {fileName}
-        </HvTypography>
-        <HvIconButton
-          title="Open in new window"
-          className={styles.buttonMargin}
-          component="a"
-          href="http://localhost:9001/iframe.html?id=components-code-editor--main"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <PopUp />
-        </HvIconButton>
-      </div>
-      <div className={styles.headerItemsWrapper}>
-        <HvIconButton
-          title="Fullscreen"
-          onClick={() => {
-            handleOpen(true);
-          }}
-        >
-          <Fullscreen />
-        </HvIconButton>
-        <HvIconButton title="Duplicate" className={styles.buttonMargin}>
-          <Duplicate />
-        </HvIconButton>
-      </div>
-    </div>
-  );
-};
-
-const defaultValueYaml =
-  'affinity: {}\nconfiguration:\n  helm: defaultTimeoutSeconds=120\nenv:\n  debug: "true"\n  hostname: foo.bar.com\nfullnameOverride: mySolution\nimage:\n  pullPolicy: IfNotPresent\n repository: foo.bar.com:5000/app\n';
-
-const defaultValueJson = `{
-    "glossary": {
-      "title": "example glossary",
-      "GlossDiv": {
-        "title": "S",
-        "GlossList": {   
-          "GlossEntry": {                    
-            "ID": "SGML",
-            "SortAs": "SGML",
-            "GlossTerm": "Standard Generalized Markup Language",
-            "Acronym": "SGML",
-            "Abbrev": "ISO 8879:1986",
-            "GlossDef": {                        
-              "para": "A meta-markup language, used to create markup languages such as DocBook.",
-              "GlossSeeAlso": ["GML", "XML"]                    
-            },
-            "GlossSee": "markup"                
-          }            
-        }        
-      }    
-    }
-  }`;
-
 export const Main: StoryObj<HvCodeEditorProps> = {
   parameters: {
     // Enables Chromatic snapshot
     chromatic: { disableSnapshot: false, delay: 5000 },
+    docs: {
+      source: { code: MainStoryRaw },
+    },
   },
-  render: () => {
-    const getModalStyle = () => {
-      return {
-        top: `54%`,
-        left: `52%`,
-        transform: `translate(-52%, -54%)`,
-      };
-    };
-
-    const [open, setOpen] = useState(false);
-    const [editorContent, setEditorContent] = useState(defaultValueJson);
-    const [modalStyle] = useState(getModalStyle);
-
-    const handleClose = () => {
-      setOpen(false);
-    };
-
-    const styles = {
-      paper: css({
-        position: "absolute",
-        width: "100%",
-        backgroundColor: "#FFF",
-        boxShadow:
-          "0px 3px 5px -1px rgba(0,0,0,0.2), 0px 5px 8px 0px rgba(0,0,0,0.14),0px 1px 14px 0px rgba(0,0,0,0.12)",
-      }),
-    };
-
-    const codeEditor = (height: number) => {
-      return (
-        <HvCodeEditor
-          height={height}
-          editorProps={{
-            language: "json",
-          }}
-          onChange={(input) => {
-            setEditorContent(input || "");
-          }}
-          value={editorContent}
-        />
-      );
-    };
-
-    const body = (
-      <div style={modalStyle} className={styles.paper}>
-        {codeEditor(500)}
-      </div>
-    );
-
-    return (
-      <>
-        <Header fileName="some file.json" handleOpen={setOpen} />
-        <Modal
-          open={open}
-          onClose={handleClose}
-          aria-labelledby="simple-modal-title"
-          aria-describedby="simple-modal-description"
-        >
-          {body}
-        </Modal>
-        {codeEditor(420)}
-      </>
-    );
-  },
+  render: () => <MainStory />,
 };
 
 export const YamlEditor: StoryObj<HvCodeEditorProps> = {
@@ -206,13 +37,24 @@ export const YamlEditor: StoryObj<HvCodeEditorProps> = {
     chromatic: { disableSnapshot: false, delay: 5000 },
   },
   render: () => {
+    const defaultValueYaml =
+      'affinity: {}\nconfiguration:\n  helm: defaultTimeoutSeconds=120\nenv:\n  debug: "true"\n  hostname: foo.bar.com\nfullnameOverride: mySolution\nimage:\n  pullPolicy: IfNotPresent\n repository: foo.bar.com:5000/app\n';
+
     return (
-      <HvCodeEditor
-        height={270}
-        language="yaml"
-        onChange={(input) => console.log(input)}
-        value={defaultValueYaml}
-      />
+      <HvCodeEditor height={270} language="yaml" value={defaultValueYaml} />
     );
   },
+};
+
+export const XMLEditor: StoryObj<HvCodeEditorProps> = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "XML is one of the languages supported, and it can be enabled by setting the `language` property to `xml`. A XML schema can also be provided through the `xsdSchema` property. By providing a XML schema, the XML written will be validated against the schema showing errors. Providing a schema will also enable the code editor to show suggestions when opening a tag (`<`), writing an attribute, and when clicking on the CTRL and SPACE keys at the same time.",
+      },
+      source: { code: XmlStoryRaw },
+    },
+  },
+  render: () => <XmlStory />,
 };

--- a/packages/code-editor/src/CodeEditor/languages/xml.ts
+++ b/packages/code-editor/src/CodeEditor/languages/xml.ts
@@ -1,0 +1,310 @@
+import { type Monaco } from "@monaco-editor/react";
+import { validateXML } from "xmllint-wasm";
+
+// Helpful notes
+// model - editor content
+// position - position of the pointer
+
+type Elements = Record<string, string[] | undefined>; // element name (key) / attributes (value)
+
+/**
+ * Gets elements and their attributes from XSD schema.
+ */
+const getXsdElementsAndAttributes = (value: string): Elements => {
+  const elements: Elements = {};
+  try {
+    // Parse XSD schema string into a DOM object
+    const parser = new DOMParser();
+    const schemaDoc = parser.parseFromString(value, "application/xml");
+
+    // Get all elements and their attributes
+    for (const element of schemaDoc.getElementsByTagName("xs:element")) {
+      const elementName = element.getAttribute("name");
+      if (elementName) {
+        const attributes = element.getElementsByTagName("xs:attribute");
+        if (attributes && attributes.length > 0) {
+          const elementAttributes = [];
+          for (const attribute of attributes) {
+            const attributeName = attribute.getAttribute("name");
+            if (attributeName) elementAttributes.push(attributeName);
+          }
+          elements[elementName] = elementAttributes;
+        } else elements[elementName] = undefined;
+      }
+    }
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    if (import.meta.env.DEV) console.error(error);
+  }
+  return elements;
+};
+
+/**
+ * Gets the last opened (but not closed) tag to suggest attributes
+ * Source code from: https://mono.software/2017/04/11/custom-intellisense-with-monaco-editor/
+ */
+const getLastOpenedTag = (content: string) => {
+  // Get all tags inside of the content
+  const tags = content.match(/<\/*(?=\S*)([a-zA-Z-]+)/g);
+  if (!tags) return undefined;
+
+  // Find closed tags
+  const closingTags = [];
+
+  for (let i = tags.length - 1; i >= 0; i--) {
+    if (tags[i].indexOf("</") === 0) {
+      // It's a closing tag since it's beginning with "</"
+      closingTags.push(tags[i].substring("</".length));
+    } else {
+      // Get the last position of the tag
+      const tagPosition = content.lastIndexOf(tags[i]);
+      const tag = tags[i].substring("<".length);
+
+      // Looking if it's self closing
+      const closingBracketIdx = content.indexOf("/>", tagPosition);
+
+      if (closingBracketIdx === -1) {
+        // If there are no closing tags or the current tag wasn't closed
+        if (
+          !closingTags.length ||
+          closingTags[closingTags.length - 1] !== tag
+        ) {
+          // Last open tag found
+          content = content.substring(tagPosition);
+          return content.indexOf(">") === -1 ? tag : undefined;
+        }
+
+        // Remove the last closed tag since it
+        closingTags.splice(closingTags.length - 1, 1);
+      }
+
+      // Remove the last closed tag and continue processing the rest of the content
+      content = content.substring(0, tagPosition);
+    }
+  }
+};
+
+/**
+ * Triggers suggestions for specific cases.
+ */
+export const getXmlCompletionProvider = (monaco: Monaco, schema?: string) => {
+  const elements = schema ? getXsdElementsAndAttributes(schema) : undefined;
+  const root = elements ? Object.keys(elements)[0] : undefined;
+  const emptySuggestions = root
+    ? [
+        /** Add root element to the editor */
+        {
+          label: "Insert root element",
+          kind: monaco.languages.CompletionItemKind.Snippet,
+          // eslint-disable-next-line no-template-curly-in-string
+          insertText: `<${root}>\n\t${"${0:}"}\n</${root}>`, // ${0:} used to position the cursor
+          insertTextRules:
+            monaco.languages.CompletionItemInsertTextRule.InsertAsSnippet,
+        },
+      ]
+    : [];
+
+  return {
+    triggerCharacters: ["<"],
+    provideCompletionItems: (model: any, position: any) => {
+      // Suggestions to show when there's nothing written (by using keys or typing a trigger characters)
+      const fullContent = model.getValue();
+      if (!String(fullContent).trim()) {
+        return {
+          suggestions: emptySuggestions.map((sug) => ({
+            ...sug,
+            range: {
+              startLineNumber: 1,
+              startColumn: 1,
+              endLineNumber: 1,
+              endColumn: 1,
+            },
+          })),
+        };
+      }
+
+      const suggestions: object[] = [];
+      const lastWordWritten = model.getWordUntilPosition(position);
+
+      // Suggestions to show when opening a tag (by typing "<")
+      const lastTypedChar = model.getValueInRange({
+        startLineNumber: position.lineNumber,
+        startColumn: position.column - 1,
+        endLineNumber: position.lineNumber,
+        endColumn: position.column,
+      });
+      if (lastTypedChar === "<" && elements) {
+        suggestions.push(
+          ...Object.keys(elements).map((element) => ({
+            label: element,
+            kind: monaco.languages.CompletionItemKind.Field,
+            insertText: element,
+            range: {
+              startLineNumber: position.lineNumber,
+              startColumn: position.column,
+              endLineNumber: position.lineNumber,
+              endColumn: position.column,
+            },
+          })),
+        );
+      }
+
+      // Suggestions to show when looking for attributes in a tag (by using keys)
+      const textUntilCursor = String(
+        model.getValueInRange({
+          startLineNumber: 1,
+          startColumn: 1,
+          endLineNumber: position.lineNumber,
+          endColumn: position.column,
+        }),
+      );
+      const lastOpenedTag = getLastOpenedTag(textUntilCursor);
+      if (
+        lastOpenedTag &&
+        elements?.[lastOpenedTag] &&
+        elements[lastOpenedTag].length > 0
+      ) {
+        const attrs = lastWordWritten.word
+          ? elements[lastOpenedTag].filter((attr) =>
+              attr.startsWith(lastWordWritten.word),
+            )
+          : elements[lastOpenedTag];
+
+        suggestions.push(
+          ...attrs.map((atr) => ({
+            label: atr,
+            kind: monaco.languages.CompletionItemKind.Field,
+            // eslint-disable-next-line no-template-curly-in-string
+            insertText: `${atr}="${"${0:}"}"`, // ${0:} used to position the cursor
+            insertTextRules:
+              monaco.languages.CompletionItemInsertTextRule.InsertAsSnippet,
+            range: {
+              startLineNumber: position.lineNumber,
+              startColumn: lastWordWritten.startColumn,
+              endLineNumber: position.lineNumber,
+              endColumn: lastWordWritten.endColumn,
+            },
+          })),
+        );
+      }
+
+      return {
+        suggestions,
+      };
+    },
+  };
+};
+
+/**
+ * Validates XML with XSD schema and create error markers to show on code editor.
+ */
+export const getXmlValidationMarkers = async (
+  content: string,
+  editor: any,
+  monaco: Monaco,
+  schema = "",
+) => {
+  const model = editor.getModel();
+
+  try {
+    const validation = await validateXML({ xml: content, schema });
+    if (!validation.valid) {
+      return validation.errors.map((error) => {
+        return {
+          severity: monaco.MarkerSeverity.Error,
+          message: error.message,
+          startLineNumber: error.loc?.lineNumber ?? 1,
+          startColumn:
+            model.getLineFirstNonWhitespaceColumn(error.loc?.lineNumber) ?? 1,
+          endLineNumber: error.loc?.lineNumber ?? 1,
+          endColumn:
+            model.getLineLastNonWhitespaceColumn(error.loc?.lineNumber) ?? 1,
+        };
+      });
+    }
+  } catch (error: any) {
+    const value = model.getValue();
+    if (!String(value).trim()) return [];
+
+    const errors = String(error?.message).split("parser error :");
+    const lastError = errors[errors.length - 1].trim();
+    const lineNumberParts = lastError.match(/(line) ([0-9]+)/);
+    const errorLine = Number(lineNumberParts?.[2]) ?? 1;
+    const cleanedError = lastError.replace(lineNumberParts?.[0] ?? "", "");
+
+    return [
+      {
+        severity: monaco.MarkerSeverity.Error,
+        message: cleanedError,
+        startLineNumber: errorLine,
+        startColumn: model.getLineFirstNonWhitespaceColumn(errorLine) ?? 1,
+        endLineNumber: errorLine,
+        endColumn: model.getLineLastNonWhitespaceColumn(errorLine) ?? 1,
+      },
+    ];
+  }
+  return [];
+};
+
+/**
+ * Auto-completes a tag when closing it: writing ">" after "<root" will automatically add "</root>"
+ * Source code from: https://github.com/microsoft/monaco-editor/issues/221
+ */
+export const handleXmlKeyDown = (event: any, editor: any, monaco: Monaco) => {
+  if (event.browserEvent.key === ">") {
+    const model = editor.getModel();
+    const edits: any[] = [];
+    const selections: any[] = [];
+
+    for (const selection of editor.getSelections()) {
+      // Shift the selection over by one to account for the new character
+      selections.push(
+        new monaco.Selection(
+          selection.selectionStartLineNumber,
+          selection.selectionStartColumn + 1,
+          selection.endLineNumber,
+          selection.endColumn + 1,
+        ),
+      );
+
+      // Line before the cursor
+      const lineBeforeChange = model.getValueInRange({
+        startLineNumber: selection.endLineNumber,
+        startColumn: 1,
+        endLineNumber: selection.endLineNumber,
+        endColumn: selection.endColumn,
+      });
+
+      // Look for the tag we are currently closing
+      const tag = String(lineBeforeChange).match(
+        /<([\w-]+)(?![^>]*\/>)[^>]*$/,
+      )?.[1];
+      if (tag) {
+        // Add the closing tag
+        edits.push({
+          range: {
+            startLineNumber: selection.endLineNumber,
+            startColumn: selection.endColumn + 1,
+            endLineNumber: selection.endLineNumber,
+            endColumn: selection.endColumn + 1,
+          },
+          text: `</${tag}>`,
+        });
+      }
+    }
+
+    // Wait for next tick to being an invalid operation
+    setTimeout(() => {
+      editor.executeEdits(model.getValue(), edits, selections);
+    }, 0);
+  }
+};
+
+/** XML custom options. */
+export const xmlOptions = {
+  formatOnType: true,
+  formatOnPaste: true,
+  autoClosingBrackets: false,
+  tabSize: 2,
+  autoIndent: "full",
+};

--- a/packages/code-editor/src/CodeEditor/plugins.ts
+++ b/packages/code-editor/src/CodeEditor/plugins.ts
@@ -1,0 +1,40 @@
+import { type Monaco } from "@monaco-editor/react";
+
+import {
+  getXmlCompletionProvider,
+  getXmlValidationMarkers,
+  handleXmlKeyDown,
+  xmlOptions,
+} from "./languages/xml";
+
+type CompletionProvider = (
+  monaco: Monaco,
+  schema?: string, // needed for XML language
+) => object;
+type ValidationMarker = (
+  content: string,
+  editor: any,
+  monaco: Monaco,
+  schema?: string, // needed for XML language
+) => Promise<object[]>;
+type KeyDownListener = (event: any, editor: any, monaco: Monaco) => void;
+
+interface LanguagePlugin {
+  completionProvider?: CompletionProvider;
+  validationMarker?: ValidationMarker;
+  keyDownListener?: KeyDownListener;
+  editorOptions?: object;
+}
+
+const xmlLanguagePlugin = (): LanguagePlugin => {
+  return {
+    completionProvider: getXmlCompletionProvider,
+    validationMarker: getXmlValidationMarkers,
+    keyDownListener: handleXmlKeyDown,
+    editorOptions: xmlOptions,
+  };
+};
+
+export const languagePlugins: Record<string, LanguagePlugin> = {
+  xml: xmlLanguagePlugin(),
+};

--- a/packages/code-editor/src/CodeEditor/stories/Main.tsx
+++ b/packages/code-editor/src/CodeEditor/stories/Main.tsx
@@ -1,0 +1,117 @@
+import { useState } from "react";
+import { css } from "@emotion/css";
+import { HvCodeEditor } from "@hitachivantara/uikit-react-code-editor";
+import {
+  HvDialog,
+  HvDialogContent,
+  HvDialogTitle,
+  HvIconButton,
+  HvTypography,
+  theme,
+} from "@hitachivantara/uikit-react-core";
+import {
+  Duplicate,
+  Fullscreen,
+  PopUp,
+} from "@hitachivantara/uikit-react-icons";
+
+const styles = {
+  actionsContainer: css({
+    display: "flex",
+    alignItems: "center",
+    gap: theme.space.xs,
+  }),
+  codeEditorHeader: css({
+    display: "flex",
+    justifyContent: "space-between",
+    height: 50,
+    border: `1px solid ${theme.colors.atmo4}`,
+    borderBottom: "none",
+    background: theme.colors.atmo1,
+    padding: theme.space.xs,
+  }),
+};
+
+const Header = ({ title, onOpen }: { title: string; onOpen: () => void }) => (
+  <div className={styles.codeEditorHeader}>
+    <div className={styles.actionsContainer}>
+      <HvTypography component="div" variant="label">
+        {title}
+      </HvTypography>
+      <HvIconButton
+        title="Open in new window"
+        component="a"
+        href="http://localhost:9001/iframe.html?id=components-code-editor--main"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        <PopUp />
+      </HvIconButton>
+    </div>
+    <div className={styles.actionsContainer}>
+      <HvIconButton title="Fullscreen" onClick={onOpen}>
+        <Fullscreen />
+      </HvIconButton>
+      <HvIconButton title="Duplicate">
+        <Duplicate />
+      </HvIconButton>
+    </div>
+  </div>
+);
+
+const defaultValueJson = `{
+  "glossary": {
+    "title": "example glossary",
+    "GlossDiv": {
+      "title": "S",
+      "GlossList": {   
+        "GlossEntry": {                    
+          "ID": "SGML",
+          "SortAs": "SGML",
+          "GlossTerm": "Standard Generalized Markup Language",
+          "Acronym": "SGML",
+          "Abbrev": "ISO 8879:1986",
+          "GlossDef": {                        
+            "para": "A meta-markup language, used to create markup languages such as DocBook.",
+            "GlossSeeAlso": ["GML", "XML"]                    
+          },
+          "GlossSee": "markup"                
+        }            
+      }        
+    }    
+  }
+}`;
+
+export const MainStory = () => {
+  const [open, setOpen] = useState(false);
+  const [editorContent, setEditorContent] = useState(defaultValueJson);
+
+  const renderCodeEditor = (height: number) => (
+    <HvCodeEditor
+      height={height}
+      editorProps={{
+        language: "json",
+      }}
+      onChange={(input) => {
+        setEditorContent(input || "");
+      }}
+      value={editorContent}
+    />
+  );
+
+  return (
+    <>
+      <Header title="some file.json" onOpen={() => setOpen(true)} />
+      {renderCodeEditor(420)}
+      <HvDialog
+        fullWidth
+        maxWidth="xl"
+        open={open}
+        onClose={() => setOpen(false)}
+      >
+        <HvDialogTitle>FullScreen</HvDialogTitle>
+        <HvDialogContent>{renderCodeEditor(500)}</HvDialogContent>
+      </HvDialog>
+    </>
+  );
+};

--- a/packages/code-editor/src/CodeEditor/stories/Xml/Xml.tsx
+++ b/packages/code-editor/src/CodeEditor/stories/Xml/Xml.tsx
@@ -1,0 +1,118 @@
+import { useRef, useState } from "react";
+import {
+  HvCodeEditor,
+  HvCodeEditorProps,
+} from "@hitachivantara/uikit-react-code-editor";
+import {
+  HvButtonProps,
+  HvDialog,
+  HvDialogContent,
+  HvDialogTitle,
+  HvTreeView,
+} from "@hitachivantara/uikit-react-core";
+
+// The code for these utils can be found at: https://github.com/lumada-design/hv-uikit-react/tree/master/packages/code-editor/src/CodeEditor/stories/Xml/utils.tsx
+import { Attributes, buildTree, Header, renderItem, Tree } from "./utils";
+
+const xsdSchema = `<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           elementFormDefault="qualified"
+           attributeFormDefault="unqualified">
+  <xs:element name="library">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="book" maxOccurs="unbounded">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="title" type="xs:string" minOccurs="1" />
+              <xs:element name="author" type="xs:string" minOccurs="1" />
+              <xs:element name="year" type="xs:integer" minOccurs="0" />
+              <xs:element name="genre" type="xs:string" minOccurs="0" />
+            </xs:sequence>
+            <xs:attribute name="isbn" type="xs:string" use="required" />
+          </xs:complexType>
+        </xs:element>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>`;
+
+const defaultValue = `<library>
+  <book isbn="123-0-456-0-789">
+    <title>Demon Copperhead</title>
+    <author>Barbara Kingsolver</author>
+    <year>2022</year>
+    <genre>Historical Fiction</genre>
+  </book>
+  <book isbn="987-0-654-0-321">
+    <title>Assassin's Apprentice</title>
+    <author>Robin Hobb</author>
+    <year>1995</year>
+    <genre>Fantasy</genre>
+  </book>
+</library>`;
+
+export const XmlStory = () => {
+  const [opened, setOpened] = useState(false);
+  const [editorValue, setEditorValue] = useState(defaultValue);
+  const [xmlTree, setXmlTree] = useState<{
+    tree: Tree;
+    attributes: Attributes;
+  }>();
+  const [defaultExpandedKeys, setDefaultExpandedKeys] = useState<string[]>([]);
+
+  const editorRef = useRef<any>(null);
+
+  const handleMount: HvCodeEditorProps["onMount"] = (editor) => {
+    editorRef.current = editor;
+  };
+
+  const handleOpenSearch: HvButtonProps["onClick"] = () => {
+    editorRef.current?.getAction("actions.find").run();
+  };
+
+  const handleClickTree: HvButtonProps["onClick"] = () => {
+    const { tree, attributes, keys } = buildTree(editorValue);
+    setXmlTree({
+      tree,
+      attributes,
+    });
+    setDefaultExpandedKeys(keys);
+    setOpened(true);
+  };
+
+  return (
+    <div>
+      <Header onClickTree={handleClickTree} onClickSearch={handleOpenSearch} />
+      <HvCodeEditor
+        height={270}
+        language="xml"
+        value={editorValue}
+        onChange={(content) => setEditorValue(content ?? "")}
+        xsdSchema={xsdSchema}
+        onMount={handleMount}
+      />
+      <HvDialog
+        fullWidth
+        maxWidth="sm"
+        open={opened}
+        onClose={() => setOpened(false)}
+      >
+        <HvDialogTitle>XML Tree Structure</HvDialogTitle>
+        <HvDialogContent>
+          {xmlTree?.tree && (
+            <HvTreeView
+              defaultExpanded={defaultExpandedKeys}
+              disableSelection
+              aria-label="XML tree structure"
+            >
+              {Object.entries(xmlTree.tree).map(([key, value]) =>
+                renderItem(key, value, xmlTree.attributes),
+              )}
+            </HvTreeView>
+          )}
+        </HvDialogContent>
+      </HvDialog>
+    </div>
+  );
+};

--- a/packages/code-editor/src/CodeEditor/stories/Xml/index.ts
+++ b/packages/code-editor/src/CodeEditor/stories/Xml/index.ts
@@ -1,0 +1,1 @@
+export * from "./Xml";

--- a/packages/code-editor/src/CodeEditor/stories/Xml/utils.tsx
+++ b/packages/code-editor/src/CodeEditor/stories/Xml/utils.tsx
@@ -1,0 +1,197 @@
+import { forwardRef } from "react";
+import { css } from "@emotion/css";
+import {
+  HvButton,
+  HvButtonProps,
+  HvTooltip,
+  HvTreeItem,
+  HvTreeItemProps,
+  HvTypography,
+  theme,
+  uniqueId,
+} from "@hitachivantara/uikit-react-core";
+import { Code, Info } from "@hitachivantara/uikit-react-icons";
+
+export const buildTree = (xml: string) => {
+  const parser = new DOMParser();
+  const xmlDoc = parser.parseFromString(xml, "application/xml");
+
+  const allKeys: string[] = [];
+  const attributes: Attributes = {};
+
+  const traverse = (node: HTMLElement | ChildNode) => {
+    const structure: Tree = {};
+    const { nodeName } = node;
+    const nodeId = uniqueId();
+    const nodeKey = `${nodeName}_${nodeId}`;
+
+    allKeys.push(nodeKey);
+    structure[nodeKey] = undefined;
+
+    // Get attributes for node
+    if ((node as any).attributes) {
+      for (let i = 0; i < (node as any).attributes.length; i++) {
+        const attr = (node as any).attributes[i];
+        attributes[nodeKey] = {
+          ...attributes[nodeKey],
+          [attr.name]: attr.value,
+        };
+      }
+    }
+
+    // Get tree structure
+    for (const child of node.childNodes) {
+      if (child.nodeType === Node.ELEMENT_NODE) {
+        const childStructure = traverse(child);
+
+        const found = Object.keys(structure).find(
+          (key) => key.split("_")[0] === nodeName,
+        );
+
+        if (found && structure[found]) {
+          if (!Array.isArray(structure[found])) {
+            structure[found] = [structure[found]];
+          }
+          if (Array.isArray(structure[found]))
+            structure[found].push(childStructure);
+        } else {
+          structure[nodeKey] = childStructure;
+        }
+      } else if (child.nodeType === Node.TEXT_NODE && child.nodeValue?.trim()) {
+        structure[nodeKey] = child.nodeValue.trim();
+      }
+    }
+    return structure;
+  };
+
+  return {
+    tree: traverse(xmlDoc.documentElement),
+    keys: allKeys,
+    attributes,
+  };
+};
+
+const classes = {
+  headerRoot: css({
+    display: "flex",
+    justifyContent: "space-between",
+    alignItems: "center",
+    border: `1px solid ${theme.colors.atmo4}`,
+    borderBottom: "none",
+    background: theme.colors.atmo1,
+    padding: theme.spacing("xs", "sm"),
+    gap: theme.space.xs,
+  }),
+  label: css({ display: "flex", alignItems: "center" }),
+};
+
+export const Header = ({
+  onClickSearch,
+  onClickTree,
+}: {
+  onClickSearch: HvButtonProps["onClick"];
+  onClickTree: HvButtonProps["onClick"];
+}) => (
+  <div className={classes.headerRoot}>
+    <HvTypography variant="label">XML</HvTypography>
+    <Code />
+    <div style={{ flex: 1 }} />
+    <HvButton variant="primaryGhost" onClick={onClickSearch}>
+      Search
+    </HvButton>
+    <HvButton variant="primaryGhost" onClick={onClickTree}>
+      XML Tree
+    </HvButton>
+  </div>
+);
+
+export type Tree = Record<string, object | object[] | string | undefined>;
+
+export type Attributes = Record<string, Record<string, string>>;
+
+interface SimpleTreeItemProps extends HvTreeItemProps {
+  attributes: Attributes;
+}
+
+const SimpleTreeItem = forwardRef<HTMLLIElement, SimpleTreeItemProps>(
+  (props, ref) => {
+    const { children, nodeId, label, attributes, ...others } = props;
+    return (
+      <HvTreeItem
+        ref={ref}
+        nodeId={nodeId}
+        label={
+          children ? (
+            <div className={classes.label}>
+              <HvTypography variant="label">{label}</HvTypography>
+              {attributes[nodeId] && (
+                <HvTooltip
+                  title={Object.entries(attributes[nodeId])
+                    .map(([key, value]) => `${key}: ${value}`)
+                    .join("; ")}
+                >
+                  <Info />
+                </HvTooltip>
+              )}
+            </div>
+          ) : (
+            label
+          )
+        }
+        {...others}
+      >
+        {children}
+      </HvTreeItem>
+    );
+  },
+);
+
+export const renderItem = (
+  key: string,
+  value: object | object[] | string | undefined,
+  attributes: Attributes,
+) => {
+  const label = key.split("_")[0];
+
+  if (Array.isArray(value)) {
+    return (
+      <SimpleTreeItem
+        key={key}
+        nodeId={key}
+        label={label}
+        attributes={attributes}
+      >
+        {value.map((childValue) => {
+          const childKey = Object.keys(childValue)[0];
+          return renderItem(childKey, childValue[childKey], attributes);
+        })}
+      </SimpleTreeItem>
+    );
+  }
+
+  if (typeof value === "object") {
+    return (
+      <SimpleTreeItem
+        key={key}
+        nodeId={key}
+        label={label}
+        attributes={attributes}
+      >
+        {Object.entries(value).map(([childKey, childValue]) =>
+          renderItem(childKey, childValue, attributes),
+        )}
+      </SimpleTreeItem>
+    );
+  }
+
+  return (
+    <SimpleTreeItem
+      key={key}
+      nodeId={key}
+      label={label}
+      attributes={attributes}
+    >
+      {value}
+    </SimpleTreeItem>
+  );
+};


### PR DESCRIPTION
- IntelliSense support for XML added:
   - When the code editor is empty, a suggestion to add the root element appears when clicking on CTRL + SPACE. Clicking on it will add the root element.
   -  The code editor auto-completes a tag when closing it: for example, writing `>` after `<root` will automatically add `</root>`.
   - The XML code is validated against the schema and the errors are highlighted:
      - The schema is provided through the `xsdSchema` property.
      - The `xmllint-wasm` package is used for validation. In Vite we need to exclude it from `optimizeDeps`.
   - When the user types `<`, suggestions are shown with the possible tags. Clicking on a tag will add it.
   - Clicking on CTRL + SPACE inside an opened tag will show suggestions with the possible attributes for the tag. Clicking on an attribute will add it.
- Stories updated.
- In the future, if we need to add a new language, we only have to:
   - Create a new file in the `languages` folder and define the new utils.
   - Set the utils inside the plugins file. `handleMount` will take care of calling the utils for the language.

ℹ️ Let me know if you think more features are needed. I tried to add the most basic features.