### PR TITLE
chore: add animation to tab change in floating mode

### DIFF
--- a/packages/styles/src/themes/pentahoPlus.ts
+++ b/packages/styles/src/themes/pentahoPlus.ts
@@ -1052,6 +1052,11 @@ const pentahoPlus = makeTheme((theme) => ({
         floating: {
           "& .HvTab-root": {
             marginTop: 0,
+            zIndex: 1,
+            "&:is(.HvTab-selected)": {
+              borderColor: "transparent",
+              backgroundColor: "transparent",
+            },
             "&:hover": {
               borderRadius: theme.radii.full,
             },
@@ -1059,21 +1064,17 @@ const pentahoPlus = makeTheme((theme) => ({
               display: "none",
             },
           },
-          "& .HvTab-selected": {
+          "& .HvTabs-indicator": {
+            height: "100%",
+            backgroundColor: theme.colors.pp.bgSurface,
             border: `1px solid ${theme.colors.primary}`,
             borderRadius: theme.radii.full,
-            backgroundColor: theme.colors.pp.bgSurface,
-          },
-          "& .HvTabs-indicator": {
-            display: "none",
           },
           "& .HvTabs-flexContainer": {
             display: "inline-flex",
             backgroundColor: theme.colors.pp.bgActive,
             borderRadius: theme.radii.full,
-            "& button:first-of-type": {
-              marginLeft: 0,
-            },
+            marginLeft: 0,
           },
         },
       },


### PR DESCRIPTION
updated the floating variant to use the underlying tab selected indicator animation to keep consistency with remaining tabs