### PR TITLE
fix(Tabs): disabled icon color & simplify styles overrides

### DIFF
--- a/packages/core/src/BaseCheckBox/BaseCheckBox.tsx
+++ b/packages/core/src/BaseCheckBox/BaseCheckBox.tsx
@@ -188,7 +188,6 @@ export const HvBaseCheckBox = forwardRef<
       onFocusVisible={onFocusVisibleCallback}
       onBlur={onBlurCallback}
       color="default"
-      disableRipple
       {...others}
     />
   );

--- a/packages/core/src/BaseRadio/BaseRadio.tsx
+++ b/packages/core/src/BaseRadio/BaseRadio.tsx
@@ -175,7 +175,6 @@ export const HvBaseRadio = forwardRef<HTMLButtonElement, HvBaseRadioProps>(
         disabled={disabled}
         required={required}
         readOnly={readOnly}
-        disableRipple
         onChange={onLocalChange}
         value={value}
         checked={checked}

--- a/packages/core/src/BaseSwitch/BaseSwitch.tsx
+++ b/packages/core/src/BaseSwitch/BaseSwitch.tsx
@@ -165,7 +165,6 @@ export const HvBaseSwitch = forwardRef<HTMLButtonElement, HvBaseSwitchProps>(
         disabled={disabled}
         required={required}
         readOnly={readOnly}
-        disableRipple
         onChange={onLocalChange}
         value={value}
         checked={checked}

--- a/packages/core/src/Tab/Tab.styles.tsx
+++ b/packages/core/src/Tab/Tab.styles.tsx
@@ -10,8 +10,7 @@ export const { staticClasses, useClasses } = createClasses("HvTab", {
     minWidth: 70,
     minHeight: 32,
     textTransform: "none",
-    fontFamily: theme.fontFamily.body,
-    ...(theme.typography.body as React.CSSProperties),
+    ...theme.typography.body,
     "&:hover": {
       backgroundColor: theme.colors.containerBackgroundHover,
       borderRadius: theme.radii.base,
@@ -21,10 +20,7 @@ export const { staticClasses, useClasses } = createClasses("HvTab", {
       },
     },
     "&$selected": {
-      color: theme.typography.label.color,
-      fontWeight: theme.typography.label.fontWeight,
-      lineHeight: theme.typography.label.lineHeight,
-      letterSpacing: theme.typography.label.letterSpacing,
+      ...theme.typography.label,
     },
     "&$disabled": {
       color: theme.colors.secondary_60,
@@ -48,6 +44,9 @@ export const { staticClasses, useClasses } = createClasses("HvTab", {
     // Override Mui styling: https://mui.com/material-ui/api/tab/#css
     "& .MuiTab-iconWrapper": {
       margin: 0,
+    },
+    "& svg .color0": {
+      fill: "currentcolor",
     },
   },
   focusVisible: {

--- a/packages/core/src/Tab/Tab.styles.tsx
+++ b/packages/core/src/Tab/Tab.styles.tsx
@@ -6,7 +6,7 @@ import { outlineStyles } from "../utils/focusUtils";
 export const { staticClasses, useClasses } = createClasses("HvTab", {
   root: {
     marginTop: "3px",
-    padding: "0 16px",
+    padding: theme.spacing(0, "sm"),
     minWidth: 70,
     minHeight: 32,
     textTransform: "none",
@@ -20,7 +20,7 @@ export const { staticClasses, useClasses } = createClasses("HvTab", {
       },
     },
     "&$selected": {
-      ...theme.typography.label,
+      fontWeight: theme.typography.label.fontWeight,
     },
     "&$disabled": {
       color: theme.colors.secondary_60,

--- a/packages/core/src/Tab/Tab.tsx
+++ b/packages/core/src/Tab/Tab.tsx
@@ -40,8 +40,6 @@ export const HvTab = (props: HvTabProps) => {
         selected: classes.selected,
         disabled: classes.disabled,
       }}
-      disableRipple
-      disableTouchRipple
       // expose the global class HvIsFocusVisible as a marker
       // not to be styled directly, only as helper in specific css queries
       focusVisibleClassName={cx("HvIsFocusVisible", classes.focusVisible)}

--- a/packages/core/src/Tabs/Tabs.stories.tsx
+++ b/packages/core/src/Tabs/Tabs.stories.tsx
@@ -239,12 +239,12 @@ export const Test: StoryObj = {
       <HvTabs value={0}>
         <HvTab label="Clickable tab 1" />
         <HvTab label="Clickable tab 2" />
-        <HvTab label="Clickable tab 3" />
+        <HvTab disabled label="Clickable tab 3" />
       </HvTabs>
       <HvTabs value={0} variant="fullWidth">
         <HvTab label="Clickable tab 1" />
         <HvTab label="Clickable tab 2" />
-        <HvTab label="Clickable tab 3" />
+        <HvTab disabled label="Clickable tab 3" />
       </HvTabs>
       <HvTabs value={0}>
         <HvTab
@@ -258,6 +258,7 @@ export const Test: StoryObj = {
           iconPosition="start"
         />
         <HvTab
+          disabled
           label="Clickable tab 3"
           icon={<DataStore />}
           iconPosition="start"
@@ -275,6 +276,7 @@ export const Test: StoryObj = {
           iconPosition="top"
         />
         <HvTab
+          disabled
           label="Clickable tab 3"
           icon={<Helicopter />}
           iconPosition="top"
@@ -283,7 +285,7 @@ export const Test: StoryObj = {
       <HvTabs value={0}>
         <HvTab icon={<Alert />} aria-label="Alert" />
         <HvTab icon={<Reload />} aria-label="Reload" />
-        <HvTab icon={<Calendar />} aria-label="Calendar" />
+        <HvTab disabled icon={<Calendar />} aria-label="Calendar" />
       </HvTabs>
       <HvTabs value={0}>
         <HvTab label={<HvBadge showCount count={2} text="Track events" />} />

--- a/packages/core/src/Tabs/Tabs.styles.tsx
+++ b/packages/core/src/Tabs/Tabs.styles.tsx
@@ -1,28 +1,16 @@
 import { createClasses } from "@hitachivantara/uikit-react-utils";
-import { theme } from "@hitachivantara/uikit-styles";
 
 export const { staticClasses, useClasses } = createClasses("HvTabs", {
   root: {
     minHeight: 0,
     overflow: "visible",
   },
-  indicator: {
-    display: "flex",
-    justifyContent: "center",
-    backgroundColor: "transparent",
-    "& > div": {
-      width: "100%",
-      backgroundColor: `${theme.colors.secondary}`,
-    },
-    height: 2,
-  },
+  indicator: {},
   scroller: {
     overflow: "visible !important",
   },
   flexContainer: {
-    "& button:first-of-type": {
-      marginLeft: "3px",
-    },
+    marginLeft: "3px",
   },
   floating: {},
 });

--- a/packages/core/src/Tabs/Tabs.tsx
+++ b/packages/core/src/Tabs/Tabs.tsx
@@ -48,13 +48,11 @@ export const HvTabs = (props: HvTabsProps) => {
   return (
     <Tabs
       classes={{
-        root: classes.root,
+        root: cx(classes.root, { [classes.floating]: floating }),
         flexContainer: classes.flexContainer,
         indicator: classes.indicator,
         scroller: classes.scroller,
       }}
-      TabIndicatorProps={{ children: <div /> }}
-      className={cx(floating && classes.floating)}
       {...others}
     />
   );

--- a/packages/core/src/providers/ThemeProvider.tsx
+++ b/packages/core/src/providers/ThemeProvider.tsx
@@ -125,6 +125,7 @@ export const HvThemeProvider = ({
         MuiButtonBase: {
           defaultProps: {
             disableRipple: true,
+            disableTouchRipple: true,
           },
         },
       },

--- a/packages/styles/src/themes/ds5.ts
+++ b/packages/styles/src/themes/ds5.ts
@@ -222,6 +222,15 @@ const ds5 = makeTheme((theme) => ({
         },
       },
     },
+    HvTab: {
+      classes: {
+        root: {
+          "&.HvTab-selected": {
+            color: theme.colors.secondary,
+          },
+        },
+      },
+    },
   } satisfies Record<string, Record<string, any> | { classes?: CSSProperties }>,
   header: {
     height: "64px",

--- a/packages/styles/src/themes/pentahoPlus.ts
+++ b/packages/styles/src/themes/pentahoPlus.ts
@@ -1047,24 +1047,8 @@ const pentahoPlus = makeTheme((theme) => ({
     HvFooter: {
       name: "Pentaho+",
     },
-    HvTab: {
-      classes: {
-        root: {
-          paddingLeft: 16,
-          paddingRight: 16,
-          "&.HvTab-selected": {
-            color: theme.colors.primary,
-          },
-        },
-      },
-    },
     HvTabs: {
       classes: {
-        indicator: {
-          "& > div": {
-            backgroundColor: `${theme.colors.primary}`,
-          },
-        },
         floating: {
           "& .HvTab-root": {
             marginTop: 0,

--- a/packages/styles/src/themes/pentahoPlus.ts
+++ b/packages/styles/src/themes/pentahoPlus.ts
@@ -1052,9 +1052,6 @@ const pentahoPlus = makeTheme((theme) => ({
         root: {
           paddingLeft: 16,
           paddingRight: 16,
-          "& svg *.color0": {
-            fill: "currentcolor",
-          },
           "&.HvTab-selected": {
             color: theme.colors.primary,
           },


### PR DESCRIPTION
- fix disabled icon colors
- simplify styles overrides in `Tab` (inherited to `primary` color) & align DS5 color
- cleanup `disableRipple` instances already set in `HvProvider`