### PR TITLE
chore: typescript improvements in docs & build

### DIFF
--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -13,6 +13,7 @@ runs:
       uses: actions/setup-node@v4
       with:
         node-version: 18
+        cache: npm
 
     - name: Install dependencies
       if: ${{ inputs.install == 'true' }}

--- a/.storybook/test-runner.ts
+++ b/.storybook/test-runner.ts
@@ -62,9 +62,10 @@ const config: TestRunnerConfig = {
 
     // Apply story-level a11y rules
     await configureAxe(page, {
-      rules: specificA11yRules.concat(
-        storyContext.parameters?.a11y?.config?.rules,
-      ),
+      rules: [
+        ...specificA11yRules,
+        ...(storyContext.parameters?.a11y?.config?.rules || []),
+      ],
     });
 
     const axeResults = await getAxeResults(page, "#storybook-root");

--- a/.storybook/types.ts
+++ b/.storybook/types.ts
@@ -1,0 +1,32 @@
+import type { A11yParameters } from "@storybook/addon-a11y";
+import type { StorybookParameters } from "@storybook/types";
+
+interface ChromaticParameters {
+  disableSnapshot?: boolean;
+  delay?: number;
+  modes?: Record<string, any>;
+  diffThreshold?: number;
+}
+
+interface DocsParameters extends Record<string, any> {
+  disable?: boolean;
+  description?: { story?: string };
+  source?: {
+    code?: string;
+    type?: "auto" | "code" | "dynamic";
+  };
+  inlineStories?: boolean;
+}
+
+interface A11yParams extends A11yParameters {
+  disable?: boolean;
+}
+
+// https://github.com/storybookjs/storybook/issues/22860
+declare module "@storybook/csf" {
+  interface Parameters extends StorybookParameters, Record<string, any> {
+    a11y?: A11yParams;
+    docs?: DocsParameters;
+    chromatic?: ChromaticParameters;
+  }
+}

--- a/docs/tests/Components.stories.tsx
+++ b/docs/tests/Components.stories.tsx
@@ -56,6 +56,7 @@ import { Variants as TextAreaVariantsStory } from "packages/core/src/TextArea/Te
 import { Multiple as ToggleButtonMultipleStory } from "packages/core/src/ToggleButton/ToggleButton.stories";
 import { Test as TypographyTestStory } from "packages/core/src/Typography/Typography.stories";
 
+import { renderStory } from "./utils";
 import { setupChromatic } from ".storybook/setupChromatic";
 
 /** Visual tests for components from the Core package */
@@ -109,52 +110,28 @@ export const Test: StoryObj = {
         >
           <div>
             <div style={{ display: "flex", height: 180 }}>
-              {AccordionDisabledStory.render?.(
-                AccordionDisabledStory.args as any,
-                context,
-              )}
-              {DotPaginationMainStory.render?.(
-                DotPaginationMainStory.args as any,
-                context,
-              )}
-              {DropDownMenuMainStory.render?.(
-                DropDownMenuMainStory.args as any,
-                context,
-              )}
+              {renderStory(AccordionDisabledStory, context)}
+              {renderStory(DotPaginationMainStory, context)}
+              {renderStory(DropDownMenuMainStory, context)}
             </div>
             <div>
-              {EmptyStateMinimalStory.render?.(
-                EmptyStateMinimalStory.args as any,
-                context,
-              )}
-              {EmptyStateWithActionStory.render?.(
-                EmptyStateWithActionStory.args as any,
-                context,
-              )}
+              {renderStory(EmptyStateMinimalStory, context)}
+              {renderStory(EmptyStateWithActionStory, context)}
             </div>
           </div>
-          {CheckBoxGroupVariantsStory.render?.(
-            CheckBoxGroupVariantsStory.args as any,
-            context,
-          )}
+          {renderStory(CheckBoxGroupVariantsStory, context)}
           <div style={{ display: "flex", flexWrap: "wrap", gap: 5 }}>
-            {InputVariantsStory.render?.(
-              InputVariantsStory.args as any,
-              context,
-            )}
+            {renderStory(InputVariantsStory, context)}
           </div>
         </HvSimpleGrid>
         <HvSimpleGrid
           cols={3}
           style={{ alignItems: "start", justifyContent: "start" }}
         >
-          {BannerVariantsStory.render?.(
-            BannerVariantsStory.args as any,
-            context,
-          )}
+          {renderStory(BannerVariantsStory, context)}
         </HvSimpleGrid>
       </div>
-      {DropdownTestStory.render?.(DropdownTestStory.args as any, context)}
+      {renderStory(DropdownTestStory, context)}
     </div>
   ),
 };
