### PR TITLE
fix(types): add exports types declaration

### DIFF
--- a/packages/code-editor/package.json
+++ b/packages/code-editor/package.json
@@ -59,6 +59,7 @@
     "types": "dist/types/index.d.ts",
     "exports": {
       ".": {
+        "types": "./dist/types/index.d.ts",
         "require": "./dist/cjs/index.cjs",
         "import": "./dist/esm/index.js"
       }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -86,6 +86,7 @@
     "types": "dist/types/index.d.ts",
     "exports": {
       ".": {
+        "types": "./dist/types/index.d.ts",
         "require": "./dist/cjs/index.cjs",
         "import": "./dist/esm/index.js"
       }

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -68,6 +68,7 @@
     "types": "dist/types/index.d.ts",
     "exports": {
       ".": {
+        "types": "./dist/types/index.d.ts",
         "require": "./dist/cjs/index.cjs",
         "import": "./dist/esm/index.js"
       }

--- a/packages/lab/package.json
+++ b/packages/lab/package.json
@@ -73,6 +73,7 @@
     "types": "dist/types/index.d.ts",
     "exports": {
       ".": {
+        "types": "./dist/types/index.d.ts",
         "require": "./dist/cjs/index.cjs",
         "import": "./dist/esm/index.js"
       }

--- a/packages/pentaho/package.json
+++ b/packages/pentaho/package.json
@@ -64,6 +64,7 @@
     "types": "dist/types/index.d.ts",
     "exports": {
       ".": {
+        "types": "./dist/types/index.d.ts",
         "require": "./dist/cjs/index.cjs",
         "import": "./dist/esm/index.js"
       }

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -54,6 +54,7 @@
     "types": "dist/types/index.d.ts",
     "exports": {
       ".": {
+        "types": "./dist/types/index.d.ts",
         "require": "./dist/cjs/index.cjs",
         "import": "./dist/esm/index.js"
       },

--- a/packages/styles/package.json
+++ b/packages/styles/package.json
@@ -46,6 +46,7 @@
     "types": "dist/types/index.d.ts",
     "exports": {
       ".": {
+        "types": "./dist/types/index.d.ts",
         "require": "./dist/cjs/index.cjs",
         "import": "./dist/esm/index.mjs"
       }

--- a/packages/uno-preset/package.json
+++ b/packages/uno-preset/package.json
@@ -55,6 +55,7 @@
     "types": "dist/types/index.d.ts",
     "exports": {
       ".": {
+        "types": "./dist/types/index.d.ts",
         "require": "./dist/cjs/index.cjs",
         "import": "./dist/esm/index.mjs"
       }

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -56,6 +56,7 @@
     "types": "dist/types/index.d.ts",
     "exports": {
       ".": {
+        "types": "./dist/types/index.d.ts",
         "require": "./dist/cjs/index.cjs",
         "import": "./dist/esm/index.js"
       }

--- a/packages/viz/package.json
+++ b/packages/viz/package.json
@@ -63,6 +63,7 @@
     "types": "dist/types/index.d.ts",
     "exports": {
       ".": {
+        "types": "./dist/types/index.d.ts",
         "require": "./dist/cjs/index.cjs",
         "import": "./dist/esm/index.js"
       }


### PR DESCRIPTION
Currently, we're only declaring our types via the (old) `types` option. The modern way is to use (which we do) the [_official_](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-7.html#packagejson-exports-imports-and-self-referencing) [`exports.types`](https://nodejs.org/api/packages.html#community-conditions-definitions) key instead. (we should keep `types` for backwards compatibility for now)

![image](https://github.com/user-attachments/assets/1a430669-f353-475e-b9f0-04057cf415ec)


