### PR TITLE
fix(CodeEditor): not autoclosing tag if attributes are opened

### DIFF
--- a/packages/code-editor/src/CodeEditor/languages/xml.ts
+++ b/packages/code-editor/src/CodeEditor/languages/xml.ts
@@ -330,9 +330,9 @@ export const hvXmlKeyDownListener = (
         endColumn: selection.endColumn,
       });
 
-      // Look for the tag we are currently closing
+      // Look for the tag we are currently closing and shouldn't have opened attributes
       const tag = String(lineBeforeChange).match(
-        /<([\w-]+)(?![^>]*\/>)[^>/]*$/,
+        /<([\w-]+)\s*(?:(?:\s+[\w-]+\s*=\s*(?:"[^"]*"|'[^']*'))*)\s*$/,
       )?.[1];
       if (tag) {
         // Add the closing tag


### PR DESCRIPTION
Fixes the following:

https://github.com/user-attachments/assets/c8a57d53-a2b0-45b1-8499-ce18435e3d3b

- The tag shouldn't be automatically closed since `>` was written inside an opened attribute.

After:

https://github.com/user-attachments/assets/4796501e-35d6-4750-9655-1bbdae29c665