@@ -189,28 +166,22 @@ export const Test2: StoryObj = {
   tags: ["skipTestRunner"],
   render: (args, context: any) => (
     <>
-      {ButtonTestStory.render?.(ButtonTestStory.args as any, context)}
+      {renderStory(ButtonTestStory, context)}
       <br />
       <HvSimpleGrid
         cols={2}
         style={{ alignItems: "start", justifyContent: "start" }}
       >
-        {CardVariantsStory.render?.(CardVariantsStory.args as any, context)}
+        {renderStory(CardVariantsStory, context)}
         <div style={{ display: "flex" }}>
-          {AvatarGroupTestStory.render?.(
-            AvatarGroupTestStory.args as any,
-            context,
-          )}
-          {BadgeTestStory.render?.(BadgeTestStory.args as any, context)}
-          {AvatarTestStory.render?.(AvatarTestStory.args as any, context)}
+          {renderStory(AvatarGroupTestStory, context)}
+          {renderStory(BadgeTestStory, context)}
+          {renderStory(AvatarTestStory, context)}
         </div>
       </HvSimpleGrid>
       <br />
       <HvSimpleGrid cols={5}>
-        {SnackbarVariantsStory.render?.(
-          SnackbarVariantsStory.args as any,
-          context,
-        )}
+        {renderStory(SnackbarVariantsStory, context)}
       </HvSimpleGrid>
     </>
   ),
@@ -252,53 +223,27 @@ export const Test3: StoryObj = {
   },
   render: (args, context: any) => (
     <>
-      {InlineEditorTestStory.render?.(
-        InlineEditorTestStory.args as any,
-        context,
-      )}
+      {renderStory(InlineEditorTestStory, context)}
       <br />
       <div style={{ display: "flex" }}>
         <div style={{ width: 1200 }}>
-          {DatePickerTestStory.render?.(
-            DatePickerTestStory.args as any,
-            context,
-          )}
+          {renderStory(DatePickerTestStory, context)}
         </div>
         <HvSimpleGrid
           cols={1}
           style={{ alignItems: "start", justifyContent: "start" }}
         >
           <div style={{ display: "flex", gap: 12 }}>
-            {ListContainerWithIconsStory.render?.(
-              ListContainerWithIconsStory.args as any,
-              context,
-            )}
+            {renderStory(ListContainerWithIconsStory, context)}
             <div>
-              {LoadingVariantsStory.render?.(
-                LoadingVariantsStory.args as any,
-                context,
-              )}
+              {renderStory(LoadingVariantsStory, context)}
               <br />
-              {SkeletonVariantsStory.render?.(
-                SkeletonVariantsStory.args as any,
-                context,
-              )}
+              {renderStory(SkeletonVariantsStory, context)}
             </div>
-            <div>
-              {SwitchVariantsStory.render?.(
-                SwitchVariantsStory.args as any,
-                context,
-              )}
-            </div>
+            <div>{renderStory(SwitchVariantsStory, context)}</div>
           </div>
-          {SelectionListVariantsStory.render?.(
-            SelectionListVariantsStory.args as any,
-            context,
-          )}
-          {ProgressBarVariantsStory.render?.(
-            ProgressBarVariantsStory.args as any,
-            context,
-          )}
+          {renderStory(SelectionListVariantsStory, context)}
+          {renderStory(ProgressBarVariantsStory, context)}
         </HvSimpleGrid>
       </div>
     </>
@@ -340,36 +285,20 @@ export const Test4: StoryObj = {
         style={{ alignItems: "start", justifyContent: "start" }}
       >
         <div style={{ display: "flex", flexDirection: "column", gap: 5 }}>
-          {RadioGroupVariantsStory.render?.(
-            RadioGroupVariantsStory.args as any,
-            context,
-          )}
-          {RadioGroupHorizontalStory.render?.(
-            RadioGroupHorizontalStory.args as any,
-            context,
-          )}
-          {RadioTestStory.render?.(RadioTestStory.args as any, context)}
+          {renderStory(RadioGroupVariantsStory, context)}
+          {renderStory(RadioGroupHorizontalStory, context)}
+          {renderStory(RadioTestStory, context)}
         </div>
         <div style={{ height: 360 }}>
-          {SelectTestStory.render?.(SelectTestStory.args as any, context)}
+          {renderStory(SelectTestStory, context)}
         </div>
-        <div>
-          {SliderRangeVariantsStory.render?.(
-            SliderRangeVariantsStory.args as any,
-            context,
-          )}
-        </div>
-        <div>
-          {SliderVariantsStory.render?.(
-            SliderVariantsStory.args as any,
-            context,
-          )}
-        </div>
+        <div>{renderStory(SliderRangeVariantsStory, context)}</div>
+        <div>{renderStory(SliderVariantsStory, context)}</div>
       </HvSimpleGrid>
       <br />
-      {MultiButtonTestStory.render?.(MultiButtonTestStory.args as any, context)}
+      {renderStory(MultiButtonTestStory, context)}
       <br />
-      {TabsTestStory.render?.(TabsTestStory.args as any, context)}
+      {renderStory(TabsTestStory, context)}
     </>
   ),
 };
@@ -405,31 +334,19 @@ export const Test5: StoryObj = {
   tags: ["skipTestRunner"],
   render: (args, context: any) => (
     <>
-      {CheckBoxTestStory.render?.(CheckBoxTestStory.args as any, context)}
-      {TagTestStory.render?.(TagTestStory.args as any, context)}
+      {renderStory(CheckBoxTestStory, context)}
+      {renderStory(TagTestStory, context)}
       <HvSimpleGrid
         cols={3}
         style={{ alignItems: "start", justifyContent: "start" }}
       >
-        {TagsInputVariantsStory.render?.(
-          TagsInputVariantsStory.args as any,
-          context,
-        )}
+        {renderStory(TagsInputVariantsStory, context)}
         <div>
-          {TextAreaVariantsStory.render?.(
-            TextAreaVariantsStory.args as any,
-            context,
-          )}
-          {IconButtonVariantsStory.render?.(
-            IconButtonVariantsStory.args as any,
-            context,
-          )}
-          {ToggleButtonMultipleStory.render?.(
-            ToggleButtonMultipleStory.args as any,
-            context,
-          )}
+          {renderStory(TextAreaVariantsStory, context)}
+          {renderStory(IconButtonVariantsStory, context)}
+          {renderStory(ToggleButtonMultipleStory, context)}
         </div>
-        {PaginationMainStory.render?.(PaginationMainStory.args as any, context)}
+        {renderStory(PaginationMainStory, context)}
       </HvSimpleGrid>
     </>
   ),
@@ -469,26 +386,20 @@ export const Test6: StoryObj = {
             alignItems: "flex-end",
           }}
         >
-          {OverflowTooltipMainStory.render?.(
-            OverflowTooltipMainStory.args as any,
-            context,
-          )}
+          {renderStory(OverflowTooltipMainStory, context)}
         </div>
-        {GridTheDesignSystemColumnsStory.render?.(
-          GridTheDesignSystemColumnsStory.args as any,
-          context,
-        )}
-        {StackTestStory.render?.(StackTestStory.args as any, context)}
+        {renderStory(GridTheDesignSystemColumnsStory, context)}
+        {renderStory(StackTestStory, context)}
       </HvSimpleGrid>
       <br />
       <HvSimpleGrid
         cols={4}
         style={{ alignItems: "start", justifyContent: "start" }}
       >
-        {ContainerMainStory.render?.(ContainerMainStory.args as any, context)}
-        {KpiMainStory.render?.(KpiMainStory.args as any, context)}
-        {PanelMainStory.render?.(PanelMainStory.args as any, context)}
-        {SimpleGridMainStory.render?.(SimpleGridMainStory.args as any, context)}
+        {renderStory(ContainerMainStory, context)}
+        {renderStory(KpiMainStory, context)}
+        {renderStory(PanelMainStory, context)}
+        {renderStory(SimpleGridMainStory, context)}
       </HvSimpleGrid>
     </>
   ),
