### PR TITLE
fix(CodeEditor): xml autocomplete closing self closing tag

### DIFF
--- a/packages/code-editor/src/CodeEditor/languages/xml.ts
+++ b/packages/code-editor/src/CodeEditor/languages/xml.ts
@@ -332,7 +332,7 @@ export const hvXmlKeyDownListener = (
 
       // Look for the tag we are currently closing
       const tag = String(lineBeforeChange).match(
-        /<([\w-]+)(?![^>]*\/>)[^>]*$/,
+        /<([\w-]+)(?![^>]*\/>)[^>/]*$/,
       )?.[1];
       if (tag) {
         // Add the closing tag


### PR DESCRIPTION
Fixes:
- When typing `>` after a `/` when closing a self closing tag, the autocomplete was adding the closing tag of the element:

https://github.com/user-attachments/assets/8b4c7ac5-bdbc-4389-9b30-30993eb75e2d

With this fix, the closing tag is only added if the element is not self closing.  