### PR TITLE
docs: add subcomponents props tables

### DIFF
--- a/apps/docs/src/components/Description.tsx
+++ b/apps/docs/src/components/Description.tsx
@@ -65,6 +65,25 @@ export const Description = () => {
             </HvIconButton>
           </div>
         </HvGrid>
+        {meta.subComponents && (
+          <>
+            <HvGrid item sm={2} xs={12}>
+              <HvTypography variant="label">Sub-components</HvTypography>
+            </HvGrid>
+            <HvGrid item sm={10} xs={12} className={classes.row}>
+              <div className={classes.import}>
+                <pre className={classes.importCode}>
+                  {meta?.subComponents
+                    .map(
+                      (sc: string) =>
+                        meta.subComponentsDocgen[sc].displayName || sc,
+                    )
+                    .join(", ")}
+                </pre>
+              </div>
+            </HvGrid>
+          </>
+        )}
         <HvGrid item sm={2} xs={12}>
           <HvTypography variant="label">Source</HvTypography>
         </HvGrid>

--- a/apps/docs/src/components/Description.tsx
+++ b/apps/docs/src/components/Description.tsx
@@ -65,7 +65,7 @@ export const Description = () => {
             </HvIconButton>
           </div>
         </HvGrid>
-        {meta.subComponents && (
+        {meta.subComponents.length > 0 && (
           <>
             <HvGrid item sm={2} xs={12}>
               <HvTypography variant="label">Sub-components</HvTypography>

--- a/apps/docs/src/components/Description.tsx
+++ b/apps/docs/src/components/Description.tsx
@@ -34,7 +34,7 @@ export const Description = () => {
 
   const [copyText, setCopyText] = useState("Copy code");
 
-  const importCode = `import { ${meta.docgen.displayName} } from "@hitachivantara/uikit-react-core";`;
+  const importCode = `import { ${meta.docgen.displayName} } from "@hitachivantara/uikit-react-${meta.package}";`;
 
   return (
     <>

--- a/apps/docs/src/components/Props.tsx
+++ b/apps/docs/src/components/Props.tsx
@@ -3,6 +3,7 @@ import { PropItem } from "react-docgen-typescript";
 import { css } from "@emotion/css";
 import { useData } from "nextra/hooks";
 import {
+  HvEmptyState,
   HvInput,
   HvTable,
   HvTableBody,
@@ -15,6 +16,7 @@ import {
   HvTypography,
   theme,
 } from "@hitachivantara/uikit-react-core";
+import { Ban } from "@hitachivantara/uikit-react-icons";
 
 const classes = {
   root: css({
@@ -27,6 +29,7 @@ const classes = {
   }),
   table: css({
     backgroundColor: "transparent",
+    marginBottom: theme.space.md,
   }),
   head: css({
     backgroundColor: "transparent",
@@ -35,6 +38,12 @@ const classes = {
     display: "table-row",
     borderColor: theme.colors.atmo3,
     backgroundColor: "transparent",
+  }),
+  emptyRow: css({
+    display: "table-row",
+    borderColor: theme.colors.atmo3,
+    backgroundColor: "transparent",
+    justifyContent: "center",
   }),
   type: css({
     fontSize: 12,
@@ -46,14 +55,17 @@ const classes = {
   }),
 };
 
+// order the props by required first and then alphabetically
 const reorderProps = (obj: Record<string, PropItem>) => {
-  const entries = Object.entries(obj);
-  const sortedEntries = entries.sort(
-    ([, a], [, b]) => (b.required ? 1 : 0) - (a.required ? 1 : 0),
+  return Object.fromEntries(
+    Object.entries(obj).sort(([keyA, a], [keyB, b]) => {
+      if (a.required === b.required) {
+        return keyA.localeCompare(keyB);
+      }
+      return a.required ? -1 : 1;
+    }),
   );
-  return Object.fromEntries(sortedEntries);
 };
-
 const columns: HvTableColumnConfig<PropItem, string>[] = [
   {
     Header: "Name",
@@ -69,50 +81,32 @@ const columns: HvTableColumnConfig<PropItem, string>[] = [
   },
 ];
 
-export const Props = () => {
-  const { meta } = useData();
+const EmptyStateRow = () => (
+  <HvTableRow className={classes.row}>
+    <HvTableCell colSpan={3} style={{ height: 64 }}>
+      <HvEmptyState message="No data to display." icon={<Ban />} />
+    </HvTableCell>
+  </HvTableRow>
+);
 
-  const props = meta.docgen?.props;
-
-  const [propsToShow, setPropsToShow] = useState(props);
-
-  const handleSearch = (
-    event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
-    value: string,
-  ) => {
-    const filteredEntries = Object.entries(props).filter(([key]) =>
-      key.includes(value),
-    );
-    setPropsToShow(Object.fromEntries(filteredEntries));
-  };
-
-  // reorder props to show required props first
-  const orderedPros = reorderProps(propsToShow);
-
+const PropsTable = ({ propsObj }: { propsObj: Record<string, PropItem> }) => {
   return (
-    <div className={classes.root}>
-      <HvInput
-        type="search"
-        placeholder="Search prop"
-        onChange={handleSearch}
-        className={classes.search}
-      />
-      <HvTypography variant="title2">
-        {meta.component} component props
-      </HvTypography>
-      <HvTableContainer className={classes.table}>
-        <HvTable>
-          <HvTableHead>
-            <HvTableRow className={classes.row}>
-              {columns.map((el) => (
-                <HvTableHeader key={el.Header} className={classes.head}>
-                  {el.Header}
-                </HvTableHeader>
-              ))}
-            </HvTableRow>
-          </HvTableHead>
-          <HvTableBody>
-            {Object.entries(orderedPros).map(
+    <HvTableContainer className={classes.table}>
+      <HvTable>
+        <HvTableHead>
+          <HvTableRow className={classes.row}>
+            {columns.map((el) => (
+              <HvTableHeader key={el.Header} className={classes.head}>
+                {el.Header}
+              </HvTableHeader>
+            ))}
+          </HvTableRow>
+        </HvTableHead>
+        <HvTableBody>
+          {Object.entries(propsObj).length === 0 ? (
+            <EmptyStateRow />
+          ) : (
+            Object.entries(propsObj).map(
               ([propKey, value]: [string, unknown]) => {
                 const propItem = value as PropItem;
                 return (
@@ -126,14 +120,14 @@ export const Props = () => {
                     <HvTableCell style={{ width: "30%" }}>
                       <HvTypography className={classes.type}>
                         <pre className={classes.tooltip}>
-                          {propItem.type.name}
+                          {propItem.type?.name}
                         </pre>
                       </HvTypography>
                     </HvTableCell>
                     <HvTableCell>
                       <HvTypography
                         dangerouslySetInnerHTML={{
-                          __html: propItem.description.replace(
+                          __html: propItem.description?.replace(
                             /`([^`]+)`/g,
                             "<code>$1</code>",
                           ),
@@ -143,10 +137,84 @@ export const Props = () => {
                   </HvTableRow>
                 );
               },
-            )}
-          </HvTableBody>
-        </HvTable>
-      </HvTableContainer>
+            )
+          )}
+        </HvTableBody>
+      </HvTable>
+    </HvTableContainer>
+  );
+};
+
+export const Props = () => {
+  const { meta } = useData();
+
+  const props = meta.docgen?.props || {};
+  const subComponentsDocgen =
+    meta.subComponentsDocgen ||
+    ({} as Record<string, { props: Record<string, PropItem> }>);
+
+  const [searchTerm, setSearchTerm] = useState("");
+
+  const orderedMainProps = reorderProps(props);
+
+  const orderedSubComponents = Object.entries(subComponentsDocgen).reduce(
+    (acc, [subComponent, docgen]) => {
+      const subComponentDocgen = docgen as { props: Record<string, PropItem> };
+      acc[subComponent] = reorderProps(subComponentDocgen.props);
+      return acc;
+    },
+    {} as Record<string, Record<string, PropItem>>,
+  );
+
+  const handleSearch = (
+    event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
+    value: string,
+  ) => {
+    setSearchTerm(value);
+  };
+
+  const filterProps = (propItems: Record<string, PropItem>, search: string) => {
+    if (!search) return propItems;
+    const filteredEntries = Object.entries(propItems).filter(([key]) =>
+      key.toLowerCase().includes(search.toLowerCase()),
+    );
+    return Object.fromEntries(filteredEntries);
+  };
+
+  const filteredMainProps = filterProps(orderedMainProps, searchTerm);
+
+  const filteredSubComponents = Object.entries(orderedSubComponents).reduce(
+    (acc, [subComponent, propsItems]) => {
+      acc[subComponent] = filterProps(propsItems, searchTerm);
+      return acc;
+    },
+    {} as Record<string, Record<string, PropItem>>,
+  );
+  return (
+    <div className={classes.root}>
+      <HvInput
+        type="search"
+        placeholder="Search prop"
+        onChange={handleSearch}
+        className={classes.search}
+      />
+      <HvTypography variant="title2">
+        {meta.docgen.displayName || meta.component} component props
+      </HvTypography>
+      <PropsTable propsObj={filteredMainProps} />
+
+      {Object.entries(filteredSubComponents).map(
+        ([subComponent, propItems]) => (
+          <div key={subComponent} className={classes.root}>
+            <HvTypography variant="title2">
+              {meta.subComponentsDocgen[subComponent].displayName ||
+                subComponent}{" "}
+              component props
+            </HvTypography>
+            <PropsTable propsObj={propItems} />
+          </div>
+        ),
+      )}
     </div>
   );
 };

--- a/apps/docs/src/components/code/Live.tsx
+++ b/apps/docs/src/components/code/Live.tsx
@@ -79,6 +79,7 @@ export const Live: React.FC<LiveProps> = ({ children }) => {
         if (component) {
           acc[componentName] = component;
         } else {
+          // eslint-disable-next-line no-console
           console.warn(`Component "${componentName}" not found in HvCore.`);
         }
         return acc;
@@ -91,6 +92,7 @@ export const Live: React.FC<LiveProps> = ({ children }) => {
       if (icon) {
         acc[iconName] = icon;
       } else {
+        // eslint-disable-next-line no-console
         console.warn(`Icon "${iconName}" not found in HvIcons.`);
       }
       return acc;

--- a/apps/docs/src/pages/components/Playground.tsx
+++ b/apps/docs/src/pages/components/Playground.tsx
@@ -8,6 +8,7 @@ import { useData } from "nextra/hooks";
 import { themes } from "prism-react-renderer";
 import {
   HvCheckBox,
+  HvInput,
   HvOption,
   HvRadio,
   HvRadioGroup,
@@ -213,6 +214,21 @@ export const Playground = ({
             onChange={(e: React.ChangeEvent, value: any) =>
               handleSelectChange(e, prop, value)
             }
+          />
+        );
+      }
+
+      console.log(control, propMeta.type);
+      if (propMeta.type.name === "string") {
+        return (
+          <HvInput
+            key={`${prop}`}
+            label={prop}
+            value={propsState[prop] || control.defaultValue}
+            onChange={(e: React.ChangeEvent, value: any) =>
+              handleSelectChange(e, prop, value)
+            }
+            classes={{ root: css({ width: "100%" }) }}
           />
         );
       }

--- a/apps/docs/src/pages/components/_meta.ts
+++ b/apps/docs/src/pages/components/_meta.ts
@@ -7,5 +7,6 @@ export default {
   badge: "Badge",
   banner: "Banner",
   button: "Button",
+  card: "Card",
   checkBox: "CheckBox",
 };

--- a/apps/docs/src/pages/components/_meta.ts
+++ b/apps/docs/src/pages/components/_meta.ts
@@ -9,4 +9,6 @@ export default {
   button: "Button",
   card: "Card",
   checkBox: "CheckBox",
+  loading: "Loading",
+  loadingContainer: "LoadingContainer",
 };

--- a/apps/docs/src/pages/components/avatar.mdx
+++ b/apps/docs/src/pages/components/avatar.mdx
@@ -8,7 +8,12 @@ import Playground from "./Playground";
 import { getComponentData } from "../../utils/utils";
 
 export const getStaticProps = async ({ params }) => {
-  const meta = await getComponentData("Avatar", "core", avatarClasses, null);
+  const meta = await getComponentData(
+    "Avatar",
+    "core",
+    avatarClasses,
+    undefined,
+  );
   return { props: { ssg: { meta: meta } } };
 };
 

--- a/apps/docs/src/pages/components/avatar.mdx
+++ b/apps/docs/src/pages/components/avatar.mdx
@@ -8,7 +8,7 @@ import Playground from "./Playground";
 import { getComponentData } from "../../utils/utils";
 
 export const getStaticProps = async ({ params }) => {
-  const meta = await getComponentData("Avatar", "core", avatarClasses);
+  const meta = await getComponentData("Avatar", "core", avatarClasses, null);
   return { props: { ssg: { meta: meta } } };
 };
 

--- a/apps/docs/src/pages/components/badge.mdx
+++ b/apps/docs/src/pages/components/badge.mdx
@@ -6,7 +6,7 @@ import { Page } from "@docs/components/Page";
 import { getComponentData } from "../../utils/utils";
 
 export const getStaticProps = async ({ params }) => {
-  const meta = await getComponentData("Badge", "core", badgeClasses, null);
+  const meta = await getComponentData("Badge", "core", badgeClasses, undefined);
   return { props: { ssg: { meta: meta } } };
 };
 

--- a/apps/docs/src/pages/components/badge.mdx
+++ b/apps/docs/src/pages/components/badge.mdx
@@ -6,7 +6,7 @@ import { Page } from "@docs/components/Page";
 import { getComponentData } from "../../utils/utils";
 
 export const getStaticProps = async ({ params }) => {
-  const meta = await getComponentData("Badge", "core", badgeClasses);
+  const meta = await getComponentData("Badge", "core", badgeClasses, null);
   return { props: { ssg: { meta: meta } } };
 };
 

--- a/apps/docs/src/pages/components/banner.mdx
+++ b/apps/docs/src/pages/components/banner.mdx
@@ -21,14 +21,14 @@ export const getStaticProps = async ({ params }) => {
   Component={HvBanner}
   componentName="HvBanner"
   controls={{
+    label: {
+      defaultValue: "This is an informational message.",
+    },
     variant: {
       defaultValue: "default",
     },
     showIcon: {
       defaultValue: true,
-    },
-    label: {
-      defaultValue: "This is an informational message.",
     },
   }}
   componentProps={{

--- a/apps/docs/src/pages/components/banner.mdx
+++ b/apps/docs/src/pages/components/banner.mdx
@@ -9,7 +9,7 @@ import Playground from "./Playground";
 import { getComponentData } from "../../utils/utils";
 
 export const getStaticProps = async ({ params }) => {
-  const meta = await getComponentData("Banner", "core", bannerClasses);
+  const meta = await getComponentData("Banner", "core", bannerClasses, null);
   return { props: { ssg: { meta: meta } } };
 };
 

--- a/apps/docs/src/pages/components/banner.mdx
+++ b/apps/docs/src/pages/components/banner.mdx
@@ -9,7 +9,12 @@ import Playground from "./Playground";
 import { getComponentData } from "../../utils/utils";
 
 export const getStaticProps = async ({ params }) => {
-  const meta = await getComponentData("Banner", "core", bannerClasses, null);
+  const meta = await getComponentData(
+    "Banner",
+    "core",
+    bannerClasses,
+    undefined,
+  );
   return { props: { ssg: { meta: meta } } };
 };
 

--- a/apps/docs/src/pages/components/banner.mdx
+++ b/apps/docs/src/pages/components/banner.mdx
@@ -27,15 +27,17 @@ export const getStaticProps = async ({ params }) => {
     showIcon: {
       defaultValue: true,
     },
+    label: {
+      defaultValue: "This is an informational message.",
+    },
   }}
   componentProps={{
     open: true,
-    label: "This is an informational message.",
     style: { position: "relative", top: 0 },
   }}
 />
 
-### Aactions
+### Actions
 
 You can add a set of actions to the banner by specifying the `actions` prop. The `onAction` prop is a callback function that is called when an action is clicked.
 

--- a/apps/docs/src/pages/components/button.mdx
+++ b/apps/docs/src/pages/components/button.mdx
@@ -13,7 +13,7 @@ import Playground from "./Playground";
 import { getComponentData } from "../../utils/utils";
 
 export const getStaticProps = async ({ params }) => {
-  const meta = await getComponentData("Button", "core", buttonClasses);
+  const meta = await getComponentData("Button", "core", buttonClasses, null);
   return { props: { ssg: { meta: meta } } };
 };
 

--- a/apps/docs/src/pages/components/button.mdx
+++ b/apps/docs/src/pages/components/button.mdx
@@ -13,7 +13,12 @@ import Playground from "./Playground";
 import { getComponentData } from "../../utils/utils";
 
 export const getStaticProps = async ({ params }) => {
-  const meta = await getComponentData("Button", "core", buttonClasses, null);
+  const meta = await getComponentData(
+    "Button",
+    "core",
+    buttonClasses,
+    undefined,
+  );
   return { props: { ssg: { meta: meta } } };
 };
 

--- a/apps/docs/src/pages/components/card.mdx
+++ b/apps/docs/src/pages/components/card.mdx
@@ -1,0 +1,25 @@
+import { cardClasses, HvCard } from "@hitachivantara/uikit-react-core";
+
+import { Description } from "@docs/components/Description";
+import { Page } from "@docs/components/Page";
+
+import Playground from "./Playground";
+
+import { getComponentData } from "../../utils/utils";
+
+export const getStaticProps = async ({ params }) => {
+  const meta = await getComponentData("Card", "core", cardClasses, [
+    "Header",
+    "Content",
+    "Media",
+  ]);
+  return { props: { ssg: { meta: meta } } };
+};
+
+<Description />
+
+<Page>
+
+### Usage
+
+</Page>

--- a/apps/docs/src/pages/components/checkBox.mdx
+++ b/apps/docs/src/pages/components/checkBox.mdx
@@ -16,7 +16,7 @@ export const getStaticProps = async ({ params }) => {
     "CheckBox",
     "core",
     checkBoxClasses,
-    null,
+    undefined,
   );
   return { props: { ssg: { meta: meta } } };
 };

--- a/apps/docs/src/pages/components/checkBox.mdx
+++ b/apps/docs/src/pages/components/checkBox.mdx
@@ -12,7 +12,12 @@ import Playground from "./Playground";
 import { getComponentData } from "../../utils/utils";
 
 export const getStaticProps = async ({ params }) => {
-  const meta = await getComponentData("CheckBox", "core", checkBoxClasses);
+  const meta = await getComponentData(
+    "CheckBox",
+    "core",
+    checkBoxClasses,
+    null,
+  );
   return { props: { ssg: { meta: meta } } };
 };
 

--- a/apps/docs/src/pages/components/loading.mdx
+++ b/apps/docs/src/pages/components/loading.mdx
@@ -1,0 +1,89 @@
+import { HvLoading, loadingClasses } from "@hitachivantara/uikit-react-core";
+
+import { Description } from "@docs/components/Description";
+import { Page } from "@docs/components/Page";
+
+import Playground from "./Playground";
+
+import { getComponentData } from "../../utils/utils";
+
+export const getStaticProps = async ({ params }) => {
+  const meta = await getComponentData("Loading", "core", loadingClasses, null);
+  return { props: { ssg: { meta: meta } } };
+};
+
+<Description />
+
+<Page>
+
+<Playground
+  Component={HvLoading}
+  componentName="HvLoading"
+  controls={{
+    label: {
+      type: "string",
+      defaultValue: "Loading...",
+    },
+    small: {
+      defaultValue: false,
+    },
+  }}
+/>
+
+### Different colors
+
+You can change the default color of the loader by passing a color name from the UI Kit color palette, a CSS color name or a hex color code.
+
+```jsx live
+<>
+  <HvLoading color="positive" />
+  <HvLoading color="cat2" />
+  <HvLoading color="aquamarine" />
+  <HvLoading color="#c73aa8" />
+</>
+```
+
+### Button loaders
+
+You can use the loading component to create a button loader. Here is an example of a button that shows a loader when clicked.
+
+```jsx live
+import { useState } from "react";
+
+export default function Demo() {
+  const [isLoading, setIsLoading] = useState(false);
+
+  const handleClick = async () => {
+    await new Promise((resolve) => {
+      setTimeout(resolve, 2000);
+    });
+  };
+
+  return (
+    <HvButton
+      style={{ width: 120 }}
+      onClick={async (event) => {
+        setIsLoading(true);
+        await handleClick();
+        setIsLoading(false);
+      }}
+    >
+      {!isLoading ? (
+        "Submit"
+      ) : (
+        <HvLoading small hidden={!isLoading} color="inherit" />
+      )}
+    </HvButton>
+  );
+}
+```
+
+### Loading container
+
+If you need to show a loader over some content, please check the `HvLoadingContainer` component.
+
+### Skeleton loaders
+
+If you need to show a skeleton loader, please check the `HvSkeleton` component.
+
+</Page>

--- a/apps/docs/src/pages/components/loading.mdx
+++ b/apps/docs/src/pages/components/loading.mdx
@@ -8,7 +8,12 @@ import Playground from "./Playground";
 import { getComponentData } from "../../utils/utils";
 
 export const getStaticProps = async ({ params }) => {
-  const meta = await getComponentData("Loading", "core", loadingClasses, null);
+  const meta = await getComponentData(
+    "Loading",
+    "core",
+    loadingClasses,
+    undefined,
+  );
   return { props: { ssg: { meta: meta } } };
 };
 
@@ -80,10 +85,10 @@ export default function Demo() {
 
 ### Loading container
 
-If you need to show a loader over some content, please check the `HvLoadingContainer` component.
+If you need to show a loader over some content, please check the <a href="/components/loadingContainer">`HvLoadingContainer`</a> component.
 
 ### Skeleton loaders
 
-If you need to show a skeleton loader, please check the `HvSkeleton` component.
+If you need to show a skeleton loader, please check the <a href="/components/skeleton">`HvSkeleton`</a> component.
 
 </Page>

--- a/apps/docs/src/pages/components/loadingContainer.mdx
+++ b/apps/docs/src/pages/components/loadingContainer.mdx
@@ -1,0 +1,58 @@
+import {
+  HvLoadingContainer,
+  loadingContainerClasses,
+} from "@hitachivantara/uikit-react-core";
+
+import { Description } from "@docs/components/Description";
+import { Page } from "@docs/components/Page";
+
+import Playground from "./Playground";
+
+import { getComponentData } from "../../utils/utils";
+
+export const getStaticProps = async ({ params }) => {
+  const meta = await getComponentData(
+    "LoadingContainer",
+    "core",
+    loadingContainerClasses,
+    null,
+  );
+  return { props: { ssg: { meta: meta } } };
+};
+
+<Description />
+
+<Page>
+
+<Playground
+  Component={HvLoadingContainer}
+  componentName="HvLoadingContainer"
+  controls={{
+    hidden: {
+      type: "check",
+      defaultValue: false,
+    },
+    opacity: {
+      type: "string",
+      defaultValue: 0.8,
+    },
+  }}
+  children={
+    <div
+      style={{
+        height: 200,
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        backgroundColor: "lightgray",
+      }}
+    >
+      My content
+    </div>
+  }
+  componentProps={{
+    style: { width: "100%" },
+  }}
+/>
+
+</Page>

--- a/apps/docs/src/pages/components/loadingContainer.mdx
+++ b/apps/docs/src/pages/components/loadingContainer.mdx
@@ -15,7 +15,7 @@ export const getStaticProps = async ({ params }) => {
     "LoadingContainer",
     "core",
     loadingContainerClasses,
-    null,
+    undefined,
   );
   return { props: { ssg: { meta: meta } } };
 };

--- a/apps/docs/src/pages/globals.css
+++ b/apps/docs/src/pages/globals.css
@@ -86,3 +86,9 @@ body,
     @apply w-full;
   }
 }
+
+@media only screen and (max-width: 1024px) {
+  .nextra-toc {
+    display: none !important;
+  }
+}

--- a/apps/docs/src/pages/globals.css
+++ b/apps/docs/src/pages/globals.css
@@ -12,8 +12,8 @@ article > main h3._mt-8 {
   @apply mt-6;
 }
 
-article > main p:not(:first-child):not(:first-child) {
-  @apply mt-8px;
+article > main h3._mt-8 + p {
+  margin-top: 8px !important;
 }
 
 article > main p,

--- a/apps/docs/src/utils/utils.ts
+++ b/apps/docs/src/utils/utils.ts
@@ -110,7 +110,7 @@ export const getComponentData = async (
       package: packageName || "",
       docgen: cleanedDocgen || {},
       classes,
-      subComponents,
+      subComponents: subComponents || [],
       subComponentsDocgen: parsedSubComponents,
     } as Meta;
   } catch (error) {

--- a/packages/core/src/Button/Button.stories.tsx
+++ b/packages/core/src/Button/Button.stories.tsx
@@ -54,7 +54,7 @@ export const Variants: StoryObj<HvButtonProps> = {
       <HvButton variant="primary" radius="none">
         Primary
       </HvButton>
-      {/* <HvButton variant="primarySubtle">Primary Subtle</HvButton>
+      <HvButton variant="primarySubtle">Primary Subtle</HvButton>
       <HvButton variant="primaryGhost">Primary Ghost</HvButton>
       <HvButton disabled variant="primary">
         Disabled
@@ -83,7 +83,7 @@ export const Variants: StoryObj<HvButtonProps> = {
       </HvButton>
       <HvButton color="rebeccapurple" variant="ghost">
         Custom Ghost
-      </HvButton> */}
+      </HvButton>
     </>
   ),
 };

--- a/packages/core/src/Button/Button.stories.tsx
+++ b/packages/core/src/Button/Button.stories.tsx
@@ -51,8 +51,10 @@ export const Variants: StoryObj<HvButtonProps> = {
   ],
   render: () => (
     <>
-      <HvButton variant="primary">Primary</HvButton>
-      <HvButton variant="primarySubtle">Primary Subtle</HvButton>
+      <HvButton variant="primary" radius="none">
+        Primary
+      </HvButton>
+      {/* <HvButton variant="primarySubtle">Primary Subtle</HvButton>
       <HvButton variant="primaryGhost">Primary Ghost</HvButton>
       <HvButton disabled variant="primary">
         Disabled
@@ -81,7 +83,7 @@ export const Variants: StoryObj<HvButtonProps> = {
       </HvButton>
       <HvButton color="rebeccapurple" variant="ghost">
         Custom Ghost
-      </HvButton>
+      </HvButton> */}
     </>
   ),
 };

--- a/packages/core/src/Loading/Loading.stories.tsx
+++ b/packages/core/src/Loading/Loading.stories.tsx
@@ -39,7 +39,7 @@ export const Variants: StoryObj<HvLoadingProps> = {
     return (
       <>
         <HvLoading />
-        <HvLoading small />
+        <HvLoading small color="" />
         <HvLoading color="positive" />
         <HvLoading label="Loading" />
       </>


### PR DESCRIPTION
- Add props tables for sub-components
  - Prop search works for all tables in the page
  - If the component has sub-components then the description portion of the page will list them
- Added doc page for the `Loading` and `LoadingContainer` components
- Refactor the control renderer generation functionality