@@ -511,19 +422,13 @@ export const Test7: StoryObj = {
   tags: ["skipTestRunner"],
   render: (args, context: any) => (
     <>
-      {TypographyTestStory.render?.(TypographyTestStory.args as any, context)}
+      {renderStory(TypographyTestStory, context)}
       <HvSimpleGrid
         cols={2}
         style={{ alignItems: "start", justifyContent: "start" }}
       >
-        {ScrollToHorizontalMainStory.render?.(
-          ScrollToHorizontalMainStory.args as any,
-          context,
-        )}
-        {ScrollToVerticalMainStory.render?.(
-          ScrollToVerticalMainStory.args as any,
-          context,
-        )}
+        {renderStory(ScrollToHorizontalMainStory, context)}
+        {renderStory(ScrollToVerticalMainStory, context)}
       </HvSimpleGrid>
     </>
   ),

--- a/docs/tests/Lab.stories.tsx
+++ b/docs/tests/Lab.stories.tsx
@@ -5,6 +5,7 @@ import { Main as DashboardMainStory } from "packages/lab/src/Dashboard/Dashboard
 import { Variants as StepNavigationVariantsStory } from "packages/lab/src/StepNavigation/StepNavigation.stories";
 import { HvSimpleGrid } from "@hitachivantara/uikit-react-core";
 
+import { renderStory } from "./utils";
 import { setupChromatic } from ".storybook/setupChromatic";
 
 /** Visual tests for components from the Lab package */
@@ -45,14 +46,11 @@ export const Test: StoryObj = {
         cols={2}
         style={{ alignItems: "start", justifyContent: "start" }}
       >
-        {DashboardMainStory.render?.(DashboardMainStory.args as any, context)}
-        {BladesMainStory.render?.(BladesMainStory.args as any, context)}
-        {BladeVariantsStory.render?.(BladeVariantsStory.args as any, context)}
+        {renderStory(DashboardMainStory, context)}
+        {renderStory(BladesMainStory, context)}
+        {renderStory(BladeVariantsStory, context)}
       </HvSimpleGrid>
-      {StepNavigationVariantsStory.render?.(
-        StepNavigationVariantsStory.args as any,
-        context,
-      )}
+      {renderStory(StepNavigationVariantsStory, context)}
     </>
   ),
 };

