### PR TITLE
feat(Input): enable portal for suggestions and suggest on focus

### DIFF
--- a/packages/core/src/Forms/Suggestions/Suggestions.styles.tsx
+++ b/packages/core/src/Forms/Suggestions/Suggestions.styles.tsx
@@ -10,9 +10,12 @@ export const { staticClasses, useClasses } = createClasses("HvSuggestions", {
     width: "100%",
   },
   popper: {
-    width: "100%",
+    width: "var(--popper-width)",
     position: "absolute",
-    transform: "translate3d(0, -1px, 0) !important",
     zIndex: theme.zIndices.tooltip,
+    ":not($portal)": {
+      transform: "translate3d(0, -1px, 0) !important",
+    },
   },
+  portal: {},
 });

--- a/packages/core/src/Input/Input.test.tsx
+++ b/packages/core/src/Input/Input.test.tsx
@@ -1,7 +1,30 @@
+import { useState } from "react";
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { Map } from "@hitachivantara/uikit-react-icons";
 
-import { HvInput } from ".";
+import { HvInput, HvInputProps } from ".";
+
+const Suggestions = ({ ...others }: Partial<HvInputProps>) => {
+  const [value, setValue] = useState("");
+
+  const suggestionHandler: HvInputProps["suggestionListCallback"] = (
+    val: string,
+  ) => {
+    if (!val && value) return null; // cleared
+    return [{ id: "value", label: "value" }]; // all other cases
+  };
+
+  return (
+    <HvInput
+      label="Select a country"
+      value={value}
+      onChange={(event, val) => setValue(val)}
+      suggestionListCallback={suggestionHandler}
+      {...others}
+    />
+  );
+};
 
 describe("Input", () => {
   it("renders the input element", () => {
@@ -56,5 +79,27 @@ describe("Input", () => {
 
     expect(screen.getByLabelText("My input")).toBeDisabled(); // can't find by role searchbox since password inputs don't have a role...
     expect(screen.getByLabelText("Reveal password")).toBeDisabled(); // role can't be used since the parent has aria-hidden
+  });
+
+  it("does not trigger the suggestions on focus by default", async () => {
+    const user = userEvent.setup();
+    render(<Suggestions />);
+
+    const input = screen.getByRole("textbox", {
+      name: "Select a country",
+    });
+    await user.click(input);
+    expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+  });
+
+  it("triggers the suggestions on focus when suggestOnFocus is true", async () => {
+    const user = userEvent.setup();
+    render(<Suggestions suggestOnFocus />);
+
+    const input = screen.getByRole("textbox", {
+      name: "Select a country",
+    });
+    await user.click(input);
+    expect(screen.getByRole("tooltip")).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
- `enablePortal` property added to the input and suggestions components to enable portal for the popper
- `suggestOnFocus` property added to the input component to enable triggering the suggestions when focusing on the input