### PR TITLE
fix(DatePicker): calendar spacing

### DIFF
--- a/packages/core/src/Calendar/CalendarHeader/CalendarHeader.styles.tsx
+++ b/packages/core/src/Calendar/CalendarHeader/CalendarHeader.styles.tsx
@@ -3,7 +3,7 @@ import { theme } from "@hitachivantara/uikit-styles";
 
 export const { staticClasses, useClasses } = createClasses("HvCalendarHeader", {
   root: {
-    paddingBottom: theme.space.md,
+    paddingBottom: theme.space.sm,
 
     "&$invalid": {
       paddingBottom: 0,

--- a/packages/core/src/Calendar/CalendarNavigation/ComposedNavigation/ComposedNavigation.styles.tsx
+++ b/packages/core/src/Calendar/CalendarNavigation/ComposedNavigation/ComposedNavigation.styles.tsx
@@ -7,7 +7,7 @@ export const { staticClasses, useClasses } = createClasses(
     navigationContainer: {
       display: "flex",
       justifyContent: "space-between",
-      padding: theme.spacing("xs", 0),
+      paddingBottom: theme.space.xs,
     },
     navigationMonth: {
       minWidth: "160px",

--- a/packages/core/src/Calendar/SingleCalendar/SingleCalendar.styles.tsx
+++ b/packages/core/src/Calendar/SingleCalendar/SingleCalendar.styles.tsx
@@ -2,20 +2,12 @@ import { createClasses } from "@hitachivantara/uikit-react-utils";
 import { theme } from "@hitachivantara/uikit-styles";
 
 export const { staticClasses, useClasses } = createClasses("HvSingleCalendar", {
-  calendarContainer: {
-    width: "318px",
-    minHeight: "440px",
-    position: "relative",
-  },
-  calendarWrapper: {
+  root: {
     overflow: "hidden",
-    backgroundColor: theme.colors.atmo1,
-    padding: theme.spacing("sm"),
   },
   calendarGrid: {
-    display: "flex",
-    flexFlow: "wrap",
-    width: "280px",
+    display: "grid",
+    gridTemplateColumns: "repeat(7, 1fr)",
     "& $cellsInRange": {
       backgroundColor: theme.colors.atmo3,
       "& $startBookend": {

--- a/packages/core/src/Calendar/SingleCalendar/SingleCalendar.tsx
+++ b/packages/core/src/Calendar/SingleCalendar/SingleCalendar.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState } from "react";
 import { type ExtractNames } from "@hitachivantara/uikit-react-utils";
 
+import { HvPanel } from "../../Panel";
 import { HvTypography } from "../../Typography";
 import { isKey } from "../../utils/keyboardUtils";
 import { setId } from "../../utils/setId";
@@ -131,48 +132,46 @@ export const HvSingleCalendar = ({
   };
 
   return (
-    <div className={cx(classes.calendarContainer, className)} {...others}>
-      <div id={id} className={classes.calendarWrapper}>
-        <HvCalendarHeader
-          id={setId(id, "header")}
-          locale={locale}
-          onChange={handleInputChange}
-          showEndDate={showEndDate && !isDateSelectionMode}
-          showDayOfWeek={showDayOfWeek}
-          invalidDateLabel={invalidDateLabel}
-        />
-        {calViewMode === "calendar" && (
-          <div>
-            <HvComposedNavigation
-              id={id}
-              locale={locale}
-              onChange={onVisibleDateChange}
-              onViewModeChange={setCalViewMode}
-              visibleYear={visibleYear || today.getFullYear()}
-              visibleMonth={visibleMonth || today.getMonth() + 1}
-            />
-            <div
-              className={classes.calendarGrid}
-              // @ts-ignore TODO: review
-              aria-controls={HvCalendarHeader?.[0]?.id}
-            >
-              {listWeekdayNames.map(renderWeekLabel)}
-              {calModel.dates.map(renderCalendarDate)}
-            </div>
-          </div>
-        )}
-        {calViewMode === "monthly" && (
-          <HvMonthSelector
+    <HvPanel id={id} className={cx(classes.root, className)} {...others}>
+      <HvCalendarHeader
+        id={setId(id, "header")}
+        locale={locale}
+        onChange={handleInputChange}
+        showEndDate={showEndDate && !isDateSelectionMode}
+        showDayOfWeek={showDayOfWeek}
+        invalidDateLabel={invalidDateLabel}
+      />
+      {calViewMode === "calendar" && (
+        <>
+          <HvComposedNavigation
             id={id}
             locale={locale}
             onChange={onVisibleDateChange}
             onViewModeChange={setCalViewMode}
+            visibleYear={visibleYear || today.getFullYear()}
             visibleMonth={visibleMonth || today.getMonth() + 1}
-            rangeMode={rangeMode}
           />
-        )}
-      </div>
-    </div>
+          <div
+            className={classes.calendarGrid}
+            // @ts-ignore TODO: review
+            aria-controls={HvCalendarHeader?.[0]?.id}
+          >
+            {listWeekdayNames.map(renderWeekLabel)}
+            {calModel.dates.map(renderCalendarDate)}
+          </div>
+        </>
+      )}
+      {calViewMode === "monthly" && (
+        <HvMonthSelector
+          id={id}
+          locale={locale}
+          onChange={onVisibleDateChange}
+          onViewModeChange={setCalViewMode}
+          visibleMonth={visibleMonth || today.getMonth() + 1}
+          rangeMode={rangeMode}
+        />
+      )}
+    </HvPanel>
   );
 };
 

--- a/packages/core/src/DatePicker/DatePicker.stories.tsx
+++ b/packages/core/src/DatePicker/DatePicker.stories.tsx
@@ -19,7 +19,7 @@ import {
 } from "@hitachivantara/uikit-react-core";
 
 const containerDecorator: Decorator = (Story) => (
-  <div className={cx("decorator", css({ width: 340, padding: 10 }))}>
+  <div className={cx("decorator", css({ width: 340, minHeight: 440 }))}>
     {Story()}
   </div>
 );

--- a/packages/styles/src/themes/ds3.ts
+++ b/packages/styles/src/themes/ds3.ts
@@ -464,7 +464,10 @@ const ds3 = makeTheme((theme) => ({
       classes: {
         root: {
           padding: theme.spacing(0, "xs"),
-          "&:not(.HvButton-icon)": { minWidth: "70px" },
+          minWidth: "70px",
+        },
+        icon: {
+          minWidth: "unset",
         },
         secondarySubtle: {
           backgroundColor: theme.colors.atmo1,


### PR DESCRIPTION
Related to #4290 but does not resolve it.

`HvDatePicker` requires lots of vertical height to be fully visible in `rangeMode` or when actions are present. After inspection, I noticed it's occupying more space than it needs to, due to:
- excessive padding of CalendarHeader input (`md` instead of `sm`)
- additive padding between CalendarHeader input and ComposedNavigation
- fixed heights and widths instead of dynamic according to content

also fixed DS3's `HvButton` `minWidth` specificity, which was causing issues