--- a/docs/tests/Pentaho.stories.tsx
+++ b/docs/tests/Pentaho.stories.tsx
@@ -3,6 +3,7 @@ import { Test as BottomPanelTestStory } from "packages/pentaho/src/Canvas/Bottom
 import { Test as ToolbarTabsTestStory } from "packages/pentaho/src/Canvas/ToolbarTabs/ToolbarTabs.stories";
 import { HvSimpleGrid } from "@hitachivantara/uikit-react-core";
 
+import { renderStory } from "./utils";
 import { setupChromatic } from ".storybook/setupChromatic";
 
 /** Visual tests for components from the Pentaho package */
@@ -30,8 +31,8 @@ export const Test: StoryObj = {
       cols={2}
       style={{ alignItems: "start", justifyContent: "start" }}
     >
-      {BottomPanelTestStory.render?.(BottomPanelTestStory.args as any, context)}
-      {ToolbarTabsTestStory.render?.(ToolbarTabsTestStory.args as any, context)}
+      {renderStory(BottomPanelTestStory, context)}
+      {renderStory(ToolbarTabsTestStory, context)}
     </HvSimpleGrid>
   ),
 };

--- a/docs/tests/Widgets.stories.tsx
+++ b/docs/tests/Widgets.stories.tsx
@@ -18,6 +18,7 @@ import { Test as GlobalActionsTestStory } from "packages/core/src/GlobalActions/
 import { Test as HeaderTestStory } from "packages/core/src/Header/Header.stories";
 import { Test as SectionTestStory } from "packages/core/src/Section/Section.stories";
 
+import { renderStory } from "./utils";
 import { setupChromatic } from ".storybook/setupChromatic";
 
 /** Visual tests for widgets from the Core package */
@@ -62,18 +63,9 @@ export const Test: StoryObj = {
         cols={3}
         style={{ alignItems: "start", justifyContent: "start" }}
       >
-        {AppSwitcherMainStory.render?.(
-          AppSwitcherMainStory.args as any,
-          context,
-        )}
-        {AppSwitcherManyEntriesStory.render?.(
-          AppSwitcherManyEntriesStory.args as any,
-          context,
-        )}
-        {FileUploaderWithPreviewThumbnailsStory.render?.(
-          FileUploaderWithPreviewThumbnailsStory.args as any,
-          context,
-        )}
+        {renderStory(AppSwitcherMainStory, context)}
+        {renderStory(AppSwitcherManyEntriesStory, context)}
+        {renderStory(FileUploaderWithPreviewThumbnailsStory, context)}
       </HvSimpleGrid>
       <HvSimpleGrid
         cols={2}
@@ -82,28 +74,19 @@ export const Test: StoryObj = {
           justifyContent: "start",
         }}
       >
