### PR TITLE
fix(MultiButton): pentaho theme

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28283,6 +28283,7 @@
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.7.tgz",
       "integrity": "sha512-LPP/3KorzCwBxfeUuZmaR6bG2kdeHSbe0P2tY3FLRU4vYrjYz5hI4QZwV0njUx3jeuKe67YukQ1LSPZBKDqO/Q==",
+      "dev": true,
       "dependencies": {
         "braces": "^3.0.3",
         "picomatch": "^2.3.1"

--- a/packages/styles/src/themes/pentahoPlus.ts
+++ b/packages/styles/src/themes/pentahoPlus.ts
@@ -430,12 +430,11 @@ const pentahoPlus = makeTheme((theme) => ({
     HvMultiButton: {
       classes: {
         multiple: {
-          borderRadius: theme.radii.full,
           "& button.HvMultiButton-button": {
             borderColor: "transparent",
             "&.HvMultiButton-firstButton": {
               borderColor: "transparent",
-              borderRadius: `${theme.radii.full} 0 0 ${theme.radii.full}`,
+              borderRadius: `${theme.radii.base} 0 0 ${theme.radii.base}`,
               "&:disabled": {
                 borderColor: "transparent",
                 "&:hover": {
@@ -445,7 +444,7 @@ const pentahoPlus = makeTheme((theme) => ({
             },
             "&.HvMultiButton-lastButton": {
               borderColor: "transparent",
-              borderRadius: `0 ${theme.radii.full} ${theme.radii.full} 0`,
+              borderRadius: `0 ${theme.radii.base} ${theme.radii.base} 0`,
               "&:disabled": {
                 borderColor: "transparent",
                 "&:hover": {
@@ -454,7 +453,6 @@ const pentahoPlus = makeTheme((theme) => ({
               },
             },
             "&.HvMultiButton-selected": {
-              borderRadius: theme.radii.full,
               borderColor: "transparent",
               color: theme.colors.primary,
               backgroundColor: theme.colors.atmo1,
@@ -479,15 +477,29 @@ const pentahoPlus = makeTheme((theme) => ({
             "&:not(.HvMultiButton-firstButton)": {
               marginLeft: 0,
             },
+            "&:not(.HvMultiButton-firstButton, .HvMultiButton-lastButton)": {
+              borderRadius: theme.radii.none,
+            },
+            "&:not(&.HvMultiButton-selected)": {
+              boxShadow: "none",
+            },
           },
         },
         vertical: {
-          borderRadius: theme.radii.full,
           "& button.HvMultiButton-button": {
-            borderRadius: theme.radii.full,
             borderColor: "transparent",
+            "&.HvMultiButton-selected": {
+              borderRadius: theme.radii.none,
+              borderColor: "transparent",
+              color: theme.colors.primary,
+              backgroundColor: theme.colors.atmo1,
+              "&:disabled": {
+                borderColor: "transparent",
+                "&:hover": { borderColor: "transparent" },
+              },
+            },
             "&.HvMultiButton-firstButton": {
-              borderRadius: theme.radii.full,
+              borderRadius: `${theme.radii.base} ${theme.radii.base} 0px 0px`,
               borderColor: "transparent",
               "&:disabled": {
                 borderColor: "transparent",
@@ -495,18 +507,8 @@ const pentahoPlus = makeTheme((theme) => ({
               },
             },
             "&.HvMultiButton-lastButton": {
-              borderRadius: theme.radii.full,
+              borderRadius: `0px 0px ${theme.radii.base} ${theme.radii.base}`,
               borderColor: "transparent",
-              "&:disabled": {
-                borderColor: "transparent",
-                "&:hover": { borderColor: "transparent" },
-              },
-            },
-            "&.HvMultiButton-selected": {
-              borderRadius: theme.radii.full,
-              borderColor: "transparent",
-              color: theme.colors.primary,
-              backgroundColor: theme.colors.atmo1,
               "&:disabled": {
                 borderColor: "transparent",
                 "&:hover": { borderColor: "transparent" },


### PR DESCRIPTION
Changes to improve the multi button component for the Pentaho+ theme while we don't have specs:
- Border radius only for the first and last buttons. The border radius was also decreased.
- Shadow removed from the buttons when not selected to better distinct selected and unselected items.
- ℹ️I didn't add borders like the previous specs or change the background colors to follow the look and feel of the Pentaho theme. 

ℹ️ Let me know if you think that more changes are needed.