### PR TITLE
feat(Button): better color handling & Pentaho+ styles

### DIFF
--- a/packages/core/src/Button/Button.stories.tsx
+++ b/packages/core/src/Button/Button.stories.tsx
@@ -55,59 +55,32 @@ export const Variants: StoryObj<HvButtonProps> = {
       <HvButton variant="primarySubtle">Primary Subtle</HvButton>
       <HvButton variant="primaryGhost">Primary Ghost</HvButton>
       <HvButton disabled variant="primary">
-        Primary
+        Disabled
       </HvButton>
       <HvButton disabled variant="primarySubtle">
-        Primary Subtle
+        Disabled Subtle
       </HvButton>
       <HvButton disabled variant="primaryGhost">
-        Primary Ghost
+        Disabled Ghost
       </HvButton>
       <div />
       <HvButton variant="secondarySubtle">Secondary Subtle</HvButton>
       <HvButton variant="secondaryGhost">Secondary Ghost</HvButton>
-      <div />
-      <HvButton variant="secondarySubtle" disabled>
-        Secondary Subtle
-      </HvButton>
-      <HvButton variant="secondaryGhost" disabled>
-        Secondary Ghost
-      </HvButton>
       <HvButton variant="positive">Positive</HvButton>
       <HvButton variant="positiveSubtle">Positive Subtle</HvButton>
       <HvButton variant="positiveGhost">Positive Ghost</HvButton>
-      <HvButton variant="positive" disabled>
-        Positive
-      </HvButton>
-      <HvButton variant="positiveSubtle" disabled>
-        Positive Subtle
-      </HvButton>
-      <HvButton variant="positiveGhost" disabled>
-        Positive Ghost
-      </HvButton>
       <HvButton variant="warning">Warning</HvButton>
       <HvButton variant="warningSubtle">Warning Subtle</HvButton>
       <HvButton variant="warningGhost">Warning Ghost</HvButton>
-      <HvButton variant="warning" disabled>
-        Warning
-      </HvButton>
-      <HvButton variant="warningSubtle" disabled>
-        Warning Subtle
-      </HvButton>
-      <HvButton variant="warningGhost" disabled>
-        Warning Ghost
-      </HvButton>
       <HvButton variant="negative">Negative</HvButton>
       <HvButton variant="negativeSubtle">Negative Subtle</HvButton>
       <HvButton variant="negativeGhost">Negative Ghost</HvButton>
-      <HvButton variant="negative" disabled>
-        Negative
+      <HvButton color="rebeccapurple">Custom</HvButton>
+      <HvButton color="rebeccapurple" variant="subtle">
+        Custom Subtle
       </HvButton>
-      <HvButton variant="negativeSubtle" disabled>
-        Negative Subtle
-      </HvButton>
-      <HvButton variant="negativeGhost" disabled>
-        Negative Ghost
+      <HvButton color="rebeccapurple" variant="ghost">
+        Custom Ghost
       </HvButton>
     </>
   ),
