### PR TITLE
fix(Loading): custom colors & LoadingContainer opacity

### DIFF
--- a/packages/core/src/Loading/Loading.stories.tsx
+++ b/packages/core/src/Loading/Loading.stories.tsx
@@ -1,11 +1,10 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { Meta, StoryObj } from "@storybook/react";
 import {
   HvButton,
   HvButtonProps,
   HvLoading,
   HvLoadingProps,
-  HvTypography,
 } from "@hitachivantara/uikit-react-core";
 
 const meta: Meta<typeof HvLoading> = {
@@ -48,105 +47,40 @@ export const Variants: StoryObj<HvLoadingProps> = {
   },
 };
 
-const Button = ({
-  label,
-  variant,
-  color = "base_dark",
-}: {
-  label: string;
-  variant?: HvButtonProps["variant"];
-  color?: HvLoadingProps["color"];
-}) => {
+const LoadingButton = ({ onClick, ...others }: HvButtonProps) => {
   const [isLoading, setIsLoading] = useState(false);
 
-  const activateTimer = () => {
-    if (!isLoading) {
-      setIsLoading(true);
-      setTimeout(() => {
-        setIsLoading(false);
-      }, 3000);
-    }
-  };
-
   return (
-    <div style={{ textAlign: "center" }}>
-      <HvTypography
-        variant="caption1"
-        style={{
-          marginBottom: "5px",
-        }}
-      >
-        {label}
-      </HvTypography>
-      <HvButton variant={variant} onClick={activateTimer}>
-        {(!isLoading && "Submit") || (
-          <HvLoading small hidden={!isLoading} color={color} />
-        )}
-      </HvButton>
-    </div>
+    <HvButton
+      style={{ width: 120 }}
+      onClick={async (event) => {
+        setIsLoading(true);
+        await onClick?.(event);
+        setIsLoading(false);
+      }}
+      {...others}
+    >
+      {!isLoading ? (
+        "Submit"
+      ) : (
+        <HvLoading small hidden={!isLoading} color="inherit" />
+      )}
+    </HvButton>
   );
 };
 
 export const Buttons = () => {
+  const handleClick = async () => {
+    await new Promise((resolve) => {
+      setTimeout(resolve, 2000);
+    });
+  };
+
   return (
     <div style={{ display: "flex", justifyContent: "space-around" }}>
-      <Button variant="primary" label="Primary button" color="base_light" />
-      <Button variant="secondarySubtle" label="Secondary Subtle button" />
-      <Button variant="secondaryGhost" label="Secondary Ghost button" />
+      <LoadingButton variant="primary" onClick={handleClick} />
+      <LoadingButton variant="secondarySubtle" onClick={handleClick} />
+      <LoadingButton variant="secondaryGhost" onClick={handleClick} />
     </div>
   );
-};
-
-const ButtonDeterminate = ({
-  label,
-  children,
-}: {
-  label: string;
-  children: React.ReactNode;
-}) => (
-  <div>
-    <HvTypography variant="caption1">{label}</HvTypography>
-    <br />
-    {children}
-  </div>
-);
-
-const Progress = ({
-  label,
-  inc,
-}: {
-  label: (val: number) => React.ReactNode;
-  inc: React.SetStateAction<number>;
-}) => {
-  const [value, setValue] = useState(0);
-
-  useEffect(() => {
-    const interval = setInterval(() => {
-      setValue(inc);
-    }, 500);
-    return () => clearInterval(interval);
-  }, [inc]);
-
-  return <HvLoading label={label?.(value)} />;
-};
-
-export const Determinate: StoryObj<HvLoadingProps> = {
-  render: () => {
-    return (
-      <div style={{ display: "flex", justifyContent: "space-around" }}>
-        <ButtonDeterminate label="Determine w/ percentages">
-          <Progress
-            label={(v) => `${v}%`}
-            inc={(v) => (v === 100 ? 0 : v + 5)}
-          />
-        </ButtonDeterminate>
-        <ButtonDeterminate label="Determine w/ progress">
-          <Progress
-            label={(v) => `${v}M/75M`}
-            inc={(v) => (v >= 75 ? 0 : Math.round(v + 5))}
-          />
-        </ButtonDeterminate>
-      </div>
-    );
-  },
 };

--- a/packages/core/src/Loading/Loading.styles.tsx
+++ b/packages/core/src/Loading/Loading.styles.tsx
@@ -1,73 +1,5 @@
-import { keyframes } from "@emotion/react";
 import { createClasses } from "@hitachivantara/uikit-react-utils";
 import { theme } from "@hitachivantara/uikit-styles";
-
-const interval = 0.11;
-
-const bars = {
-  "&:nth-of-type(1)": {
-    animationDelay: "0",
-  },
-  "&:nth-of-type(2)": {
-    animationDelay: `${interval * 2}s`,
-  },
-  "&:nth-of-type(3)": {
-    animationDelay: `${interval * 4}s`,
-  },
-};
-
-const small = {
-  width: "2px",
-  height: "18px",
-  margin: "0px 2px",
-  ...bars,
-};
-
-const regular = {
-  width: "4px",
-  height: "30px",
-  margin: "0 3px",
-  ...bars,
-};
-
-const regularAnimation = keyframes`
-  0% { 
-    transform: scale(1);
-    background-color: ${theme.colors.brand};
-  }
-  50% { 
-    transform: scale(1, 0.6); 
-    background-color: ${theme.colors.secondary};
-  }
-`;
-
-const regularColorAnimation = keyframes`
-  0% { 
-    transform: scale(1);
-  }
-  50% { 
-    transform: scale(1, 0.6); 
-  }
-`;
-
-const smallAnimation = keyframes`
-  0% { 
-    transform: scale(1);
-  }
-  50% { 
-    transform: scale(1, 0.223); 
-  }
-  100%: {},
-`;
-
-const smallColorAnimation = keyframes`
-  0% { 
-    transform: scale(1);
-  }
-  50% { 
-    transform: scale(1, 0.223); 
-  }
-`;
 
 export const { staticClasses, useClasses } = createClasses("HvLoading", {
   root: {
@@ -75,36 +7,50 @@ export const { staticClasses, useClasses } = createClasses("HvLoading", {
     flexDirection: "column",
     alignItems: "center",
     justifyContent: "center",
+    gap: theme.space.xs,
   },
-  barContainer: { display: "flex" },
-  loadingBar: {
-    display: "inline-block",
+  barContainer: {
+    display: "flex",
+    justifyContent: "space-around",
 
-    "@keyframes loading-small": {
-      "0%": {
-        transform: "scale(1)",
-      },
-      "50%": {
-        transform: "scale(1,0.223)",
-      },
-      "100%": {},
+    ":has($regular)": {
+      width: 30,
+      height: 30,
+    },
+
+    ":has($small)": {
+      "--scaleY": "0.223",
+      width: 18,
+      height: 18,
     },
   },
-  label: { marginTop: "15px" },
+  loadingBar: {
+    backgroundColor: "currentcolor",
+    display: "inline-block",
+    animation: "loading 1s ease-in-out infinite",
+    // TODO: make this the default when it has better support
+    width: "round(up, 0.11em, 2px)",
+
+    "@keyframes loading": {
+      "50%": {
+        transform: "scale(1, var(--scaleY, 0.6))",
+        backgroundColor: `var(--customColor, ${theme.colors.secondary})`,
+      },
+    },
+
+    ":nth-of-type(2)": { animationDelay: "0.22s" },
+    ":nth-of-type(3)": { animationDelay: "0.44s" },
+  },
+  label: {},
   overlay: {},
   blur: {},
   hidden: { display: "none" },
-  small: { animation: `${smallAnimation} 1s ease-in-out infinite`, ...small },
+  small: {
+    width: 2,
+  },
   regular: {
-    animation: `${regularAnimation} 1s ease-in-out infinite`,
-    ...regular,
+    width: 4,
   },
-  smallColor: {
-    animation: `${smallColorAnimation} 1s ease-in-out infinite`,
-    ...small,
-  },
-  regularColor: {
-    animation: `${regularColorAnimation} 1s ease-in-out infinite`,
-    ...regular,
-  },
+  smallColor: {},
+  regularColor: {},
 });

--- a/packages/core/src/Loading/Loading.tsx
+++ b/packages/core/src/Loading/Loading.tsx
@@ -1,4 +1,5 @@
 import {
+  mergeStyles,
   useDefaultProps,
   type ExtractNames,
 } from "@hitachivantara/uikit-react-utils";
@@ -36,6 +37,7 @@ export const HvLoading = (props: HvLoadingProps) => {
     small,
     label,
     classes: classesProp,
+    style,
     className,
     ...others
   } = useDefaultProps("HvLoading", props);
@@ -43,15 +45,15 @@ export const HvLoading = (props: HvLoadingProps) => {
   const { classes, cx } = useClasses(classesProp);
 
   const size = small ? "small" : "regular";
-  const colorVariant = color ? "Color" : "";
-  const variant = `${size}${colorVariant}` as const;
+  const colorVariant = color && (`${size}Color` as const);
 
-  const inline = {
-    backgroundColor: getColor(color, small ? "secondary" : "brand"),
-  };
   return (
     <div
       hidden={!!hidden}
+      style={mergeStyles(style, {
+        color: getColor(color, small ? "secondary" : "brand"),
+        "--customColor": getColor(color),
+      })}
       className={cx(
         classes.root,
         {
@@ -65,8 +67,12 @@ export const HvLoading = (props: HvLoadingProps) => {
         {range(3).map((e) => (
           <div
             key={e}
-            style={inline}
-            className={cx(classes.loadingBar, classes[variant])}
+            className={cx(
+              classes.loadingBar,
+              // TODO: hoist to parent & remove unused `colorVariant` in v6
+              classes[size],
+              classes[colorVariant!],
+            )}
           />
         ))}
       </div>

--- a/packages/core/src/LoadingContainer/LoadingContainer.stories.tsx
+++ b/packages/core/src/LoadingContainer/LoadingContainer.stories.tsx
@@ -7,6 +7,8 @@ import {
   HvPanel,
 } from "@hitachivantara/uikit-react-core";
 
+import { setupChromatic } from ".storybook/setupChromatic";
+
 export default {
   title: "Components/Loading/Loading Container",
   component: HvLoadingContainer,
@@ -21,6 +23,9 @@ export const Main: StoryObj<HvLoadingContainerProps> = {
   },
   argTypes: {
     classes: { control: { disable: true } },
+  },
+  parameters: {
+    ...setupChromatic(),
   },
   render: (args) => (
     <HvLoadingContainer style={{ display: "inline-flex" }} {...args}>

--- a/packages/core/src/LoadingContainer/LoadingContainer.styles.ts
+++ b/packages/core/src/LoadingContainer/LoadingContainer.styles.ts
@@ -12,7 +12,7 @@ const { staticClasses, useClasses } = createClasses("HvLoadingContainer", {
     inset: 0,
     zIndex: theme.zIndices.overlay,
     transition: "background-color .2s ease",
-    backgroundColor: theme.alpha("atmo1", "var(--opacity, 0.8)"),
+    backgroundColor: theme.alpha("atmo1", "var(--opacity, 80%)"),
   },
 });
 

--- a/packages/core/src/LoadingContainer/LoadingContainer.tsx
+++ b/packages/core/src/LoadingContainer/LoadingContainer.tsx
@@ -43,9 +43,7 @@ export const HvLoadingContainer = (props: HvLoadingContainerProps) => {
   const { classes, cx } = useClasses(classesProp);
 
   const ariaLabel =
-    ariaLabelProp || (typeof label === "string" && label)
-      ? (label as string)
-      : "Loading";
+    ariaLabelProp || (typeof label === "string" && label) || "Loading";
 
   return (
     <div className={cx(classes.root, className)} {...others}>
@@ -56,7 +54,9 @@ export const HvLoadingContainer = (props: HvLoadingContainerProps) => {
         label={label}
         hidden={hidden}
         aria-label={ariaLabel}
-        style={mergeStyles({}, { "--opacity": opacity })}
+        style={mergeStyles(undefined, {
+          "--opacity": opacity && `${opacity * 100}%`,
+        })}
       />
       {children}
     </div>


### PR DESCRIPTION
- fix `HvLoadingContainer` opacity
  - add Chromatic test
- add better custom color Loading support (eg. "inherit")
  - refactor animations to use CSS vars, reducing code complexity
- fix Loading text margin
- improve `LoadingButton` samples
  - simplify code
  - use `"inherit"` color which works well multi-theme