### PR TITLE
fix(theme): theme.base required & usage in components

### DIFF
--- a/packages/core/src/Button/Button.tsx
+++ b/packages/core/src/Button/Button.tsx
@@ -4,6 +4,7 @@ import {
   useTheme,
   type ExtractNames,
 } from "@hitachivantara/uikit-react-utils";
+import { HvBaseTheme } from "@hitachivantara/uikit-styles";
 
 import {
   fixedForwardRef,
@@ -67,7 +68,7 @@ export type HvButtonProps<C extends React.ElementType = "button"> =
  */
 const mapVariant = (
   variant: HvButtonVariant,
-  theme?: string,
+  theme?: HvBaseTheme,
 ): HvButtonVariant => {
   if (theme === "ds3") return variant;
 
@@ -118,7 +119,7 @@ export const HvButton = fixedForwardRef(function HvButton<
   const { activeTheme } = useTheme();
   const variant = mapVariant(
     variantProp ?? (icon ? "secondaryGhost" : "primary"),
-    activeTheme?.name,
+    activeTheme?.base,
   );
 
   const handleClick: HvButtonProps["onClick"] = (e) => {

--- a/packages/core/src/Carousel/Carousel.tsx
+++ b/packages/core/src/Carousel/Carousel.tsx
@@ -113,7 +113,7 @@ export const HvCarousel = (props: HvCarouselProps) => {
   const thumbnailsRef = useRef<HTMLDivElement>(null);
   const [isFullscreen, setIsFullscreen] = useState(false);
 
-  const isDs3 = activeTheme?.name === "ds3";
+  const isDs3 = activeTheme?.base === "ds3";
   const actionsPosition = isDs3 ? "header" : "controls";
   const controlsPosition = controlsPositionProp ?? (isDs3 ? "bottom" : "top");
   const thumbnailsPosition = thumbnailsPositionProp ?? "bottom";

--- a/packages/core/src/Typography/Typography.tsx
+++ b/packages/core/src/Typography/Typography.tsx
@@ -104,7 +104,7 @@ export const HvTypography = fixedForwardRef(function HvTypography<
   const { classes, cx } = useClasses(classesProp);
   const { activeTheme } = useTheme();
 
-  const variant = mapVariant(variantProp, activeTheme?.name);
+  const variant = mapVariant(variantProp, activeTheme?.base);
 
   const Component =
     ComponentProp || (paragraph && "p") || HvTypographyMap[variant] || "span";

--- a/packages/core/src/Typography/utils.ts
+++ b/packages/core/src/Typography/utils.ts
@@ -1,3 +1,5 @@
+import { HvBaseTheme } from "@hitachivantara/uikit-styles";
+
 export const typographyVariants = [
   "display",
   "title1",
@@ -73,7 +75,7 @@ const isLegacyVariant = (variant: string) => {
   ].includes(variant);
 };
 
-export const mapVariant = (variant: Variant, theme?: string) => {
+export const mapVariant = (variant: Variant, theme?: HvBaseTheme) => {
   if (theme === "ds3") return variant;
   const mappedVariant = mappableVariants.get(variant);
 

--- a/packages/styles/src/types.ts
+++ b/packages/styles/src/types.ts
@@ -118,7 +118,7 @@ export interface HvThemeStructure<Mode extends string = string>
     HvThemeTypography,
     Omit<HvThemeTokens, "colors"> {
   name: string;
-  base?: HvBaseTheme;
+  base: HvBaseTheme;
   colors: {
     modes: Record<Mode, HvThemeColorModeStructure>;
   };


### PR DESCRIPTION
- use `theme.base` instead of `theme.name` in components
- make `theme.base` output required (already is always present)