### PR TITLE
fix(SimpleGrid): breakpoints spacing

### DIFF
--- a/packages/core/src/SimpleGrid/SimpleGrid.stories.tsx
+++ b/packages/core/src/SimpleGrid/SimpleGrid.stories.tsx
@@ -6,9 +6,6 @@ import {
   theme,
 } from "@hitachivantara/uikit-react-core";
 
-const range = (max: number, min = 1) =>
-  Array.from(Array(max), (v, i) => i + min);
-
 const style = {
   display: "flex",
   justifyContent: "center",
@@ -39,8 +36,8 @@ export const Main: StoryObj<HvSimpleGridProps> = {
   render: (args) => {
     return (
       <HvSimpleGrid className={css({ "& > div": style })} {...args}>
-        {range(5).map((i) => (
-          <div key={i}>{i}</div>
+        {[...Array(5).keys()].map((i) => (
+          <div key={i}>{i + 1}</div>
         ))}
       </HvSimpleGrid>
     );
@@ -65,8 +62,8 @@ export const BreakpointsGrid: StoryObj<HvSimpleGridProps> = {
         cols={cols}
         className={css({ "& > div": style })}
       >
-        {range(5).map((i) => (
-          <div key={i}>{i}</div>
+        {[...Array(5).keys()].map((i) => (
+          <div key={i}>{i + 1}</div>
         ))}
       </HvSimpleGrid>
     );

--- a/packages/core/src/SimpleGrid/SimpleGrid.tsx
+++ b/packages/core/src/SimpleGrid/SimpleGrid.tsx
@@ -2,6 +2,7 @@ import {
   useDefaultProps,
   type ExtractNames,
 } from "@hitachivantara/uikit-react-utils";
+import { HvBreakpoints } from "@hitachivantara/uikit-styles";
 
 import { HvBaseProps } from "../types/generic";
 import {
@@ -9,31 +10,34 @@ import {
   staticClasses,
   useClasses,
 } from "./SimpleGrid.styles";
-import { Breakpoint, Spacing } from "./types";
 
 export { staticClasses as simpleGridClasses };
+
+// TODO: remove in v6
+export type Spacing = HvBreakpoints;
+
+// TODO: rename in v6 (or inline)
+export interface Breakpoint {
+  cols?: number;
+  maxWidth?: number;
+  minWidth?: number;
+  spacing?: HvBreakpoints;
+}
 
 export type HvSimpleGridClasses = ExtractNames<typeof useClasses>;
 
 /** Grid component that enables you to create columns of equal width and define your own breakpoints and responsive behavior. */
 export interface HvSimpleGridProps extends HvBaseProps {
-  /**
-   * Spacing with pre-defined values according the values defined in the theme
-   */
-  spacing?: Spacing;
+  /** Spacing with pre-defined values according the values defined in the theme */
+  spacing?: HvBreakpoints;
   /**
    * Provide an array to define responsive behavior:
-   *
-   *    maxWidth or minWidth: max-width or min-width at which media query will work
-   *
-   *    cols: number of columns per row at given max-width
-   *
-   *    spacing: optional spacing at given max-width, if not provided spacing from component prop will be used instead
+   * - `maxWidth` or `minWidth`: max-width or min-width at which media query will work
+   * - `cols`: number of columns per row at given max-width
+   * - `spacing`: optional spacing at given max-width, if not provided spacing from component prop will be used instead
    */
   breakpoints?: Breakpoint[];
-  /**
-   * Number of how many columns the content will be displayed
-   */
+  /** Number of how many columns the content will be displayed */
   cols?: number;
   /** A Jss Object used to override or extend the styles applied to the component. */
   classes?: HvSimpleGridClasses;
@@ -43,7 +47,7 @@ export const HvSimpleGrid = (props: HvSimpleGridProps) => {
   const {
     children,
     breakpoints,
-    spacing = "sm",
+    spacing,
     cols,
     className,
     classes: classesProp,
@@ -52,7 +56,7 @@ export const HvSimpleGrid = (props: HvSimpleGridProps) => {
 
   const { classes, cx, css } = useClasses(classesProp);
 
-  const containerStyle = getContainerStyle({ breakpoints, spacing, cols });
+  const containerStyle = getContainerStyle(breakpoints, spacing, cols);
 
   return (
     <div

--- a/packages/core/src/SimpleGrid/index.ts
+++ b/packages/core/src/SimpleGrid/index.ts
@@ -1,2 +1,1 @@
 export * from "./SimpleGrid";
-export * from "./types";

--- a/packages/core/src/SimpleGrid/types.ts
+++ b/packages/core/src/SimpleGrid/types.ts
@@ -1,8 +1,0 @@
-export type Spacing = "sm" | "md" | "lg" | "xl";
-
-export interface Breakpoint {
-  cols?: number;
-  maxWidth?: number;
-  minWidth?: number;
-  spacing?: Spacing;
-}


### PR DESCRIPTION
I noticed the `HvSimpleBreakpoint` was off by 1 pixel compared to the `HvGrid`'s breakpoints. After taking a look, I also noticed that `breakpoint.spacing` was not being used respected (fallback always to `spacing` prop)

- fix off-by-1 breakpoints
- fix custom `breakpoint.spacing` being ignored
- leverage CSS var for number of colums `--cols`, reducing dynamic styles & overall style injection
- add `xs` breakpoint - aligning with `HvBreakpoints`
- type docs & warnings regarding the names
