### PR TITLE
feat(icons): add rotate animation & size prop

### DIFF
--- a/docs/foundation/Icons/Icons.stories.tsx
+++ b/docs/foundation/Icons/Icons.stories.tsx
@@ -33,7 +33,7 @@ const disabledArgs = {
 
 export const Main: StoryObj<typeof IconBase> = {
   args: {
-    iconSize: "S",
+    size: "sm",
     color: "secondary",
   },
   argTypes: {
@@ -54,7 +54,7 @@ export const CustomColors = {
   render: () => (
     <Bookmark
       color={["brand", "secondary"]}
-      iconSize="M"
+      size="M"
       title="Click to bookmark"
     />
   ),
@@ -73,8 +73,8 @@ export const Accessibility = {
   },
   render: () => (
     <>
-      <Machine iconSize="M" />
-      <Level4 title="Warning!" iconSize="M" color="negative" />
+      <Machine size="M" />
+      <Level4 title="Warning!" size="M" color="negative" />
       <HvIconButton title="Close" onClick={() => {}}>
         <Close />
       </HvIconButton>
@@ -89,11 +89,7 @@ export const CustomSize = {
     },
   },
   render: () => (
-    <CheckboxCheck
-      width={200}
-      height={200}
-      style={{ width: 240, height: 240 }}
-    />
+    <CheckboxCheck size={200} style={{ width: 240, height: 240 }} />
   ),
 };
 
@@ -102,7 +98,7 @@ export const IconSprites: StoryObj<HvIconSpriteProps> = {
     iconName: "CheckboxCheck",
     spriteUrl: "./assets/icons.svg",
     color: "secondary",
-    iconSize: "S",
+    size: "sm",
   },
   argTypes: {
     ...disabledArgs,
@@ -175,6 +171,12 @@ export const TestSizes: StoryObj<IconBaseProps> = {
         <CheckboxCheck iconSize="S" />
         <CheckboxCheck iconSize="M" />
         <CheckboxCheck iconSize="L" />
+        <CheckboxCheck size="xs" />
+        <CheckboxCheck size="sm" />
+        <CheckboxCheck size="md" />
+        <CheckboxCheck size="lg" />
+        <CheckboxCheck size="xl" />
+        <CheckboxCheck size={120} />
       </div>
 
       <div className="flex">
@@ -182,6 +184,12 @@ export const TestSizes: StoryObj<IconBaseProps> = {
         <SpriteCheckbox iconSize="S" />
         <SpriteCheckbox iconSize="M" />
         <SpriteCheckbox iconSize="L" />
+        <SpriteCheckbox size="xs" />
+        <SpriteCheckbox size="sm" />
+        <SpriteCheckbox size="md" />
+        <SpriteCheckbox size="lg" />
+        <SpriteCheckbox size="xl" />
+        <SpriteCheckbox size={120} />
       </div>
 
       <div className="flex">
@@ -190,6 +198,8 @@ export const TestSizes: StoryObj<IconBaseProps> = {
           height={100}
           style={{ width: 140, height: 140 }}
         />
+        <CheckboxCheck size={100} style={{ width: 140, height: 140 }} />
+        <CheckboxCheck size={100} />
       </div>
     </>
   ),

--- a/packages/cli/src/templates/Canvas/index.tsx
+++ b/packages/cli/src/templates/Canvas/index.tsx
@@ -186,7 +186,6 @@ const Page = () => {
         <DropUpXS
           iconSize="XS"
           style={{ rotate: !minimize ? "180deg" : undefined }}
-          className={classes.toggleIcon}
         />
       ),
     },

--- a/packages/cli/src/templates/Canvas/styles.tsx
+++ b/packages/cli/src/templates/Canvas/styles.tsx
@@ -36,7 +36,6 @@ export const classes = {
     top: `calc(${theme.header.height} + ${theme.header.secondLevelHeight})`,
     height: `calc(100% - ${theme.header.height} - ${theme.header.secondLevelHeight})`,
   }),
-  toggleIcon: css({ transition: "rotate 0.2s ease" }),
   titleRoot: css({
     display: "flex",
     width: "100%",

--- a/packages/core/src/DropdownButton/DropdownButton.styles.tsx
+++ b/packages/core/src/DropdownButton/DropdownButton.styles.tsx
@@ -58,7 +58,4 @@ export const { staticClasses, useClasses } = createClasses("HvDropdownButton", {
   arrowContainer: {
     marginRight: theme.spacing(-2),
   },
-  arrow: {
-    transition: "rotate 0.2s ease",
-  },
 });

--- a/packages/core/src/DropdownButton/DropdownButton.tsx
+++ b/packages/core/src/DropdownButton/DropdownButton.tsx
@@ -50,11 +50,7 @@ export const HvDropdownButton = forwardRef<
   const { classes, cx } = useClasses(classesProp);
 
   const endIcon = icon ? undefined : (
-    <DropDownXS
-      iconSize="XS"
-      style={{ rotate: open ? "180deg" : undefined }}
-      className={classes.arrow}
-    />
+    <DropDownXS iconSize="XS" style={{ rotate: open ? "180deg" : undefined }} />
   );
 
   return (

--- a/packages/icons/src/IconBase.tsx
+++ b/packages/icons/src/IconBase.tsx
@@ -7,55 +7,13 @@ import {
   theme,
 } from "@hitachivantara/uikit-styles";
 
-import { isSemantic, isXS } from "./utils";
-
-const calcSize = (size: number, isLarger = false) =>
-  isLarger ? size + 8 : size;
+import { getSizeStyles } from "./utils";
 
 const getColorVars = (colorArray: string[]) => {
   return colorArray.reduce<Record<string, string>>((acc, value, index) => {
     acc[`--color-${index}`] = value;
     return acc;
   }, {});
-};
-
-/** sizes for the <svg> icon */
-const getSvgSize = (size: IconBaseProps["size"] | IconSize) => {
-  switch (size) {
-    case "xs":
-    case "XS":
-      return 12;
-    case "sm":
-    case "S":
-    case undefined:
-      return 16;
-    case "md":
-    case "M":
-      return 32;
-    case "lg":
-    case "L":
-      return 96;
-    case "xl":
-      return 112;
-    default:
-      return size;
-  }
-};
-
-const getSizeStyles = (
-  iconName: string,
-  size: IconBaseProps["size"] = isXS(iconName) ? "XS" : "S",
-) => {
-  const baseSize = getSvgSize(size);
-  const fontSize = calcSize(baseSize, isSemantic(iconName));
-  if (fontSize === 16) return; // use default values
-
-  const containerSize = baseSize + 2 * (baseSize === 12 ? 10 : 8);
-
-  return {
-    fontSize,
-    "--size": `${containerSize}px`,
-  };
 };
 
 const getIconColors = (

--- a/packages/icons/src/IconBase.tsx
+++ b/packages/icons/src/IconBase.tsx
@@ -59,7 +59,21 @@ export interface IconBaseProps
    * @example ["brand", "inherit"]
    */
   color?: HvColorAny | HvColorAny[];
-  /** The size of the SVG icon */
+  /**
+   * The size of the SVG icon. Takes in a `number` in pixels or any `HvSize` or `IconSize`.
+   *
+   * Using this new prop:
+   * - overrides the deprecated `iconSize`, `height`, and `width` props
+   * - makes the icon use the `"currentcolor"`, if the `color` isn't passed
+   *
+   * @example
+   * size={16} // 16px
+   * size="S" // 16px
+   * size="sm" // 16px
+   * size="md" // 32px
+   *
+   * @default "S"
+   */
   size?: HvSize | IconSize | number;
   /** Sets one of the standard sizes of the icons @deprecated use `size` instead */
   iconSize?: IconSize;
@@ -152,12 +166,19 @@ const IconBaseInternal = (
   const colorArray = getIconColors(palette, color, semantic, inverted);
   const title = titleProp ?? ariaLabel;
 
+  /** Whether the icon colors should be inherited. Used for icons:
+   * - using the new `size` prop (backwards compatibility) - TODO: make default in v6
+   * - without a custom user-provided `color`
+   * - with a single `palette` color
+   */
+  const inheritColor = !!size && !color && palette?.length === 1;
+
   return (
     <StyledIconBase
       ref={ref}
       data-name={iconName}
       style={{
-        ...getColorVars(colorArray),
+        ...(!inheritColor && getColorVars(colorArray)),
         ...getSizeStyles(iconName, size ?? iconSize),
         ...styleProp,
       }}

--- a/packages/icons/src/IconBase.tsx
+++ b/packages/icons/src/IconBase.tsx
@@ -129,6 +129,7 @@ export const StyledIconBase = styled("div")({
   // TODO: remove box in v6?
   width: "var(--size, 32px)",
   height: "var(--size, 32px)",
+  transition: "rotate 0.2s ease",
 });
 
 const StyledSvg = styled("svg")({

--- a/packages/icons/src/IconSprite.tsx
+++ b/packages/icons/src/IconSprite.tsx
@@ -1,7 +1,7 @@
 import { type HvColor } from "@hitachivantara/uikit-styles";
 
-import { getIconSize, IconBase, IconBaseProps } from "./IconBase";
-import { isSelector, isSemantic, isSort, isXS } from "./utils";
+import { IconBase, IconBaseProps } from "./IconBase";
+import { isSelector, isSort } from "./utils";
 
 const getSecondaryColor = (iconName: string): HvColor => {
   if (isSelector(iconName)) return "atmo1";
@@ -25,34 +25,14 @@ export interface HvIconSpriteProps
 export const HvIconSprite = ({
   spriteUrl,
   iconName,
-  color,
-  iconSize: iconSizeProp,
-  height,
-  width,
   ...others
 }: HvIconSpriteProps) => {
-  const iconSize = iconSizeProp ?? (isXS(iconName) ? "XS" : "S");
-
   // this color array is fragile... we know it currently covers all the existing icons
   const baseColors: HvColor[] = ["secondary", getSecondaryColor(iconName)];
 
-  const size = getIconSize(iconSize, isSemantic(iconName), width, height);
-
   return (
-    <IconBase
-      iconName={iconName}
-      iconSize={iconSize}
-      color={color}
-      palette={baseColors}
-      height={size.height}
-      width={size.width}
-      {...others}
-    >
-      <use
-        href={`${spriteUrl}#${iconName}`}
-        height={size.height}
-        width={size.width}
-      />
+    <IconBase iconName={iconName} palette={baseColors} {...others}>
+      <use href={`${spriteUrl}#${iconName}`} />
     </IconBase>
   );
 };

--- a/packages/icons/src/utils.ts
+++ b/packages/icons/src/utils.ts
@@ -1,3 +1,5 @@
+import type { IconBaseProps, IconSize } from "./IconBase";
+
 const selectors = ["Checkbox", "RadioButton"];
 
 const largerIcons = [
@@ -22,3 +24,46 @@ export const isSort = (iconName: string) => iconName.startsWith("Sort");
 export const isSemantic = (iconName: string) => largerIcons.includes(iconName);
 
 export const isXS = (iconName: string) => iconName.endsWith("XS");
+
+// TODO: remove in v6?
+const getCustomSize = (size: number, iconName: string) =>
+  isSemantic(iconName) ? size + 8 : size;
+
+/** sizes for the <svg> icon */
+const getSvgSize = (size: IconBaseProps["size"] | IconSize) => {
+  switch (size) {
+    case "xs":
+    case "XS":
+      return 12;
+    case "sm":
+    case "S":
+    case undefined:
+      return 16;
+    case "md":
+    case "M":
+      return 32;
+    case "lg":
+    case "L":
+      return 96;
+    case "xl":
+      return 112;
+    default:
+      return size;
+  }
+};
+
+export const getSizeStyles = (
+  iconName: string,
+  size: IconBaseProps["size"] = isXS(iconName) ? "XS" : "S",
+) => {
+  const baseSize = getSvgSize(size);
+  const fontSize = getCustomSize(baseSize, iconName);
+  if (fontSize === 16) return; // use default values
+
+  const containerSize = baseSize + 2 * (baseSize === 12 ? 10 : 8);
+
+  return {
+    fontSize,
+    "--size": `${containerSize}px`,
+  };
+};


### PR DESCRIPTION
- add rotation transition to icons, as it's often used
- add `size` prop to replace `iconSize`, which is already deprecated without replacement
  - accepts any `number`, `HvSize` (`"xs"`, `"sm"`, etc.), and `IconSize` (for backwards compatibility)
  - svg container (`div`) grows dynamically according to the set svg size (eg. 120px svg -> 128px container)
- if the `size` prop is used, the colors are inherited by default (for forwards compatibility)

> [!IMPORTANT]
> Please don't squash the commits when merging