-        {BreadCrumbTestStory.render?.(BreadCrumbTestStory.args as any, context)}
+        {renderStory(BreadCrumbTestStory, context)}
         <div style={{ display: "flex", flexDirection: "column", gap: 2 }}>
-          {ActionBarMainStory.render?.(ActionBarMainStory.args as any, context)}
-          {FooterCustomLabelsStory.render?.(
-            FooterCustomLabelsStory.args as any,
-            context,
-          )}
-          {GlobalActionsTestStory.render?.(
-            GlobalActionsTestStory.args as any,
-            context,
-          )}
+          {renderStory(ActionBarMainStory, context)}
+          {renderStory(FooterCustomLabelsStory, context)}
+          {renderStory(GlobalActionsTestStory, context)}
         </div>
       </HvSimpleGrid>
       <HvSimpleGrid
         cols={2}
         style={{ alignItems: "start", justifyContent: "start" }}
       >
-        {BulkActionsTestStory.render?.(
-          BulkActionsTestStory.args as any,
-          context,
-        )}
-        {HeaderTestStory.render?.(HeaderTestStory.args as any, context)}
+        {renderStory(BulkActionsTestStory, context)}
+        {renderStory(HeaderTestStory, context)}
       </HvSimpleGrid>
     </>
   ),
@@ -141,21 +124,12 @@ export const Test2: StoryObj = {
         style={{ alignItems: "start", justifyContent: "start" }}
       >
         <div style={{ display: "flex", gap: 5 }}>
-          {CarouselEmbeddedStory.render?.(
-            CarouselEmbeddedStory.args as any,
-            context,
-          )}
+          {renderStory(CarouselEmbeddedStory, context)}
           <div style={{ width: 650 }}>
-            {CarouselActionsStory.render?.(
-              CarouselActionsStory.args as any,
-              context,
-            )}
+            {renderStory(CarouselActionsStory, context)}
           </div>
         </div>
-        {ColorPickerTestStory.render?.(
-          ColorPickerTestStory.args as any,
-          context,
-        )}
+        {renderStory(ColorPickerTestStory, context)}
       </HvSimpleGrid>
       <br />
       <br />
@@ -164,7 +138,7 @@ export const Test2: StoryObj = {
         cols={4}
         style={{ alignItems: "start", justifyContent: "start" }}
       >
-        {SectionTestStory.render?.(SectionTestStory.args as any, context)}
+        {renderStory(SectionTestStory, context)}
       </HvSimpleGrid>
     </>
   ),

--- a/docs/tests/utils.ts
+++ b/docs/tests/utils.ts
@@ -1,0 +1,3 @@
+export const renderStory = (story: any, ctx: any) => {
+  return story.render?.(story.args, ctx);
+};

--- a/nx.json
+++ b/nx.json
@@ -5,9 +5,6 @@
       "dependsOn": ["^build"],
       "cache": true
     },
