### PR TITLE
fix(QueryBuilder): decimal values for numeric value

### DIFF
--- a/packages/core/src/QueryBuilder/QueryBuilder.test.tsx
+++ b/packages/core/src/QueryBuilder/QueryBuilder.test.tsx
@@ -958,4 +958,73 @@ describe("QueryBuilder", () => {
     expect(warning).not.toBeInTheDocument();
     expect(warning).toBeNull();
   });
+
+  it("accepts decimal numbers in numeric input", async () => {
+    const user = userEvent.setup();
+    renderUncontrolled({
+      defaultValue: {
+        combinator: "and",
+        rules: [
+          {
+            attribute: "price",
+            operator: "notEqual",
+            value: 12,
+          },
+        ],
+      },
+    });
+
+    const textbox = screen.getByRole("textbox", {
+      name: /value/i,
+    });
+
+    await user.type(textbox, ".55");
+
+    const error = screen.queryByRole("status");
+    expect(textbox).toHaveValue("12.55");
+    expect(error).not.toBeInTheDocument();
+  });
+
+  it("accepts decimal numbers in range numeric input", async () => {
+    const user = userEvent.setup();
+    renderUncontrolled({
+      defaultValue: {
+        combinator: "and",
+        rules: [
+          {
+            attribute: "price",
+            operator: "range",
+            value: {
+              from: 12,
+              to: 20,
+            },
+          },
+        ],
+      },
+    });
+
+    const fromTextbox = screen.getByRole("textbox", {
+      name: "From",
+    });
+    const toTextbox = screen.getByRole("textbox", {
+      name: "To",
+    });
+
+    await user.type(fromTextbox, ".55");
+    await user.type(toTextbox, ".55");
+
+    let error = screen.queryByRole("status");
+    expect(fromTextbox).toHaveValue("12.55");
+    expect(toTextbox).toHaveValue("20.55");
+    expect(error).not.toBeInTheDocument();
+
+    await user.clear(fromTextbox);
+    await user.type(fromTextbox, "9.5");
+    await user.clear(toTextbox);
+    await user.type(toTextbox, "9.4");
+
+    error = screen.getByRole("status");
+    expect(error).toBeInTheDocument();
+    expect(error).toHaveTextContent("Needs to be greater.");
+  });
 });

--- a/packages/core/src/QueryBuilder/Rule/Value/NumericValue/NumericValue.tsx
+++ b/packages/core/src/QueryBuilder/Rule/Value/NumericValue/NumericValue.tsx
@@ -35,11 +35,10 @@ export const NumericValue = ({
       event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
       data: string,
     ) => {
-      const numericData = !data ? null : Number(data);
       dispatchAction({
         type: "set-value",
         id,
-        value: Number.isNaN(numericData) ? data : numericData,
+        value: data ?? null,
       });
     },
     [dispatchAction, id],
@@ -51,16 +50,15 @@ export const NumericValue = ({
       data: string,
       from = true,
     ) => {
-      const numericData = !data ? null : Number(data);
       const currentValue = value;
       const numericRange = {
         from: currentValue?.from,
         to: currentValue?.to,
       };
       if (from) {
-        numericRange.from = Number.isNaN(numericData) ? data : numericData;
+        numericRange.from = data ?? null;
       } else {
-        numericRange.to = Number.isNaN(numericData) ? data : numericData;
+        numericRange.to = data ?? null;
       }
       dispatchAction({
         type: "set-value",


### PR DESCRIPTION
It wasn't possible to use decimal numbers in the numeric input. This PR fixes this bug. 
- Typing `.55` worked but not `0.55` because `Number()` was removing the `.` when typing `0.`