### PR TITLE
fix(Table): add alignContent to support non-table displays

### DIFF
--- a/packages/core/src/Table/TableCell/TableCell.styles.tsx
+++ b/packages/core/src/Table/TableCell/TableCell.styles.tsx
@@ -7,6 +7,7 @@ export const { staticClasses, useClasses } = createClasses("HvTableCell", {
   /** Styles applied to the component root class. */
   root: {
     verticalAlign: "inherit",
+    alignContent: "inherit",
     textAlign: "left",
     padding: `calc(${theme.space.xs} - 2px ) ${theme.space.xs} calc(${
       theme.space.xs
@@ -17,6 +18,7 @@ export const { staticClasses, useClasses } = createClasses("HvTableCell", {
   head: {
     height: 52,
     verticalAlign: "top",
+    alignContent: "start",
 
     backgroundColor: theme.colors.atmo1,
     borderTop: "1px solid transparent",
@@ -104,6 +106,7 @@ export const { staticClasses, useClasses } = createClasses("HvTableCell", {
   /** Styles applied to the cell when its variant is list and actions. */
   variantListactions: {
     verticalAlign: "middle",
+    alignContent: "center",
     borderLeft: "none",
     paddingLeft: "0",
     textAlign: "center",

--- a/packages/core/src/Table/TableHeader/TableHeader.styles.tsx
+++ b/packages/core/src/Table/TableHeader/TableHeader.styles.tsx
@@ -7,6 +7,7 @@ export const { staticClasses, useClasses } = createClasses("HvTableHeader", {
     "--cell-height": "32px",
     height: "var(--cell-height)",
     verticalAlign: "inherit",
+    alignContent: "inherit",
     textAlign: "left",
     padding: theme.spacing(0, 1, 0, 4),
     borderBottom: `1px solid ${theme.colors.atmo4}`,
@@ -14,6 +15,7 @@ export const { staticClasses, useClasses } = createClasses("HvTableHeader", {
   head: {
     paddingTop: 8,
     verticalAlign: "top",
+    alignContent: "start",
     ...theme.typography.label,
     transition: "background-color 150ms cubic-bezier(0.4, 0, 0.2, 1) 0ms",
     backgroundColor: theme.colors.atmo1,
@@ -34,6 +36,7 @@ export const { staticClasses, useClasses } = createClasses("HvTableHeader", {
 
     "&$sortable": {
       verticalAlign: "initial",
+      alignContent: "initial",
       paddingTop: 0,
       paddingLeft: 0,
       cursor: "pointer",

--- a/packages/core/src/Table/TableRow/TableRow.styles.tsx
+++ b/packages/core/src/Table/TableRow/TableRow.styles.tsx
@@ -9,6 +9,7 @@ export const { staticClasses, useClasses } = createClasses("HvTableRow", {
     color: "inherit",
     backgroundColor: theme.colors.atmo1,
     verticalAlign: "middle",
+    alignContent: "center",
     outline: 0,
   },
   /** Styles applied to the component root when inside a `HvTableHead`. */

--- a/packages/core/src/Table/stories/TableSamples/GroupedRows.tsx
+++ b/packages/core/src/Table/stories/TableSamples/GroupedRows.tsx
@@ -11,13 +11,13 @@ import {
 
 import { getGroupedRowsColumns, makeData } from "../storiesUtils";
 
+const style = {
+  borderRight: `1px solid ${theme.colors.atmo4}`,
+};
+
 export const GroupedRows = () => {
   const columns = getGroupedRowsColumns();
   const data = makeData(8);
-
-  const style = {
-    borderRight: `solid 1px ${theme.colors.atmo4}`,
-  };
 
   return (
     <HvTableContainer>
@@ -25,7 +25,7 @@ export const GroupedRows = () => {
         <HvTableHead>
           <HvTableRow>
             {columns.map((el, index) => (
-              <HvTableHeader key={el.Header} {...(index === 0 && { ...style })}>
+              <HvTableHeader key={el.Header} {...(index === 0 && { style })}>
                 {el.Header}
               </HvTableHeader>
             ))}
@@ -35,10 +35,7 @@ export const GroupedRows = () => {
           {data.map((el, index) => (
             <HvTableRow key={el.id}>
               {index % 3 === 0 && (
-                <HvTableCell
-                  rowSpan={3}
-                  style={{ verticalAlign: "top", ...style }}
-                >
+                <HvTableCell rowSpan={3} style={style}>
                   {el.name}
                 </HvTableCell>
               )}


### PR DESCRIPTION
- add `alignContent` styles to support non-table displays (eg. when using custom table components or `useBlockLayout`)
- fix GroupedRows sample