@@ -115,17 +88,7 @@ export const Variants: StoryObj<HvButtonProps> = {
 
 export const Sizes: StoryObj<HvButtonProps> = {
   decorators: [
-    (Story) => (
-      <div
-        style={{
-          display: "flex",
-          flexWrap: "wrap",
-          gap: 10,
-        }}
-      >
-        {Story()}
-      </div>
-    ),
+    (Story) => <div className="flex flex-wrap gap-sm">{Story()}</div>,
   ],
   render: () => (
     <>
@@ -447,13 +410,13 @@ export const Test: StoryObj = {
         <Play />
       </HvButton>
 
-      <HvButton icon aria-label="Pause" variant="primarySubtle" size="sm">
+      <HvButton icon aria-label="Play" variant="primarySubtle" size="sm">
         <Play />
       </HvButton>
-      <HvButton icon aria-label="Pause" variant="primarySubtle" size="md">
+      <HvButton icon aria-label="Play" variant="primarySubtle" size="md">
         <Play />
       </HvButton>
-      <HvButton icon disabled aria-label="Stop" variant="primary" size="lg">
+      <HvButton icon disabled aria-label="Play" variant="primary" size="lg">
         <Play />
       </HvButton>
 
@@ -481,6 +444,14 @@ export const Test: StoryObj = {
       </HvButton>
       <HvButton endIcon={<Stop />} disabled variant="secondaryGhost">
         Stop
+      </HvButton>
+      <HvButton color="rebeccapurple">rebeccapurple</HvButton>
+      <HvButton variant="subtle" color="rebeccapurple">
+        rebeccapurple
+      </HvButton>
+      <HvButton color="lightcyan">lightcyan</HvButton>
+      <HvButton variant="subtle" color="lightcyan">
+        lightcyan
       </HvButton>
     </div>
   ),

--- a/packages/core/src/Button/Button.styles.ts
+++ b/packages/core/src/Button/Button.styles.ts
@@ -1,5 +1,5 @@
 import { createClasses } from "@hitachivantara/uikit-react-utils";
-import { HvRadius, HvSize, theme } from "@hitachivantara/uikit-styles";
+import { theme, type HvSize } from "@hitachivantara/uikit-styles";
 
 import { outlineStyles } from "../utils/focusUtils";
 
@@ -16,20 +16,23 @@ export const { staticClasses, useClasses } = createClasses("HvButton", {
     whiteSpace: "nowrap",
 
     // Background color common for almost all variants
-    "&:hover": {
-      backgroundColor: theme.colors.containerBackgroundHover,
+    ":where(:not($disabled))": {
+      ":hover, :focus-visible": {
+        backgroundColor: theme.colors.containerBackgroundHover,
+      },
     },
-    "&:focus-visible": {
+    ":focus-visible": {
       ...outlineStyles,
-      backgroundColor: theme.colors.containerBackgroundHover,
     },
 
     // Default button - no size specified
     fontFamily: theme.fontFamily.body,
     ...theme.typography.label,
+    color: "var(--color, currentcolor)",
+    backgroundColor: "transparent",
     height: "var(--HvButton-height)",
-    border: "1px solid currentcolor",
-    borderRadius: theme.radii.base,
+    border: "1px solid transparent",
+    borderRadius: `var(--radius, ${theme.radii.base})`,
     padding: theme.spacing(0, "sm"),
   },
   startIcon: {
@@ -42,11 +45,11 @@ export const { staticClasses, useClasses } = createClasses("HvButton", {
   disabled: {
     cursor: "not-allowed",
     color: theme.colors.secondary_60,
-    borderColor: theme.colors.atmo3,
-    backgroundColor: theme.colors.atmo3,
-    "&:hover, &:focus-visible": {
-      backgroundColor: theme.colors.atmo3,
-      borderColor: theme.colors.atmo3,
+    backgroundColor: "transparent",
+    borderColor: "transparent",
+    ":hover, :focus-visible": {
+      backgroundColor: "transparent",
+      borderColor: "transparent",
     },
   },
   icon: {
@@ -57,27 +60,22 @@ export const { staticClasses, useClasses } = createClasses("HvButton", {
       margin: -1,
     },
   },
+  contained: {
+    color: theme.colors.atmo1, // `color-contrast(var(--color) vs ${colors.atmo1}, ${colors.base_light}, ${colors.base_dark})`,
+    backgroundColor: "var(--color)",
+    ":where(:not($disabled))": {
+      ":hover, :focus-visible": {
+        backgroundColor: "color-mix(in srgb, var(--color), black 20%)",
+      },
+      ":active": {
+        backgroundColor: "color-mix(in srgb, var(--color), black 30%)",
+      },
+    },
+  },
   subtle: {
-    backgroundColor: "transparent",
-    "&$disabled": {
-      backgroundColor: "transparent",
-      "&:hover, &:focus-visible": {
-        backgroundColor: "transparent",
-      },
-    },
+    borderColor: "currentcolor",
   },
-  ghost: {
-    borderColor: "transparent",
-    backgroundColor: "transparent",
-    "&$disabled": {
-      borderColor: "transparent",
-      backgroundColor: "transparent",
-      "&:hover, &:focus-visible": {
-        borderColor: "transparent",
-        backgroundColor: "transparent",
-      },
-    },
-  },
+  ghost: {},
   semantic: {
     color: theme.colors.base_dark,
     backgroundColor: "transparent",
@@ -101,61 +99,24 @@ export const { staticClasses, useClasses } = createClasses("HvButton", {
   secondary: {},
 });
 
-export const getColoringStyle = (color: string, type?: string) => {
-  if (type)
-    return {
-      color:
-        theme.colors[
-          (color !== "warning"
-            ? color
-            : `${color}_140`) as keyof typeof theme.colors
-        ],
-    };
-
-  const bg =
-    theme.colors[
-      (color !== "warning"
-        ? color
-        : `${color}_120`) as keyof typeof theme.colors
-    ];
-  const hoverBg =
-    theme.colors[
-      (color !== "warning"
-        ? `${color}_80`
-        : `${color}_140`) as keyof typeof theme.colors
-    ];
-  return {
-    color: theme.colors.atmo1,
-    backgroundColor: bg,
-    borderColor: bg,
-    "&:hover, &:focus-visible": {
-      backgroundColor: hoverBg,
-      borderColor: hoverBg,
-    },
-  };
-};
-
-export const getRadiusStyles = (radius: HvRadius) => ({
-  borderRadius: theme.radii[radius],
-});
-
 // TODO - remove xs and xl in v6 since they are not DS spec
-const sizes = {
-  xs: { height: "24px", space: "sm", typography: "captionLabel" },
-  sm: { height: "24px", space: "sm", typography: "captionLabel" },
-  md: { height: "32px", space: "sm", typography: "label" },
-  lg: { height: "48px", space: "md", typography: "label" },
-  xl: { height: "48px", space: "md", typography: "label" },
+const sizes: Record<
+  HvSize,
+  { height: string; space?: HvSize; fontSize?: keyof typeof theme.fontSizes }
+> = {
+  xs: { height: "24px", fontSize: "sm" },
+  sm: { height: "24px", fontSize: "sm" },
+  md: { height: "32px" },
+  lg: { height: "48px", space: "md" },
+  xl: { height: "48px", space: "md" },
 };
 
 export const getSizeStyles = (size: HvSize) => {
-  const { height, space, typography } = sizes[size];
-  const { color, ...typoProps } =
-    theme.typography[typography as keyof typeof theme.typography];
+  const { height, space = "sm", fontSize } = sizes[size];
   return {
     height,
     padding: theme.spacing(0, space),
-    ...typoProps,
+    fontSize: fontSize && theme.fontSizes[fontSize],
   };
 };
 

--- a/packages/core/src/Button/Button.styles.ts
+++ b/packages/core/src/Button/Button.styles.ts
@@ -1,8 +1,7 @@
 import { createClasses } from "@hitachivantara/uikit-react-utils";
-import { theme } from "@hitachivantara/uikit-styles";
+import { HvRadius, HvSize, theme } from "@hitachivantara/uikit-styles";
 
 import { outlineStyles } from "../utils/focusUtils";
-import { HvButtonRadius, HvButtonSize } from "./types";
 
 export const { staticClasses, useClasses } = createClasses("HvButton", {
   /**
@@ -136,7 +135,7 @@ export const getColoringStyle = (color: string, type?: string) => {
   };
 };
 
-export const getRadiusStyles = (radius: HvButtonRadius) => ({
+export const getRadiusStyles = (radius: HvRadius) => ({
   borderRadius: theme.radii[radius],
 });
 
@@ -149,7 +148,7 @@ const sizes = {
   xl: { height: "48px", space: "md", typography: "label" },
 };
 
-export const getSizeStyles = (size: HvButtonSize) => {
+export const getSizeStyles = (size: HvSize) => {
   const { height, space, typography } = sizes[size];
   const { color, ...typoProps } =
     theme.typography[typography as keyof typeof theme.typography];
@@ -160,7 +159,7 @@ export const getSizeStyles = (size: HvButtonSize) => {
   };
 };
 
-export const getIconSizeStyles = (size: HvButtonSize) => {
+export const getIconSizeStyles = (size: HvSize) => {
   const { height } = sizes[size];
   return {
     height,

--- a/packages/core/src/Button/Button.test.tsx
+++ b/packages/core/src/Button/Button.test.tsx
@@ -5,7 +5,26 @@ import { Alert } from "@hitachivantara/uikit-react-icons";
 
 import { HvLoading } from "../Loading";
 import { HvButton } from "./Button";
-import { buttonVariant } from "./types";
+
+const buttonVariant = [
+  "primary",
+  "primarySubtle",
+  "primaryGhost",
+  "positive",
+  "positiveSubtle",
+  "positiveGhost",
+  "negative",
+  "negativeSubtle",
+  "negativeGhost",
+  "warning",
+  "warningSubtle",
+  "warningGhost",
+  "secondarySubtle",
+  "secondaryGhost",
+  "semantic",
+  "secondary",
+  "ghost",
+] as const;
 
 describe("Button", () => {
   it("renders the content", () => {

--- a/packages/core/src/Button/Button.tsx
+++ b/packages/core/src/Button/Button.tsx
@@ -4,7 +4,7 @@ import {
   useTheme,
   type ExtractNames,
 } from "@hitachivantara/uikit-react-utils";
-import { HvBaseTheme } from "@hitachivantara/uikit-styles";
+import { HvBaseTheme, HvRadius, HvSize } from "@hitachivantara/uikit-styles";
 
 import {
   fixedForwardRef,
@@ -20,7 +20,7 @@ import {
   getSizeStyles,
   useClasses,
 } from "./Button.styles";
-import { HvButtonRadius, HvButtonSize, HvButtonVariant } from "./types";
+import { HvButtonVariant } from "./types";
 
 export { buttonClasses };
 
@@ -43,9 +43,9 @@ export type HvButtonProps<C extends React.ElementType = "button"> =
       /** Element placed after the children. */
       endIcon?: React.ReactNode;
       /** Button size. */
-      size?: HvButtonSize;
+      size?: HvSize;
       /** Button border radius. */
-      radius?: HvButtonRadius;
+      radius?: HvRadius;
       /** Defines the default colors of the button are forced into the icon. */
       overrideIconColors?: boolean;
       /** A Jss Object used to override or extend the styles applied. */

--- a/packages/core/src/Button/types.ts
+++ b/packages/core/src/Button/types.ts
@@ -4,6 +4,8 @@ import { HvRadius, HvSize } from "@hitachivantara/uikit-styles";
 type TypeSuffix = "" | "Subtle" | "Ghost";
 
 export type HvButtonVariant =
+  | "contained"
+  | "subtle"
   | "ghost"
   | `primary${TypeSuffix}`
   | `secondary${TypeSuffix}`

--- a/packages/core/src/Button/types.ts
+++ b/packages/core/src/Button/types.ts
@@ -1,33 +1,19 @@
-export const buttonVariant = [
-  "primary",
-  "primarySubtle",
-  "primaryGhost",
-  "positive",
-  "positiveSubtle",
-  "positiveGhost",
-  "negative",
-  "negativeSubtle",
-  "negativeGhost",
-  "warning",
-  "warningSubtle",
-  "warningGhost",
-  "secondarySubtle",
-  "secondaryGhost",
-  "semantic",
-  // deprecated props
-  "secondary",
-  "ghost",
-] as const;
-export type HvButtonVariant = (typeof buttonVariant)[number];
+import { HvRadius, HvSize } from "@hitachivantara/uikit-styles";
 
-export const buttonSize = ["xs", "sm", "md", "lg", "xl"] as const;
-export type HvButtonSize = (typeof buttonSize)[number];
+// "contained" has no suffix
+type TypeSuffix = "" | "Subtle" | "Ghost";
 
-export const buttonRadius = [
-  "none",
-  "base",
-  "round",
-  "circle",
-  "full",
-] as const;
-export type HvButtonRadius = (typeof buttonRadius)[number];
+export type HvButtonVariant =
+  | "ghost"
+  | `primary${TypeSuffix}`
+  | `secondary${TypeSuffix}`
+  | `positive${TypeSuffix}`
+  | `negative${TypeSuffix}`
+  | `warning${TypeSuffix}`
+  | "semantic";
+
+/** @deprecated use `HvSize` */
+export type HvButtonSize = HvSize;
+
+/** @deprecated use `HvRadius` */
+export type HvButtonRadius = HvRadius;

--- a/packages/core/src/DropDownMenu/DropDownMenu.tsx
+++ b/packages/core/src/DropDownMenu/DropDownMenu.tsx
@@ -5,10 +5,11 @@ import {
   useDefaultProps,
   type ExtractNames,
 } from "@hitachivantara/uikit-react-utils";
+import { HvSize } from "@hitachivantara/uikit-styles";
 
 import { HvBaseDropdown, HvBaseDropdownProps } from "../BaseDropdown";
 import { useBaseDropdownContext } from "../BaseDropdown/BaseDropdownContext/BaseDropdownContext";
-import { HvButtonSize, HvButtonVariant } from "../Button";
+import { HvButtonVariant } from "../Button";
 import { HvDropdownButton, HvDropdownButtonProps } from "../DropdownButton";
 import { useControlled } from "../hooks/useControlled";
 import { useLabels } from "../hooks/useLabels";
@@ -79,7 +80,7 @@ export interface HvDropDownMenuProps
   /** The variant to be used in the header. */
   variant?: HvButtonVariant;
   /** Button size. */
-  size?: HvButtonSize;
+  size?: HvSize;
   /** A Jss Object used to override or extend the styles applied to the component. */
   classes?: HvDropDownMenuClasses;
   /** An object containing all the labels. */

--- a/packages/core/src/MultiButton/MultiButton.tsx
+++ b/packages/core/src/MultiButton/MultiButton.tsx
@@ -9,8 +9,9 @@ import {
   useDefaultProps,
   type ExtractNames,
 } from "@hitachivantara/uikit-react-utils";
+import { HvSize } from "@hitachivantara/uikit-styles";
 
-import { HvButtonSize, HvButtonVariant } from "../Button";
+import { HvButtonVariant } from "../Button";
 import { HvBaseProps } from "../types/generic";
 import { staticClasses, useClasses } from "./MultiButton.styles";
 
@@ -27,7 +28,7 @@ export interface HvMultiButtonProps extends HvBaseProps {
   /** A Jss Object used to override or extend the styles applied to the component. */
   classes?: HvMultiButtonClasses;
   /** Button size. */
-  size?: HvButtonSize;
+  size?: HvSize;
   /** Add a split between buttons */
   split?: boolean;
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -20,7 +20,7 @@ export type {
   HvCategoricalColor,
   HvColor,
   HvColorAny,
-  // SIZES
+  HvRadius,
   HvSize,
 } from "@hitachivantara/uikit-styles";
 

--- a/packages/styles/src/themes/ds3.ts
+++ b/packages/styles/src/themes/ds3.ts
@@ -477,9 +477,7 @@ const ds3 = makeTheme((theme) => ({
           backgroundColor: theme.colors.atmo1,
           borderColor: theme.colors.atmo4,
         },
-        ghost: {
-          color: theme.colors.secondary,
-        },
+        ghost: {},
         disabled: {
           "&:not(.HvButton-ghost):not(.HvButton-semantic)": {
             backgroundColor: theme.colors.atmo3,

--- a/packages/styles/src/themes/ds5.ts
+++ b/packages/styles/src/themes/ds5.ts
@@ -185,10 +185,44 @@ const ds5 = makeTheme((theme) => ({
       textDecoration: "underline",
     },
   },
-  components: {} satisfies Record<
-    string,
-    Record<string, any> | { classes?: CSSProperties }
-  >,
+  components: {
+    HvButton: {
+      classes: {
+        root: {
+          ":where(:not(.HvButton-disabled,.HvButton-contained))": {
+            "&[data-color=warning]": { color: theme.colors.warning_140 },
+          },
+        },
+        contained: {
+          ":where([data-color=primary]:not(.HvButton-disabled))": {
+            ":hover, &:focus-visible": {
+              backgroundColor: theme.colors.primary_80,
+              borderColor: theme.colors.primary_80,
+            },
+          },
+          ":where([data-color=positive]:not(.HvButton-disabled))": {
+            ":hover, &:focus-visible": {
+              backgroundColor: theme.colors.positive_80,
+              borderColor: theme.colors.positive_80,
+            },
+          },
+          ":where([data-color=warning]:not(.HvButton-disabled))": {
+            backgroundColor: theme.colors.warning_120,
+            ":hover, &:focus-visible": {
+              backgroundColor: theme.colors.warning_140,
+              borderColor: theme.colors.warning_140,
+            },
+          },
+          ":where([data-color=negative]:not(.HvButton-disabled))": {
+            ":hover, &:focus-visible": {
+              backgroundColor: theme.colors.negative_80,
+              borderColor: theme.colors.negative_80,
+            },
+          },
+        },
+      },
+    },
+  } satisfies Record<string, Record<string, any> | { classes?: CSSProperties }>,
   header: {
     height: "64px",
     secondLevelHeight: "56px",

--- a/packages/styles/src/themes/pentahoPlus.ts
+++ b/packages/styles/src/themes/pentahoPlus.ts
@@ -7,6 +7,7 @@ import {
   amber,
   blue,
   cyan,
+  emerald,
   green,
   neutral,
   orange,
@@ -17,6 +18,33 @@ import {
   slate,
   yellow,
 } from "../tokens/colorsPalette";
+
+/** light-dark alias */
+const ld = (c1: string, c2: string) => `light-dark(${c1}, ${c2})`;
+
+/** custom button using `light-dark` theming scheme */
+const buttonColors = {
+  primary: {
+    subtleBg: ld(blue[50], blue[950]),
+    subtleBorder: ld(blue[200], blue[800]),
+  },
+  secondary: {
+    subtleBg: ld(slate[100], slate[800]),
+    subtleBorder: ld(slate[300], slate[700]),
+  },
+  success: {
+    subtleBorder: ld(green[200], green[800]),
+    subtleBg: ld(emerald[100], green[900]),
+  },
+  warning: {
+    subtleBorder: ld(amber[200], amber[800]),
+    subtleBg: ld(amber[100], amber[900]),
+  },
+  error: {
+    subtleBorder: ld(red[200], red[800]),
+    subtleBg: ld(red[100], red[900]),
+  },
+};
 
 const pentahoPlus = makeTheme((theme) => ({
   name: "pentahoPlus",
@@ -529,107 +557,86 @@ const pentahoPlus = makeTheme((theme) => ({
     HvButton: {
       classes: {
         root: {
-          border: "none",
           borderRadius: theme.radii.full,
-          padding: theme.spacing(0, "sm"),
-          [`&[data-color="positive"]`]: {
-            "&:hover": {
-              backgroundColor: theme.colors.pp.successAction,
-            },
-            "&:active": {
-              backgroundColor: theme.colors.pp.successStrong,
-            },
-          },
-          [`&[data-color="negative"]`]: {
-            "&:hover": {
-              backgroundColor: theme.colors.pp.errorAction,
-            },
-            "&:active": {
-              backgroundColor: theme.colors.pp.errorStrong,
-            },
-          },
-          [`&[data-color="warning"]`]: {
-            "&:hover": {
-              backgroundColor: theme.colors.pp.warningAction,
-            },
-            "&:active": {
-              backgroundColor: theme.colors.pp.warningStrong,
-            },
+          ":where(:not(.HvButton-disabled,.HvButton-contained))": {
+            "&[data-color=positive]": { color: theme.colors.pp.success },
+            "&[data-color=warning]": { color: theme.colors.pp.warning },
+            "&[data-color=negative]": { color: theme.colors.pp.error },
+            ":hover": { backgroundColor: theme.colors.pp.primaryDimmed },
+            ":active": { backgroundColor: theme.colors.pp.primarySubtle },
           },
         },
-        primary: {
-          "&:hover": {
-            backgroundColor: theme.colors.pp.primaryAction,
-          },
-          "&:active": {
-            backgroundColor: theme.colors.pp.primaryStrong,
+        contained: {
+          ":where(:not(.HvButton-disabled))": {
+            color: "#FFFFFF",
+            "&[data-color=primary]": {
+              backgroundColor: blue[600],
+              ":hover": { backgroundColor: blue[700] },
+              ":active": { backgroundColor: blue[800] },
+            },
+            "&[data-color=positive]": {
+              ":hover": { backgroundColor: theme.colors.pp.successAction },
+              ":active": { backgroundColor: theme.colors.pp.successStrong },
+            },
+            "&[data-color=warning]": {
+              ":hover": { backgroundColor: theme.colors.pp.warningAction },
+              ":active": { backgroundColor: theme.colors.pp.warningStrong },
+            },
+            "&[data-color=negative]": {
+              ":hover": { backgroundColor: theme.colors.pp.errorAction },
+              ":active": { backgroundColor: theme.colors.pp.errorStrong },
+            },
           },
         },
         subtle: {
-          borderTop: `1px solid ${theme.colors.atmo1}`,
-          borderBottom: `1px solid ${theme.colors.atmo4}`,
-          backgroundColor: theme.colors.atmo1,
-          "&:hover": {
-            backgroundColor: theme.colors.pp.bgHover,
-          },
-          "&:active": {
-            backgroundColor: theme.colors.pp.primarySubtle,
-            borderTop: `1px solid ${theme.colors.pp.primarySubtle}`,
-            borderBottom: `1px solid ${theme.colors.pp.primarySubtle}`,
-            border: "none",
-          },
-          "&.HvButton-disabled": {
-            backgroundColor: theme.colors.pp.bgDisabled,
-            "&:hover": {
-              backgroundColor: theme.colors.pp.bgDisabled,
+          borderColor: "color-mix(in srgb, currentcolor, transparent 60%)",
+          ":where(:not(.HvButton-disabled))": {
+            "&[data-color=primary]": {
+              backgroundColor: buttonColors.primary.subtleBg,
             },
-          },
-          "&[data-color=positive]": {
-            "&:hover,&:active": {
+            "&[data-color=secondary]": {
+              backgroundColor: buttonColors.secondary.subtleBg,
+            },
+            ":hover": {
+              backgroundColor: theme.colors.pp.primaryDimmed,
+            },
+            ":active": {
+              borderColor: "transparent",
+              backgroundColor: theme.colors.pp.primarySubtle,
+            },
+            "&[data-color=positive]": {
+              borderColor: buttonColors.success.subtleBorder,
               backgroundColor: theme.colors.pp.successDimmed,
+              ":hover": { backgroundColor: buttonColors.success.subtleBg },
+              ":active": { backgroundColor: buttonColors.success.subtleBorder },
             },
-          },
-          [`&[data-color="negative"]`]: {
-            color: theme.colors.negative_120,
-            "&:hover,&:active": {
-              backgroundColor: theme.colors.pp.errorDimmed,
-            },
-          },
-          [`&[data-color="warning"]`]: {
-            color: theme.colors.warning_120,
-            "&:hover,&:active": {
+            "&[data-color=warning]": {
+              borderColor: buttonColors.warning.subtleBorder,
               backgroundColor: theme.colors.pp.warningDimmed,
+              ":hover": { backgroundColor: buttonColors.warning.subtleBg },
+              ":active": { backgroundColor: buttonColors.warning.subtleBorder },
             },
-          },
-          "&:HvButton-disabled": {
-            backgroundColor: theme.colors.pp.bgDisabled,
-            borderColor: theme.colors.pp.bgDisabled,
+            "&[data-color=negative]": {
+              borderColor: buttonColors.error.subtleBorder,
+              backgroundColor: theme.colors.pp.errorDimmed,
+              ":hover": { backgroundColor: buttonColors.error.subtleBg },
+              ":active": { backgroundColor: buttonColors.error.subtleBorder },
+            },
           },
         },
         ghost: {
-          "&:hover": {
-            backgroundColor: theme.colors.pp.primaryDimmed,
-          },
-          "&:active": {
-            backgroundColor: theme.colors.pp.primarySubtle,
-            borderBottom: `1px solid ${theme.colors.pp.primarySubtle}`,
-            border: "none",
-          },
-          [`&[data-color="positive"]`]: {
-            "&:hover,&:active": {
-              backgroundColor: theme.colors.pp.successDimmed,
+          ":where(:not(.HvButton-disabled))": {
+            "&[data-color=positive]": {
+              ":hover": { backgroundColor: theme.colors.pp.successDimmed },
+              ":active": { backgroundColor: buttonColors.success.subtleBg },
             },
-          },
-          [`&[data-color="negative"]`]: {
-            color: theme.colors.negative_120,
-            "&:hover,&:active": {
-              backgroundColor: theme.colors.pp.errorDimmed,
+            "&[data-color=warning]": {
+              ":hover": { backgroundColor: theme.colors.pp.warningDimmed },
+              ":active": { backgroundColor: buttonColors.warning.subtleBg },
             },
-          },
-          [`&[data-color="warning"]`]: {
-            color: theme.colors.warning_120,
-            "&:hover,&:active": {
-              backgroundColor: theme.colors.pp.warningDimmed,
+            "&[data-color=negative]": {
+              ":hover": { backgroundColor: theme.colors.pp.errorDimmed },
+              ":active": { backgroundColor: buttonColors.error.subtleBg },
             },
           },
         },
@@ -646,22 +653,14 @@ const pentahoPlus = makeTheme((theme) => ({
         },
 
         disabled: {
-          border: "none",
-          backgroundColor: theme.colors.pp.bgDisabled,
           color: theme.colors.pp.textDisabled,
-          "&:hover": {
+          ":not(.HvButton-ghost)": {
+            borderColor: "transparent",
             backgroundColor: theme.colors.pp.bgDisabled,
-          },
-          "&[data-color=positive],&[data-color=warning],&[data-color=negative]":
-            {
-              color: theme.colors.pp.textDisabled,
-              "&:hover,&:active": {
-                backgroundColor: theme.colors.pp.bgDisabled,
-              },
-              "&.HvButton-ghost": {
-                backgroundColor: "transparent",
-              },
+            "&:hover, &:active": {
+              backgroundColor: theme.colors.pp.bgDisabled,
             },
+          },
         },
       },
     },

--- a/packages/styles/src/themes/pentahoPlus.ts
+++ b/packages/styles/src/themes/pentahoPlus.ts
@@ -517,6 +517,13 @@ const pentahoPlus = makeTheme((theme) => ({
         },
       },
     },
+    HvSelect: {
+      classes: {
+        panel: {
+          borderColor: buttonColors.secondary.subtleBorder,
+        },
+      },
+    },
     HvTag: {
       classes: {
         root: {
@@ -592,9 +599,11 @@ const pentahoPlus = makeTheme((theme) => ({
           borderColor: "color-mix(in srgb, currentcolor, transparent 60%)",
           ":where(:not(.HvButton-disabled))": {
             "&[data-color=primary]": {
+              borderColor: buttonColors.primary.subtleBorder,
               backgroundColor: buttonColors.primary.subtleBg,
             },
             "&[data-color=secondary]": {
+              borderColor: buttonColors.secondary.subtleBorder,
               backgroundColor: buttonColors.secondary.subtleBg,
             },
             ":hover": {

--- a/packages/styles/src/tokens/radii.ts
+++ b/packages/styles/src/tokens/radii.ts
@@ -5,3 +5,5 @@ export const radii = {
   circle: "50%",
   full: "9999px",
 };
+
+export type HvRadius = keyof typeof radii;


### PR DESCRIPTION
Changes:
- deprecate `HvButtonRadius`, `HvButtonSize` in favor or global `HvRadius` & `HvSize`
- refactor/improve Button styles.
  - reduce specificity with `:where`
  - reduce style overrides with `contained` class
- add `color` prop to allow overriding button color & adapt button styles to support it
  - add `:hover` & `:active` styles based on `color`
  - ~add text color being inferred from `color-constrast`~
- Hoist NEXT "semantic" button styles to the theme
- Add new Pentaho+ styles
- Align P+ `HvSelect`'s outline with the new "softer" `subtle` button outline

Expected visual changes:
- NEXT disabled state styles update
- P+ button
  - size always `32px` size due to border always existing (aligned with NEXT)
  - styles update (primarily on the `subtle` variants)