### PR TITLE
feat(Button): review `HvButton` styles according to latest PD specs

### DIFF
--- a/packages/core/src/Button/Button.stories.tsx
+++ b/packages/core/src/Button/Button.stories.tsx
@@ -80,12 +80,39 @@ export const Variants: StoryObj<HvButtonProps> = {
       <HvButton variant="positive">Positive</HvButton>
       <HvButton variant="positiveSubtle">Positive Subtle</HvButton>
       <HvButton variant="positiveGhost">Positive Ghost</HvButton>
+      <HvButton variant="positive" disabled>
+        Positive
+      </HvButton>
+      <HvButton variant="positiveSubtle" disabled>
+        Positive Subtle
+      </HvButton>
+      <HvButton variant="positiveGhost" disabled>
+        Positive Ghost
+      </HvButton>
       <HvButton variant="warning">Warning</HvButton>
       <HvButton variant="warningSubtle">Warning Subtle</HvButton>
       <HvButton variant="warningGhost">Warning Ghost</HvButton>
+      <HvButton variant="warning" disabled>
+        Warning
+      </HvButton>
+      <HvButton variant="warningSubtle" disabled>
+        Warning Subtle
+      </HvButton>
+      <HvButton variant="warningGhost" disabled>
+        Warning Ghost
+      </HvButton>
       <HvButton variant="negative">Negative</HvButton>
       <HvButton variant="negativeSubtle">Negative Subtle</HvButton>
       <HvButton variant="negativeGhost">Negative Ghost</HvButton>
+      <HvButton variant="negative" disabled>
+        Negative
+      </HvButton>
+      <HvButton variant="negativeSubtle" disabled>
+        Negative Subtle
+      </HvButton>
+      <HvButton variant="negativeGhost" disabled>
+        Negative Ghost
+      </HvButton>
     </>
   ),
 };
