### PR TITLE
feat(Badge): label prop supports ReactNode & handles numbers

### DIFF
--- a/packages/core/src/Badge/Badge.stories.tsx
+++ b/packages/core/src/Badge/Badge.stories.tsx
@@ -21,9 +21,8 @@ export default meta;
 
 export const Main: StoryObj<HvBadgeProps> = {
   args: {
-    count: 1,
+    label: 1,
     showCount: true,
-    label: "",
     maxCount: 99,
     text: "Messages",
     textVariant: "label",
@@ -39,10 +38,10 @@ export const Multiple: StoryObj<HvBadgeProps> = {
   render: () => {
     return (
       <>
-        <HvBadge count={1} />
-        <HvBadge showCount count={8} />
-        <HvBadge showCount count={22} />
-        <HvBadge showCount count={100} />
+        <HvBadge label={1} />
+        <HvBadge showCount label={8} />
+        <HvBadge showCount label={22} />
+        <HvBadge showCount label={100} />
         <HvBadge label="100%" />
       </>
     );
@@ -58,11 +57,11 @@ export const WithIcon: StoryObj<HvBadgeProps> = {
   render: () => {
     return (
       <>
-        <HvBadge count={0} icon={<Alert />} />
-        <HvBadge count={1} icon={<Alert />} />
-        <HvBadge showCount count={8} icon={<Alert />} />
-        <HvBadge showCount count={88} icon={<Alert />} />
-        <HvBadge showCount count={888} icon={<Alert />} />
+        <HvBadge label={0} icon={<Alert />} />
+        <HvBadge label={1} icon={<Alert />} />
+        <HvBadge showCount label={8} icon={<Alert />} />
+        <HvBadge showCount label={88} icon={<Alert />} />
+        <HvBadge showCount label={888} icon={<Alert />} />
         <HvBadge label="100%" icon={<Alert />} />
       </>
     );
@@ -78,11 +77,11 @@ export const WithText: StoryObj<HvBadgeProps> = {
   render: () => {
     return (
       <>
-        <HvBadge count={0} text="Events" textVariant="label" />
-        <HvBadge count={1} text="Events" textVariant="label" />
-        <HvBadge showCount count={8} text="Events" textVariant="title4" />
-        <HvBadge showCount count={88} text="Events" textVariant="title4" />
-        <HvBadge showCount count={888} text="Events" textVariant="title3" />
+        <HvBadge label={0} text="Events" textVariant="label" />
+        <HvBadge label={1} text="Events" textVariant="label" />
+        <HvBadge showCount label={8} text="Events" textVariant="title4" />
+        <HvBadge showCount label={88} text="Events" textVariant="title4" />
+        <HvBadge showCount label={888} text="Events" textVariant="title3" />
         <HvBadge label="100%" text="Events" textVariant="title2" />
       </>
     );
@@ -104,7 +103,7 @@ export const WithState: StoryObj<HvBadgeProps> = {
     return (
       <>
         <HvButton onClick={addCount}>Double Value</HvButton>
-        <HvBadge showCount count={count} text="Events" textVariant="title4" />
+        <HvBadge showCount label={count} text="Events" textVariant="title4" />
       </>
     );
   },
@@ -121,7 +120,7 @@ export const Accessibility: StoryObj<HvBadgeProps> = {
   render: () => (
     <HvBadge
       showCount
-      count={25}
+      label={25}
       text="Events"
       textVariant="title4"
       role="status"
@@ -138,12 +137,12 @@ export const Test: StoryObj = {
     <div style={{ display: "flex", gap: 60, flexWrap: "wrap" }}>
       <HvBadge count={10} icon={<Alert />} />
       <HvBadge showCount count={8} icon={<Alert />} />
-      <HvBadge showCount count={88} icon={<Alert />} />
-      <HvBadge showCount count={888} icon={<Alert />} />
+      <HvBadge showCount label={88} icon={<Alert />} />
+      <HvBadge showCount label={888} icon={<Alert />} />
       <HvBadge count={0} text="Events" textVariant="label" />
-      <HvBadge count={10} text="Events" />
-      <HvBadge showCount count={10} maxCount={5} text="Events" />
-      <HvBadge showCount count={8} text="Events" textVariant="title4" />
+      <HvBadge label={10} text="Events" />
+      <HvBadge showCount label={10} maxCount={5} text="Events" />
+      <HvBadge showCount label={8} text="Events" textVariant="title4" />
     </div>
   ),
 };

--- a/packages/core/src/Badge/Badge.styles.tsx
+++ b/packages/core/src/Badge/Badge.styles.tsx
@@ -1,26 +1,37 @@
 import { createClasses } from "@hitachivantara/uikit-react-utils";
 import { theme } from "@hitachivantara/uikit-styles";
 
-const labelBaseStyle: React.CSSProperties = {
-  ...theme.typography.caption2,
-  padding: "0 5px",
-  color: theme.colors.atmo1,
-  lineHeight: "16px",
-};
-
 export const { staticClasses, useClasses } = createClasses("HvBadge", {
   root: { position: "relative", "&>*": { float: "left" } },
+  /** class applied to the badge container when it has content */
   badgeContainer: { width: 0 },
-  badgePosition: {},
-  badge: {
-    borderRadius: theme.space.xs,
+  /** class applied to the badge */
+  badgePosition: {
+    ...theme.typography.caption2,
+    color: theme.colors.atmo1,
+    borderRadius: theme.radii.full,
     backgroundColor: theme.colors.secondary,
+    lineHeight: "16px",
+    minWidth: 8,
+    padding: "0 5px",
     float: "left",
-    minHeight: "8px",
-    minWidth: "8px",
+    wordBreak: "keep-all",
+    textAlign: "center",
+
+    ":empty": {
+      height: 8,
+      width: 8,
+      padding: 0,
+    },
   },
-  showCount: { ...labelBaseStyle, wordBreak: "keep-all" },
-  showLabel: { ...labelBaseStyle, wordBreak: "keep-all" },
+  /** applied to the badge when it's visible */
+  badge: {},
+  /** applied to the badge when it's hidden */
+  badgeHidden: {
+    display: "none",
+  },
+  showCount: {},
+  showLabel: {},
   badgeIcon: { position: "relative", top: "1px", left: "-7px" },
-  badgeOneDigit: { padding: 0, width: "16px", textAlign: "center" },
+  badgeOneDigit: { padding: 0, width: "16px" },
 });

--- a/packages/core/src/Badge/Badge.test.tsx
+++ b/packages/core/src/Badge/Badge.test.tsx
@@ -6,38 +6,38 @@ import { HvBadge } from "./Badge";
 
 describe("Badge", () => {
   it("should render a small dot when count>0 without showCount", () => {
-    render(<HvBadge count={12} />);
+    render(<HvBadge label={12} />);
     expect(screen.queryByText("12")).toBeNull();
   });
 
   it("should render correctly with showCount", () => {
-    render(<HvBadge count={12} showCount />);
+    render(<HvBadge label={12} showCount />);
     expect(screen.getByText("12")).toBeInTheDocument();
   });
 
   it("should render correctly with showCount and one-digit count", () => {
-    render(<HvBadge count={9} showCount />);
+    render(<HvBadge label={9} showCount />);
     expect(screen.getByText("9")).toBeInTheDocument();
   });
 
   it("should render nothing when count is 0 even with showCount", () => {
-    render(<HvBadge count={0} showCount />);
+    render(<HvBadge label={0} showCount />);
     expect(screen.queryByText("0")).toBeNull();
   });
 
   it("should render correctly with maxCount", () => {
-    render(<HvBadge count={100} showCount />);
+    render(<HvBadge label={100} showCount />);
     expect(screen.getByText("99+")).toBeInTheDocument();
   });
 
   it("should render correctly with text", () => {
-    render(<HvBadge count={100} showCount text="hello" textVariant="title3" />);
+    render(<HvBadge label={100} showCount text="hello" textVariant="title3" />);
     expect(screen.queryByText("99+")).toBeInTheDocument();
     expect(screen.getByText("hello")).toBeInTheDocument();
   });
 
   it("should render correctly with svg", () => {
-    render(<HvBadge count={100} showCount icon={<Alert title="Alert" />} />);
+    render(<HvBadge label={100} showCount icon={<Alert title="Alert" />} />);
     expect(screen.queryByText("99+")).toBeInTheDocument();
     expect(screen.getByRole("img", { name: "Alert" })).toBeInTheDocument();
   });
@@ -56,5 +56,18 @@ describe("Badge", () => {
     render(<HvBadge label="New!" count={23} showCount />);
     expect(screen.getByText("New!")).toBeInTheDocument();
     expect(screen.queryByText("23")).toBeNull();
+  });
+
+  // TODO: remove in v6
+  describe("deprecated APIs", () => {
+    it("should render a small dot when count>0 without showCount", () => {
+      render(<HvBadge count={12} />);
+      expect(screen.queryByText("12")).toBeNull();
+    });
+
+    it("should render correctly with maxCount", () => {
+      render(<HvBadge count={100} showCount />);
+      expect(screen.getByText("99+")).toBeInTheDocument();
+    });
   });
 });

--- a/packages/styles/src/themes/pentahoPlus.ts
+++ b/packages/styles/src/themes/pentahoPlus.ts
@@ -363,6 +363,14 @@ const pentahoPlus = makeTheme((theme) => ({
     base: "6px",
   },
   components: {
+    HvBadge: {
+      classes: {
+        badgePosition: {
+          color: theme.colors.base_light,
+          backgroundColor: "#334155",
+        },
+      },
+    },
     HvBaseCheckBox: {
       classes: {
         root: {


### PR DESCRIPTION
- add missing `forwardRef`
- extend `label` to support any `ReactNode` instead of only string
  - also handles numeric values (same as `count`). deprecate `count` as it's now redundant
- refactor styles so they're easier to override
- add Pentaho+ styles