### PR TITLE
docs(Canvas): fix toolbar InlineEditor

### DIFF
--- a/packages/pentaho/src/Canvas/Toolbar/stories/Custom.tsx
+++ b/packages/pentaho/src/Canvas/Toolbar/stories/Custom.tsx
@@ -38,7 +38,7 @@ export const CustomStory = () => (
         <Backwards />
       </HvButton>
     }
-    title={<HvInlineEditor value="Toolbar Title" variant="title4" />}
+    title={<HvInlineEditor defaultValue="Toolbar Title" variant="title4" />}
     classes={{ root: classes.toolbar }}
   >
     <HvIconButton title="Undo">


### PR DESCRIPTION
we can't the title's value because it's controlled