### PR TITLE
docs: fix broken links & move CONTRIBUTING

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,6 +1,8 @@
 # Contribution guidelines
 
-We welcome contributions to our project. Here are a few guidelines that will help you along the way:
+We welcome contributions to our project. You can help us fixing bugs or submit any new ideas, as [pull requests](#submitting-a-pull-request) or as [GitHub issues](#submitting-an-issue).
+
+Here are a few guidelines that will help you along the way:
 
 - [Getting started](#getting-started)
 - [Question or problem?](#question-or-problem)
@@ -29,7 +31,7 @@ Use GitHub issues for bug reports and feature requests or one of our available c
 
 <h2 id="new-components">New components</h2>
 
-New components should be contributed to the `lab` package in `packages/lab/src/components/<COMPONENT_NAME>`.
+New components should be contributed to the `lab` package in `packages/lab/src/<COMPONENT_NAME>`.
 
 Check out our [Component Guidelines](./?path=/docs/overview-community-component-guidelines--docs) for a guide on how to structure components, and the [submitting a pull request](#submitting-a-pull-request) on how to contribute it.
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 ![License](https://img.shields.io/badge/license-Apache%202-blue.svg)
 ![React](https://img.shields.io/badge/react-17|18-blue.svg)
 ![Node](https://img.shields.io/badge/node-16|18-brightgreen.svg)
-![Master Nightly](https://github.com/lumada-design/hv-uikit-react/workflows/Master%20Nightly/badge.svg)
+[![Nightly](https://github.com/lumada-design/hv-uikit-react/actions/workflows/nightly.yml/badge.svg)](https://github.com/lumada-design/hv-uikit-react/actions/workflows/nightly.yml)
 
 </div>
 
@@ -33,7 +33,7 @@ Check the [project status](https://lumada-design.github.io/uikit/master/?path=/d
 
 ## Installation 🚀
 
-The fastest way to setup a new **NEXT UI Kit** project is by using [`hv-uikit-cli`](https://github.com/lumada-design/hv-uikit-cli/). Follow the link for usage documentation.
+The fastest way to setup a new **NEXT UI Kit** project is by using [`hv-uikit-cli`](./packages/cli). Follow the link for usage documentation.
 
 ```sh
 npx @hitachivantara/hv-uikit-cli@latest create
@@ -60,11 +60,7 @@ See our documentation site [here](https://lumada-design.github.io/uikit/master/)
 
 ## Contributing
 
-Please check out our [Contribution Guidelines](/CONTRIBUTING.md) and let's build a better UI Kit together.
-
-We welcome all contributions. You can help us fixing bugs or submit any new ideas, as [pull requests](https://github.com/lumada-design/hv-uikit-react/blob/master/CONTRIBUTING.md#submitting-a-pull-request) or as [GitHub issues](https://github.com/lumada-design/hv-uikit-react/blob/master/CONTRIBUTING.md#submitting-an-issue).
-
-Join and support the project!
+Please check out our [Contribution Guidelines](/.github/CONTRIBUTING.md) and let's build a better UI Kit together!
 
 ## Contributors 🤟
 

--- a/apps/docs/pages/docs/get-started.mdx
+++ b/apps/docs/pages/docs/get-started.mdx
@@ -5,8 +5,8 @@ If you're adding UI Kit to an existing project, follow the [**Manual setup**](#m
 
 ## Automatic setup
 
-NEXT UI Kit offers an interactive command-line tool to easily bootstrap new projects, [**hv-uikit-cli**](https://github.com/lumada-design/hv-uikit-cli/).
-Follow [this link](https://github.com/lumada-design/hv-uikit-cli/#usage) for usage documentation.
+NEXT UI Kit offers an interactive command-line tool to easily bootstrap new projects, [**hv-uikit-cli**](https://github.com/lumada-design/hv-uikit-react/tree/master/packages/cli/).
+Follow [this link](https://github.com/lumada-design/hv-uikit-react/tree/master/packages/cli/#usage) for usage documentation.
 
 ```sh
 npx @hitachivantara/hv-uikit-cli@latest create

--- a/docs/overview/GetStarted.mdx
+++ b/docs/overview/GetStarted.mdx
@@ -9,8 +9,8 @@ If you're adding UI Kit to an existing project, follow the [**Manual setup**](#m
 
 ## Automatic setup
 
-NEXT UI Kit offers an interactive command-line tool to easily bootstrap new projects, [**hv-uikit-cli**](https://github.com/lumada-design/hv-uikit-cli/).
-Follow [this link](https://github.com/lumada-design/hv-uikit-cli/#usage) for usage documentation.
+NEXT UI Kit offers an interactive command-line tool to easily bootstrap new projects, [**hv-uikit-cli**](https://github.com/lumada-design/hv-uikit-react/tree/master/packages/cli/).
+Follow [this link](https://github.com/lumada-design/hv-uikit-react/tree/master/packages/cli/#usage) for usage documentation.
 
 ```sh
 npx @hitachivantara/hv-uikit-cli@latest create

--- a/docs/overview/community/Contributing.mdx
+++ b/docs/overview/community/Contributing.mdx
@@ -1,6 +1,6 @@
 import { Markdown, Meta } from "@storybook/addon-docs";
 
-import Contributing from "../../../CONTRIBUTING.md?raw";
+import Contributing from "../../../.github/CONTRIBUTING.md?raw";
 
 <Meta title="Overview/Community/Contributing" />
 


### PR DESCRIPTION
- Fix broken & outdated links in docs
- Simplify CONTRIBUTING and put in under `.github` for a cleaner root directory 😎 @francisco-guilherme 