### PR TITLE
fix(utils): CJS by default to align with other UI Kit packages

### DIFF
--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -66,7 +66,8 @@
     "withoutPublish": true,
     "tempDir": "package",
     "fields": [
-      "main"
+      "main",
+      "type"
     ],
     "files": [
       "tsconfig.json"


### PR DESCRIPTION
Align `@hitachivantara/uikit-react-utils` to be CJS (not having `type: "module"`) like other UI Kit packages.

This is leading to issues when importing CJS modules `@hitachivantara/uikit-react-shared` in some cases (`vitest`):

```
Named export 'useEmotionCache' not found. The requested module '@hitachivantara/uikit-react-shared' is a CommonJS module, which may not support all module.exports as named exports.
CommonJS modules can always be imported via the default export, for example using:

import pkg from '@hitachivantara/uikit-react-shared';
const { useEmotionCache } = pkg;

file:///.../node_modules/@hitachivantara/uikit-react-utils/dist/esm/hooks/useCss.js:5
import { useEmotionCache } from "@hitachivantara/uikit-react-shared";
         ^^^^^^^^^^^^^^^
SyntaxError: Named export 'useEmotionCache' not found. The requested module '@hitachivantara/uikit-react-shared' is a CommonJS module, which may not support all module.exports as named exports.
CommonJS modules can always be imported via the default export, for example using:
```