### PR TITLE
fix: Section actions alignment & Panel borderRadius

### DIFF
--- a/packages/core/src/Panel/Panel.styles.tsx
+++ b/packages/core/src/Panel/Panel.styles.tsx
@@ -7,5 +7,6 @@ export const { useClasses, staticClasses } = createClasses("HvPanel", {
     padding: theme.space.sm,
     backgroundColor: theme.colors.atmo1,
     overflow: "auto",
+    borderRadius: "inherit",
   },
 });

--- a/packages/core/src/Section/Section.styles.tsx
+++ b/packages/core/src/Section/Section.styles.tsx
@@ -19,21 +19,25 @@ export const { staticClasses, useClasses } = createClasses("HvSection", {
     padding: theme.space.sm,
   },
   content: {
-    padding: theme.spacing(0, "sm", "sm", "sm"),
+    padding: theme.space.sm,
+    borderRadius: "inherit",
   },
-  spaceTop: {
-    paddingTop: theme.space.sm,
+  hasHeader: {
+    paddingTop: 0,
   },
+  /** @deprecated use `hasHeader` instead */
+  spaceTop: {},
   actions: {
     display: "flex",
     gap: theme.space.xs,
-    position: "absolute",
-    right: 0,
+    marginLeft: "auto",
   },
   raisedHeader: {
-    zIndex: 1,
-    boxShadow: theme.colors.shadow,
-    "+ div": {
+    "& $header": {
+      zIndex: 1,
+      boxShadow: theme.colors.shadow,
+    },
+    "& $content": {
       paddingTop: theme.space.sm,
     },
   },

--- a/packages/core/src/Section/Section.tsx
+++ b/packages/core/src/Section/Section.tsx
@@ -70,21 +70,19 @@ export const HvSection = forwardRef<HTMLDivElement, HvSectionProps>(
       defaultExpanded,
     });
 
-    const showContent = expandable ? !!isOpen : true;
+    const hasHeader = title || actions || expandable;
 
     return (
       <div
         ref={ref}
         id={id}
-        className={cx(classes.root, className)}
+        className={cx(classes.root, className, {
+          [classes.raisedHeader]: raisedHeader && isOpen,
+        })}
         {...others}
       >
-        {(title || actions || expandable) && (
-          <div
-            className={cx(classes.header, {
-              [classes.raisedHeader]: raisedHeader && isOpen,
-            })}
-          >
+        {hasHeader && (
+          <div className={classes.header}>
             {expandable && (
               <HvButton
                 icon
@@ -107,8 +105,9 @@ export const HvSection = forwardRef<HTMLDivElement, HvSectionProps>(
           ref={contentRef}
           hidden={!isOpen}
           className={cx(classes.content, {
-            [classes.hidden]: !showContent,
-            [classes.spaceTop]: !(title || actions || expandable),
+            [classes.hidden]: expandable && !isOpen,
+            [classes.spaceTop]: !hasHeader,
+            [classes.hasHeader]: hasHeader,
           })}
           {...(expandable && regionProps)}
         >

--- a/packages/core/src/Snackbar/Snackbar.tsx
+++ b/packages/core/src/Snackbar/Snackbar.tsx
@@ -128,9 +128,7 @@ export const HvSnackbar = ({
   return (
     <MuiSnackbar
       style={
-        anchorOriginOffset[
-          `anchorOrigin${capitalize(anchorOrigin.vertical)}` as keyof typeof anchorOriginOffset
-        ]
+        anchorOriginOffset[`anchorOrigin${capitalize(anchorOrigin.vertical)}`]
       }
       classes={classes}
       className={className}

--- a/packages/core/src/Table/TableCell/TableCell.tsx
+++ b/packages/core/src/Table/TableCell/TableCell.tsx
@@ -96,16 +96,13 @@ export const HvTableCell = forwardRef<HTMLElement, HvTableCellProps>(
         style={style}
         className={cx(
           classes.root,
-          classes[type as keyof HvTableCellClasses],
+          classes[type],
+          align !== "inherit" && classes[`align${capitalize(align)}`],
+          variant !== "default" && classes[`variant${capitalize(variant)}`],
           {
-            [classes[`align${capitalize(align)}` as keyof HvTableCellClasses]]:
-              align !== "inherit",
             [classes.variantList]: tableContext.variant === "listrow",
             [classes.variantListHead]:
               tableContext.variant === "listrow" && type !== "body",
-            [classes[
-              `variant${capitalize(variant)}` as keyof HvTableCellClasses
-            ]]: variant !== "default",
             [classes.sorted]: sorted,
             [classes.stickyColumn]: stickyColumn,
             [classes.stickyColumnMostLeft]: stickyColumnMostLeft,

--- a/packages/core/src/Table/TableHeader/TableHeader.tsx
+++ b/packages/core/src/Table/TableHeader/TableHeader.tsx
@@ -140,7 +140,7 @@ export const HvTableHeader = forwardRef<HTMLElement, HvTableHeaderProps>(
         style={style}
         className={cx(
           classes.root,
-          classes[type as keyof HvTableHeaderClasses],
+          classes[type],
           type === "body" &&
             css({
               [`&.${staticClasses.sorted}`]: {
@@ -150,6 +150,8 @@ export const HvTableHeader = forwardRef<HTMLElement, HvTableHeaderProps>(
                 ),
               },
             }),
+          align !== "inherit" && classes[`align${capitalize(align)}`],
+          variant !== "default" && classes[`variant${capitalize(variant)}`],
           {
             [classes.groupColumnMostLeft]: groupColumnMostLeft,
             [classes.groupColumnMostRight]: groupColumnMostRight,
@@ -161,12 +163,6 @@ export const HvTableHeader = forwardRef<HTMLElement, HvTableHeaderProps>(
             [classes.stickyColumnMostLeft]: stickyColumnMostLeft,
             [classes.stickyColumnLeastRight]: stickyColumnLeastRight,
             [classes.variantList]: tableContext.variant === "listrow",
-            [classes[
-              `align${capitalize(align)}` as keyof HvTableHeaderClasses
-            ]]: align !== "inherit",
-            [classes[
-              `variant${capitalize(variant)}` as keyof HvTableHeaderClasses
-            ]]: variant !== "default",
           },
           className,
         )}
@@ -174,11 +170,10 @@ export const HvTableHeader = forwardRef<HTMLElement, HvTableHeaderProps>(
         {...others}
       >
         <div
-          className={cx(classes.headerContent, {
-            [classes[
-              `alignFlex${capitalize(align)}` as keyof HvTableHeaderClasses
-            ]]: align !== "inherit",
-          })}
+          className={cx(
+            classes.headerContent,
+            align !== "inherit" && classes[`alignFlex${capitalize(align)}`],
+          )}
         >
           {isHeadCell && sortable && (
             <HvButton

--- a/packages/core/src/TableSection/TableSection.styles.tsx
+++ b/packages/core/src/TableSection/TableSection.styles.tsx
@@ -12,11 +12,13 @@ export const { staticClasses, useClasses } = createClasses("HvTableSection", {
   root: {},
   header: {
     // Only apply the border to divide the header and content when both are displayed
-    "+ div": { borderTop: `1px solid ${theme.colors.atmo3}` },
+    "+ div": {
+      borderTop: `1px solid ${theme.colors.atmo3}`,
+      borderTopLeftRadius: 0,
+      borderTopRightRadius: 0,
+    },
   },
-  actions: {
-    right: theme.space.sm,
-  },
+  actions: {},
   content: {
     marginTop: 0,
     padding: 0,
@@ -94,9 +96,11 @@ export const { staticClasses, useClasses } = createClasses("HvTableSection", {
   },
   hidden: {},
   raisedHeader: {
-    "+ div": {
+    "& $content": {
       paddingTop: 0,
     },
   },
-  spaceTop: { paddingTop: 0 },
+  hasHeader: {},
+  /** @deprecated use `hasHeader` instead */
+  spaceTop: {},
 });

--- a/packages/core/src/TableSection/TableSection.styles.tsx
+++ b/packages/core/src/TableSection/TableSection.styles.tsx
@@ -24,14 +24,14 @@ export const { staticClasses, useClasses } = createClasses("HvTableSection", {
     // Apply border radius to the first child if there's not an header
     "&:first-of-type": {
       "& > :first-of-type": {
-        borderTopLeftRadius: theme.radii.round,
-        borderTopRightRadius: theme.radii.round,
+        borderTopLeftRadius: "inherit",
+        borderTopRightRadius: "inherit",
       },
     },
 
     "& > :last-child": {
-      borderBottomLeftRadius: theme.radii.round,
-      borderBottomRightRadius: theme.radii.round,
+      borderBottomLeftRadius: "inherit",
+      borderBottomRightRadius: "inherit",
     },
 
     [`& .${tableContainerClasses.root}`]: {

--- a/packages/core/src/utils/helpers.ts
+++ b/packages/core/src/utils/helpers.ts
@@ -6,8 +6,8 @@ export const range = (length: number, start = 0) => {
   return Array.from({ length: length - start }, (_, i) => i + start);
 };
 
-export const capitalize = (string = "") => {
-  return string.charAt(0).toUpperCase() + string.slice(1).toLowerCase();
+export const capitalize = <T extends string>(string: T) => {
+  return (string.charAt(0).toUpperCase() + string.slice(1)) as Capitalize<T>;
 };
 
 export function isEqual(obj1: unknown, obj2: unknown) {

--- a/packages/styles/src/utils.ts
+++ b/packages/styles/src/utils.ts
@@ -9,7 +9,7 @@ import type {
 export const spacingUtil = (value: SpacingValue, vars: HvThemeVars): string => {
   switch (typeof value) {
     case "number":
-      return `calc(${vars.space.base} * ${value}px)`;
+      return value === 0 ? "0" : `calc(${vars.space.base} * ${value}px)`;
     case "string":
       return vars.space[value as HvThemeBreakpoint] || value;
     default:


### PR DESCRIPTION
- change `HvPanel` to inherit `borderRadius`
- fix `HvSection` actions alignment (right padding, `absolute` > `flex`)
  - also rename `spaceTop` > `hasHeader`
- improve `theme.spacing` calc for `0` case value (`0` instead of `calc(0 * var(--theme-space-unit))`)
- improve `capitalize` value inference, to get rid of some `as` casts

![image](https://github.com/user-attachments/assets/597cc810-4e63-4040-9010-3553ec8c3b5a)

![image](https://github.com/user-attachments/assets/fecc06d7-6081-42d3-bb4e-250e9d8528f2)
