### PR TITLE
feat(header): pentaho theme updates and duplicated shadow removed

### DIFF
--- a/packages/cli/src/templates/Canvas/Node.tsx
+++ b/packages/cli/src/templates/Canvas/Node.tsx
@@ -119,11 +119,12 @@ export const Node = ({ id, data = {} }: NodeProps<NodeData>) => {
 
   return (
     <div
-      style={{
-        // @ts-ignore
-        "--node-border-color": status ? status.color : color,
-        "--icon-bg-color": color,
-      }}
+      style={
+        {
+          "--node-border-color": status ? status.color : color,
+          "--icon-bg-color": color,
+        } as React.CSSProperties
+      }
       className={cx(
         "nowheel", // Disables the default canvas pan behaviour when scrolling inside the node
         classes.root,

--- a/packages/core/src/Header/Actions/Actions.styles.tsx
+++ b/packages/core/src/Header/Actions/Actions.styles.tsx
@@ -3,6 +3,7 @@ import { theme } from "@hitachivantara/uikit-styles";
 
 import { buttonClasses } from "../../Button";
 
+// TODO - rename to HvHeaderActions (the actual component's name) in v6
 export const { staticClasses, useClasses } = createClasses("HvHeader-Actions", {
   root: {
     backgroundColor: "transparent",

--- a/packages/core/src/Header/Brand/Brand.styles.tsx
+++ b/packages/core/src/Header/Brand/Brand.styles.tsx
@@ -1,6 +1,7 @@
 import { createClasses } from "@hitachivantara/uikit-react-utils";
 import { theme } from "@hitachivantara/uikit-styles";
 
+// TODO - rename to HvHeaderBrand (the actual component's name) in v6
 export const { staticClasses, useClasses } = createClasses("HvHeader-Brand", {
   root: { display: "flex", alignItems: "center" },
   separator: {

--- a/packages/core/src/Header/Header.styles.tsx
+++ b/packages/core/src/Header/Header.styles.tsx
@@ -12,7 +12,6 @@ export const { staticClasses, useClasses } = createClasses("HvHeader", {
     flexShrink: 0,
     zIndex: theme.zIndices.banner,
     borderTop: "none",
-    position: "var(--header-position)" as any,
     boxShadow: theme.colors.shadow,
   },
   header: {

--- a/packages/core/src/Header/Header.styles.tsx
+++ b/packages/core/src/Header/Header.styles.tsx
@@ -11,8 +11,9 @@ export const { staticClasses, useClasses } = createClasses("HvHeader", {
     boxSizing: "border-box",
     flexShrink: 0,
     zIndex: theme.zIndices.banner,
-    boxShadow: theme.colors.shadow,
     borderTop: "none",
+    position: "var(--header-position)" as any,
+    boxShadow: theme.colors.shadow,
   },
   header: {
     display: "flex",
@@ -20,10 +21,10 @@ export const { staticClasses, useClasses } = createClasses("HvHeader", {
     width: "100%",
     height: "100%",
     padding: `0 ${theme.space.sm}`,
-    boxShadow: theme.colors.shadow,
     "& > *:not(nav)": {
       zIndex: 2,
     },
   },
+  fixed: { position: "fixed", top: 0, left: "auto", right: 0 },
   backgroundColor: {},
 });

--- a/packages/core/src/Header/Header.tsx
+++ b/packages/core/src/Header/Header.tsx
@@ -40,10 +40,7 @@ export const HvHeader = (props: HvHeaderProps) => {
 
   return (
     <header
-      style={{
-        // @ts-ignore
-        "--header-position": position,
-      }}
+      style={{ position }}
       className={cx(
         classes.root,
         classes.backgroundColor,

--- a/packages/core/src/Header/Header.tsx
+++ b/packages/core/src/Header/Header.tsx
@@ -36,21 +36,18 @@ export const HvHeader = (props: HvHeaderProps) => {
     ...others
   } = useDefaultProps("HvHeader", props);
 
-  const { classes, cx, css } = useClasses(classesProp);
+  const { classes, cx } = useClasses(classesProp);
 
   return (
     <header
+      style={{
+        // @ts-ignore
+        "--header-position": position,
+      }}
       className={cx(
         classes.root,
         classes.backgroundColor,
-        css({
-          position,
-          ...(position === "fixed" && {
-            top: 0,
-            left: "auto",
-            right: 0,
-          }),
-        }),
+        { [classes.fixed]: position === "fixed" },
         className,
       )}
       {...others}

--- a/packages/core/src/Header/Navigation/MenuBar/Bar.styles.tsx
+++ b/packages/core/src/Header/Navigation/MenuBar/Bar.styles.tsx
@@ -16,6 +16,7 @@ const hide = {
   transitionDuration: "300ms",
 };
 
+// TODO - rename to HvHeaderMenuBar (the actual component's name) in v6
 export const { staticClasses, useClasses } = createClasses("HvHeader-MenuBar", {
   root: {
     left: 0,

--- a/packages/core/src/Header/Navigation/MenuItem/MenuItem.styles.tsx
+++ b/packages/core/src/Header/Navigation/MenuItem/MenuItem.styles.tsx
@@ -41,6 +41,7 @@ const item: CSSInterpolation = {
   },
 };
 
+// TODO - rename to HvHeaderMenuItem (the actual component's name) in v6
 export const { staticClasses, useClasses } = createClasses(
   "HvHeader-MenuItem",
   {

--- a/packages/core/src/Header/Navigation/Navigation.styles.tsx
+++ b/packages/core/src/Header/Navigation/Navigation.styles.tsx
@@ -1,5 +1,6 @@
 import { createClasses } from "@hitachivantara/uikit-react-utils";
 
+// TODO - rename to HvHeaderNavigation (the actual component's name) in v6
 export const { staticClasses, useClasses } = createClasses(
   "HvHeader-Navigation",
   {

--- a/packages/core/src/TreeView/stories/VerticalNavigation.tsx
+++ b/packages/core/src/TreeView/stories/VerticalNavigation.tsx
@@ -11,6 +11,7 @@ import {
   useHvTreeItem,
 } from "@hitachivantara/uikit-react-core";
 import { DropDownXS } from "@hitachivantara/uikit-react-icons";
+import { mergeStyles } from "@hitachivantara/uikit-react-utils";
 
 interface CustomTreeItemProps extends HvTreeItemProps {
   /** Triggered when the tree item is expanded */
@@ -44,10 +45,13 @@ const NavigationItem = forwardRef<HTMLLIElement, CustomTreeItemProps>(
       <HvTreeItem
         ref={ref}
         nodeId={nodeId}
-        style={{
-          ["--level" as string]: level,
-          pointerEvents: disabled ? "none" : undefined,
-        }}
+        style={mergeStyles(
+          {},
+          {
+            "--level": level,
+            pointerEvents: disabled ? "none" : undefined,
+          },
+        )}
         classes={{
           group: classes.group,
           content: classes.content,

--- a/packages/core/src/VerticalNavigation/TreeView/TreeViewItem.tsx
+++ b/packages/core/src/VerticalNavigation/TreeView/TreeViewItem.tsx
@@ -9,6 +9,7 @@ import {
 } from "react";
 import { DropDownXS, DropUpXS } from "@hitachivantara/uikit-react-icons";
 import {
+  mergeStyles,
   useDefaultProps,
   type ExtractNames,
 } from "@hitachivantara/uikit-react-utils";
@@ -490,10 +491,12 @@ export const HvVerticalNavigationTreeViewItem = forwardRef(
               showAvatar={!icon && useIcons}
               isOpen={isOpen}
               hasAnyChildWithData={hasAnyChildWithData}
-              style={{
-                // @ts-expect-error csstype doesn't support CSS vars
-                "--icon-margin-left": hasAnyChildWithData ? "auto" : "unset",
-              }}
+              style={mergeStyles(
+                {},
+                {
+                  "--icon-margin-left": hasAnyChildWithData ? "auto" : "unset",
+                },
+              )}
               className={classes.icon}
             />
 

--- a/packages/core/src/VerticalNavigation/stories/Custom.tsx
+++ b/packages/core/src/VerticalNavigation/stories/Custom.tsx
@@ -19,6 +19,7 @@ import {
   Forwards,
   Job,
 } from "@hitachivantara/uikit-react-icons";
+import { mergeStyles } from "@hitachivantara/uikit-react-utils";
 
 const classes = {
   header: css({
@@ -71,10 +72,12 @@ export const Custom = () => {
     <HvVerticalNavigation open={!collapsed} useIcons>
       <div
         className={classes.header}
-        style={{
-          // @ts-ignore
-          "--header-alignment": collapsed ? "center" : "stretch",
-        }}
+        style={mergeStyles(
+          {},
+          {
+            "--header-alignment": collapsed ? "center" : "stretch",
+          },
+        )}
       >
         {collapsed ? (
           <>

--- a/packages/lab/package.json
+++ b/packages/lab/package.json
@@ -46,6 +46,7 @@
     "@hitachivantara/uikit-react-core": "^5.69.0",
     "@hitachivantara/uikit-react-icons": "^5.10.9",
     "@hitachivantara/uikit-styles": "^5.32.1",
+    "@hitachivantara/uikit-react-utils": "^0.2.1",
     "@mui/base": "^5.0.0-beta.40",
     "@types/react-grid-layout": "^1.3.5",
     "react-grid-layout": "^1.4.4",

--- a/packages/lab/src/Flow/Node/BaseNode.tsx
+++ b/packages/lab/src/Flow/Node/BaseNode.tsx
@@ -6,6 +6,7 @@ import {
   HvTypography,
   useLabels,
 } from "@hitachivantara/uikit-react-core";
+import { mergeStyles } from "@hitachivantara/uikit-react-utils";
 
 import { HvUseNodeParams, useHvNode } from "../hooks";
 import {
@@ -139,10 +140,12 @@ export const HvFlowBaseNode = ({
 
   return (
     <div
-      style={{
-        // @ts-ignore
-        "--node-color": color,
-      }}
+      style={mergeStyles(
+        {},
+        {
+          "--node-color": color,
+        },
+      )}
       className={cx(
         "nowheel", // Disables the default canvas pan behaviour when scrolling inside the node
         classes.root,
@@ -164,10 +167,12 @@ export const HvFlowBaseNode = ({
       </NodeToolbar>
       <div className={classes.headerContainer}>
         <div
-          style={{
-            // @ts-ignore
-            "--icon-color": iconColor,
-          }}
+          style={mergeStyles(
+            {},
+            {
+              "--icon-color": iconColor,
+            },
+          )}
           className={classes.titleContainer}
         >
           {icon}

--- a/packages/lab/src/Flow/stories/BaseHook/Node.tsx
+++ b/packages/lab/src/Flow/stories/BaseHook/Node.tsx
@@ -13,6 +13,7 @@ import {
   useFlowNodeEdges,
   useHvNode,
 } from "@hitachivantara/uikit-react-lab";
+import { mergeStyles } from "@hitachivantara/uikit-react-utils";
 import { theme } from "@hitachivantara/uikit-styles";
 
 const classes = {
@@ -88,10 +89,12 @@ export const Node = ({ id, groupId = "teapot", input, output }: NodeProps) => {
 
   return (
     <div
-      style={{
-        // @ts-ignore
-        "--color": color,
-      }}
+      style={mergeStyles(
+        {},
+        {
+          "--color": color,
+        },
+      )}
       className={cx("nowheel", classes.root)}
       onMouseEnter={toggleShowActions}
       onMouseLeave={toggleShowActions}

--- a/packages/styles/src/themes/pentahoPlus.ts
+++ b/packages/styles/src/themes/pentahoPlus.ts
@@ -568,6 +568,41 @@ const pentahoPlus = makeTheme((theme) => ({
         },
       },
     },
+    HvHeader: {
+      classes: {
+        root: {
+          borderBottom: `1px solid ${theme.colors.atmo3}`,
+          boxShadow: "none",
+        },
+      },
+    },
+    HvHeaderBrand: {
+      classes: {
+        separator: {
+          backgroundColor: theme.colors.atmo4,
+          margin: theme.spacing(0, "md"),
+          height: 32,
+        },
+      },
+    },
+    HvHeaderMenuBarBar: {
+      classes: {
+        active: {
+          boxShadow: "none",
+          borderBottom: `1px solid ${theme.colors.atmo3}`,
+        },
+        list: {
+          "& li:hover > .HvHeader-MenuBar-hidden": {
+            boxShadow: "none",
+            borderBottom: `1px solid ${theme.colors.atmo3}`,
+          },
+          "& li:focus-within > .HvHeader-MenuBar-hidden": {
+            boxShadow: "none",
+            borderBottom: `1px solid ${theme.colors.atmo3}`,
+          },
+        },
+      },
+    },
     HvVerticalNavigation: {
       classes: {
         root: {


### PR DESCRIPTION
- Duplicated shadow removed from header
- Header style updated for Pentaho theme
- The `ts-ignore` added to ignore errors when creating CSS vars inside the `style` prop were removed to use type assertion instead.