### PR TITLE
fix(TimeAgo): respect locale and allow setting 12 or 24 hour format

### DIFF
--- a/packages/core/src/TimeAgo/TimeAgo.stories.tsx
+++ b/packages/core/src/TimeAgo/TimeAgo.stories.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
+import { css } from "@emotion/css";
 import { Meta, StoryObj } from "@storybook/react";
-import dayjs from "dayjs";
 import {
   HvRadio,
   HvRadioGroup,
@@ -8,12 +8,6 @@ import {
   HvTimeAgoProps,
   theme,
 } from "@hitachivantara/uikit-react-core";
-
-import "dayjs/locale/fr";
-import "dayjs/locale/de";
-import "dayjs/locale/pt";
-
-import { css } from "@emotion/css";
 
 const styles = {
   root: css({
@@ -44,7 +38,7 @@ export default meta;
 
 export const Main: StoryObj<HvTimeAgoProps> = {
   args: {
-    timestamp: dayjs().valueOf(),
+    timestamp: new Date().getTime(),
     locale: "en",
     disableRefresh: false,
     showSeconds: false,
@@ -62,19 +56,21 @@ export const Main: StoryObj<HvTimeAgoProps> = {
 
 const dates = [
   new Date(),
-  new Date().setSeconds(new Date().getSeconds() - 30),
+  new Date().setSeconds(new Date().getSeconds() - 10),
+  new Date().setSeconds(new Date().getSeconds() - 90),
   new Date().setMinutes(new Date().getMinutes() - 1),
   new Date().setMinutes(new Date().getMinutes() - 10),
   new Date().setMinutes(new Date().getMinutes() - 59),
   new Date().setMinutes(new Date().getMinutes() - 80),
   new Date().setHours(0),
   new Date().setDate(new Date().getDate() - 1),
-  new Date().setDate(new Date().getDate() - new Date().getDay()),
   new Date().setDate(0),
   new Date().setMonth(new Date().getMonth() - 1),
-  new Date().setMonth(new Date().getMonth() - 2),
-  new Date().setMonth(new Date().getMonth() - 4),
-  new Date().setFullYear(new Date().getFullYear() - 1),
+  new Date().setSeconds(new Date().getSeconds() + 90),
+  new Date().setMinutes(new Date().getMinutes() + 5),
+  new Date().setHours(23, 59, 59, 999),
+  new Date().setDate(new Date().getDate() + 1),
+  new Date().setMonth(new Date().getMonth() + 6),
 ].map((date) => date.valueOf());
 
 export const Samples: StoryObj<HvTimeAgoProps> = {
@@ -106,10 +102,7 @@ export const LocaleOverride: StoryObj<HvTimeAgoProps> = {
   parameters: {
     docs: {
       description: {
-        story:
-          "Sample dates and locale controlled externally.<br /> \
-        `HvTimeAgo` leverages `dayjs` for locales and custom dates. To use a locale, import it with `dayjs/locale/{locale}`<br />\
-        Locale strings can be overridden using [dayjs.updateLocale](https://day.js.org/docs/en/plugin/update-locale)",
+        story: "Sample dates and locale controlled externally.",
       },
     },
   },
@@ -132,6 +125,7 @@ export const LocaleOverride: StoryObj<HvTimeAgoProps> = {
             <HvRadio label="🇫🇷 French" value="fr" />
             <HvRadio label="🇩🇪 German" value="de" />
             <HvRadio label="🇵🇹 Portuguese" value="pt" />
+            <HvRadio label="🇯🇵 Japanese" value="ja" />
           </HvRadioGroup>
         </div>
         <table className={styles.table}>
@@ -146,7 +140,7 @@ export const LocaleOverride: StoryObj<HvTimeAgoProps> = {
               <tr key={dateTs}>
                 <td>{new Date(dateTs).toISOString()}</td>
                 <td aria-label="Time ago">
-                  <HvTimeAgo timestamp={dateTs} locale={locale} />
+                  <HvTimeAgo timestamp={dateTs} locale={locale} showSeconds />
                 </td>
               </tr>
             ))}

--- a/packages/core/src/TimeAgo/TimeAgo.stories.tsx
+++ b/packages/core/src/TimeAgo/TimeAgo.stories.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useState } from "react";
 import { Meta, StoryObj } from "@storybook/react";
 import dayjs from "dayjs";
 import {
@@ -6,7 +6,6 @@ import {
   HvRadioGroup,
   HvTimeAgo,
   HvTimeAgoProps,
-  HvTypography,
   theme,
 } from "@hitachivantara/uikit-react-core";
 
@@ -61,24 +60,25 @@ export const Main: StoryObj<HvTimeAgoProps> = {
   },
 };
 
+const dates = [
+  new Date(),
+  new Date().setSeconds(new Date().getSeconds() - 30),
+  new Date().setMinutes(new Date().getMinutes() - 1),
+  new Date().setMinutes(new Date().getMinutes() - 10),
+  new Date().setMinutes(new Date().getMinutes() - 59),
+  new Date().setMinutes(new Date().getMinutes() - 80),
+  new Date().setHours(0),
+  new Date().setDate(new Date().getDate() - 1),
+  new Date().setDate(new Date().getDate() - new Date().getDay()),
+  new Date().setDate(0),
+  new Date().setMonth(new Date().getMonth() - 1),
+  new Date().setMonth(new Date().getMonth() - 2),
+  new Date().setMonth(new Date().getMonth() - 4),
+  new Date().setFullYear(new Date().getFullYear() - 1),
+].map((date) => date.valueOf());
+
 export const Samples: StoryObj<HvTimeAgoProps> = {
   render: () => {
-    const dates = useMemo(
-      () =>
-        [
-          dayjs(),
-          dayjs().subtract(1, "minutes"),
-          dayjs().subtract(10, "minutes"),
-          dayjs().subtract(59, "minutes"),
-          dayjs().hour(0),
-          dayjs().day(0),
-          dayjs().date(0),
-          dayjs().month(-2),
-          dayjs().month(-4),
-        ].map((date) => date.valueOf()),
-      [],
-    );
-
     return (
       <table className={styles.table}>
         <thead>
@@ -88,11 +88,11 @@ export const Samples: StoryObj<HvTimeAgoProps> = {
           </tr>
         </thead>
         <tbody>
-          {dates.map((dateTs, idx) => (
-            <tr key={`${dateTs}-${idx}`}>
+          {dates.map((dateTs) => (
+            <tr key={dateTs}>
               <td>{new Date(dateTs).toISOString()}</td>
               <td aria-label="Time ago">
-                <HvTimeAgo timestamp={dateTs} />
+                <HvTimeAgo timestamp={dateTs} showSeconds />
               </td>
             </tr>
           ))}
@@ -115,7 +115,6 @@ export const LocaleOverride: StoryObj<HvTimeAgoProps> = {
   },
   render: () => {
     const [locale, setLocale] = useState("en");
-    const [time /* , setTime */] = useState(Date.now());
 
     return (
       <div className={css(styles.container)}>
@@ -127,7 +126,6 @@ export const LocaleOverride: StoryObj<HvTimeAgoProps> = {
               // dynamically import locales. if the supported locales are known beforehand,
               // its preferable to import them statically, to avoid bundling unnecessary locales
               setLocale(newLocale);
-              dayjs.updateLocale("fr", {});
             }}
           >
             <HvRadio label="🇬🇧 English" value="en" />
@@ -136,12 +134,24 @@ export const LocaleOverride: StoryObj<HvTimeAgoProps> = {
             <HvRadio label="🇵🇹 Portuguese" value="pt" />
           </HvRadioGroup>
         </div>
-        <div>
-          <HvTypography variant="title3">
-            <HvTimeAgo timestamp={time} locale={locale} />
-          </HvTypography>
-          <span>{new Date(time).toISOString()}</span>
-        </div>
+        <table className={styles.table}>
+          <thead>
+            <tr>
+              <th>ISO Date</th>
+              <th>{"<TimeAgo />"}</th>
+            </tr>
+          </thead>
+          <tbody>
+            {dates.map((dateTs) => (
+              <tr key={dateTs}>
+                <td>{new Date(dateTs).toISOString()}</td>
+                <td aria-label="Time ago">
+                  <HvTimeAgo timestamp={dateTs} locale={locale} />
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
       </div>
     );
   },

--- a/packages/core/src/TimeAgo/TimeAgo.test.tsx
+++ b/packages/core/src/TimeAgo/TimeAgo.test.tsx
@@ -28,7 +28,31 @@ describe("TimeAgo with timestamp", () => {
     const timestamp = Date.now();
     render(<HvTimeAgo timestamp={timestamp} />);
 
-    expect(screen.getByText("a few seconds")).toBeVisible();
+    expect(screen.getByText("now")).toBeVisible();
+  });
+
+  it("should contain the relative time when the day is yesterday", () => {
+    const timestamp = new Date().setDate(new Date().getDate() - 1);
+    render(<HvTimeAgo timestamp={timestamp} />);
+
+    expect(screen.getByText(/^yesterday/)).toBeVisible();
+  });
+
+  it("should contain the relative time when the day is tomorrow", () => {
+    const timestamp = new Date().setDate(new Date().getDate() + 1);
+    render(<HvTimeAgo timestamp={timestamp} />);
+
+    expect(screen.getByText(/^tomorrow/)).toBeVisible();
+  });
+});
+
+describe("TimeAgo with custom locale", () => {
+  it("should present the time in the appropriate locale", () => {
+    const timestamp = new Date(2024, 0, 1, 15, 0, 0).getTime();
+    render(<HvTimeAgo timestamp={timestamp} locale="en-US" />);
+    expect(screen.getByText("Jan 1, 2024, 3:00 PM")).toBeVisible();
+    render(<HvTimeAgo timestamp={timestamp} locale="en-GB" />);
+    expect(screen.getByText("1 Jan 2024, 15:00")).toBeVisible();
   });
 });
 
@@ -46,14 +70,14 @@ describe("TimeAgo with justText", () => {
     const timestamp = Date.now();
     render(<HvTimeAgo justText timestamp={timestamp} />);
 
-    expect(screen.getByText("a few seconds")).toBeInTheDocument();
+    expect(screen.getByText("now")).toBeInTheDocument();
   });
 
   it("should not render the custom component", () => {
     const timestamp = Date.now();
     render(<HvTimeAgo justText timestamp={timestamp} component="button" />);
 
-    expect(screen.getByText("a few seconds")).toBeInTheDocument();
+    expect(screen.getByText("now")).toBeInTheDocument();
     expect(screen.queryByRole("button")).toBeNull();
   });
 });

--- a/packages/core/src/TimeAgo/TimeAgo.tsx
+++ b/packages/core/src/TimeAgo/TimeAgo.tsx
@@ -26,10 +26,10 @@ export type HvTimeAgoProps<C extends React.ElementType = "p"> =
        */
       timestamp?: number;
       /**
-       * The locale to be used. Should be on of the dayjs supported locales and explicitly imported
-       * @see https://day.js.org/docs/en/i18n/i18n
+       * The locale to be used. Should be on of the JS supported locales
+       * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl#locales_argument
        */
-      locale?: string;
+      locale?: Intl.LocalesArgument;
       /**
        * The element to render when the timestamp is null or 0
        * Defaults to `—` (Em Dash)
@@ -59,7 +59,7 @@ export const HvTimeAgo = fixedForwardRef(function HvTimeAgo<
     classes: classesProp,
     className,
     timestamp,
-    locale: localeProp = "en",
+    locale = "en",
     component: Component = HvTypography,
     emptyElement = "—",
     disableRefresh = false,
@@ -69,7 +69,6 @@ export const HvTimeAgo = fixedForwardRef(function HvTimeAgo<
   } = useDefaultProps("HvTimeAgo", props);
 
   const { classes, cx } = useClasses(classesProp);
-  const locale = localeProp || "en";
   const timeAgo = useTimeAgo(timestamp, {
     locale,
     disableRefresh,

--- a/packages/core/src/TimeAgo/formatUtils.ts
+++ b/packages/core/src/TimeAgo/formatUtils.ts
@@ -1,3 +1,26 @@
+const isDateInPeriod = (
+  timeAgoMs: number,
+  period: "tomorrow" | "afterTomorrow",
+  referenceDate = new Date(),
+) => {
+  const date = new Date(timeAgoMs);
+
+  const startOfToday = new Date(referenceDate);
+  startOfToday.setHours(0, 0, 0, 0);
+  const startOfTomorrow = new Date(startOfToday);
+  startOfTomorrow.setDate(startOfToday.getDate() + 1);
+  const startOfDayAfterTomorrow = new Date(startOfTomorrow);
+  startOfDayAfterTomorrow.setDate(startOfTomorrow.getDate() + 1);
+
+  if (period === "tomorrow") {
+    return date >= startOfTomorrow && date < startOfDayAfterTomorrow;
+  }
+  if (period === "afterTomorrow") {
+    return date >= startOfDayAfterTomorrow;
+  }
+  return false;
+};
+
 /**
  * Relative time thresholds defined by
  * {@link https://xd.adobe.com/view/1b7df235-5cf8-4b51-a2f0-0be1bb591c55-4e2e/ Design System}
@@ -37,6 +60,16 @@ export const formatTimeAgo = (
   const minsAgo = Math.floor(secsAgo / 60);
 
   switch (true) {
+    case isDateInPeriod(timeAgoMs, "afterTomorrow", referenceDate):
+      return fullFormatter.format(date);
+    case isDateInPeriod(timeAgoMs, "tomorrow", referenceDate):
+      return `${relFormatter.format(1, "days")}, ${dayFormatter.format(date)}`;
+    case minsAgo < -60: // Future date more than 1 hour ahead
+      return `${relFormatter.format(0, "days")}, ${dayFormatter.format(date)}`;
+    case minsAgo < -2: // Future date more than 2 minutes ahead
+      return relFormatter.format(-minsAgo, "minutes");
+    case secsAgo < 0: // Future date within 1 minute
+      return `${relFormatter.format(Math.abs(secsAgo), "seconds")}`;
     case secsAgo < 20:
       return relFormatter.format(0, "seconds");
     case minsAgo < 2:

--- a/packages/core/src/TimeAgo/formatUtils.ts
+++ b/packages/core/src/TimeAgo/formatUtils.ts
@@ -1,153 +1,55 @@
-import dayjs from "dayjs";
-import calendar from "dayjs/plugin/calendar";
-import duration from "dayjs/plugin/duration";
-import localeData from "dayjs/plugin/localeData";
-import localizedFormat from "dayjs/plugin/localizedFormat";
-import relativeTime from "dayjs/plugin/relativeTime";
-import updateLocale from "dayjs/plugin/updateLocale";
-
 /**
  * Relative time thresholds defined by
  * {@link https://xd.adobe.com/view/1b7df235-5cf8-4b51-a2f0-0be1bb591c55-4e2e/ Design System}
- *
- * Implementation using day.js {@link https://day.js.org/docs/en/customization/relative-time relativeTime}
- */
-const thresholds = [
-  { l: "s", r: 119, d: "second" },
-  { l: "m", r: 1 },
-  { l: "mm", r: 59, d: "minute" },
-  { l: "h", r: 1 },
-  { l: "hh", r: 23, d: "hour" },
-  { l: "d", r: 1 },
-  { l: "dd", r: 29, d: "day" },
-  { l: "M", r: 1 },
-  { l: "MM", r: 11, d: "month" },
-  { l: "y", r: 17 },
-  { l: "yy", d: "year" },
-];
-
-dayjs.extend(localeData);
-dayjs.extend(duration);
-dayjs.extend(calendar);
-dayjs.extend(localizedFormat);
-dayjs.extend(relativeTime, { thresholds });
-dayjs.extend(updateLocale);
-
-export const secondsUntilNextDay = (date = new Date()) => {
-  const midnight = new Date(date.getTime());
-
-  midnight.setDate(midnight.getDate() + 1);
-  midnight.setHours(0);
-  midnight.setMinutes(0);
-  midnight.setSeconds(0);
-  midnight.setMilliseconds(0);
-
-  return (midnight.getTime() - date.getTime()) / 1000;
-};
-
-const secondsUntilNextWeek = (date = new Date()) => {
-  const firstMonthDayOfWeek = date.getDate() - date.getDay();
-  const firstMonthDayOfNextWeek = firstMonthDayOfWeek + 7; // auto roll over to next month if needed
-
-  const firstDayNextWeek = new Date(date.getTime());
-
-  firstDayNextWeek.setDate(firstMonthDayOfNextWeek);
-  firstDayNextWeek.setHours(0);
-  firstDayNextWeek.setMinutes(0);
-  firstDayNextWeek.setSeconds(0);
-  firstDayNextWeek.setMilliseconds(0);
-
-  return (firstDayNextWeek.getTime() - date.getTime()) / 1000;
-};
-
-/**
- * @typedef {Object} TimeAgo
- * @property {string} timeAgo - the formatted date using the "time ago format"
- * @property {number} delay - the time until the date needs to be updated
- */
-
-/**
- * Formats a date to the a relative time format using dayjs.
- *
- * @param {Date} date - date to format.
- * @param {String} locale - locale to use.
- * @param {Boolean} [showSeconds=false] - if seconds should be part of the result.
- * @param {Date} referenceDate - reference date to use when formatting (defaults to current date).
- *
- * @return {TimeAgo} the formatted date using the "time ago format" and the time until it needs to be updated
  */
 export const formatTimeAgo = (
-  date: Date,
-  locale: string,
+  timeAgoMs: number,
+  locale: Intl.LocalesArgument,
   showSeconds = false,
   referenceDate = new Date(),
 ) => {
-  const dayReferenceDate = dayjs(referenceDate);
-  const dayDate = dayjs(date).locale(locale);
+  const relFormatter = new Intl.RelativeTimeFormat(locale, { numeric: "auto" });
+  const dayFormatter = new Intl.DateTimeFormat(locale, {
+    hour: "numeric",
+    minute: "numeric",
+    second: showSeconds ? "numeric" : undefined,
+  });
+  const weekFormatter = new Intl.DateTimeFormat(locale, {
+    weekday: "short",
+    hour: "numeric",
+    minute: "numeric",
+    second: showSeconds ? "numeric" : undefined,
+  });
+  const fullFormatter = new Intl.DateTimeFormat(locale, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "numeric",
+    second: showSeconds ? "numeric" : undefined,
+  });
+  const date = new Date(timeAgoMs);
+  const secsInDay =
+    date.getHours() * 3600 + date.getMinutes() * 60 + date.getSeconds();
+  const secsInWeek = date.getDay() * 86400 + secsInDay;
 
-  const dayDiffSeconds = dayReferenceDate.diff(dayDate, "second");
+  const secsAgo = Math.floor((referenceDate.getTime() - timeAgoMs) / 1000);
+  const minsAgo = Math.floor(secsAgo / 60);
 
-  const formatUseSeconds = showSeconds ? "LTS" : "LT";
-
-  // check if the date is after the reference date
-  if (date.getTime() > referenceDate.getTime()) {
-    return {
-      timeAgo: dayDate.format(`L ${formatUseSeconds}`),
-      delay: (date.getTime() - referenceDate.getTime()) / 1000,
-    };
+  switch (true) {
+    case secsAgo < 20:
+      return relFormatter.format(0, "seconds");
+    case minsAgo < 2:
+      return relFormatter.format(-secsAgo, "seconds");
+    case minsAgo < 60:
+      return relFormatter.format(-minsAgo, "minutes");
+    case secsAgo < secsInDay: // today
+      return `${relFormatter.format(0, "days")}, ${dayFormatter.format(date)}`;
+    case secsAgo < secsInDay + 86400: // yesterday
+      return `${relFormatter.format(-1, "days")}, ${dayFormatter.format(date)}`;
+    case secsAgo < secsInWeek: // this week
+      return weekFormatter.format(date);
+    default:
+      return fullFormatter.format(date);
   }
-
-  // just now, until the 2 minutes
-  if (dayDiffSeconds < 120) {
-    return {
-      timeAgo: dayjs
-        .duration(dayDiffSeconds, "second")
-        .locale(locale)
-        .humanize(),
-      delay: 120 - dayDiffSeconds,
-    };
-  }
-
-  // ago in minutes, until the 1 hour mark
-  const dayDiffMinutes = dayReferenceDate.diff(dayDate, "minute");
-
-  if (dayDiffMinutes < 60) {
-    return {
-      timeAgo: dayjs
-        .duration(-dayDiffMinutes, "minute")
-        .locale(locale)
-        .humanize(true),
-      delay: 60 * (dayDiffMinutes + 1) - dayDiffSeconds,
-    };
-  }
-
-  // formatted date with text description for today
-  if (dayReferenceDate.isSame(dayDate, "day")) {
-    return {
-      timeAgo: `${dayDate.calendar(dayReferenceDate)}`,
-      delay: secondsUntilNextDay(referenceDate),
-    };
-  }
-
-  // formatted date with text description for yesterday
-  if (dayReferenceDate.subtract(1, "day").isSame(dayDate, "day")) {
-    return {
-      timeAgo: `${dayDate.calendar(dayReferenceDate)}`,
-      delay: secondsUntilNextDay(referenceDate),
-    };
-  }
-
-  // formatted date with week during the current week
-  if (dayDate.isSame(dayReferenceDate, "week")) {
-    return {
-      timeAgo: dayDate.format(`ddd, ${formatUseSeconds}`),
-      delay: secondsUntilNextWeek(date),
-    };
-  }
-
-  // formatted without special gimmicks
-  return {
-    timeAgo: dayDate.format(`L ${formatUseSeconds}`),
-    delay: 0,
-  };
 };

--- a/packages/core/src/TimeAgo/useTimeAgo.ts
+++ b/packages/core/src/TimeAgo/useTimeAgo.ts
@@ -14,12 +14,14 @@ const fmt = (timestamp: any, locale: any, showSeconds?: boolean) => {
 };
 
 export default function useTimeAgo(
-  timestamp: number | undefined,
+  timestamp = Date.now(),
   options?: Pick<HvTimeAgoProps, "locale" | "disableRefresh" | "showSeconds">,
 ) {
   const { locale, disableRefresh = false, showSeconds = false } = options || {};
-  const [timeAgo, setTimeAgo] = useState(fmt(timestamp, locale, showSeconds));
-  const refreshTime = disableRefresh ? 0 : timeAgo.delay * 1000;
+  const [timeAgo, setTimeAgo] = useState(() =>
+    fmt(timestamp, locale, showSeconds),
+  );
+  const refreshTime = disableRefresh ? 0 : 10_000;
 
   useEffect(() => {
     const newTimeAgo = fmt(timestamp, locale, showSeconds);
@@ -31,5 +33,5 @@ export default function useTimeAgo(
     setTimeAgo(newTimeAgo);
   }, refreshTime);
 
-  return timeAgo.timeAgo;
+  return timeAgo;
 }

--- a/packages/core/src/TimeAgo/useTimeAgo.ts
+++ b/packages/core/src/TimeAgo/useTimeAgo.ts
@@ -10,7 +10,7 @@ import { useTimeout } from "./useTimeout";
 const fmt = (timestamp: any, locale: any, showSeconds?: boolean) => {
   const timestampMs =
     String(timestamp).length > 11 ? timestamp : timestamp * 1000;
-  return formatTimeAgo(new Date(timestampMs), locale, showSeconds);
+  return formatTimeAgo(timestampMs, locale, showSeconds);
 };
 
 export default function useTimeAgo(


### PR DESCRIPTION
- This PRs addresses an issue where the locale was not being respected in specific scenarios. 
- This also removes the usage of `dayjs` and uses the native [`Intl.RelativeTimeFormat` ](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/RelativeTimeFormat)
- Updated some of the docs
- Updated tests