### PR TITLE
ci: replace licenses script

### DIFF
--- a/.config/license-compliancerc.js
+++ b/.config/license-compliancerc.js
@@ -1,0 +1,28 @@
+export default {
+  format: "text",
+  report: "detailed",
+  allow: [
+    "Apache-2.0",
+    "BlueOak-1.0.0",
+    "0BSD",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "CC-BY-3.0",
+    "CC-BY-4.0",
+    "CC0-1.0",
+    "EPL-2.0",
+    "Hippocratic-2.1",
+    "ISC",
+    "MIT",
+    "MPL-2.0",
+    "Python-2.0",
+    "Unlicense",
+    "W3C",
+    "Zlib",
+  ],
+  exclude: [
+    "browser-assert", // MIT: https://github.com/socialally/browser-assert/pull/1
+    "flatbuffers", // Apache-2.0: https://github.com/google/flatbuffers
+    "gitconfiglocal", // BSD-3: https://github.com/soldair/node-gitconfiglocal/pull/13
+  ],
+};

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,9 +4,6 @@ on:
   workflow_dispatch:
   workflow_call:
 
-env:
-  LICENSES_WHITELIST: Apache-2.0;ISC;BSD-2-Clause;BSD-3-Clause;MIT;W3C;Zlib;CC-BY-4.0;Hippocratic-2.1;Python-2.0;MPL-2.0;Unlicense;EPL-2.0;BSD;BlueOak-1.0.0;CC0-1.0;CC-BY-3.0;WTFPL
-
 jobs:
   checks:
     name: Static Checks
@@ -20,8 +17,7 @@ jobs:
         uses: ./.github/actions/install-dependencies
 
       - name: License Check
-        run: |
-          npx license-checker-rseidelsohn --onlyAllow "${{ env.LICENSES_WHITELIST }}" --excludePackagesStartingWith "buffers;flatbuffers"
+        run: npx license-compliance
 
       - name: Security Audit
         run: npm audit --workspaces --omit dev


### PR DESCRIPTION
- replace `license-checker-rseidelsohn` (has [a bug](https://github.com/lumada-design/hv-uikit-react/actions/runs/10636622443/job/29488809093?pr=4304#step:4:9)) with `license-compliance`
  - it has better maintenance & supports a configuration file
    - added config in `.config`  (thanks [cosmicconfig](https://github.com/cosmiconfig/cosmiconfig)) & explained exclusions with comments