### PR TITLE
style(MultiButton): change split to use ::after

### DIFF
--- a/packages/core/src/MultiButton/MultiButton.styles.tsx
+++ b/packages/core/src/MultiButton/MultiButton.styles.tsx
@@ -1,8 +1,6 @@
 import { createClasses } from "@hitachivantara/uikit-react-utils";
 import { theme } from "@hitachivantara/uikit-styles";
 
-import { HvButtonSize } from "../Button";
-import { getColoringStyle, getSizeStyles } from "../Button/Button.styles";
 import { dropDownMenuClasses } from "../DropDownMenu";
 
 export const { staticClasses, useClasses } = createClasses("HvMultiButton", {
@@ -101,45 +99,41 @@ export const { staticClasses, useClasses } = createClasses("HvMultiButton", {
     width: "fit-content",
     background: theme.colors.atmo1,
 
-    // Button
-    "& button$button": {
-      "&$firstButton": {
-        borderTopRightRadius: 0,
-        borderBottomRightRadius: 0,
-        "& + div$splitContainer": {
-          marginLeft: -1,
-        },
-      },
-      "&$lastButton": {
-        borderTopLeftRadius: 0,
-        borderBottomLeftRadius: 0,
-      },
-    },
-
-    // Dropdown Menu
-    [`& .${dropDownMenuClasses.root}`]: {
-      "&:has($firstButton)": {
-        "& + div$splitContainer": {
-          marginRight: -1,
-        },
-      },
-    },
-    "& $button$firstButton > button": {
-      marginRight: -1.5,
-      borderTopRightRadius: 0,
-      borderBottomRightRadius: 0,
-    },
-    "& $button$lastButton > button": {
-      marginLeft: -1.5,
+    // HvButton, HvDropDownMenu
+    "& button$button:not($firstButton), & $button:not($firstButton) button": {
       borderTopLeftRadius: 0,
       borderBottomLeftRadius: 0,
+      "&:not([aria-controls])": {
+        borderLeftWidth: 0,
+      },
     },
+    // HvButton, HvDropDownMenu
+    "& button$button:not($lastButton), & $button:not($lastButton) button": {
+      borderTopRightRadius: 0,
+      borderBottomRightRadius: 0,
+      "&:not([aria-controls])": {
+        borderRightWidth: 0,
+      },
+
+      "&::after": {
+        content: "''",
+        position: "absolute",
+        inset: "4px -1px 4px auto",
+        width: 1,
+        zIndex: 1,
+        height: "auto",
+        backgroundColor: "currentcolor",
+      },
+    },
+    // HvDropDownMenu
     [`& .${dropDownMenuClasses.iconSelected}`]: {
       zIndex: 2,
     },
   },
   splitGroupDisabled: { background: theme.colors.atmo3 },
-  button: {},
+  button: {
+    position: "relative",
+  },
   selected: {},
   vertical: {
     flexDirection: "column",
@@ -201,23 +195,6 @@ export const { staticClasses, useClasses } = createClasses("HvMultiButton", {
       },
     },
   },
-  split: {
-    width: 1,
-    height: "100%",
-    background: "currentColor",
-  },
-  splitContainer: {
-    display: "flex",
-    justifyContent: "center",
-    zIndex: 1,
-    width: 2,
-    paddingTop: 4,
-    paddingBottom: 4,
-    height: "calc(32px - 2px)",
-  },
-  splitDisabled: {
-    color: theme.colors.secondary_60,
-  },
   firstButton: {},
   lastButton: {},
 
@@ -228,21 +205,4 @@ export const { staticClasses, useClasses } = createClasses("HvMultiButton", {
   secondary: {},
   secondarySubtle: {},
   secondaryGhost: {},
-});
-
-export const getSplitContainerColor = (
-  color: string,
-  type?: string,
-  disabled?: boolean,
-) => ({
-  color: getColoringStyle(color, type).color,
-  backgroundColor: disabled
-    ? theme.colors.atmo3
-    : type === "subtle"
-      ? theme.colors.atmo1
-      : "transparent",
-});
-
-export const getSplitContainerHeight = (size: HvButtonSize) => ({
-  height: `calc(${getSizeStyles(size).height} - 2px)`,
 });

--- a/packages/core/src/MultiButton/MultiButton.tsx
+++ b/packages/core/src/MultiButton/MultiButton.tsx
@@ -1,7 +1,6 @@
 import {
   Children,
   cloneElement,
-  Fragment,
   isValidElement,
   ReactElement,
   useMemo,
@@ -13,13 +12,7 @@ import {
 
 import { HvButtonSize, HvButtonVariant } from "../Button";
 import { HvBaseProps } from "../types/generic";
-import { setId } from "../utils/setId";
-import {
-  getSplitContainerColor,
-  getSplitContainerHeight,
-  staticClasses,
-  useClasses,
-} from "./MultiButton.styles";
+import { staticClasses, useClasses } from "./MultiButton.styles";
 
 export { staticClasses as multiButtonClasses };
 export type HvMultiButtonClasses = ExtractNames<typeof useClasses>;
@@ -41,7 +34,6 @@ export interface HvMultiButtonProps extends HvBaseProps {
 
 export const HvMultiButton = (props: HvMultiButtonProps) => {
   const {
-    id,
     className,
     children,
     classes: classesProp,
@@ -52,18 +44,7 @@ export const HvMultiButton = (props: HvMultiButtonProps) => {
     split,
     ...others
   } = useDefaultProps("HvMultiButton", props);
-  const { classes, cx, css } = useClasses(classesProp);
-
-  const [color, type] = useMemo(() => {
-    const result = variant.split(/(?=[A-Z])/);
-    if (
-      result[0] === "ghost" ||
-      result[0] === "semantic" ||
-      (result[0] === "secondary" && !result[1])
-    )
-      return [];
-    return result.map((x) => x.toLowerCase());
-  }, [variant]);
+  const { classes, cx } = useClasses(classesProp);
 
   // Filter children: remove invalid and undefined/null
   const buttons = useMemo(() => {
@@ -78,7 +59,6 @@ export const HvMultiButton = (props: HvMultiButtonProps) => {
 
   return (
     <div
-      id={id}
       className={cx(
         classes.root,
         {
@@ -94,36 +74,17 @@ export const HvMultiButton = (props: HvMultiButtonProps) => {
     >
       {buttons.map((child, index) => {
         const childIsSelected = !!child.props.selected;
-        const btnKey = setId([id, index]);
-        return (
-          <Fragment key={btnKey}>
-            {cloneElement(child, {
-              variant,
-              disabled: disabled || child.props.disabled,
-              size,
-              className: cx(child.props.className, classes.button, {
-                [classes.firstButton]: index === 0,
-                [classes.lastButton]: index === buttons.length - 1,
-                [classes.selected]: childIsSelected,
-              }),
-            })}
-            {split && index < buttons.length - 1 && (
-              <div
-                className={cx(
-                  classes.splitContainer,
-                  color && css(getSplitContainerColor(color, type, disabled)),
-                  size && css(getSplitContainerHeight(size)),
-                  {
-                    [classes.splitDisabled]: disabled,
-                  },
-                  classes[variant as keyof HvMultiButtonClasses], // TODO - remove in v6
-                )}
-              >
-                <div className={classes.split} />
-              </div>
-            )}
-          </Fragment>
-        );
+        return cloneElement(child, {
+          key: index,
+          variant,
+          disabled: disabled || child.props.disabled,
+          size,
+          className: cx(child.props.className, classes.button, {
+            [classes.firstButton]: index === 0,
+            [classes.lastButton]: index === buttons.length - 1,
+            [classes.selected]: childIsSelected,
+          }),
+        });
       })}
     </div>
   );

--- a/packages/styles/src/themes/pentahoPlus.ts
+++ b/packages/styles/src/themes/pentahoPlus.ts
@@ -726,35 +726,8 @@ const pentahoPlus = makeTheme((theme) => ({
         },
         splitGroup: {
           backgroundColor: "transparent",
-          // Button
-          "& button.HvMultiButton-button": {
-            "&.HvMultiButton-firstButton": {
-              "& + div.HvMultiButton-splitContainer": {
-                marginLeft: 0,
-              },
-            },
-          },
-          // Dropdown Menu
-          "& .HvDropDownMenu-root": {
-            "&:has(.HvMultiButton-firstButton)": {
-              "& + div.HvMultiButton-splitContainer": {
-                marginRight: -1,
-              },
-            },
-          },
-          "& .HvMultiButton-button.HvMultiButton-firstButton > button": {
-            marginRight: -1,
-          },
-          "& .HvMultiButton-button.HvMultiButton-lastButton > button": {
-            marginLeft: -1,
-          },
         },
         splitGroupDisabled: { backgroundColor: "transparent" },
-        splitContainer: {
-          width: 1,
-          zIndex: theme.zIndices.docked,
-          "&&": { backgroundColor: "transparent" },
-        },
       },
     },
     HvDropdownButton: {


### PR DESCRIPTION
change `HvMultiButton` `split` separator to use `::after` instead of HMTL elements, which inherits button's color, height, etc. (+disabled) - making it easier to style and simplifies DOM

Visual changes:
- the 0.5/1px changes are expected
- indirectly fixes the "split separator" when `disabled` in Pentaho+ theme