### PR TITLE
style(theme): add Inter font fallbacks to Pentaho+ theme

### DIFF
--- a/packages/styles/src/themes/pentahoPlus.ts
+++ b/packages/styles/src/themes/pentahoPlus.ts
@@ -183,7 +183,7 @@ const pentahoPlus = makeTheme((theme) => ({
     },
   },
   fontFamily: {
-    body: "Inter",
+    body: "Inter, Arial, Helvetica, sans-serif",
   },
   typography: {
     display: {


### PR DESCRIPTION
Add CSS font fallbacks for `Inter` font

I found this nice fallback strategy, but currently there isn't a simple way to include this per-theme: https://developer.chrome.com/blog/framework-tools-font-fallback