### PR TITLE
chore(security): mark micromatch as dev

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28283,6 +28283,7 @@
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.7.tgz",
       "integrity": "sha512-LPP/3KorzCwBxfeUuZmaR6bG2kdeHSbe0P2tY3FLRU4vYrjYz5hI4QZwV0njUx3jeuKe67YukQ1LSPZBKDqO/Q==",
+      "dev": true,
       "dependencies": {
         "braces": "^3.0.3",
         "picomatch": "^2.3.1"


### PR DESCRIPTION
mark `micromatch` as dev dependency while [CVE-2024-4067](https://nvd.nist.gov/vuln/detail/CVE-2024-4067) isn't addressed
this library is effectively a "dev" dependency of the cli package