### PR TITLE
fix(Badge): update pentaho+ styles

### DIFF
--- a/packages/core/src/Badge/Badge.styles.tsx
+++ b/packages/core/src/Badge/Badge.styles.tsx
@@ -13,7 +13,7 @@ export const { staticClasses, useClasses } = createClasses("HvBadge", {
   badgeContainer: { width: 0 },
   badgePosition: {},
   badge: {
-    borderRadius: theme.space.xs,
+    borderRadius: theme.space.sm,
     backgroundColor: theme.colors.secondary,
     float: "left",
     minHeight: "8px",

--- a/packages/styles/src/themes/pentahoPlus.ts
+++ b/packages/styles/src/themes/pentahoPlus.ts
@@ -363,6 +363,16 @@ const pentahoPlus = makeTheme((theme) => ({
     base: "6px",
   },
   components: {
+    HvBadge: {
+      classes: {
+        showCount: {
+          padding: "2px 5px",
+        },
+        showLabel: {
+          padding: "2px 5px",
+        },
+      },
+    },
     HvBaseCheckBox: {
       classes: {
         root: {


### PR DESCRIPTION
- update the `borderRadius` of the Badge component both on the DS theme and P+ theme
- update the `padding` values for the P+ theme