### PR TITLE
docs(viz): move `HvVizProvider` to viz decorators

### DIFF
--- a/.storybook/decorators/ThemeDecorator.tsx
+++ b/.storybook/decorators/ThemeDecorator.tsx
@@ -55,15 +55,13 @@ export const ThemeDecorator: Decorator = (Story) => {
         theme={theme}
         colorMode={mode}
       >
-        <HvVizProvider>
-          <div
-            ref={containerRef}
-            className="hv-story-sample"
-            style={{ padding: 20 }}
-          >
-            <Story />
-          </div>
-        </HvVizProvider>
+        <div
+          ref={containerRef}
+          className="hv-story-sample"
+          style={{ padding: 20 }}
+        >
+          <Story />
+        </div>
       </HvProvider>
     </>
   );

--- a/docs/guides/layout/Layout.stories.tsx
+++ b/docs/guides/layout/Layout.stories.tsx
@@ -12,7 +12,7 @@ import {
   theme,
   useTheme,
 } from "@hitachivantara/uikit-react-core";
-import { HvBarChart } from "@hitachivantara/uikit-react-viz";
+import { HvBarChart, HvVizProvider } from "@hitachivantara/uikit-react-viz";
 
 export default {
   title: "Guides/Layout",
@@ -107,27 +107,29 @@ export const Grid: StoryObj = {
               }),
             }}
           >
-            <HvBarChart
-              height={300}
-              data={{
-                Group: ["Group 1", "Group 2", "Group 3"],
-                "Sales Target": [2300, 1000, 7800],
-                "Sales Per Rep": [6000, 3900, 1000],
-                "Monthly Sales": [3700, 6700, 1100],
-                Target: [2100, 7700, 3000],
-                Cash: [500, 7600, 7800],
-              }}
-              groupBy="Group"
-              measures={[
-                "Sales Target",
-                "Sales Per Rep",
-                "Monthly Sales",
-                "Target",
-                "Cash",
-              ]}
-              horizontal
-              grid={{ bottom: 0 }}
-            />
+            <HvVizProvider>
+              <HvBarChart
+                height={300}
+                data={{
+                  Group: ["Group 1", "Group 2", "Group 3"],
+                  "Sales Target": [2300, 1000, 7800],
+                  "Sales Per Rep": [6000, 3900, 1000],
+                  "Monthly Sales": [3700, 6700, 1100],
+                  Target: [2100, 7700, 3000],
+                  Cash: [500, 7600, 7800],
+                }}
+                groupBy="Group"
+                measures={[
+                  "Sales Target",
+                  "Sales Per Rep",
+                  "Monthly Sales",
+                  "Target",
+                  "Cash",
+                ]}
+                horizontal
+                grid={{ bottom: 0 }}
+              />
+            </HvVizProvider>
           </HvCardContent>
         </HvCard>
       </HvGrid>

--- a/packages/core/src/Section/Section.stories.tsx
+++ b/packages/core/src/Section/Section.stories.tsx
@@ -7,7 +7,7 @@ import {
   theme,
 } from "@hitachivantara/uikit-react-core";
 import { Duplicate, Ticket } from "@hitachivantara/uikit-react-icons";
-import { HvDonutChart } from "@hitachivantara/uikit-react-viz";
+import { HvDonutChart, HvVizProvider } from "@hitachivantara/uikit-react-viz";
 
 import { HvActionsGeneric } from "../ActionsGeneric";
 import { HvButton } from "../Button";
@@ -141,11 +141,13 @@ export const WithActions: StoryObj<HvSectionProps> = {
           </HvTypography>
 
           <div className={classes.root}>
-            <HvDonutChart
-              data={data}
-              groupBy="Country"
-              measure="Tickets Sold"
-            />
+            <HvVizProvider>
+              <HvDonutChart
+                data={data}
+                groupBy="Country"
+                measure="Tickets Sold"
+              />
+            </HvVizProvider>
             <div className={classes.content}>
               <Ticket iconSize="M" />
               <HvTypography variant="title3">

--- a/packages/lab/src/Dashboard/Dashboard.stories.tsx
+++ b/packages/lab/src/Dashboard/Dashboard.stories.tsx
@@ -12,6 +12,7 @@ import {
   HvBarChart,
   HvDonutChart,
   HvLineChart,
+  HvVizProvider,
 } from "@hitachivantara/uikit-react-viz";
 
 const meta: Meta<typeof HvDashboard> = {
@@ -102,7 +103,7 @@ export const DataDriven: StoryObj<HvDashboardProps> = {
     const [canResize, setCanResize] = useState(true);
 
     return (
-      <>
+      <HvVizProvider>
         <HvButton
           variant="secondaryGhost"
           startIcon={<Tool />}
@@ -157,7 +158,7 @@ export const DataDriven: StoryObj<HvDashboardProps> = {
             );
           })}
         </HvDashboard>
-      </>
+      </HvVizProvider>
     );
   },
 };

--- a/packages/lab/src/Flow/stories/Flow.stories.tsx
+++ b/packages/lab/src/Flow/stories/Flow.stories.tsx
@@ -8,6 +8,7 @@ import {
   HvFlowProps,
   HvFlowSidebar,
 } from "@hitachivantara/uikit-react-lab";
+import { HvVizProvider } from "@hitachivantara/uikit-react-viz";
 
 import { BaseHook as BaseHookStory } from "./BaseHook";
 import BaseHookRaw from "./BaseHook?raw";
@@ -52,6 +53,7 @@ const meta: Meta<typeof HvFlow> = {
       },
     },
   },
+  decorators: [(Story) => <HvVizProvider>{Story()}</HvVizProvider>],
 };
 export default meta;
 

--- a/packages/viz/src/BaseChart/stories/utils.tsx
+++ b/packages/viz/src/BaseChart/stories/utils.tsx
@@ -1,30 +1,17 @@
-import { css } from "@emotion/css";
 import { Decorator } from "@storybook/react";
-import { theme } from "@hitachivantara/uikit-react-core";
+import { HvPanel } from "@hitachivantara/uikit-react-core";
+import { HvVizProvider } from "@hitachivantara/uikit-react-viz";
 
 export const vizDecorator: Decorator = (Story) => (
-  <div
-    className={css({
-      backgroundColor: theme.colors.atmo1,
-      padding: 20,
-      display: "flex",
-      flexDirection: "column",
-      height: 500,
-    })}
-  >
-    {Story()}
-  </div>
+  <HvVizProvider>
+    <HvPanel className="flex flex-col" style={{ height: 500 }}>
+      {Story()}
+    </HvPanel>
+  </HvVizProvider>
 );
 
 export const confusionMatrixDecorator: Decorator = (Story) => (
-  <div
-    className={css({
-      backgroundColor: theme.colors.atmo1,
-      padding: 20,
-      display: "flex",
-      flexDirection: "column",
-    })}
-  >
-    {Story()}
-  </div>
+  <HvVizProvider>
+    <HvPanel className="flex flex-col">{Story()}</HvPanel>
+  </HvVizProvider>
 );


### PR DESCRIPTION
- load `HvVizProvider` only on pages it's needed, saving over 1MB and over 50 requests in other pages
- use `HvPanel` in viz samples