### PR TITLE
feat(Loading): update to PD 0.2 specs

### DIFF
--- a/packages/core/src/Loading/Loading.stories.tsx
+++ b/packages/core/src/Loading/Loading.stories.tsx
@@ -40,7 +40,7 @@ export const Variants: StoryObj<HvLoadingProps> = {
       <>
         <HvLoading />
         <HvLoading small />
-        <HvLoading color="primary" />
+        <HvLoading color="positive" />
         <HvLoading label="Loading" />
       </>
     );

--- a/packages/core/src/Loading/Loading.styles.tsx
+++ b/packages/core/src/Loading/Loading.styles.tsx
@@ -11,6 +11,7 @@ export const { staticClasses, useClasses } = createClasses("HvLoading", {
   },
   barContainer: {
     display: "flex",
+    alignItems: "center",
     justifyContent: "space-around",
 
     ":has($regular)": {
@@ -19,7 +20,7 @@ export const { staticClasses, useClasses } = createClasses("HvLoading", {
     },
 
     ":has($small)": {
-      "--scaleY": "0.223",
+      "--height": "40%",
       width: 18,
       height: 18,
     },
@@ -30,10 +31,11 @@ export const { staticClasses, useClasses } = createClasses("HvLoading", {
     animation: "loading 1s ease-in-out infinite",
     // TODO: make this the default when it has better support
     width: "round(up, 0.11em, 2px)",
+    height: "100%",
 
     "@keyframes loading": {
       "50%": {
-        transform: "scale(1, var(--scaleY, 0.6))",
+        height: "var(--height, 60%)",
         backgroundColor: `var(--customColor, ${theme.colors.secondary})`,
       },
     },

--- a/packages/styles/src/themes/pentahoPlus.ts
+++ b/packages/styles/src/themes/pentahoPlus.ts
@@ -26,6 +26,7 @@ const pentahoPlus = makeTheme((theme) => ({
         type: "light",
         ...colors.common,
         ...colors.light,
+        brand: blue[600],
         containerBackgroundHover: `color-mix(in srgb, ${blue[600]} 10%, transparent)`,
         backgroundColor: slate[100],
         atmo1: slate[50],
@@ -363,6 +364,13 @@ const pentahoPlus = makeTheme((theme) => ({
     base: "6px",
   },
   components: {
+    HvLoading: {
+      classes: {
+        loadingBar: {
+          borderRadius: 1,
+        },
+      },
+    },
     HvBadge: {
       classes: {
         badgePosition: {


### PR DESCRIPTION
- added the color override for the color token `brand` in the P+ theme
- I needed to change the animation a bit: because we were using `scale` to change the height of each bar, now that it has a rounded border the change in scale changes the rounded borders as the element grows and shrinks. I opted to animate the height instead. 
