### PR TITLE
feat: export xml code formatter and optional auto format

### DIFF
--- a/packages/code-editor/src/CodeEditor/CodeEditor.stories.tsx
+++ b/packages/code-editor/src/CodeEditor/CodeEditor.stories.tsx
@@ -49,7 +49,7 @@ export const XMLEditor: StoryObj<HvCodeEditorProps> = {
     docs: {
       description: {
         story:
-          "XML is one of the languages supported, and it can be enabled by setting the `language` property to `xml`. A XML schema can also be provided through the `xsdSchema` property. By providing a XML schema, the XML written will be validated against the schema showing errors. Providing a schema will also enable the code editor to show suggestions when opening a tag (`<`), writing an attribute, and when clicking on the CTRL and SPACE keys at the same time.",
+          "XML is one of the languages supported, and it can be enabled by setting the `language` property to `xml`. A XML schema can also be provided through the `xsdSchema` property. By providing a XML schema, the XML written will be validated against the schema showing errors. Providing a schema will also enable the code editor to show suggestions when opening a tag (`<`), writing an attribute, and when clicking on the CTRL and SPACE keys at the same time. By default, the XML code editor is formatted automatically. The property `disableAutoFormat` can be set to `true` to disable this behavior. You can also format manually the code using the `hvXmlFormatter` util.",
       },
       source: { code: XmlStoryRaw },
     },

--- a/packages/code-editor/src/CodeEditor/index.ts
+++ b/packages/code-editor/src/CodeEditor/index.ts
@@ -1,1 +1,2 @@
 export * from "./CodeEditor";
+export * from "./languages";

--- a/packages/code-editor/src/CodeEditor/languages/index.ts
+++ b/packages/code-editor/src/CodeEditor/languages/index.ts
@@ -1,0 +1,1 @@
+export { hvXmlFormatter } from "./xml";

--- a/packages/code-editor/src/CodeEditor/languages/xml.ts
+++ b/packages/code-editor/src/CodeEditor/languages/xml.ts
@@ -1,5 +1,5 @@
 import { type Monaco } from "@monaco-editor/react";
-import formatter from "xml-formatter";
+import formatter, { XMLFormatterOptions } from "xml-formatter";
 import { validateXML } from "xmllint-wasm";
 
 // Helpful notes
@@ -354,9 +354,31 @@ export const xmlOptions = {
   autoClosingBrackets: false,
 };
 
-/** XML code formatter. */
-export const xmlFormatter = (unformattedCode: string) =>
-  formatter(unformattedCode, {
-    collapseContent: true,
-    forceSelfClosingEmptyTag: true,
-  });
+/**
+ * XML code formatter.
+ * When the code has errors, it is not formatted and `undefined` is returned.
+ * @param content Current code editor content
+ * @param editor Editor instance
+ * @param monaco Monaco instance
+ * @param options XML formatter options
+ * @returns `string with the formatted code or `undefined`
+ */
+export const hvXmlFormatter = async (
+  content: string,
+  editor: any,
+  monaco: Monaco,
+  options?: XMLFormatterOptions,
+) => {
+  const validation = await getXmlValidationMarkers(content, editor, monaco); // without schema for XML
+  const hasError = validation.some(
+    (marker: any) => marker?.severity === monaco.MarkerSeverity.Error,
+  );
+
+  // Format only if there are no errors
+  return hasError
+    ? undefined
+    : formatter(content, {
+        collapseContent: true,
+        ...options,
+      });
+};

--- a/packages/code-editor/src/CodeEditor/plugins.ts
+++ b/packages/code-editor/src/CodeEditor/plugins.ts
@@ -4,7 +4,7 @@ import {
   getXmlCompletionProvider,
   getXmlValidationMarkers,
   handleXmlKeyDown,
-  xmlFormatter,
+  hvXmlFormatter,
   xmlOptions,
 } from "./languages/xml";
 
@@ -19,7 +19,11 @@ type ValidationMarker = (
   schema?: string, // needed for XML language
 ) => Promise<object[]>;
 type KeyDownListener = (event: any, editor: any, monaco: Monaco) => void;
-type Formatter = (unformattedCode: string) => Promise<string> | string;
+export type Formatter = (
+  content: string,
+  editor: any,
+  monaco: Monaco,
+) => Promise<string | undefined>;
 
 interface LanguagePlugin {
   completionProvider?: CompletionProvider;
@@ -35,7 +39,7 @@ const xmlLanguagePlugin = (): LanguagePlugin => {
     validationMarker: getXmlValidationMarkers,
     keyDownListener: handleXmlKeyDown,
     editorOptions: xmlOptions,
-    formatter: xmlFormatter,
+    formatter: hvXmlFormatter,
   };
 };
 

--- a/packages/code-editor/src/CodeEditor/stories/Xml/utils.tsx
+++ b/packages/code-editor/src/CodeEditor/stories/Xml/utils.tsx
@@ -89,9 +89,11 @@ const classes = {
 export const Header = ({
   onClickSearch,
   onClickTree,
+  onFormat,
 }: {
   onClickSearch: HvButtonProps["onClick"];
   onClickTree: HvButtonProps["onClick"];
+  onFormat: HvButtonProps["onClick"];
 }) => (
   <div className={classes.headerRoot}>
     <HvTypography variant="label">XML</HvTypography>
@@ -102,6 +104,9 @@ export const Header = ({
     </HvButton>
     <HvButton variant="primaryGhost" onClick={onClickTree}>
       XML Tree
+    </HvButton>
+    <HvButton variant="primaryGhost" onClick={onFormat}>
+      Format
     </HvButton>
   </div>
 );


### PR DESCRIPTION
- `hvXmlFormatter` exported in case users may need it: the formatter only works if there are no errors in the code (not using XSD validation) because the formatter was removing unclosed tags, etc
- `disableAutoFormat` property added to disable auto format if needed
- Auto format triggered on mount
- XML story updated to show the new features and to show how to get the validation state