### PR TITLE
fix(Switch): improve onChange types

### DIFF
--- a/packages/core/src/BaseSwitch/BaseSwitch.tsx
+++ b/packages/core/src/BaseSwitch/BaseSwitch.tsx
@@ -63,7 +63,11 @@ export interface HvBaseSwitchProps
   /**
    * The callback fired when the switch is pressed.
    */
-  onChange?: (event: React.ChangeEvent, checked: boolean, value: any) => void;
+  onChange?: (
+    event: React.ChangeEvent<HTMLInputElement>,
+    checked: boolean,
+    value: any,
+  ) => void;
   /**
    * Properties passed on to the input element.
    */

--- a/packages/core/src/Switch/Switch.test.tsx
+++ b/packages/core/src/Switch/Switch.test.tsx
@@ -1,95 +1,104 @@
-import { fireEvent, render } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
-import { describe, expect, it } from "vitest";
+import { useState } from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent, {
+  PointerEventsCheckLevel,
+} from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
 
 import { HvSwitch } from "./Switch";
 
+const ControlledSwitch = () => {
+  const [checked, setChecked] = useState(false);
+
+  return (
+    <HvSwitch
+      aria-label="Controlled"
+      checked={checked}
+      onChange={(evt) => setChecked(evt.target.checked)}
+    />
+  );
+};
+
 describe("Switch", () => {
-  describe("Basic functionality", () => {
-    it("should match snapshot", () => {
-      const { container } = render(
-        <>
-          <HvSwitch aria-label="Engine 1" />
-          <HvSwitch defaultChecked aria-label="Engine 2" />
-        </>,
-      );
-      expect(container).toBeDefined();
-    });
-
-    it("correctly render the switches", () => {
-      const { getByLabelText } = render(
-        <>
-          <HvSwitch aria-label="Engine 1" />
-          <HvSwitch defaultChecked aria-label="Engine 2" />
-        </>,
-      );
-      const switch1 = getByLabelText("Engine 1");
-      const switch2 = getByLabelText("Engine 2");
-      expect(switch1).toBeInTheDocument();
-      expect(switch1).not.toBeChecked();
-
-      expect(switch2).toBeInTheDocument();
-      expect(switch2).toBeChecked();
-    });
-
-    it("changes state when clicked", async () => {
-      const { getByLabelText } = render(
-        <>
-          <HvSwitch aria-label="Engine 1" />
-          <HvSwitch defaultChecked aria-label="Engine 2" />
-        </>,
-      );
-
-      const switchComponent = getByLabelText("Engine 1");
-
-      expect(switchComponent).toBeInTheDocument();
-      expect(switchComponent).not.toBeChecked();
-      await userEvent.click(switchComponent);
-      expect(switchComponent).toBeChecked();
-    });
+  it("renders the labels", () => {
+    render(
+      <>
+        <HvSwitch aria-label="Engine 1" />
+        <HvSwitch defaultChecked aria-label="Engine 2" />
+      </>,
+    );
+    const switch1 = screen.getByRole("checkbox", { name: "Engine 1" });
+    const switch2 = screen.getByRole("checkbox", { name: "Engine 2" });
+    expect(switch1).not.toBeChecked();
+    expect(switch2).toBeChecked();
   });
 
-  describe("Disabled switch", () => {
-    it("should match snapshot", () => {
-      const { container } = render(
-        <>
-          <HvSwitch disabled aria-label="Engine 1" />
-          <HvSwitch defaultChecked disabled aria-label="Engine 2" />
-        </>,
-      );
-      expect(container).toBeDefined();
+  it("changes state when clicked Uncontrolled", async () => {
+    render(<HvSwitch aria-label="Engine 1" />);
+
+    const switchElement = screen.getByLabelText("Engine 1");
+
+    expect(switchElement).not.toBeChecked();
+    await userEvent.click(switchElement);
+    expect(switchElement).toBeChecked();
+  });
+
+  it("changes state when clicked Controlled", async () => {
+    render(<ControlledSwitch />);
+
+    const switchElement = screen.getByRole("checkbox");
+
+    expect(switchElement).not.toBeChecked();
+    await userEvent.click(switchElement);
+    expect(switchElement).toBeChecked();
+  });
+
+  it("changes state when clicked", async () => {
+    const changeMock = vi.fn();
+    render(
+      <HvSwitch
+        name="cookies"
+        value="accepted"
+        aria-label="Switch"
+        onChange={changeMock}
+      />,
+    );
+
+    const switchElement = screen.getByRole("checkbox");
+
+    expect(switchElement).not.toBeChecked();
+    await userEvent.click(switchElement);
+    expect(switchElement).toBeChecked();
+    expect(changeMock).toHaveBeenCalledTimes(1);
+    expect(changeMock).toHaveBeenCalledWith(
+      expect.anything(),
+      true,
+      "accepted",
+    );
+  });
+
+  it("renders the labels when disabled", () => {
+    render(
+      <>
+        <HvSwitch disabled aria-label="Engine 1" />
+        <HvSwitch defaultChecked disabled aria-label="Engine 2" />
+      </>,
+    );
+    const switch1 = screen.getByLabelText("Engine 1");
+    const switch2 = screen.getByLabelText("Engine 2");
+    expect(switch1).not.toBeChecked();
+    expect(switch2).toBeChecked();
+  });
+
+  it("doesn't change state when disabled", async () => {
+    render(<HvSwitch disabled aria-label="Engine 1" />);
+
+    const switchComponent = screen.getByLabelText("Engine 1");
+
+    expect(switchComponent).not.toBeChecked();
+    await userEvent.click(switchComponent, {
+      pointerEventsCheck: PointerEventsCheckLevel.Never,
     });
-
-    it("correctly render the switches", () => {
-      const { getByLabelText } = render(
-        <>
-          <HvSwitch disabled aria-label="Engine 1" />
-          <HvSwitch defaultChecked disabled aria-label="Engine 2" />
-        </>,
-      );
-      const switch1 = getByLabelText("Engine 1");
-      const switch2 = getByLabelText("Engine 2");
-      expect(switch1).toBeInTheDocument();
-      expect(switch1).not.toBeChecked();
-
-      expect(switch2).toBeInTheDocument();
-      expect(switch2).toBeChecked();
-    });
-
-    it("changes state when clicked", async () => {
-      const { getByLabelText } = render(
-        <>
-          <HvSwitch disabled aria-label="Engine 1" />
-          <HvSwitch defaultChecked disabled aria-label="Engine 2" />
-        </>,
-      );
-
-      const switchComponent = getByLabelText("Engine 1");
-
-      expect(switchComponent).toBeInTheDocument();
-      expect(switchComponent).not.toBeChecked();
-      await fireEvent.click(switchComponent);
-      expect(switchComponent).toBeChecked();
-    });
+    expect(switchComponent).not.toBeChecked();
   });
 });

--- a/packages/core/src/Switch/Switch.tsx
+++ b/packages/core/src/Switch/Switch.tsx
@@ -99,7 +99,11 @@ export interface HvSwitchProps
   /**
    * The callback fired when the switch is pressed.
    */
-  onChange?: (event: React.ChangeEvent, checked: boolean, value: any) => void;
+  onChange?: (
+    event: React.ChangeEvent<HTMLInputElement>,
+    checked: boolean,
+    value: any,
+  ) => void;
   /**
    * Properties passed on to the input element.
    */
@@ -166,7 +170,7 @@ export const HvSwitch = forwardRef<HTMLButtonElement, HvSwitchProps>(
     const [validationMessage] = useControlled(statusMessage, "Required");
 
     const onLocalChange = useCallback(
-      (evt: React.ChangeEvent, newChecked: boolean) => {
+      (evt: React.ChangeEvent<HTMLInputElement>, newChecked: boolean) => {
         setIsChecked(() => {
           // this will only run if uncontrolled
           if (required && !newChecked) {


### PR DESCRIPTION
Narrow down `onChange` to be of `HTMLInputElement`, so that `event` can be used without casting