### PR TITLE
feat(Flow): add groups to subflow sample

### DIFF
--- a/packages/lab/src/Flow/base.ts
+++ b/packages/lab/src/Flow/base.ts
@@ -232,8 +232,6 @@ export const flowStyles = css`
   .react-flow__node-input,
   .react-flow__node-output,
   .react-flow__node-group {
-    border-radius: 0px 16px 16px 16px;
-    border: unset;
     color: ${theme.colors.secondary};
     text-align: center;
   }
@@ -258,7 +256,6 @@ export const flowStyles = css`
   .react-flow__node-group.selectable.selected,
   .react-flow__node-group.selectable:focus,
   .react-flow__node-group.selectable:focus-visible {
-    box-shadow: 0 0 0 0.5px #1a192b;
   }
   .react-flow__node-group {
     background-color: rgba(240, 240, 240, 0.25);

--- a/packages/lab/src/Flow/base.ts
+++ b/packages/lab/src/Flow/base.ts
@@ -232,13 +232,10 @@ export const flowStyles = css`
   .react-flow__node-input,
   .react-flow__node-output,
   .react-flow__node-group {
-    padding: ${theme.space.sm};
-    border-radius: ${theme.radii.round};
-    width: 150px;
+    border-radius: 0px 16px 16px 16px;
+    border: unset;
     color: ${theme.colors.secondary};
     text-align: center;
-    border: 1px solid ${theme.colors.negative};
-    background-color: ${theme.colors.negative_20};
   }
   .react-flow__node-default::before {
     content: "Unknown node type";
@@ -248,7 +245,6 @@ export const flowStyles = css`
   .react-flow__node-input.selectable:hover,
   .react-flow__node-output.selectable:hover,
   .react-flow__node-group.selectable:hover {
-    box-shadow: 0 1px 4px 1px rgba(0, 0, 0, 0.08);
   }
   .react-flow__node-default.selectable.selected,
   .react-flow__node-default.selectable:focus,
@@ -270,7 +266,6 @@ export const flowStyles = css`
   .react-flow__nodesselection-rect,
   .react-flow__selection {
     background: rgba(0, 89, 220, 0.08);
-    border: 1px dotted rgba(0, 89, 220, 0.8);
   }
   .react-flow__nodesselection-rect:focus,
   .react-flow__nodesselection-rect:focus-visible,
@@ -372,9 +367,9 @@ export const flowStyles = css`
   }
   /* line styles */
   .react-flow__resize-control.line {
-    border-color: ${theme.colors.primary};
+    border-color: ${theme.colors.primary_80};
     border-width: 0;
-    border-style: solid;
+    border-style: dashed;
   }
   .react-flow__resize-control.line.left,
   .react-flow__resize-control.line.right {

--- a/packages/lab/src/Flow/base.ts
+++ b/packages/lab/src/Flow/base.ts
@@ -230,7 +230,15 @@ export const flowStyles = css`
   }
   .react-flow__node-default,
   .react-flow__node-input,
-  .react-flow__node-output,
+  .react-flow__node-output {
+    padding: ${theme.space.sm};
+    border-radius: ${theme.radii.round};
+    width: 150px;
+    color: ${theme.colors.secondary};
+    text-align: center;
+    border: 1px solid ${theme.colors.negative};
+    background-color: ${theme.colors.negative_20};
+  }
   .react-flow__node-group {
     color: ${theme.colors.secondary};
     text-align: center;

--- a/packages/lab/src/Flow/hooks/useFlowNode.ts
+++ b/packages/lab/src/Flow/hooks/useFlowNode.ts
@@ -170,7 +170,7 @@ export function useFlowNodeUtils<NodeData = any>(id?: string) {
   );
 }
 
-export function useFlowNodeGetIntersections<NodeData = any>(id?: string) {
+export function useFlowNodeIntersections<NodeData = any>(id?: string) {
   const nodeId = useNodeId(id);
   const node = useFlowNode(nodeId ?? "");
   const reactFlowInstance = useFlowInstance<NodeData>();

--- a/packages/lab/src/Flow/hooks/useFlowNode.ts
+++ b/packages/lab/src/Flow/hooks/useFlowNode.ts
@@ -1,5 +1,6 @@
 import { useCallback, useMemo } from "react";
 import {
+  CoordinateExtent,
   Edge,
   Node,
   ReactFlowState,
@@ -138,7 +139,7 @@ export function useFlowNodeUtils<NodeData = any>(id?: string) {
   );
 
   const setNodeParent = useCallback(
-    (node: Node<any>) => {
+    (node?: Node<any>, extent?: "parent" | CoordinateExtent) => {
       if (!nodeId) return;
 
       reactFlowInstance.setNodes((nodes) => {
@@ -146,9 +147,11 @@ export function useFlowNodeUtils<NodeData = any>(id?: string) {
           if (n.id === nodeId) {
             return {
               ...n,
-              parentId: node.id,
-              extent: "parent",
-              position: relativePosition(node.position, n.position),
+              parentId: node ? node.id : undefined,
+              extent,
+              position: node
+                ? relativePosition(node.position, n.position)
+                : (n.positionAbsolute ?? n.position),
             };
           }
           return n;

--- a/packages/lab/src/Flow/hooks/useNode.tsx
+++ b/packages/lab/src/Flow/hooks/useNode.tsx
@@ -24,8 +24,8 @@ import { useFlowContext } from "./useFlowContext";
 import { useFlowInstance } from "./useFlowInstance";
 import {
   useFlowNode,
-  useFlowNodeGetIntersections,
   useFlowNodeInputEdges,
+  useFlowNodeIntersections,
   useFlowNodeOutputEdges,
   useFlowNodeUtils,
 } from "./useFlowNode";
@@ -81,7 +81,7 @@ export function useHvNode(props: HvUseNodeParams) {
   const outputs = useMemo(() => identifyHandles(outputsProp), [outputsProp]);
   const outputEdges = useFlowNodeOutputEdges();
   const { nodeGroups } = useFlowContext();
-  const intersections = useFlowNodeGetIntersections();
+  const intersections = useFlowNodeIntersections();
   const { setNodeParent, setNodeData } = useFlowNodeUtils();
 
   const node = useFlowNode();

--- a/packages/lab/src/Flow/hooks/useNode.tsx
+++ b/packages/lab/src/Flow/hooks/useNode.tsx
@@ -24,8 +24,10 @@ import { useFlowContext } from "./useFlowContext";
 import { useFlowInstance } from "./useFlowInstance";
 import {
   useFlowNode,
+  useFlowNodeGetIntersections,
   useFlowNodeInputEdges,
   useFlowNodeOutputEdges,
+  useFlowNodeUtils,
 } from "./useFlowNode";
 
 const DEFAULT_LABELS = {
@@ -79,6 +81,8 @@ export function useHvNode(props: HvUseNodeParams) {
   const outputs = useMemo(() => identifyHandles(outputsProp), [outputsProp]);
   const outputEdges = useFlowNodeOutputEdges();
   const { nodeGroups } = useFlowContext();
+  const intersections = useFlowNodeGetIntersections();
+  const { setNodeParent, setNodeData } = useFlowNodeUtils();
 
   const node = useFlowNode();
 
@@ -182,11 +186,14 @@ export function useHvNode(props: HvUseNodeParams) {
       node,
       nodeActions,
       showActions,
+      intersections,
       // prop getters
       getNodeToolbarProps,
       // actions
       toggleShowActions,
       handleDefaultAction,
+      setNodeData,
+      setNodeParent,
     }),
     [
       id,
@@ -202,9 +209,12 @@ export function useHvNode(props: HvUseNodeParams) {
       node,
       nodeActions,
       showActions,
+      intersections,
       getNodeToolbarProps,
       toggleShowActions,
       handleDefaultAction,
+      setNodeData,
+      setNodeParent,
     ],
   );
 }

--- a/packages/lab/src/Flow/stories/Flow.stories.tsx
+++ b/packages/lab/src/Flow/stories/Flow.stories.tsx
@@ -202,7 +202,8 @@ export const SubFlow: StoryObj<HvFlowProps> = {
   parameters: {
     docs: {
       description: {
-        story: "This sample demonstrate the use of a sub flow",
+        story:
+          "This sample demonstrate the use of a sub flow to create groups of nodes. Drag the node to the group node to add it, drag out of it to remove it.",
       },
       source: {
         code: SubFlowRaw,

--- a/packages/lab/src/Flow/stories/SubFlow/Level.tsx
+++ b/packages/lab/src/Flow/stories/SubFlow/Level.tsx
@@ -106,7 +106,7 @@ export const Level = ({
   const hasChildren = !!children;
 
   return (
-    <div className={cx(classes.root, classesProp?.root)} id={id} key={id}>
+    <div className={cx(classes.root, classesProp?.root)} id={id}>
       <div
         className={cx(classes.header, classesProp?.header, {
           [classes.childless]: !hasChildren,

--- a/packages/lab/src/Flow/stories/SubFlow/Level.tsx
+++ b/packages/lab/src/Flow/stories/SubFlow/Level.tsx
@@ -106,7 +106,7 @@ export const Level = ({
   const hasChildren = !!children;
 
   return (
-    <div className={cx(classes.root, classesProp?.root)} id={id}>
+    <div className={cx(classes.root, classesProp?.root)} id={id} key={id}>
       <div
         className={cx(classes.header, classesProp?.header, {
           [classes.childless]: !hasChildren,

--- a/packages/lab/src/Flow/stories/SubFlow/Node.tsx
+++ b/packages/lab/src/Flow/stories/SubFlow/Node.tsx
@@ -3,7 +3,7 @@ import { css, cx } from "@emotion/css";
 import { NodeProps as ReactFlowNodeProps } from "reactflow";
 import { theme } from "@hitachivantara/uikit-react-core";
 import {
-  useFlowNodeGetIntersections,
+  useFlowNodeIntersections,
   useHvNode,
 } from "@hitachivantara/uikit-react-lab";
 
@@ -62,8 +62,9 @@ export const Node = ({ id: idProp, groupId, hierarchyData }: NodeProps) => {
     groupId,
   });
 
-  const intersections = useFlowNodeGetIntersections(id);
+  const intersections = useFlowNodeIntersections(id);
 
+  /** this variable is used to only run the logic when the dragging has stopped by saving the previous state */
   const [draggingFlag, setDraggingFlag] = useState(false);
 
   const sublevels = useMemo(
@@ -73,9 +74,11 @@ export const Node = ({ id: idProp, groupId, hierarchyData }: NodeProps) => {
 
   useEffect(() => {
     if (!node) return;
+    /** when node was still (draggingFlag == false) and dragging has started change the flag to true */
     if (node.dragging && !draggingFlag) {
       setDraggingFlag(true);
     }
+    /**  when node was being dragged (draggingFlag == true) and has stopped run logic to check intersections */
     if (!node.dragging && draggingFlag) {
       const groupIntersections = intersections.filter(
         (n) => n.type === "group" && n.id !== node.parentId,

--- a/packages/lab/src/Flow/stories/SubFlow/Node.tsx
+++ b/packages/lab/src/Flow/stories/SubFlow/Node.tsx
@@ -4,7 +4,6 @@ import { NodeProps as ReactFlowNodeProps } from "reactflow";
 import { theme } from "@hitachivantara/uikit-react-core";
 import {
   useFlowNodeGetIntersections,
-  useFlowNodeUtils,
   useHvNode,
 } from "@hitachivantara/uikit-react-lab";
 
@@ -30,17 +29,23 @@ const classes = {
   }),
 };
 
-const renderItem = ({ label, children, type, ...others }: HierarchyData) => {
+const renderItem = ({
+  label,
+  children,
+  type,
+  id,
+  ...others
+}: HierarchyData) => {
   if (type === "level") {
     return (
-      <Level title={label} {...others}>
+      <Level title={label} {...others} key={id} id={id}>
         {children?.map(renderItem)}
       </Level>
     );
   }
 
   return (
-    <FactTable title={label} {...others}>
+    <FactTable title={label} {...others} key={id} id={id}>
       {children?.map(renderItem)}
     </FactTable>
   );
@@ -52,13 +57,12 @@ interface NodeProps extends ReactFlowNodeProps {
 }
 
 export const Node = ({ id: idProp, groupId, hierarchyData }: NodeProps) => {
-  const { title, icon, id, node } = useHvNode({
+  const { title, icon, id, node, setNodeParent } = useHvNode({
     id: idProp,
     groupId,
   });
 
   const intersections = useFlowNodeGetIntersections(id);
-  const { setNodeParent } = useFlowNodeUtils(id);
 
   const [draggingFlag, setDraggingFlag] = useState(false);
 
@@ -78,6 +82,9 @@ export const Node = ({ id: idProp, groupId, hierarchyData }: NodeProps) => {
       );
       if (Array.isArray(groupIntersections) && groupIntersections.length >= 1)
         groupIntersections.forEach((elem) => setNodeParent(elem));
+      else {
+        setNodeParent();
+      }
       setDraggingFlag(false);
     }
   }, [draggingFlag, intersections, node, setNodeParent]);

--- a/packages/lab/src/Flow/stories/SubFlow/NodeGroup.tsx
+++ b/packages/lab/src/Flow/stories/SubFlow/NodeGroup.tsx
@@ -64,6 +64,18 @@ const classes = {
   actions: css({
     marginLeft: "auto",
   }),
+  nodeResizeIcon: css({
+    position: "relative",
+    left: -50,
+    bottom: -20,
+    display: "inline-block",
+    border: dashedBorder,
+    borderRadius: theme.radii.round,
+  }),
+  nodeResizeLine: {
+    borderColor: "transparent",
+    borderRadius: containerBorderRadius,
+  },
 };
 
 interface NodeProps extends ReactFlowNodeProps {
@@ -77,14 +89,19 @@ export const NodeGroup = ({ id: idProp, groupId, actions = [] }: NodeProps) => {
     groupId,
   });
 
+  /** this variable is used to only run the logic when the dragging has stopped by saving the previous state */
   const [draggingFlag, setDraggingFlag] = useState(false);
 
   useEffect(() => {
     if (!node) return;
     if (node.dragging && !draggingFlag) {
+      /** when node was still (draggingFlag == false)
+       * and dragging has started change the flag to true */
       setDraggingFlag(true);
     }
     if (!node.dragging && draggingFlag) {
+      /**  when node was being dragged (draggingFlag == true)
+       * and has stopped run logic to check intersections */
       const groupIntersections = intersections.filter(
         (n) => n.type === "group" && n.id !== node.parentId,
       );
@@ -97,32 +114,19 @@ export const NodeGroup = ({ id: idProp, groupId, actions = [] }: NodeProps) => {
   return (
     <div id={id} className={cx("nowheel", classes.root)}>
       <NodeResizer
-        lineStyle={{
-          // borderStyle: "dashed",
-          borderColor: "transparent",
-          borderRadius: containerBorderRadius,
-        }}
+        lineStyle={classes.nodeResizeLine}
         minWidth={minWidth}
         minHeight={minHeight}
       />
       <NodeResizeControl position="top-right" minWidth={300} minHeight={200}>
-        <div
-          style={{
-            position: "relative",
-            left: -50,
-            bottom: -20,
-            display: "inline-block",
-            border: dashedBorder,
-            borderRadius: theme.radii.round,
-          }}
-        >
+        <div className={classes.nodeResizeIcon}>
           <Fullscreen />
         </div>
       </NodeResizeControl>
       <div
         className={cx(classes.headerBackground, css({ zIndex: node?.zIndex }))}
       >
-        <div className={cx(classes.header)}>
+        <div className={classes.header}>
           {icon}
           <HvTypography
             variant="title4"
@@ -140,7 +144,6 @@ export const NodeGroup = ({ id: idProp, groupId, actions = [] }: NodeProps) => {
         </div>
       </div>
       <div className={classes.content} />
-      <div />
     </div>
   );
 };

--- a/packages/lab/src/Flow/stories/SubFlow/NodeGroup.tsx
+++ b/packages/lab/src/Flow/stories/SubFlow/NodeGroup.tsx
@@ -1,0 +1,104 @@
+import { css, cx } from "@emotion/css";
+import {
+  NodeResizeControl,
+  NodeResizer,
+  NodeProps as ReactFlowNodeProps,
+} from "reactflow";
+import {
+  HvDropDownMenu,
+  HvListValue,
+  HvTypography,
+  theme,
+} from "@hitachivantara/uikit-react-core";
+import { Fullscreen } from "@hitachivantara/uikit-react-icons";
+import { useHvNode } from "@hitachivantara/uikit-react-lab";
+
+const classes = {
+  root: css({
+    display: "flex",
+    minWidth: 200,
+    minHeight: 200,
+    width: "100%",
+    height: "100%",
+    backgroundColor: theme.colors.atmo1,
+    borderRadius: "0 16px 16px 16px",
+  }),
+  content: css({
+    borderRadius: "0 16px 16px 16px",
+    backgroundColor: theme.colors.primary_20,
+    width: "100%",
+  }),
+  header: css({
+    display: "flex",
+    width: "100%",
+    height: "100%",
+    padding: theme.spacing("2px", "xs", "2px", "xs"),
+    borderRadius: "16px 16px 0 0",
+    border: `1px dashed ${theme.colors.primary_80}`,
+    borderBottom: "none",
+    flexDirection: "row",
+    alignItems: "center",
+    backgroundColor: theme.colors.primary_20,
+  }),
+  headerBackground: css({
+    display: "flex",
+    position: "absolute",
+    top: "-35px",
+    backgroundColor: theme.colors.atmo1,
+    borderRadius: "16px 16px 0 0",
+    borderBottom: "none",
+  }),
+  title: css({
+    overflow: "hidden",
+    textOverflow: "ellipsis",
+  }),
+  actions: css({
+    marginLeft: "auto",
+  }),
+};
+
+interface NodeProps extends ReactFlowNodeProps {
+  groupId: string;
+  actions?: HvListValue[];
+}
+
+export const NodeGroup = ({ id: idProp, groupId, actions = [] }: NodeProps) => {
+  const { title, icon, id } = useHvNode({
+    id: idProp,
+    groupId,
+  });
+
+  return (
+    <div id={id} className={cx("nowheel", classes.root)}>
+      <NodeResizer
+        lineStyle={{
+          borderStyle: "dashed",
+          borderRadius: "0 16px 16px 16px",
+        }}
+      />
+      <NodeResizeControl position="top-right">
+        <Fullscreen style={{ position: "relative", left: -40 }} />
+      </NodeResizeControl>
+      <div className={cx(classes.headerBackground, css({ zIndex: 0 }))}>
+        <div className={cx(classes.header, css({ zIndex: 0 }))}>
+          {icon}
+          <HvTypography
+            variant="title4"
+            component="p"
+            className={classes.title}
+          >
+            {title}
+          </HvTypography>
+          {actions && (
+            <HvDropDownMenu
+              dataList={actions}
+              classes={{ root: classes.actions }}
+            />
+          )}
+        </div>
+      </div>
+      <div className={classes.content} />
+      <div />
+    </div>
+  );
+};

--- a/packages/lab/src/Flow/stories/SubFlow/index.tsx
+++ b/packages/lab/src/Flow/stories/SubFlow/index.tsx
@@ -14,6 +14,7 @@ import {
   Add,
   Backwards,
   Column,
+  Cube,
   DataFlow,
   Fail,
   Leaf,
@@ -31,15 +32,25 @@ import {
 import { restrictToSample } from "../Base";
 import { HierarchyData } from "./Level";
 import { Node } from "./Node";
+import { NodeGroup } from "./NodeGroup";
 
 // Initial state
 const initialState = {
   nodes: [
     {
+      width: 400,
+      height: 400,
+      id: "testGroup",
+      position: { x: 0, y: 0 },
+      positionAbsolute: { x: 0, y: 0 },
+      data: {},
+      type: "group",
+    },
+    {
       width: 250,
       height: 365,
       id: "1caf2381eaf",
-      position: { x: 194, y: -160 },
+      position: { x: 194, y: 160 },
       data: {},
       type: "dimensionTable",
     },
@@ -47,7 +58,7 @@ const initialState = {
       width: 250,
       height: 274,
       id: "caf2381eaf3",
-      position: { x: 637, y: -367 },
+      position: { x: 637, y: 367 },
       data: {},
       type: "factTable",
     },
@@ -160,6 +171,10 @@ const FactTableNode = (props: NodeProps) => (
   <Node groupId="factTable" hierarchyData={factTableDataObject} {...props} />
 );
 
+const CubeNodeGroup = (props: NodeProps) => (
+  <NodeGroup {...props} groupId="groupNode" />
+);
+
 const nodeGroups = {
   dimensionTable: {
     label: "Dimension Table",
@@ -173,11 +188,18 @@ const nodeGroups = {
     icon: <Table />,
     items: [{ nodeType: "factTable", label: "Fact Table" }],
   },
+  groupNode: {
+    label: "Group Node",
+    color: "cat2_40",
+    icon: <Cube />,
+    items: [{ nodeType: "group", label: "Group Node" }],
+  },
 } satisfies HvFlowProps["nodeGroups"];
 
 const nodeTypes = {
   dimensionTable: DimTableNode,
   factTable: FactTableNode,
+  group: CubeNodeGroup,
 } satisfies HvFlowProps["nodeTypes"];
 
 // Classes

--- a/packages/lab/src/Flow/stories/SubFlow/index.tsx
+++ b/packages/lab/src/Flow/stories/SubFlow/index.tsx
@@ -38,8 +38,8 @@ import { NodeGroup } from "./NodeGroup";
 const initialState = {
   nodes: [
     {
-      width: 400,
-      height: 400,
+      width: 500,
+      height: 300,
       id: "testGroup",
       position: { x: 0, y: 0 },
       positionAbsolute: { x: 0, y: 0 },
@@ -50,7 +50,7 @@ const initialState = {
       width: 250,
       height: 365,
       id: "1caf2381eaf",
-      position: { x: 194, y: 160 },
+      position: { x: 0, y: 360 },
       data: {},
       type: "dimensionTable",
     },
@@ -58,7 +58,7 @@ const initialState = {
       width: 250,
       height: 274,
       id: "caf2381eaf3",
-      position: { x: 637, y: 367 },
+      position: { x: 637, y: 0 },
       data: {},
       type: "factTable",
     },
@@ -190,7 +190,7 @@ const nodeGroups = {
   },
   groupNode: {
     label: "Group Node",
-    color: "cat2_40",
+    color: "primary_20",
     icon: <Cube />,
     items: [{ nodeType: "group", label: "Group Node" }],
   },


### PR DESCRIPTION
I tried creating some hooks in `useHvNode` so that the you wouldn't need to implement it in every node, like a onDragEnd event but was unsuccessful as it would always trigger to many re-renders. If you have an idea to remove some logic from the `Node` or `NodeGroup` let me know.

I also noted that we use the type property of the `reactflow` nodes in order to choose which component to use in a node, (i.e.: the Dimension Table node is of type: "dimensionTable"), but in order to create a group this property has to be 'group' creating multiple types of groups would have to be done some other way.