### PR TITLE
perf(theme): use color-mix for theme.alpha coloring

### DIFF
--- a/packages/pentaho/src/Canvas/SidePanel/SidePanel.styles.tsx
+++ b/packages/pentaho/src/Canvas/SidePanel/SidePanel.styles.tsx
@@ -1,5 +1,7 @@
 import { createClasses, theme } from "@hitachivantara/uikit-react-core";
 
+const boxShadow = `4px 0px 8px -4px ${theme.alpha("base_dark", "12%")}`;
+
 export const { staticClasses, useClasses } = createClasses(
   "HvCanvasSidePanel",
   {
@@ -8,8 +10,7 @@ export const { staticClasses, useClasses } = createClasses(
       position: "absolute",
       top: 0,
       left: 0,
-      boxShadow:
-        "4px 0px 8px -4px color-mix(in srgb, #414141 12%, transparent)",
+      boxShadow,
       backgroundColor: "transparent",
       transition: "visibility 0.3s ease, width 0.3s ease",
       overflow: "hidden",
@@ -31,8 +32,7 @@ export const { staticClasses, useClasses } = createClasses(
       width: "35px",
       display: "flex",
       justifyContent: "center",
-      boxShadow:
-        "4px 0px 8px -4px color-mix(in srgb, #414141 12%, transparent)",
+      boxShadow,
       backgroundColor: theme.colors.atmo1,
       borderRadius: "0px 16px 16px 0px",
       position: "absolute",

--- a/packages/styles/src/theme.ts
+++ b/packages/styles/src/theme.ts
@@ -106,11 +106,14 @@ const themeVars: HvThemeVars = mapCSSVars({
   ...typographySpec,
 });
 
-const rgbVars = mapCSSVars({
-  rgb: {
-    ...colorTokens,
-  },
-});
+function getColorOrFallback(color?: HvColorAny) {
+  return themeVars.colors[color as HvColor] || color;
+}
+
+/** Get a `color` from the theme palette, or `fallbackColor` if not found */
+export function getColor(color?: HvColorAny, fallbackColor?: HvColorAny) {
+  return getColorOrFallback(color) || getColorOrFallback(fallbackColor);
+}
 
 /**
  * Utility function to generate spacing values from the theme.
@@ -141,13 +144,28 @@ const spacing = (...args: [SpacingValue[]] | SpacingValue[]) => {
 };
 
 /**
+ * Utility function to mix two colors. Accepts theme and CSS colors.
+ *
+ * @example
+ * theme.mix("atmo1", 0.7) // 70% atmo1, 30% transparent
+ * theme.mix("cat1", "60%", "orange") // 60% cat1, 30% orange
+ */
+const mix = (
+  color1: HvColorAny,
+  factor: string | number,
+  color2: HvColorAny = "transparent",
+) => {
+  const percent = typeof factor === "number" ? `${factor * 100}%` : factor;
+  return `color-mix(in srgb, ${getColor(color1)} ${percent}, ${getColor(color2)})`;
+};
+
+/**
  * Utility function to apply an alpha channel to a color from the theme.
  *
  * @example
  * theme.alpha("atmo1", 0.5) // rgb( R G B / 0.5)
  */
-const alpha = (color: HvColor, factor: number | string) =>
-  `rgb(${rgbVars.rgb[color]} / ${factor})`;
+const alpha = (color: HvColor, factor: number | string) => mix(color, factor);
 
 /**
  * UI Kit static theme object, containing values and utility functions that leverage the injected CSS variables.
@@ -164,13 +182,3 @@ export const theme = {
 };
 
 export type HvTheme = typeof theme;
-
-const getColorOrFallback = (color: HvColorAny | undefined) => {
-  return (color && theme.colors[color as HvColor]) || color;
-};
-
-/** Get a `color` from the theme palette, or `fallbackColor` if not found */
-export const getColor = (
-  color: HvColorAny | undefined,
-  fallbackColor?: HvColorAny,
-) => getColorOrFallback(color) || getColorOrFallback(fallbackColor);

--- a/packages/styles/src/utils.ts
+++ b/packages/styles/src/utils.ts
@@ -147,52 +147,6 @@ export const getThemesList = (themes: Record<string, any>) => {
   return list;
 };
 
-/**
- * Takes a color and returns the R G B channels if possible
- * @param color - Color
- * @returns R G B channels if possible
- */
-const colorToRgb = (color: string) => {
-  // Matches rgba
-  const rgbaRegex =
-    /^rgba\(\s*(-?\d+|-?\d*\.\d+(?=%))(%?)\s*,\s*(-?\d+|-?\d*\.\d+(?=%))(\2)\s*,\s*(-?\d+|-?\d*\.\d+(?=%))(\2)\s*,\s*(-?\d+|-?\d*.\d+)\s*\)$/g;
-
-  // Matches rgb
-  const rgbRegex =
-    /^rgb\(\s*(-?\d+|-?\d*\.\d+(?=%))(%?)\s*,\s*(-?\d+|-?\d*\.\d+(?=%))(\2)\s*,\s*(-?\d+|-?\d*\.\d+(?=%))(\2)\s*\)$/g;
-
-  const match = color.trim().match(rgbaRegex) || color.trim().match(rgbRegex);
-
-  if (match) {
-    const channels = match[0].replace(/rgba|rgb|\(|\)/g, "").split(",");
-    if (channels.length > 3) {
-      channels.pop();
-    }
-    return channels.join(" ");
-  }
-
-  // Matches hex color with 3, 4, 6 or 8 digits
-  const hexRegex =
-    /^(?:#)(?:[a-f0-9]{3}|[a-f0-9]{4}|[a-f0-9]{6}|[a-f0-9]{8})$/gi;
-
-  const hexMatch = color.trim().match(hexRegex);
-
-  if (!hexMatch) return;
-
-  let value = hexMatch[0].replace("#", "");
-  if (value.length === 3 || value.length === 4) {
-    value = Array.from(value)
-      .map((d) => `${d}${d}`)
-      .join("");
-  }
-
-  return [
-    parseInt(value.substring(0, 2), 16),
-    parseInt(value.substring(2, 4), 16),
-    parseInt(value.substring(4, 6), 16),
-  ].join(" ");
-};
-
 export const getThemesVars = (themes: HvThemeStructure[]) => {
   const vars: Record<string, any> = {};
 
@@ -207,22 +161,9 @@ export const getThemesVars = (themes: HvThemeStructure[]) => {
       // @ts-expect-error align HvTheme <-> HvThemeStructure?
       const { components, name, colors, palette, ...rest } = theme;
 
-      const rgbColors = Object.entries(colors.modes[colorMode]).reduce(
-        (acc, [key, value]) => {
-          const rgb = colorToRgb(value);
-          if (rgb) acc[key] = rgb;
-          return acc;
-        },
-        {} as Record<string, string>,
-      );
-
       vars[styleName] = toCSSVars({
         colors: {
           ...colors.modes[colorMode],
-        },
-        // Colors as R G B channels
-        rgb: {
-          ...rgbColors,
         },
       });
 


### PR DESCRIPTION
Leverage CSS `color-mix` for the `theme.alpha` utility. We're already using this utility in some places, and [browser support is good](https://caniuse.com/mdn-css_types_color_color-mix)