-    "typecheck": {
-      "cache": true
-    },
     "test": {
       "cache": true
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,6 +42,7 @@
         "@storybook/react-vite": "^8.3.1",
         "@storybook/test": "^8.3.1",
         "@storybook/test-runner": "^0.19.1",
+        "@storybook/types": "^8.3.1",
         "@testing-library/dom": "^10.4.0",
         "@testing-library/jest-dom": "^6.4.2",
         "@testing-library/react": "^16.0.0",
@@ -7761,6 +7762,20 @@
       "version": "8.3.1",
       "resolved": "https://registry.npmjs.org/@storybook/theming/-/theming-8.3.1.tgz",
       "integrity": "sha512-R6YZnIdN9P9gTauVkZfVmob0/i6/yaAQxnwfMgRLCaFD0TFQ+UQ2pCz40zPAUp3BcNPwMD168GVxmheBb8cGag==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "storybook": "^8.3.1"
+      }
+    },
+    "node_modules/@storybook/types": {
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/@storybook/types/-/types-8.3.1.tgz",
+      "integrity": "sha512-XtPfYvb0go8F57u4jIj7p1kLGpazkZDTtaECsyw3OLSAkp38X+b59tgnk/hoiyi36l56/c48SzB1tqR8b01PQA==",
       "dev": true,
       "license": "MIT",
       "funding": {

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "@storybook/react-vite": "^8.3.1",
     "@storybook/test": "^8.3.1",
     "@storybook/test-runner": "^0.19.1",
+    "@storybook/types": "^8.3.1",
     "@testing-library/dom": "^10.4.0",
     "@testing-library/jest-dom": "^6.4.2",
     "@testing-library/react": "^16.0.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "lint": "eslint . --ext .ts,.tsx --cache",
     "lint:fix": "npm run lint -- --fix",
     "lint-staged": "lint-staged",
-    "typecheck": "lerna run typecheck",
+    "typecheck": "tsc --noEmit",
     "depcheck": "npx -y owasp-dependency-check --project uikit -o reports --cveStartYear 2015",
     "publish-dry": "lerna publish --no-push --registry \"http://localhost:4873/\"",
     "publish": "lerna publish",

--- a/packages/code-editor/package.json
+++ b/packages/code-editor/package.json
@@ -27,7 +27,6 @@
   "scripts": {
     "build": "npm run clean && vite build",
     "clean": "npx rimraf dist package",
-    "typecheck": "tsc --noEmit",
     "prepublishOnly": "npm run build && npx clean-publish"
   },
   "peerDependencies": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -29,7 +29,6 @@
     "test": "vitest",
     "test:ui": "vitest --ui",
     "clean": "npx rimraf dist package",
-    "typecheck": "tsc --noEmit",
     "prepublishOnly": "npm run build && npx clean-publish"
   },
   "peerDependencies": {

--- a/packages/lab/package.json
+++ b/packages/lab/package.json
@@ -29,7 +29,6 @@
     "test": "vitest",
     "test:ui": "vitest --ui",
     "clean": "npx rimraf dist package",
-    "typecheck": "tsc --noEmit",
     "prepublishOnly": "npm run build && npx clean-publish"
   },
   "peerDependencies": {

--- a/packages/pentaho/package.json
+++ b/packages/pentaho/package.json
@@ -28,7 +28,6 @@
     "test": "vitest",
     "test:ui": "vitest --ui",
     "clean": "npx rimraf dist package",
-    "typecheck": "tsc --noEmit",
     "prepublishOnly": "npm run build && npx clean-publish"
   },
   "peerDependencies": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -27,7 +27,6 @@
   "scripts": {
     "build": "npm run clean && vite build",
     "clean": "npx rimraf dist package",
-    "typecheck": "tsc --noEmit",
     "prepublishOnly": "npm run build && npx clean-publish"
   },
   "peerDependencies": {

--- a/packages/styles/package.json
+++ b/packages/styles/package.json
@@ -26,7 +26,6 @@
   "scripts": {
     "build": "npm run clean && vite build",
     "clean": "npx rimraf dist package",
-    "typecheck": "tsc --noEmit",
     "prepublishOnly": "npm run build && npx clean-publish"
   },
   "dependencies": {

--- a/packages/uno-preset/package.json
+++ b/packages/uno-preset/package.json
@@ -28,7 +28,6 @@
   "scripts": {
     "build": "npm run clean && vite build",
     "clean": "npx rimraf dist package",
-    "typecheck": "tsc --noEmit",
     "prepublishOnly": "npm run build && npx clean-publish"
   },
   "peerDependencies": {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -27,7 +27,6 @@
   "scripts": {
     "build": "npm run clean && vite build",
     "clean": "npx rimraf dist package",
-    "typecheck": "tsc --noEmit",
     "prepublishOnly": "npm run build && npx clean-publish"
   },
   "peerDependencies": {

--- a/packages/utils/src/hooks/useCss.ts
+++ b/packages/utils/src/hooks/useCss.ts
@@ -54,7 +54,7 @@ const cssFactory = (() => {
 
     const cx = (...args: any) => merge(cache.registered, css, clsx(args));
 
-    return { css, cx };
+    return { css, cx } as const;
   }
 
   return innerCssFactory;

--- a/packages/viz/package.json
+++ b/packages/viz/package.json
@@ -29,7 +29,6 @@
     "test": "vitest",
     "test:ui": "vitest --ui",
     "clean": "npx rimraf dist package",
-    "typecheck": "tsc --noEmit",
     "prepublishOnly": "npm run build && npx clean-publish"
   },
   "peerDependencies": {

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -4,6 +4,7 @@
     "target": "ES2022",
     "lib": ["DOM", "ES2022", "dom.iterable"],
     "moduleResolution": "Node",
+    "noEmit": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "skipLibCheck": true,


### PR DESCRIPTION
- add CSF `parameters` (partial) typings
- improve `typecheck` script; we were basically running the script `N` times (for each package)
  - now it's much faster, with better coverage (whole repo), and errors aren't duplicated
- improve `classes` type inference
- use built-in `setup-node`'s install cache