### PR TITLE
feat(ToolbarTabs): create new and remove tab optional

### DIFF
--- a/docs/tests/Pentaho.stories.tsx
+++ b/docs/tests/Pentaho.stories.tsx
@@ -1,6 +1,6 @@
 import { Meta, StoryObj } from "@storybook/react";
 import { Test as BottomPanelTestStory } from "packages/pentaho/src/Canvas/BottomPanel/BottomPanel.stories";
-import { Main as ToolbarTabsMainStory } from "packages/pentaho/src/Canvas/ToolbarTabs/ToolbarTabs.stories";
+import { Test as ToolbarTabsTestStory } from "packages/pentaho/src/Canvas/ToolbarTabs/ToolbarTabs.stories";
 import { HvSimpleGrid } from "@hitachivantara/uikit-react-core";
 
 import { setupChromatic } from ".storybook/setupChromatic";
@@ -31,7 +31,7 @@ export const Test: StoryObj = {
       style={{ alignItems: "start", justifyContent: "start" }}
     >
       {BottomPanelTestStory.render?.(BottomPanelTestStory.args as any, context)}
-      {ToolbarTabsMainStory.render?.(ToolbarTabsMainStory.args as any, context)}
+      {ToolbarTabsTestStory.render?.(ToolbarTabsTestStory.args as any, context)}
     </HvSimpleGrid>
   ),
 };

--- a/packages/pentaho/src/Canvas/ToolbarTabs/ToolbarTabs.stories.tsx
+++ b/packages/pentaho/src/Canvas/ToolbarTabs/ToolbarTabs.stories.tsx
@@ -62,9 +62,17 @@ export const Controlled: StoryObj<HvCanvasToolbarTabsProps> = {
 };
 
 export const NotEditable: StoryObj<HvCanvasToolbarTabsProps> = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "By default all tabs' labels are editable. If this is not desired for your use case, the `disableTabEdit` property should be set to `true`.",
+      },
+    },
+  },
   render: () => (
     <HvCanvasToolbarTabs
-      allowTabEdit={false}
+      disableTabEdit
       icon={<Leaf />}
       defaultTabs={[
         {
@@ -79,5 +87,91 @@ export const NotEditable: StoryObj<HvCanvasToolbarTabsProps> = {
         },
       ]}
     />
+  ),
+};
+
+export const NotRemovable: StoryObj<HvCanvasToolbarTabsProps> = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "By default the tabs are removable. If this is not desired for your use case, the `fixed` property should be set to `true` at the tab level. Thus, it's possible to have both removable and not removable tabs. The `hideCreateNew` property also enables you to hide the 'Create new' button if needed.",
+      },
+    },
+  },
+  render: () => (
+    <HvCanvasToolbarTabs
+      hideCreateNew
+      disableTabEdit
+      defaultTabs={[
+        {
+          id: "tab1",
+          label: "Tab 1",
+          fixed: true,
+        },
+        {
+          id: "tab2",
+          label: "Tab 2",
+        },
+      ]}
+    />
+  ),
+};
+
+export const Test: StoryObj = {
+  args: {
+    defaultTabs: [
+      {
+        id: "tab1",
+        label: "My first tab",
+        icon: <Leaf />,
+      },
+      {
+        id: "tab2",
+        label: "My tab with a very long label",
+        icon: <Leaf />,
+      },
+    ],
+  },
+  parameters: {
+    docs: { disable: true },
+  },
+  render: (args) => (
+    <div style={{ display: "flex", flexDirection: "column", gap: 5 }}>
+      <HvCanvasToolbarTabs />
+      <HvCanvasToolbarTabs hideCreateNew />
+      <HvCanvasToolbarTabs
+        defaultTabs={[
+          { id: "tab1", label: "My tab with a very long label" },
+          { id: "tab2", label: "My tab" },
+        ]}
+      />
+      <HvCanvasToolbarTabs
+        hideCreateNew
+        defaultTabs={[
+          { id: "tab1", label: "My tab with a very long label" },
+          { id: "tab2", label: "My tab" },
+        ]}
+      />
+      <HvCanvasToolbarTabs
+        disableTabEdit
+        defaultTabs={[
+          { id: "tab1", label: "My tab with a very long label" },
+          { id: "tab2", label: "My tab" },
+        ]}
+      />
+      <HvCanvasToolbarTabs
+        defaultTabs={[
+          {
+            id: "tab1",
+            label: "My tab with a very long label",
+            fixed: true,
+          },
+          { id: "tab2", label: "My tab" },
+        ]}
+      />
+      {/* Note: Passed through args because the icons freeze storybook otherwise */}
+      <HvCanvasToolbarTabs {...args} />
+    </div>
   ),
 };

--- a/packages/pentaho/src/Canvas/ToolbarTabs/ToolbarTabs.styles.tsx
+++ b/packages/pentaho/src/Canvas/ToolbarTabs/ToolbarTabs.styles.tsx
@@ -24,6 +24,7 @@ export const { staticClasses, useClasses } = createClasses(
       boxShadow: theme.colors.shadow,
       borderRadius: `0px 0px ${theme.radii.base} ${theme.radii.base}`,
       transition: "width 0.3s ease",
+      height: TAB_HEIGHT,
     },
     tabsContainer: {
       display: "flex",

--- a/packages/pentaho/src/Canvas/ToolbarTabs/ToolbarTabs.test.tsx
+++ b/packages/pentaho/src/Canvas/ToolbarTabs/ToolbarTabs.test.tsx
@@ -144,4 +144,16 @@ describe("CanvasToolbarTabs", () => {
     await user.keyboard("{tab}");
     expect(onTabChangeMock).not.toHaveBeenCalled();
   });
+
+  it("shows 'Create new' button by default", () => {
+    render(<Sample />);
+    const createButton = screen.getByRole("button", { name: "Create new" });
+    expect(createButton).toBeInTheDocument();
+  });
+
+  it("doesn't show 'Create new' button when hideCreateNew is true", () => {
+    render(<Sample hideCreateNew />);
+    const createButton = screen.queryByRole("button", { name: "Create new" });
+    expect(createButton).not.toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
- `hideCreateNew` property added and default to `false`: hides the "Create new" button if needed
- `fixed` property added at the tab level and default to `false`: prevents delete for specific tabs if needed
- `allowTabEdit` renamed to `disableTabEdit` for more of a "opt-in" behaviour: the prop defaults to `false` instead of `true`
- test updated/added