@@ -351,6 +378,15 @@ export const Test: StoryObj = {
       <HvButton size="sm" variant="positiveGhost" disabled>
         Positive Ghost
       </HvButton>
+      <HvButton variant="positive" disabled>
+        Positive
+      </HvButton>
+      <HvButton variant="positiveSubtle" disabled>
+        Positive Subtle
+      </HvButton>
+      <HvButton variant="positiveGhost" disabled>
+        Positive Ghost
+      </HvButton>
       <HvButton size="md" variant="warning">
         Warning
       </HvButton>
@@ -369,6 +405,15 @@ export const Test: StoryObj = {
       <HvButton size="md" variant="warningGhost" disabled>
         Warning Ghost
       </HvButton>
+      <HvButton variant="warning" disabled>
+        Warning
+      </HvButton>
+      <HvButton variant="warningSubtle" disabled>
+        Warning Subtle
+      </HvButton>
+      <HvButton variant="warningGhost" disabled>
+        Warning Ghost
+      </HvButton>
       <HvButton size="lg" variant="negative">
         Negative
       </HvButton>
@@ -385,6 +430,15 @@ export const Test: StoryObj = {
         Negative Subtle
       </HvButton>
       <HvButton size="lg" variant="negativeGhost" disabled>
+        Negative Ghost
+      </HvButton>
+      <HvButton variant="negative" disabled>
+        Negative
+      </HvButton>
+      <HvButton variant="negativeSubtle" disabled>
+        Negative Subtle
+      </HvButton>
+      <HvButton variant="negativeGhost" disabled>
         Negative Ghost
       </HvButton>
 

--- a/packages/core/src/Button/Button.tsx
+++ b/packages/core/src/Button/Button.tsx
@@ -170,6 +170,7 @@ export const HvButton = fixedForwardRef(function HvButton<
         sizeStyles && css(sizeStyles),
         className,
       )}
+      data-color={color}
       onClick={handleClick}
       onMouseDown={handleMouseDown}
       {...(Component === "button" && { type: "button" })}

--- a/packages/styles/src/themes/pentahoPlus.ts
+++ b/packages/styles/src/themes/pentahoPlus.ts
@@ -62,6 +62,8 @@ const pentahoPlus = makeTheme((theme) => ({
         pp: {
           primary: blue[600],
           primaryAction: blue[700],
+          primaryStrong: blue[800],
+          primarySubtle: blue[200],
           primaryDimmed: blue[100],
           success: green[600],
           successAction: green[700],
@@ -94,7 +96,7 @@ const pentahoPlus = makeTheme((theme) => ({
           bgSurface: slate[50],
           bgActive: slate[200],
           bgHover: blue[100],
-          bgDisabled: slate[200],
+          bgDisabled: neutral[200],
           bgOverlay: `color-mix(in srgb, ${slate[900]} 60%, transparent)`,
           dimmer: "#FFFFFF",
         },
@@ -139,6 +141,8 @@ const pentahoPlus = makeTheme((theme) => ({
         pp: {
           primary: blue[400],
           primaryAction: blue[300],
+          primaryStrong: blue[200],
+          primarySubtle: blue[900],
           primaryDimmed: blue[950],
           success: green[600],
           successAction: green[500],
@@ -171,7 +175,7 @@ const pentahoPlus = makeTheme((theme) => ({
           bgSurface: slate[900],
           bgActive: slate[900],
           bgHover: blue[950],
-          bgDisabled: slate[900],
+          bgDisabled: neutral[900],
           bgOverlay: `color-mix(in srgb, ${slate[900]} 40%, transparent)`,
           dimmer: "#000000",
         },
@@ -472,40 +476,134 @@ const pentahoPlus = makeTheme((theme) => ({
     HvButton: {
       classes: {
         root: {
+          border: "none",
           borderRadius: theme.radii.full,
           padding: theme.spacing(0, "sm"),
-          "&:active": {
-            boxShadow: `inset 0 1px 2px 0 #00000033`, // 33 = 20% opacity
+          [`&[data-color="positive"]`]: {
+            "&:hover": {
+              backgroundColor: theme.colors.pp.successAction,
+            },
+            "&:active": {
+              backgroundColor: theme.colors.pp.successStrong,
+            },
           },
-        },
-        disabled: {
-          "&:active": {
-            boxShadow: "none",
+          [`&[data-color="negative"]`]: {
+            "&:hover": {
+              backgroundColor: theme.colors.pp.errorAction,
+            },
+            "&:active": {
+              backgroundColor: theme.colors.pp.errorStrong,
+            },
+          },
+          [`&[data-color="warning"]`]: {
+            "&:hover": {
+              backgroundColor: theme.colors.pp.warningAction,
+            },
+            "&:active": {
+              backgroundColor: theme.colors.pp.warningStrong,
+            },
           },
         },
         primary: {
           "&:hover": {
-            backgroundColor: theme.colors.primary_80,
+            backgroundColor: theme.colors.pp.primaryAction,
           },
           "&:active": {
-            backgroundColor: theme.colors.primary_80,
-            boxShadow: `inset 0 1px 2px 0 #0000004D`, // 4D = 30% opacity
+            backgroundColor: theme.colors.pp.primaryStrong,
           },
         },
         subtle: {
-          borderColor: "transparent",
+          borderTop: `1px solid ${theme.colors.atmo1}`,
+          borderBottom: `1px solid ${theme.colors.atmo4}`,
           backgroundColor: theme.colors.atmo1,
-          boxShadow: theme.colors.shadow,
+          "&:hover": {
+            backgroundColor: theme.colors.pp.bgHover,
+          },
+          "&:active": {
+            backgroundColor: theme.colors.pp.primarySubtle,
+            borderBottom: `1px solid ${theme.colors.pp.primarySubtle}`,
+            border: "none",
+          },
           "&.HvButton-disabled": {
-            backgroundColor: theme.colors.atmo3,
-            boxShadow: "none",
+            backgroundColor: theme.colors.pp.bgDisabled,
             "&:hover": {
-              backgroundColor: theme.colors.atmo3,
-            },
-            "&:active": {
-              boxShadow: "none",
+              backgroundColor: theme.colors.pp.bgDisabled,
             },
           },
+          "&[data-color=positive]": {
+            "&:hover,&:active": {
+              backgroundColor: theme.colors.pp.successDimmed,
+            },
+          },
+          [`&[data-color="negative"]`]: {
+            color: theme.colors.negative_120,
+            "&:hover,&:active": {
+              backgroundColor: theme.colors.pp.errorDimmed,
+            },
+          },
+          [`&[data-color="warning"]`]: {
+            color: theme.colors.warning_120,
+            "&:hover,&:active": {
+              backgroundColor: theme.colors.pp.warningDimmed,
+            },
+          },
+        },
+        ghost: {
+          "&:hover": {
+            backgroundColor: theme.colors.pp.primaryDimmed,
+          },
+          "&:active": {
+            backgroundColor: theme.colors.pp.primarySubtle,
+            borderBottom: `1px solid ${theme.colors.pp.primarySubtle}`,
+            border: "none",
+          },
+          [`&[data-color="positive"]`]: {
+            "&:hover,&:active": {
+              backgroundColor: theme.colors.pp.successDimmed,
+            },
+          },
+          [`&[data-color="negative"]`]: {
+            color: theme.colors.negative_120,
+            "&:hover,&:active": {
+              backgroundColor: theme.colors.pp.errorDimmed,
+            },
+          },
+          [`&[data-color="warning"]`]: {
+            color: theme.colors.warning_120,
+            "&:hover,&:active": {
+              backgroundColor: theme.colors.pp.warningDimmed,
+            },
+          },
+        },
+
+        semantic: {
+          "&:hover": {
+            backgroundColor: theme.colors.pp.primaryDimmed,
+          },
+          "&:active": {
+            backgroundColor: theme.colors.pp.primarySubtle,
+            borderBottom: `1px solid ${theme.colors.pp.primarySubtle}`,
+            border: "none",
+          },
+        },
+
+        disabled: {
+          border: "none",
+          backgroundColor: theme.colors.pp.bgDisabled,
+          color: theme.colors.pp.textDisabled,
+          "&:hover": {
+            backgroundColor: theme.colors.pp.bgDisabled,
+          },
+          "&[data-color=positive],&[data-color=warning],&[data-color=negative]":
+            {
+              color: theme.colors.pp.textDisabled,
+              "&:hover,&:active": {
+                backgroundColor: theme.colors.pp.bgDisabled,
+              },
+              "&.HvButton-ghost": {
+                backgroundColor: "transparent",
+              },
+            },
         },
       },
     },

--- a/packages/styles/src/themes/pentahoPlus.ts
+++ b/packages/styles/src/themes/pentahoPlus.ts
@@ -547,6 +547,10 @@ const pentahoPlus = makeTheme((theme) => ({
               backgroundColor: theme.colors.pp.warningDimmed,
             },
           },
+          "&:HvButton-disabled": {
+            backgroundColor: theme.colors.pp.bgDisabled,
+            borderColor: theme.colors.pp.bgDisabled,
+          },
         },
         ghost: {
           "&:hover": {
@@ -745,6 +749,24 @@ const pentahoPlus = makeTheme((theme) => ({
         openDown: {
           borderRadius:
             "calc(var(--HvButton-height) / 2) calc(var(--HvButton-height) / 2) 0px 0px",
+        },
+        disabled: {
+          backgroundColor: theme.colors.pp.bgDisabled,
+          borderColor: theme.colors.pp.bgDisabled,
+          "&.HvButton-subtle": {
+            backgroundColor: theme.colors.pp.bgDisabled,
+            borderColor: theme.colors.pp.bgDisabled,
+            "&:hover": {
+              backgroundColor: theme.colors.pp.bgDisabled,
+            },
+          },
+          "&.HvButton-ghost": {
+            backgroundColor: theme.colors.pp.bgDisabled,
+            borderColor: theme.colors.pp.bgDisabled,
+            "&:hover": {
+              backgroundColor: theme.colors.pp.bgDisabled,
+            },
+          },
         },
       },
     },

--- a/packages/styles/src/tokens/colors.ts
+++ b/packages/styles/src/tokens/colors.ts
@@ -4,7 +4,8 @@ interface ColorTokens {
   // #region semantic
   primary: string;
   primaryAction: string;
-  // primaryStrong: string;
+  primaryStrong: string;
+  primarySubtle: string;
   primaryDimmed: string;
   success: string;
   successAction: string;
@@ -269,6 +270,8 @@ const utilsLight = {
 const newLight = {
   primary: accentLight.primary,
   primaryAction: accentLight.primary_80,
+  primaryStrong: accentLight.primary_80,
+  primarySubtle: accentLight.primary_20,
   primaryDimmed: accentLight.primary_20,
   success: semanticLight.positive,
   successAction: semanticLight.positive_80,
@@ -375,6 +378,8 @@ const utilsDark = {
 const newDark = {
   primary: accentDark.primary,
   primaryAction: accentDark.primary_80,
+  primaryStrong: accentDark.primary_80,
+  primarySubtle: accentDark.primary_20,
   primaryDimmed: accentDark.primary_20,
   success: semanticDark.positive,
   successAction: semanticDark.positive_80,

--- a/packages/styles/src/tokens/colorsPalette.ts
+++ b/packages/styles/src/tokens/colorsPalette.ts
@@ -273,6 +273,7 @@ export const palette = {
   neutral,
   blue,
   red,
+  amber,
   orange,
   yellow,
   lime,


### PR DESCRIPTION
- added `primaryStrong` and `primarySubtle` tokens
- also exporting the `amber` colors as those were not being exported.
