### PR TITLE
fix: add `forwardRef` & name to components

### DIFF
--- a/docs/overview/community/ComponentGuidelines.mdx
+++ b/docs/overview/community/ComponentGuidelines.mdx
@@ -115,7 +115,11 @@ export interface HvCompProps extends HvBaseProps<HTMLDivElement> {
 
 // 👇 Add a JSDoc block to the component explaining its purpose
 /** HvComp does some amazing stuff */
-export const HvComp = forwardRef<HTMLDivElement, HvCompProps>((props, ref) => {
+export const HvComp = forwardRef<
+  // no-indent
+  React.ComponentRef<"div">,
+  HvCompProps
+>(function HvComp(props, ref) {
   const {
     children,
     // fix collisions 👇 by renaming to `<x>Prop`

--- a/packages/core/src/Accordion/Accordion.tsx
+++ b/packages/core/src/Accordion/Accordion.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from "react";
+import { forwardRef, useCallback, useMemo } from "react";
 import { DropUpXS } from "@hitachivantara/uikit-react-icons";
 import {
   useDefaultProps,
@@ -44,9 +44,12 @@ export interface HvAccordionProps
 /**
  * A accordion is a design element that expands in place to expose hidden information.
  */
-export const HvAccordion = (props: HvAccordionProps) => {
+export const HvAccordion = forwardRef<
+  React.ComponentRef<"div">,
+  HvAccordionProps
+>((props, ref) => {
   const {
-    id: idProp,
+    id,
     className,
     classes: classesProp,
     disabled = false,
@@ -64,7 +67,7 @@ export const HvAccordion = (props: HvAccordionProps) => {
   const { classes, cx } = useClasses(classesProp);
 
   const { isOpen, toggleOpen, buttonProps, regionProps } = useExpandable({
-    id: idProp,
+    id,
     expanded,
     disabled,
     defaultExpanded,
@@ -123,7 +126,7 @@ export const HvAccordion = (props: HvAccordionProps) => {
   ]);
 
   return (
-    <div id={idProp} className={cx(classes.root, className)} {...others}>
+    <div ref={ref} id={id} className={cx(classes.root, className)} {...others}>
       {accordionHeader}
       <div
         className={cx(classes.container, { [classes.hidden]: !isOpen })}
@@ -135,4 +138,4 @@ export const HvAccordion = (props: HvAccordionProps) => {
       </div>
     </div>
   );
-};
+});

--- a/packages/core/src/Accordion/Accordion.tsx
+++ b/packages/core/src/Accordion/Accordion.tsx
@@ -47,7 +47,7 @@ export interface HvAccordionProps
 export const HvAccordion = forwardRef<
   React.ComponentRef<"div">,
   HvAccordionProps
->((props, ref) => {
+>(function HvAccordion(props, ref) {
   const {
     id,
     className,

--- a/packages/core/src/ActionBar/ActionBar.tsx
+++ b/packages/core/src/ActionBar/ActionBar.tsx
@@ -1,3 +1,4 @@
+import { forwardRef } from "react";
 import {
   useDefaultProps,
   type ExtractNames,
@@ -15,7 +16,10 @@ export interface HvActionBarProps extends HvBaseProps {
   classes?: HvActionBarClasses;
 }
 
-export const HvActionBar = (props: HvActionBarProps) => {
+export const HvActionBar = forwardRef<
+  React.ComponentRef<"div">,
+  HvActionBarProps
+>((props, ref) => {
   const {
     classes: classesProp,
     className,
@@ -25,8 +29,8 @@ export const HvActionBar = (props: HvActionBarProps) => {
   const { classes, cx } = useClasses(classesProp);
 
   return (
-    <div className={cx(classes.root, className)} {...others}>
+    <div ref={ref} className={cx(classes.root, className)} {...others}>
       {children}
     </div>
   );
-};
+});

--- a/packages/core/src/ActionBar/ActionBar.tsx
+++ b/packages/core/src/ActionBar/ActionBar.tsx
@@ -19,7 +19,7 @@ export interface HvActionBarProps extends HvBaseProps {
 export const HvActionBar = forwardRef<
   React.ComponentRef<"div">,
   HvActionBarProps
->((props, ref) => {
+>(function HvActionBar(props, ref) {
   const {
     classes: classesProp,
     className,

--- a/packages/core/src/ActionsGeneric/ActionsGeneric.tsx
+++ b/packages/core/src/ActionsGeneric/ActionsGeneric.tsx
@@ -69,7 +69,7 @@ export interface HvActionsGenericProps extends HvBaseProps {
 export const HvActionsGeneric = forwardRef<
   React.ComponentRef<"div">,
   HvActionsGenericProps
->((props, ref) => {
+>(function HvActionsGeneric(props, ref) {
   const {
     id: idProp,
     classes: classesProp,

--- a/packages/core/src/ActionsGeneric/ActionsGeneric.tsx
+++ b/packages/core/src/ActionsGeneric/ActionsGeneric.tsx
@@ -1,4 +1,4 @@
-import { isValidElement } from "react";
+import { forwardRef, isValidElement } from "react";
 import { MoreOptionsVertical } from "@hitachivantara/uikit-react-icons";
 import {
   useDefaultProps,
@@ -66,7 +66,10 @@ export interface HvActionsGenericProps extends HvBaseProps {
   classes?: HvActionsGenericClasses;
 }
 
-export const HvActionsGeneric = (props: HvActionsGenericProps) => {
+export const HvActionsGeneric = forwardRef<
+  React.ComponentRef<"div">,
+  HvActionsGenericProps
+>((props, ref) => {
   const {
     id: idProp,
     classes: classesProp,
@@ -182,6 +185,7 @@ export const HvActionsGeneric = (props: HvActionsGenericProps) => {
 
   return (
     <div
+      ref={ref}
       className={cx(
         classes.root,
         { [classes.actionContainer]: actionOverflow },
@@ -194,4 +198,4 @@ export const HvActionsGeneric = (props: HvActionsGenericProps) => {
         : actions.map((action, idx) => renderButton(action, idx))}
     </div>
   );
-};
+});

--- a/packages/core/src/AppSwitcher/AppSwitcher.tsx
+++ b/packages/core/src/AppSwitcher/AppSwitcher.tsx
@@ -49,7 +49,7 @@ export interface HvAppSwitcherProps extends HvBaseProps {
 export const HvAppSwitcher = forwardRef<
   React.ComponentRef<typeof HvPanel>,
   HvAppSwitcherProps
->((props, ref) => {
+>(function HvAppSwitcher(props, ref) {
   const {
     className,
     classes: classesProp,

--- a/packages/core/src/AppSwitcher/AppSwitcher.tsx
+++ b/packages/core/src/AppSwitcher/AppSwitcher.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { forwardRef, useMemo } from "react";
 import {
   useDefaultProps,
   type ExtractNames,
@@ -46,7 +46,10 @@ export interface HvAppSwitcherProps extends HvBaseProps {
   classes?: HvAppSwitcherClasses;
 }
 
-export const HvAppSwitcher = (props: HvAppSwitcherProps) => {
+export const HvAppSwitcher = forwardRef<
+  React.ComponentRef<typeof HvPanel>,
+  HvAppSwitcherProps
+>((props, ref) => {
   const {
     className,
     classes: classesProp,
@@ -92,6 +95,7 @@ export const HvAppSwitcher = (props: HvAppSwitcherProps) => {
 
   return (
     <HvPanel
+      ref={ref}
       className={cx(
         classes.root,
         classes[layout],
@@ -133,4 +137,4 @@ export const HvAppSwitcher = (props: HvAppSwitcherProps) => {
       )}
     </HvPanel>
   );
-};
+});

--- a/packages/core/src/Avatar/Avatar.tsx
+++ b/packages/core/src/Avatar/Avatar.tsx
@@ -65,7 +65,11 @@ export interface HvAvatarProps extends HvBaseProps {
  * Avatars can be used to represent a user or a brand.
  * They can show an image, an icon or the initial letters of a name, for example.
  */
-export const HvAvatar = forwardRef<any, HvAvatarProps>((props, ref) => {
+export const HvAvatar = forwardRef<
+  // no-indent
+  React.ComponentRef<"div">,
+  HvAvatarProps
+>((props, ref) => {
   const {
     className,
     style,

--- a/packages/core/src/Avatar/Avatar.tsx
+++ b/packages/core/src/Avatar/Avatar.tsx
@@ -69,7 +69,7 @@ export const HvAvatar = forwardRef<
   // no-indent
   React.ComponentRef<"div">,
   HvAvatarProps
->((props, ref) => {
+>(function HvAvatar(props, ref) {
   const {
     className,
     style,

--- a/packages/core/src/AvatarGroup/AvatarGroup.tsx
+++ b/packages/core/src/AvatarGroup/AvatarGroup.tsx
@@ -138,7 +138,7 @@ const Overflow = ({
  * The AvatarGroup component is used to group multiple avatars.
  */
 export const HvAvatarGroup = forwardRef<HTMLDivElement, HvAvatarGroupProps>(
-  (props, ref) => {
+  function HvAvatarGroup(props, ref) {
     const {
       className,
       style,

--- a/packages/core/src/Badge/Badge.tsx
+++ b/packages/core/src/Badge/Badge.tsx
@@ -51,7 +51,7 @@ export const HvBadge = forwardRef<
   // no-indent
   HTMLDivElement,
   HvBadgeProps
->((props, ref) => {
+>(function HvBadge(props, ref) {
   const {
     classes: classesProp,
     className,

--- a/packages/core/src/Banner/Banner.tsx
+++ b/packages/core/src/Banner/Banner.tsx
@@ -77,7 +77,7 @@ export interface HvBannerProps
 export const HvBanner = forwardRef<
   React.ComponentRef<typeof Snackbar>,
   HvBannerProps
->((props, ref) => {
+>(function HvBanner(props, ref) {
   const {
     id,
     classes: classesProp,

--- a/packages/core/src/Banner/Banner.tsx
+++ b/packages/core/src/Banner/Banner.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from "react";
+import { forwardRef, useCallback } from "react";
 import Slide, { SlideProps } from "@mui/material/Slide";
 import Snackbar, {
   SnackbarProps as MuiSnackbarProps,
@@ -74,7 +74,10 @@ export interface HvBannerProps
  * A Banner displays an important and succinct message. It can also provide actions for the user to address, or dismiss.
  * It requires a user action, for it to be dismissed. Banners should appear at the top of the screen, below a top app bar.
  */
-export const HvBanner = (props: HvBannerProps) => {
+export const HvBanner = forwardRef<
+  React.ComponentRef<typeof Snackbar>,
+  HvBannerProps
+>((props, ref) => {
   const {
     id,
     classes: classesProp,
@@ -119,6 +122,7 @@ export const HvBanner = (props: HvBannerProps) => {
 
   return (
     <Snackbar
+      ref={ref}
       id={id}
       open={open}
       className={className}
@@ -148,4 +152,4 @@ export const HvBanner = (props: HvBannerProps) => {
       />
     </Snackbar>
   );
-};
+});

--- a/packages/core/src/Banner/BannerContent/BannerContent.tsx
+++ b/packages/core/src/Banner/BannerContent/BannerContent.tsx
@@ -46,7 +46,7 @@ export interface HvBannerContentProps
 }
 
 export const HvBannerContent = forwardRef<HTMLDivElement, HvBannerContentProps>(
-  (props, ref) => {
+  function HvBannerContent(props, ref) {
     const {
       id,
       classes: classesProp,

--- a/packages/core/src/BaseCheckBox/BaseCheckBox.tsx
+++ b/packages/core/src/BaseCheckBox/BaseCheckBox.tsx
@@ -103,7 +103,7 @@ const getSelectorIcons = () => {
 export const HvBaseCheckBox = forwardRef<
   HTMLButtonElement,
   HvBaseCheckBoxProps
->((props, ref) => {
+>(function HvBaseCheckBox(props, ref) {
   const {
     id,
     classes: classesProp,

--- a/packages/core/src/BaseDropdown/BaseDropdown.tsx
+++ b/packages/core/src/BaseDropdown/BaseDropdown.tsx
@@ -421,7 +421,7 @@ const BaseDropdown = forwardRef<
 });
 
 export const HvBaseDropdown = forwardRef<HTMLDivElement, HvBaseDropdownProps>(
-  (props, ref) => {
+  function HvBaseDropdown(props, ref) {
     const {
       popperProps = {},
       variableWidth,

--- a/packages/core/src/BaseInput/BaseInput.tsx
+++ b/packages/core/src/BaseInput/BaseInput.tsx
@@ -1,10 +1,11 @@
-import { useContext } from "react";
+import { forwardRef, useContext } from "react";
 import { css as emotionCss, Global } from "@emotion/react";
 import MuiInput, { InputProps as MuiInputProps } from "@mui/material/Input";
 import {
   InputBaseProps,
   InputBaseComponentProps as MuiInputBaseComponentProps,
 } from "@mui/material/InputBase";
+import { useForkRef } from "@mui/material/utils";
 import {
   useDefaultProps,
   type ExtractNames,
@@ -52,7 +53,7 @@ const baseInputStyles = emotionCss({
 });
 
 export interface HvBaseInputProps
-  extends Omit<MuiInputProps, "onChange" | "classes"> {
+  extends Omit<MuiInputProps, "onChange" | "classes" | "ref"> {
   /** The input name. */
   name?: string;
   /** The value of the input, when controlled. */
@@ -93,7 +94,11 @@ export interface HvBaseInputProps
  * An Input component that only posses the most basic functionalities.
  * It should be used alongside the other form elements to construct a proper accessible form.
  */
-export const HvBaseInput = (props: HvBaseInputProps) => {
+export const HvBaseInput = forwardRef<
+  // no-indent
+  unknown,
+  HvBaseInputProps
+>(function HvBaseInput(props, ref) {
   const {
     classes: classesProp,
     className = "",
@@ -123,6 +128,8 @@ export const HvBaseInput = (props: HvBaseInputProps) => {
     required,
     formElementContext,
   );
+
+  const forkedRef = useForkRef(ref, inputRef);
 
   const localInvalid = invalid || formElementProps.status === "invalid";
 
@@ -182,7 +189,7 @@ export const HvBaseInput = (props: HvBaseInputProps) => {
             ...inputProps,
             ...ariaProps,
           }}
-          inputRef={inputRef}
+          inputRef={forkedRef}
           multiline={multiline}
           rows={10}
           {...others}
@@ -193,4 +200,4 @@ export const HvBaseInput = (props: HvBaseInputProps) => {
       </div>
     </>
   );
-};
+});

--- a/packages/core/src/BaseRadio/BaseRadio.tsx
+++ b/packages/core/src/BaseRadio/BaseRadio.tsx
@@ -99,7 +99,7 @@ export const getSelectorIcons = () => {
  * use unless implementing a custom use case not covered by the Radio Button form element.
  */
 export const HvBaseRadio = forwardRef<HTMLButtonElement, HvBaseRadioProps>(
-  (props, ref) => {
+  function HvBaseRadio(props, ref) {
     const {
       classes: classesProp,
       className,

--- a/packages/core/src/BaseSwitch/BaseSwitch.tsx
+++ b/packages/core/src/BaseSwitch/BaseSwitch.tsx
@@ -90,7 +90,7 @@ export interface HvBaseSwitchProps
  * implementing a custom use case not covered by the Switch form element.
  */
 export const HvBaseSwitch = forwardRef<HTMLButtonElement, HvBaseSwitchProps>(
-  (props, ref) => {
+  function HvBaseSwitch(props, ref) {
     const {
       classes: classesProp,
       className,

--- a/packages/core/src/BreadCrumb/BreadCrumb.tsx
+++ b/packages/core/src/BreadCrumb/BreadCrumb.tsx
@@ -1,4 +1,4 @@
-import { isValidElement } from "react";
+import { forwardRef, isValidElement } from "react";
 import {
   useDefaultProps,
   type ExtractNames,
@@ -38,7 +38,10 @@ export interface HvBreadCrumbProps
 /**
  * A breadcrumb is a graphical control element frequently used as a navigational aid.
  */
-export const HvBreadCrumb = (props: HvBreadCrumbProps) => {
+export const HvBreadCrumb = forwardRef<
+  React.ComponentRef<"nav">,
+  HvBreadCrumbProps
+>((props, ref) => {
   const {
     classes: classesProp,
     className,
@@ -86,7 +89,7 @@ export const HvBreadCrumb = (props: HvBreadCrumbProps) => {
       : listPath;
 
   return (
-    <nav id={id} className={cx(classes.root, className)} {...others}>
+    <nav ref={ref} id={id} className={cx(classes.root, className)} {...others}>
       <ol className={classes.orderedList}>
         {listPath.map((elem, index) => {
           const key = `key_${index}`;
@@ -123,4 +126,4 @@ export const HvBreadCrumb = (props: HvBreadCrumbProps) => {
       </ol>
     </nav>
   );
-};
+});

--- a/packages/core/src/BreadCrumb/BreadCrumb.tsx
+++ b/packages/core/src/BreadCrumb/BreadCrumb.tsx
@@ -41,7 +41,7 @@ export interface HvBreadCrumbProps
 export const HvBreadCrumb = forwardRef<
   React.ComponentRef<"nav">,
   HvBreadCrumbProps
->((props, ref) => {
+>(function HvBreadCrumb(props, ref) {
   const {
     classes: classesProp,
     className,

--- a/packages/core/src/BulkActions/BulkActions.tsx
+++ b/packages/core/src/BulkActions/BulkActions.tsx
@@ -63,7 +63,7 @@ export interface HvBulkActionsProps extends HvBaseProps {
 export const HvBulkActions = forwardRef<
   React.ComponentRef<"div">,
   HvBulkActionsProps
->((props, ref) => {
+>(function HvBulkActions(props, ref) {
   const {
     id,
     className,

--- a/packages/core/src/BulkActions/BulkActions.tsx
+++ b/packages/core/src/BulkActions/BulkActions.tsx
@@ -1,3 +1,4 @@
+import { forwardRef } from "react";
 import {
   useDefaultProps,
   useTheme,
@@ -59,7 +60,10 @@ export interface HvBulkActionsProps extends HvBaseProps {
  * Bulk Actions allow users to perform an action on a single or multiple items.
  * Also known as "batch production" of multiple items at once, one stage at a time.
  */
-export const HvBulkActions = (props: HvBulkActionsProps) => {
+export const HvBulkActions = forwardRef<
+  React.ComponentRef<"div">,
+  HvBulkActionsProps
+>((props, ref) => {
   const {
     id,
     className,
@@ -111,6 +115,7 @@ export const HvBulkActions = (props: HvBulkActionsProps) => {
 
   return (
     <div
+      ref={ref}
       id={id}
       className={cx(
         classes.root,
@@ -165,4 +170,4 @@ export const HvBulkActions = (props: HvBulkActionsProps) => {
       />
     </div>
   );
-};
+});

--- a/packages/core/src/Card/Card.tsx
+++ b/packages/core/src/Card/Card.tsx
@@ -1,3 +1,4 @@
+import { forwardRef } from "react";
 import {
   mergeStyles,
   useDefaultProps,
@@ -36,7 +37,11 @@ export interface HvCardProps extends HvBaseProps {
  * linked short representation of a conceptual unit. For that reason,
  * this pattern must be used as an entry-point for further information.
  */
-export const HvCard = (props: HvCardProps) => {
+export const HvCard = forwardRef<
+  // no-indent
+  React.ComponentRef<"div">,
+  HvCardProps
+>((props) => {
   const {
     classes: classesProp,
     style,
@@ -82,4 +87,4 @@ export const HvCard = (props: HvCardProps) => {
       {children}
     </div>
   );
-};
+});

--- a/packages/core/src/Carousel/Carousel.tsx
+++ b/packages/core/src/Carousel/Carousel.tsx
@@ -1,4 +1,11 @@
-import { Children, useCallback, useEffect, useRef, useState } from "react";
+import {
+  Children,
+  forwardRef,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
 import useCarousel from "embla-carousel-react";
 import {
   Backwards,
@@ -83,7 +90,10 @@ export interface HvCarouselProps
  * A Carousel is commonly used to browse images, it can also be used to browse any kind of content like text, video, or charts.
  * It allows you to focus on a particular content while having a notion of how many you have to explore.
  */
-export const HvCarousel = (props: HvCarouselProps) => {
+export const HvCarousel = forwardRef<
+  React.ComponentRef<typeof HvContainer>,
+  HvCarouselProps
+>((props, ref) => {
   const {
     className,
     classes: classesProp,
@@ -245,6 +255,7 @@ export const HvCarousel = (props: HvCarouselProps) => {
 
   return (
     <HvContainer
+      ref={ref}
       className={cx(classes.root, className, {
         [classes.xs]: xs,
         [classes.fullscreen]: isFullscreen,
@@ -309,4 +320,4 @@ export const HvCarousel = (props: HvCarouselProps) => {
       {thumbnailsPosition === "bottom" && thumbnails}
     </HvContainer>
   );
-};
+});

--- a/packages/core/src/Carousel/Carousel.tsx
+++ b/packages/core/src/Carousel/Carousel.tsx
@@ -93,7 +93,7 @@ export interface HvCarouselProps
 export const HvCarousel = forwardRef<
   React.ComponentRef<typeof HvContainer>,
   HvCarouselProps
->((props, ref) => {
+>(function HvCarousel(props, ref) {
   const {
     className,
     classes: classesProp,

--- a/packages/core/src/Carousel/CarouselThumbnails.tsx
+++ b/packages/core/src/Carousel/CarouselThumbnails.tsx
@@ -24,7 +24,7 @@ interface HvCarouselThumbnailsProps
 export const HvCarouselThumbnails = forwardRef<
   HTMLDivElement,
   HvCarouselThumbnailsProps
->((props, ref) => {
+>(function HvCarouselThumbnails(props, ref) {
   const {
     classes: classesProp,
     className,

--- a/packages/core/src/CheckBox/CheckBox.tsx
+++ b/packages/core/src/CheckBox/CheckBox.tsx
@@ -65,7 +65,7 @@ export interface HvCheckBoxProps extends Omit<HvBaseCheckBoxProps, "classes"> {
  * the Toggle Switch and Toggle Button aren't more appropriate.
  */
 export const HvCheckBox = forwardRef<HTMLButtonElement, HvCheckBoxProps>(
-  (props, ref) => {
+  function HvCheckBox(props, ref) {
     const {
       id,
       classes: classesProp,

--- a/packages/core/src/CheckBoxGroup/CheckBoxGroup.tsx
+++ b/packages/core/src/CheckBoxGroup/CheckBoxGroup.tsx
@@ -147,7 +147,7 @@ export interface HvCheckBoxGroupProps
  * A checkbox group is a type of selection list that allows the user to select multiple options through the use of checkboxes.
  */
 export const HvCheckBoxGroup = forwardRef<HTMLDivElement, HvCheckBoxGroupProps>(
-  (props, ref) => {
+  function HvCheckBoxGroup(props, ref) {
     const {
       id,
       classes: classesProp,

--- a/packages/core/src/ColorPicker/ColorPicker.tsx
+++ b/packages/core/src/ColorPicker/ColorPicker.tsx
@@ -103,7 +103,7 @@ const DEFAULT_LABELS = {
  * It receives a color string in HEX format and outputs an HEX formatted color.
  */
 export const HvColorPicker = forwardRef<HTMLDivElement, HvColorPickerProps>(
-  (props, ref) => {
+  function HvColorPicker(props, ref) {
     const {
       id,
       name,

--- a/packages/core/src/Container/Container.tsx
+++ b/packages/core/src/Container/Container.tsx
@@ -43,7 +43,7 @@ export interface HvContainerProps extends Omit<MuiContainerProps, "classes"> {
 
 /** The container enables you to center your content horizontally and bound it to a specific breakpoint. */
 export const HvContainer = forwardRef<HTMLDivElement, HvContainerProps>(
-  (props, ref) => {
+  function HvContainer(props, ref) {
     const {
       maxWidth = false,
       classes: classesProp,

--- a/packages/core/src/DatePicker/DatePicker.tsx
+++ b/packages/core/src/DatePicker/DatePicker.tsx
@@ -141,7 +141,7 @@ export interface HvDatePickerProps
  * interface widget which allows the user to select a date from a calendar.
  */
 export const HvDatePicker = forwardRef<HTMLDivElement, HvDatePickerProps>(
-  (props, ref) => {
+  function HvDatePicker(props, ref) {
     const {
       classes: classesProp,
       className,

--- a/packages/core/src/Drawer/Drawer.tsx
+++ b/packages/core/src/Drawer/Drawer.tsx
@@ -75,7 +75,7 @@ export interface HvDrawerProps extends Omit<MuiDrawerProps, "classes"> {
 export const HvDrawer = forwardRef<
   React.ComponentRef<typeof MuiDrawer>,
   HvDrawerProps
->((props, ref) => {
+>(function HvDrawer(props, ref) {
   const {
     className,
     classes: classesProp,

--- a/packages/core/src/Drawer/Drawer.tsx
+++ b/packages/core/src/Drawer/Drawer.tsx
@@ -1,3 +1,4 @@
+import { forwardRef } from "react";
 import MuiDrawer, { DrawerProps as MuiDrawerProps } from "@mui/material/Drawer";
 import { Close } from "@hitachivantara/uikit-react-icons";
 import {
@@ -71,7 +72,10 @@ export interface HvDrawerProps extends Omit<MuiDrawerProps, "classes"> {
  * It only provides the pane with a close button, the rest of the
  * content can be customized.
  */
-export const HvDrawer = (props: HvDrawerProps) => {
+export const HvDrawer = forwardRef<
+  React.ComponentRef<typeof MuiDrawer>,
+  HvDrawerProps
+>((props, ref) => {
   const {
     className,
     classes: classesProp,
@@ -102,6 +106,7 @@ export const HvDrawer = (props: HvDrawerProps) => {
 
   return (
     <MuiDrawer
+      ref={ref}
       className={cx(classes.root, className)}
       id={id}
       anchor={anchor}
@@ -133,4 +138,4 @@ export const HvDrawer = (props: HvDrawerProps) => {
       {children}
     </MuiDrawer>
   );
-};
+});

--- a/packages/core/src/DropDownMenu/DropDownMenu.tsx
+++ b/packages/core/src/DropDownMenu/DropDownMenu.tsx
@@ -112,7 +112,10 @@ const HeaderComponent = forwardRef<HTMLButtonElement, HvDropdownButtonProps>(
 /**
  * A dropdown menu is a graphical control element, similar to a list box, that allows the user to choose a value from a list.
  */
-export const HvDropDownMenu = (props: HvDropDownMenuProps) => {
+export const HvDropDownMenu = forwardRef<
+  React.ComponentRef<typeof HvBaseDropdown>,
+  HvDropDownMenuProps
+>((props, ref) => {
   const {
     id: idProp,
     classes: classesProp,
@@ -175,6 +178,7 @@ export const HvDropDownMenu = (props: HvDropDownMenuProps) => {
 
   return (
     <HvBaseDropdown
+      ref={ref}
       id={id}
       className={cx(classes.container, className)}
       classes={{
@@ -227,4 +231,4 @@ export const HvDropDownMenu = (props: HvDropDownMenuProps) => {
       </HvPanel>
     </HvBaseDropdown>
   );
-};
+});

--- a/packages/core/src/DropDownMenu/DropDownMenu.tsx
+++ b/packages/core/src/DropDownMenu/DropDownMenu.tsx
@@ -115,7 +115,7 @@ const HeaderComponent = forwardRef<HTMLButtonElement, HvDropdownButtonProps>(
 export const HvDropDownMenu = forwardRef<
   React.ComponentRef<typeof HvBaseDropdown>,
   HvDropDownMenuProps
->((props, ref) => {
+>(function HvDropDownMenu(props, ref) {
   const {
     id: idProp,
     classes: classesProp,

--- a/packages/core/src/DropdownButton/DropdownButton.tsx
+++ b/packages/core/src/DropdownButton/DropdownButton.tsx
@@ -33,7 +33,7 @@ export interface HvDropdownButtonProps
 export const HvDropdownButton = forwardRef<
   HTMLButtonElement,
   HvDropdownButtonProps
->((props, ref) => {
+>(function HvDropdownButton(props, ref) {
   const {
     className,
     classes: classesProp,

--- a/packages/core/src/EmptyState/EmptyState.tsx
+++ b/packages/core/src/EmptyState/EmptyState.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { forwardRef } from "react";
 import { useTheme } from "@mui/material/styles";
 import useMediaQuery from "@mui/material/useMediaQuery";
 import {
@@ -32,7 +32,10 @@ export interface HvEmptyStateProps
 /**
  * Empty states communicate that there’s no information, data or values to display in a given context.
  */
-export const HvEmptyState = (props: HvEmptyStateProps) => {
+export const HvEmptyState = forwardRef<
+  React.ComponentRef<"div">,
+  HvEmptyStateProps
+>((props, ref) => {
   const {
     action,
     icon,
@@ -64,7 +67,7 @@ export const HvEmptyState = (props: HvEmptyStateProps) => {
     );
 
   return (
-    <div className={cx(classes.root, className)} {...others}>
+    <div ref={ref} className={cx(classes.root, className)} {...others}>
       <div
         className={cx(
           classes.container,
@@ -94,4 +97,4 @@ export const HvEmptyState = (props: HvEmptyStateProps) => {
       </div>
     </div>
   );
-};
+});

--- a/packages/core/src/EmptyState/EmptyState.tsx
+++ b/packages/core/src/EmptyState/EmptyState.tsx
@@ -35,7 +35,7 @@ export interface HvEmptyStateProps
 export const HvEmptyState = forwardRef<
   React.ComponentRef<"div">,
   HvEmptyStateProps
->((props, ref) => {
+>(function HvEmptyState(props, ref) {
   const {
     action,
     icon,

--- a/packages/core/src/FilterGroup/FilterContent/FilterContent.tsx
+++ b/packages/core/src/FilterGroup/FilterContent/FilterContent.tsx
@@ -48,7 +48,7 @@ export interface HvFilterGroupContentProps
 export const HvFilterGroupContent = forwardRef<
   HTMLDivElement,
   HvFilterGroupContentProps
->((props, ref) => {
+>(function HvFilterGroupContent(props, ref) {
   const {
     id,
     status,

--- a/packages/core/src/FilterGroup/FilterGroup.tsx
+++ b/packages/core/src/FilterGroup/FilterGroup.tsx
@@ -121,7 +121,7 @@ export type HvFilterGroupLabels = Partial<typeof DEFAULT_LABELS>;
  * while we do not provide a better approach for building this component with smaller and more composable parts.
  */
 export const HvFilterGroup = forwardRef<HTMLDivElement, HvFilterGroupProps>(
-  (props, ref) => {
+  function HvFilterGroup(props, ref) {
     const {
       className,
       id,

--- a/packages/core/src/Footer/Footer.tsx
+++ b/packages/core/src/Footer/Footer.tsx
@@ -1,3 +1,4 @@
+import { forwardRef } from "react";
 import { useTheme } from "@mui/material/styles";
 import useMediaQuery from "@mui/material/useMediaQuery";
 import {
@@ -27,7 +28,11 @@ export interface HvFooterProps extends HvBaseProps {
 /**
  * A Footer is a way of providing extra information at the end of a page.
  */
-export const HvFooter = (props: HvFooterProps) => {
+export const HvFooter = forwardRef<
+  // no-indent
+  React.ComponentRef<"footer">,
+  HvFooterProps
+>((props, ref) => {
   const {
     name = "Hitachi Vantara",
     copyright = `© Hitachi Vantara LLC ${new Date().getFullYear()}. All Rights Reserved.`,
@@ -43,6 +48,7 @@ export const HvFooter = (props: HvFooterProps) => {
 
   return (
     <footer
+      ref={ref}
       className={cx(classes.root, { [classes.small]: isSmDown }, className)}
       {...others}
     >
@@ -56,4 +62,4 @@ export const HvFooter = (props: HvFooterProps) => {
       </div>
     </footer>
   );
-};
+});

--- a/packages/core/src/Footer/Footer.tsx
+++ b/packages/core/src/Footer/Footer.tsx
@@ -32,7 +32,7 @@ export const HvFooter = forwardRef<
   // no-indent
   React.ComponentRef<"footer">,
   HvFooterProps
->((props, ref) => {
+>(function HvFooter(props, ref) {
   const {
     name = "Hitachi Vantara",
     copyright = `© Hitachi Vantara LLC ${new Date().getFullYear()}. All Rights Reserved.`,

--- a/packages/core/src/Forms/Suggestions/Suggestions.tsx
+++ b/packages/core/src/Forms/Suggestions/Suggestions.tsx
@@ -52,7 +52,11 @@ export interface HvSuggestionsProps extends HvBaseProps {
   enablePortal?: boolean;
 }
 
-export const HvSuggestions = forwardRef((props: HvSuggestionsProps, extRef) => {
+export const HvSuggestions = forwardRef<
+  // no-indent
+  unknown,
+  HvSuggestionsProps
+>((props, extRef) => {
   const {
     id,
     className,

--- a/packages/core/src/GlobalActions/GlobalActions.tsx
+++ b/packages/core/src/GlobalActions/GlobalActions.tsx
@@ -1,3 +1,4 @@
+import React, { forwardRef } from "react";
 import { useTheme as useMuiTheme } from "@mui/material/styles";
 import useMediaQuery from "@mui/material/useMediaQuery";
 import {
@@ -43,7 +44,10 @@ export interface HvGlobalActionsProps
  * Global Actions are actions that affect the entire page they live in.
  * They should persist while scrolling down the screen.
  */
-export const HvGlobalActions = (props: HvGlobalActionsProps) => {
+export const HvGlobalActions = forwardRef<
+  React.ComponentRef<"div">,
+  HvGlobalActionsProps
+>((props, ref) => {
   const {
     children,
     classes: classesProp,
@@ -67,6 +71,7 @@ export const HvGlobalActions = (props: HvGlobalActionsProps) => {
 
   return (
     <div
+      ref={ref}
       className={cx(
         classes.root,
         {
@@ -106,4 +111,4 @@ export const HvGlobalActions = (props: HvGlobalActionsProps) => {
       </div>
     </div>
   );
-};
+});

--- a/packages/core/src/GlobalActions/GlobalActions.tsx
+++ b/packages/core/src/GlobalActions/GlobalActions.tsx
@@ -47,7 +47,7 @@ export interface HvGlobalActionsProps
 export const HvGlobalActions = forwardRef<
   React.ComponentRef<"div">,
   HvGlobalActionsProps
->((props, ref) => {
+>(function HvGlobalActions(props, ref) {
   const {
     children,
     classes: classesProp,

--- a/packages/core/src/Grid/Grid.tsx
+++ b/packages/core/src/Grid/Grid.tsx
@@ -252,7 +252,11 @@ const WidthGrid = forwardRef<HTMLDivElement, HvGridProps>((props, ref) => {
  * The HvGrid sets them to the same value as the vertical gutters, depending on the breakpoint.
  * It can be overridden by setting the `rowSpacing` prop.
  */
-export const HvGrid = forwardRef<HTMLDivElement, HvGridProps>((props, ref) => {
+export const HvGrid = forwardRef<
+  // no-indent
+  HTMLDivElement,
+  HvGridProps
+>(function HvGrid(props, ref) {
   const {
     item,
     container,

--- a/packages/core/src/Header/Actions/Actions.tsx
+++ b/packages/core/src/Header/Actions/Actions.tsx
@@ -18,7 +18,7 @@ export interface HvHeaderActionsProps extends HvBaseProps {
 export const HvHeaderActions = forwardRef<
   React.ElementRef<"div">,
   HvHeaderActionsProps
->((props, ref) => {
+>(function HvHeaderActions(props, ref) {
   const {
     classes: classesProp,
     className,

--- a/packages/core/src/Header/Brand/Brand.tsx
+++ b/packages/core/src/Header/Brand/Brand.tsx
@@ -24,7 +24,7 @@ export interface HvHeaderBrandProps extends HvBaseProps {
 export const HvHeaderBrand = forwardRef<
   React.ElementRef<"div">,
   HvHeaderBrandProps
->((props, ref) => {
+>(function HvHeaderBrand(props, ref) {
   const {
     classes: classesProp,
     logo,

--- a/packages/core/src/Header/Header.tsx
+++ b/packages/core/src/Header/Header.tsx
@@ -1,3 +1,4 @@
+import { forwardRef } from "react";
 import {
   useDefaultProps,
   type ExtractNames,
@@ -27,7 +28,11 @@ export interface HvHeaderProps extends HvBaseProps {
 /**
  * Header component is used to render a header bar with logo and brand name, navigation and actions.
  */
-export const HvHeader = (props: HvHeaderProps) => {
+export const HvHeader = forwardRef<
+  // no-indent
+  React.ComponentRef<"header">,
+  HvHeaderProps
+>((props, ref) => {
   const {
     className,
     classes: classesProp,
@@ -40,6 +45,7 @@ export const HvHeader = (props: HvHeaderProps) => {
 
   return (
     <header
+      ref={ref}
       style={{ position }}
       className={cx(
         classes.root,
@@ -52,4 +58,4 @@ export const HvHeader = (props: HvHeaderProps) => {
       <div className={classes.header}>{children}</div>
     </header>
   );
-};
+});

--- a/packages/core/src/Header/Header.tsx
+++ b/packages/core/src/Header/Header.tsx
@@ -32,7 +32,7 @@ export const HvHeader = forwardRef<
   // no-indent
   React.ComponentRef<"header">,
   HvHeaderProps
->((props, ref) => {
+>(function HvHeader(props, ref) {
   const {
     className,
     classes: classesProp,

--- a/packages/core/src/Header/Navigation/Navigation.tsx
+++ b/packages/core/src/Header/Navigation/Navigation.tsx
@@ -38,7 +38,7 @@ export interface HvHeaderNavigationProps
 export const HvHeaderNavigation = forwardRef<
   React.ElementRef<"nav">,
   HvHeaderNavigationProps
->((props, ref) => {
+>(function HvHeaderNavigation(props, ref) {
   const {
     data,
     selected,

--- a/packages/core/src/Input/Input.tsx
+++ b/packages/core/src/Input/Input.tsx
@@ -227,7 +227,11 @@ const changeInputValue = (input: HTMLInputElement | null, value = "") => {
 /**
  * A text input box is a graphical control element intended to enable the user to input text information to be used by the software.
  */
-export const HvInput = forwardRef<InputElement, HvInputProps>((props, ref) => {
+export const HvInput = forwardRef<
+  // no-indent
+  InputElement,
+  HvInputProps
+>(function HvInput(props, ref) {
   const {
     classes: classesProp,
     className,

--- a/packages/core/src/Input/Input.tsx
+++ b/packages/core/src/Input/Input.tsx
@@ -54,7 +54,6 @@ import { useLabels } from "../hooks/useLabels";
 import { useUniqueId } from "../hooks/useUniqueId";
 import { HvTooltip } from "../Tooltip";
 import { HvInputSuggestion, HvValidationMessages } from "../types/forms";
-import { HvBaseProps } from "../types/generic";
 import { isKey } from "../utils/keyboardUtils";
 import { setId } from "../utils/setId";
 import { staticClasses, useClasses } from "./Input.styles";
@@ -66,10 +65,7 @@ export type HvInputClasses = ExtractNames<typeof useClasses>;
 type InputElement = HTMLInputElement | HTMLTextAreaElement;
 
 export interface HvInputProps
-  extends HvBaseProps<
-    HTMLElement,
-    "onChange" | "onBlur" | "onFocus" | "onKeyDown" | "color"
-  > {
+  extends Omit<HvBaseInputProps, "onBlur" | "onFocus" | "onKeyDown"> {
   /** The form element name. */
   name?: string;
   /** The value of the form element. */
@@ -102,11 +98,6 @@ export interface HvInputProps
   status?: HvFormStatus;
   /** The error message to show when `status` is "invalid". */
   statusMessage?: string;
-  /**
-   * The function that will be executed onChange, allows modification of the input,
-   * it receives the value. If a new value should be presented it must returned it.
-   */
-  onChange?: HvBaseInputProps["onChange"];
   /**
    * Callback called when the user submits the value by pressing Enter/Return.
    *

--- a/packages/core/src/ListContainer/ListContainer.tsx
+++ b/packages/core/src/ListContainer/ListContainer.tsx
@@ -45,7 +45,7 @@ export interface HvListContainerProps extends HvBaseProps<HTMLUListElement> {
 export const HvListContainer = forwardRef<
   HTMLUListElement,
   HvListContainerProps
->((props, ref) => {
+>(function HvListContainer(props, ref) {
   const {
     id,
     classes: classesProp,

--- a/packages/core/src/ListContainer/ListItem/ListItem.tsx
+++ b/packages/core/src/ListContainer/ListItem/ListItem.tsx
@@ -97,7 +97,11 @@ const applyClassNameToElement = (
 /**
  * ListItem description/documentation paragraph
  */
-export const HvListItem = forwardRef<any, HvListItemProps>((props, ref) => {
+export const HvListItem = forwardRef<
+  // no-indent
+  React.ComponentRef<"li">,
+  HvListItemProps
+>((props, ref) => {
   const {
     classes: classesProp,
     className,

--- a/packages/core/src/ListContainer/ListItem/ListItem.tsx
+++ b/packages/core/src/ListContainer/ListItem/ListItem.tsx
@@ -101,7 +101,7 @@ export const HvListItem = forwardRef<
   // no-indent
   React.ComponentRef<"li">,
   HvListItemProps
->((props, ref) => {
+>(function HvListItem(props, ref) {
   const {
     classes: classesProp,
     className,

--- a/packages/core/src/Loading/Loading.tsx
+++ b/packages/core/src/Loading/Loading.tsx
@@ -1,3 +1,4 @@
+import { forwardRef } from "react";
 import {
   mergeStyles,
   useDefaultProps,
@@ -30,7 +31,11 @@ export interface HvLoadingProps extends HvBaseProps {
 /**
  * Loading provides feedback about a process that is taking place in the application.
  */
-export const HvLoading = (props: HvLoadingProps) => {
+export const HvLoading = forwardRef<
+  // no-indent
+  React.ComponentRef<"div">,
+  HvLoadingProps
+>((props, ref) => {
   const {
     color,
     hidden,
@@ -49,6 +54,7 @@ export const HvLoading = (props: HvLoadingProps) => {
 
   return (
     <div
+      ref={ref}
       hidden={!!hidden}
       style={mergeStyles(style, {
         color: getColor(color, small ? "secondary" : "brand"),
@@ -83,4 +89,4 @@ export const HvLoading = (props: HvLoadingProps) => {
       )}
     </div>
   );
-};
+});

--- a/packages/core/src/Loading/Loading.tsx
+++ b/packages/core/src/Loading/Loading.tsx
@@ -35,7 +35,7 @@ export const HvLoading = forwardRef<
   // no-indent
   React.ComponentRef<"div">,
   HvLoadingProps
->((props, ref) => {
+>(function HvLoading(props, ref) {
   const {
     color,
     hidden,

--- a/packages/core/src/LoadingContainer/LoadingContainer.tsx
+++ b/packages/core/src/LoadingContainer/LoadingContainer.tsx
@@ -1,3 +1,4 @@
+import { forwardRef } from "react";
 import {
   mergeStyles,
   useDefaultProps,
@@ -28,7 +29,10 @@ export interface HvLoadingContainerProps
  *  <MyComponent>
  * </HvLoadingContainer>
  * */
-export const HvLoadingContainer = (props: HvLoadingContainerProps) => {
+export const HvLoadingContainer = forwardRef<
+  React.ComponentRef<"div">,
+  HvLoadingContainerProps
+>((props, ref) => {
   const {
     children,
     className,
@@ -46,7 +50,7 @@ export const HvLoadingContainer = (props: HvLoadingContainerProps) => {
     ariaLabelProp || (typeof label === "string" && label) || "Loading";
 
   return (
-    <div className={cx(classes.root, className)} {...others}>
+    <div ref={ref} className={cx(classes.root, className)} {...others}>
       <HvLoading
         className={classes.loading}
         role="progressbar"
@@ -61,4 +65,4 @@ export const HvLoadingContainer = (props: HvLoadingContainerProps) => {
       {children}
     </div>
   );
-};
+});

--- a/packages/core/src/LoadingContainer/LoadingContainer.tsx
+++ b/packages/core/src/LoadingContainer/LoadingContainer.tsx
@@ -32,7 +32,7 @@ export interface HvLoadingContainerProps
 export const HvLoadingContainer = forwardRef<
   React.ComponentRef<"div">,
   HvLoadingContainerProps
->((props, ref) => {
+>(function HvLoadingContainer(props, ref) {
   const {
     children,
     className,

--- a/packages/core/src/Login/Login.stories.tsx
+++ b/packages/core/src/Login/Login.stories.tsx
@@ -1,18 +1,14 @@
-import { FormEventHandler, forwardRef } from "react";
 import styled from "@emotion/styled";
 import { Meta, StoryObj } from "@storybook/react";
 import {
   dropdownClasses,
   HvButton,
-  HvButtonProps,
   HvCheckBox,
   HvDropdown,
   HvInput,
-  HvInputProps,
   HvLogin,
   HvLoginProps,
   HvTypography,
-  PolymorphicRef,
   theme,
 } from "@hitachivantara/uikit-react-core";
 
@@ -29,16 +25,12 @@ const StyledRoot = styled("div")({
   },
 });
 
-const StyledInput = styled((props: HvInputProps) => <HvInput {...props} />)({
+const StyledInput = styled(HvInput)({
   marginTop: 20,
   height: 90,
 });
 
-const StyledButton = styled(
-  forwardRef((props: HvButtonProps, ref?: PolymorphicRef<"button">) => {
-    return <HvButton {...props} ref={ref} />;
-  }),
-)({
+const StyledButton = styled(HvButton)({
   width: 120,
   float: "right",
   marginTop: theme.spacing(8),
@@ -78,21 +70,21 @@ export const Main: StoryObj<HvLoginProps> = {
     ...setupChromatic(["DS5 dawn"], 5000),
   },
   render: () => {
-    const handleSubmit: FormEventHandler<HTMLFormElement> = (event) => {
-      event.preventDefault();
-
-      const formData = new FormData(event.currentTarget);
-      const data = Object.fromEntries(formData.entries());
-
-      alert(JSON.stringify(data, null, 2));
-    };
-
     return (
       <HvLogin background="https://lumada-design.github.io/assets/login-bg1.png">
         <StyledRoot>
           <HvTypography variant="title2">Welcome</HvTypography>
 
-          <form onSubmit={handleSubmit}>
+          <form
+            onSubmit={(event) => {
+              event.preventDefault();
+
+              const formData = new FormData(event.currentTarget);
+              const data = Object.fromEntries(formData.entries());
+
+              alert(JSON.stringify(data, null, 2));
+            }}
+          >
             <StyledInput
               required
               name="username"
@@ -124,20 +116,20 @@ export const CustomBackground: StoryObj<HvLoginProps> = {
     classes: { control: { disable: true } },
   },
   render: () => {
-    const handleSubmit: FormEventHandler<HTMLFormElement> = (event) => {
-      event.preventDefault();
-      const formData = new FormData(event.currentTarget);
-      const data = Object.fromEntries(formData.entries());
-
-      alert(JSON.stringify(data, null, 2));
-    };
-
     return (
       <HvLogin background="https://lumada-design.github.io/assets/login-bg2.png">
         <StyledRoot>
           <HvTypography variant="title2">Welcome</HvTypography>
 
-          <form onSubmit={handleSubmit}>
+          <form
+            onSubmit={(event) => {
+              event.preventDefault();
+              const formData = new FormData(event.currentTarget);
+              const data = Object.fromEntries(formData.entries());
+
+              alert(JSON.stringify(data, null, 2));
+            }}
+          >
             <StyledInput
               required
               name="username"

--- a/packages/core/src/Login/Login.tsx
+++ b/packages/core/src/Login/Login.tsx
@@ -29,7 +29,7 @@ export const HvLogin = forwardRef<
   // no-indent
   React.ComponentRef<"div">,
   HvLoginProps
->((props, ref) => {
+>(function HvLogin(props, ref) {
   const {
     className,
     classes: classesProp,

--- a/packages/core/src/Login/Login.tsx
+++ b/packages/core/src/Login/Login.tsx
@@ -1,3 +1,4 @@
+import { forwardRef } from "react";
 import {
   useDefaultProps,
   type ExtractNames,
@@ -24,9 +25,12 @@ export interface HvLoginProps extends HvBaseProps {
 /**
  * Container layout for the login form.
  */
-export const HvLogin = (props: HvLoginProps) => {
+export const HvLogin = forwardRef<
+  // no-indent
+  React.ComponentRef<"div">,
+  HvLoginProps
+>((props, ref) => {
   const {
-    id,
     className,
     classes: classesProp,
     children,
@@ -38,7 +42,7 @@ export const HvLogin = (props: HvLoginProps) => {
 
   return (
     <div
-      id={id}
+      ref={ref}
       className={cx(classes.root, className)}
       style={{
         backgroundImage: background && `url(${background})`,
@@ -48,4 +52,4 @@ export const HvLogin = (props: HvLoginProps) => {
       <div className={classes.formContainer}>{children}</div>
     </div>
   );
-};
+});

--- a/packages/core/src/Pagination/Pagination.tsx
+++ b/packages/core/src/Pagination/Pagination.tsx
@@ -98,7 +98,7 @@ export interface HvPaginationProps extends HvBaseProps {
 export const HvPagination = forwardRef<
   React.ComponentRef<"div">,
   HvPaginationProps
->((props, ref) => {
+>(function HvPagination(props, ref) {
   const {
     classes: classesProp,
     className,

--- a/packages/core/src/Pagination/Pagination.tsx
+++ b/packages/core/src/Pagination/Pagination.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import React, { forwardRef, useCallback, useEffect, useState } from "react";
 import { useMediaQuery, useTheme } from "@mui/material";
 import {
   Backwards,
@@ -95,7 +95,10 @@ export interface HvPaginationProps extends HvBaseProps {
  * Pagination is the process of dividing a document into discrete pages. It relates to how users interact
  * with structured content on a website or application.
  */
-export const HvPagination = (props: HvPaginationProps) => {
+export const HvPagination = forwardRef<
+  React.ComponentRef<"div">,
+  HvPaginationProps
+>((props, ref) => {
   const {
     classes: classesProp,
     className,
@@ -171,7 +174,7 @@ export const HvPagination = (props: HvPaginationProps) => {
   );
 
   return (
-    <div id={id} className={cx(classes.root, className)} {...others}>
+    <div ref={ref} id={id} className={cx(classes.root, className)} {...others}>
       <div className={classes.pageSizeOptions} {...showPageProps}>
         {showPageSizeOptions && (
           <>
@@ -269,4 +272,4 @@ export const HvPagination = (props: HvPaginationProps) => {
       </div>
     </div>
   );
-};
+});

--- a/packages/core/src/Panel/Panel.tsx
+++ b/packages/core/src/Panel/Panel.tsx
@@ -22,7 +22,7 @@ export interface HvPanelProps extends HvBaseProps {
  * Regardless of its content, a panel look and feel should be consistent.
  */
 export const HvPanel = forwardRef<HTMLDivElement, HvPanelProps>(
-  (props, ref) => {
+  function HvPanel(props, ref) {
     const {
       className,
       classes: classesProp,

--- a/packages/core/src/Radio/Radio.tsx
+++ b/packages/core/src/Radio/Radio.tsx
@@ -132,7 +132,7 @@ export interface HvRadioProps
  * respond to the browser's native management of radio inputs checked state.
  */
 export const HvRadio = forwardRef<HTMLButtonElement, HvRadioProps>(
-  (props, ref) => {
+  function HvRadio(props, ref) {
     const {
       classes: classesProp,
       className,

--- a/packages/core/src/RadioGroup/RadioGroup.tsx
+++ b/packages/core/src/RadioGroup/RadioGroup.tsx
@@ -125,7 +125,7 @@ const getValueFromSelectedChildren = (children: React.ReactNode) => {
  * A radio group is a type of selection list that can only have a single entry checked at any one time.
  */
 export const HvRadioGroup = forwardRef<HTMLDivElement, HvRadioGroupProps>(
-  (props, ref) => {
+  function HvRadioGroup(props, ref) {
     const {
       id,
       classes: classesProp,

--- a/packages/core/src/Section/Section.tsx
+++ b/packages/core/src/Section/Section.tsx
@@ -45,7 +45,7 @@ export interface HvSectionProps
  * Sections allow grouping information on a page under the same topic.
  */
 export const HvSection = forwardRef<HTMLDivElement, HvSectionProps>(
-  (props, ref) => {
+  function HvSection(props, ref) {
     const {
       id,
       classes: classesProp,

--- a/packages/core/src/Select/OptionGroup.tsx
+++ b/packages/core/src/Select/OptionGroup.tsx
@@ -23,7 +23,7 @@ export interface HvOptionGroupProps extends OptionGroupProps {
 }
 
 export const HvOptionGroup = forwardRef<HTMLLIElement, HvOptionGroupProps>(
-  (props, ref) => {
+  function HvOptionGroup(props, ref) {
     const {
       className,
       classes: classesProp,

--- a/packages/core/src/SelectionList/SelectionList.tsx
+++ b/packages/core/src/SelectionList/SelectionList.tsx
@@ -115,7 +115,7 @@ const getValueFromSelectedChildren = (
 export const HvSelectionList = forwardRef<
   HTMLUListElement,
   HvSelectionListProps
->((props, ref) => {
+>(function HvSelectionList(props, ref) {
   const {
     id,
     classes: classesProp,

--- a/packages/core/src/Snackbar/Snackbar.tsx
+++ b/packages/core/src/Snackbar/Snackbar.tsx
@@ -1,11 +1,14 @@
-import { useCallback } from "react";
+import { forwardRef, useCallback } from "react";
 import Slide, { SlideProps } from "@mui/material/Slide";
 import MuiSnackbar, {
   SnackbarProps as MuiSnackbarProps,
   SnackbarCloseReason,
   SnackbarOrigin,
 } from "@mui/material/Snackbar";
-import { type ExtractNames } from "@hitachivantara/uikit-react-utils";
+import {
+  useDefaultProps,
+  type ExtractNames,
+} from "@hitachivantara/uikit-react-utils";
 
 import { HvActionGeneric, HvActionsGenericProps } from "../ActionsGeneric";
 import { capitalize } from "../utils/helpers";
@@ -79,28 +82,32 @@ export interface HvSnackbarProps
  * One is the HvSnackbar, which wraps all the positioning, transition, auto hide, etc.
  * The other is the HvSnackbarContent, which allows a finer control and customization of the content of the Snackbar.
  */
-export const HvSnackbar = ({
-  classes: classesProp,
-  className,
-  id,
-  open = false,
-  onClose,
-  label = "",
-  anchorOrigin = { vertical: "top", horizontal: "right" },
-  autoHideDuration = 5000,
-  variant = "default",
-  showIcon = false,
-  customIcon = null,
-  action = null,
-  actionCallback, // TODO - remove in v6
-  onAction,
-  transitionDuration = 300,
-  transitionDirection = "left",
-  container,
-  offset = 60,
-  snackbarContentProps,
-  ...others
-}: HvSnackbarProps) => {
+export const HvSnackbar = forwardRef<
+  React.ComponentRef<typeof MuiSnackbar>,
+  HvSnackbarProps
+>((props, ref) => {
+  const {
+    classes: classesProp,
+    className,
+    id,
+    open = false,
+    onClose,
+    label = "",
+    anchorOrigin = { vertical: "top", horizontal: "right" },
+    autoHideDuration = 5000,
+    variant = "default",
+    showIcon = false,
+    customIcon = null,
+    action = null,
+    actionCallback, // TODO - remove in v6
+    onAction,
+    transitionDuration = 300,
+    transitionDirection = "left",
+    container,
+    offset = 60,
+    snackbarContentProps,
+    ...others
+  } = useDefaultProps("HvSnackbar", props);
   const { classes } = useClasses(classesProp);
 
   const anchorOriginOffset = {
@@ -127,6 +134,7 @@ export const HvSnackbar = ({
 
   return (
     <MuiSnackbar
+      ref={ref}
       style={
         anchorOriginOffset[
           `anchorOrigin${capitalize(anchorOrigin.vertical)}` as keyof typeof anchorOriginOffset
@@ -156,4 +164,4 @@ export const HvSnackbar = ({
       />
     </MuiSnackbar>
   );
-};
+});

--- a/packages/core/src/Snackbar/Snackbar.tsx
+++ b/packages/core/src/Snackbar/Snackbar.tsx
@@ -85,7 +85,7 @@ export interface HvSnackbarProps
 export const HvSnackbar = forwardRef<
   React.ComponentRef<typeof MuiSnackbar>,
   HvSnackbarProps
->((props, ref) => {
+>(function HvSnackbar(props, ref) {
   const {
     classes: classesProp,
     className,

--- a/packages/core/src/Switch/Switch.tsx
+++ b/packages/core/src/Switch/Switch.tsx
@@ -127,7 +127,7 @@ const isSemantical = (color: HvColorAny) =>
  * changes in the system.
  */
 export const HvSwitch = forwardRef<HTMLButtonElement, HvSwitchProps>(
-  (props, ref) => {
+  function HvSwitch(props, ref) {
     const {
       classes: classesProp,
       className,

--- a/packages/core/src/Tab/Tab.tsx
+++ b/packages/core/src/Tab/Tab.tsx
@@ -1,3 +1,4 @@
+import { forwardRef } from "react";
 import Tab, { TabProps as MuiTabProps } from "@mui/material/Tab";
 import {
   useDefaultProps,
@@ -24,7 +25,11 @@ export interface HvTabProps extends Omit<MuiTabProps, "children"> {
   classes?: HvTabClasses;
 }
 
-export const HvTab = (props: HvTabProps) => {
+export const HvTab = forwardRef<
+  // no-indent
+  React.ComponentRef<typeof Tab>,
+  HvTabProps
+>((props, ref) => {
   const {
     classes: classesProp,
     iconPosition = "top",
@@ -35,6 +40,7 @@ export const HvTab = (props: HvTabProps) => {
 
   return (
     <Tab
+      ref={ref}
       classes={{
         root: classes.root,
         selected: classes.selected,
@@ -48,4 +54,4 @@ export const HvTab = (props: HvTabProps) => {
       {...others}
     />
   );
-};
+});

--- a/packages/core/src/Tab/Tab.tsx
+++ b/packages/core/src/Tab/Tab.tsx
@@ -29,7 +29,7 @@ export const HvTab = forwardRef<
   // no-indent
   React.ComponentRef<typeof Tab>,
   HvTabProps
->((props, ref) => {
+>(function HvTab(props, ref) {
   const {
     classes: classesProp,
     iconPosition = "top",

--- a/packages/core/src/Table/Table.tsx
+++ b/packages/core/src/Table/Table.tsx
@@ -81,7 +81,11 @@ const computeTablePartComponents = (rootComponent: React.ElementType<any>) => {
  * For better data handling and **advanced features** we recommend the use of the utility hooks collection.
  * See the <a href="?id=guides-table-table-hooks--use-hv-hooks&viewMode=docs" target="_self">Table Hooks documentation</a> for more details.
  */
-export const HvTable = forwardRef<HTMLElement, HvTableProps>((props, ref) => {
+export const HvTable = forwardRef<
+  // no-indent
+  HTMLElement,
+  HvTableProps
+>(function HvTable(props, ref) {
   const {
     classes: classesProp,
     className,

--- a/packages/core/src/TableSection/TableSection.tsx
+++ b/packages/core/src/TableSection/TableSection.tsx
@@ -19,7 +19,7 @@ export interface HvTableSectionProps extends HvSectionProps {}
  * specific stylings for tables that follow the latest DS specifications.
  */
 export const HvTableSection = forwardRef<HTMLDivElement, HvTableSectionProps>(
-  (props, ref) => {
+  function HvTableSection(props, ref) {
     const {
       id,
       classes: classesProp,

--- a/packages/core/src/Tabs/Tabs.tsx
+++ b/packages/core/src/Tabs/Tabs.tsx
@@ -41,7 +41,7 @@ export const HvTabs = forwardRef<
   // no-indent
   React.ComponentRef<typeof Tabs>,
   HvTabsProps
->((props, ref) => {
+>(function HvTabs(props, ref) {
   const {
     classes: classesProp,
     floating,

--- a/packages/core/src/Tabs/Tabs.tsx
+++ b/packages/core/src/Tabs/Tabs.tsx
@@ -1,3 +1,4 @@
+import { forwardRef } from "react";
 import Tabs, { TabsProps as MuiTabsProps } from "@mui/material/Tabs";
 import {
   useDefaultProps,
@@ -36,10 +37,14 @@ export interface HvTabsProps extends Omit<MuiTabsProps, "onChange"> {
  * A Tab is a graphical control element that allows multiple documents or panels to be contained within a single window.
  * Tabs can be used as a navigational widget for switching between sets of documents.
  */
-export const HvTabs = (props: HvTabsProps) => {
+export const HvTabs = forwardRef<
+  // no-indent
+  React.ComponentRef<typeof Tabs>,
+  HvTabsProps
+>((props, ref) => {
   const {
     classes: classesProp,
-    floating = false,
+    floating,
     ...others
   } = useDefaultProps("HvTabs", props);
 
@@ -47,6 +52,7 @@ export const HvTabs = (props: HvTabsProps) => {
 
   return (
     <Tabs
+      ref={ref}
       classes={{
         root: cx(classes.root, { [classes.floating]: floating }),
         flexContainer: classes.flexContainer,
@@ -56,4 +62,4 @@ export const HvTabs = (props: HvTabsProps) => {
       {...others}
     />
   );
-};
+});

--- a/packages/core/src/Tag/Tag.tsx
+++ b/packages/core/src/Tag/Tag.tsx
@@ -70,7 +70,11 @@ const getCategoricalColor = (customColor?: HvColorAny, colors?: any) => {
  *
  * It leverages the Chip component from Material UI
  */
-export const HvTag = forwardRef<HTMLDivElement, HvTagProps>((props, ref) => {
+export const HvTag = forwardRef<
+  // no-indent
+  HTMLDivElement,
+  HvTagProps
+>(function HvTag(props, ref) {
   const {
     classes: classesProp,
     className,

--- a/packages/core/src/TagsInput/TagsInput.tsx
+++ b/packages/core/src/TagsInput/TagsInput.tsx
@@ -114,7 +114,7 @@ export interface HvTagsInputProps
  * A tags input is a single or multiline control that allows the input of tags.
  */
 export const HvTagsInput = forwardRef<HTMLUListElement, HvTagsInputProps>(
-  (props, ref) => {
+  function HvTagsInput(props, ref) {
     const {
       classes: classesProp,
       className,

--- a/packages/core/src/TextArea/TextArea.tsx
+++ b/packages/core/src/TextArea/TextArea.tsx
@@ -161,7 +161,10 @@ export interface HvTextAreaProps
 /**
  * A text area is a multiline text input box, with an optional character counter when there is a length limit.
  */
-export const HvTextArea = forwardRef<any, HvTextAreaProps>((props, ref) => {
+export const HvTextArea = forwardRef<
+  React.ComponentRef<"textarea">,
+  HvTextAreaProps
+>((props, ref) => {
   const {
     id,
     className,

--- a/packages/core/src/TextArea/TextArea.tsx
+++ b/packages/core/src/TextArea/TextArea.tsx
@@ -164,7 +164,7 @@ export interface HvTextAreaProps
 export const HvTextArea = forwardRef<
   React.ComponentRef<"textarea">,
   HvTextAreaProps
->((props, ref) => {
+>(function HvTextArea(props, ref) {
   const {
     id,
     className,

--- a/packages/core/src/TimePicker/Placeholder.tsx
+++ b/packages/core/src/TimePicker/Placeholder.tsx
@@ -48,7 +48,7 @@ export interface PlaceholderProps extends HvBaseProps<HTMLDivElement> {
 }
 
 export const Placeholder = forwardRef<HTMLDivElement, PlaceholderProps>(
-  (props, ref) => {
+  function Placeholder(props, ref) {
     const { name, state, placeholders, onKeyDown, ...others } = props;
     const { value, segments } = state;
 

--- a/packages/core/src/TimePicker/TimePicker.tsx
+++ b/packages/core/src/TimePicker/TimePicker.tsx
@@ -113,7 +113,7 @@ export interface HvTimePickerProps
  * A Time Picker allows the user to choose a specific time or a time range.
  */
 export const HvTimePicker = forwardRef<HTMLDivElement, HvTimePickerProps>(
-  (props, ref) => {
+  function HvTimePicker(props, ref) {
     const {
       classes: classesProp,
       className,

--- a/packages/core/src/ToggleButton/ToggleButton.tsx
+++ b/packages/core/src/ToggleButton/ToggleButton.tsx
@@ -27,7 +27,7 @@ export interface HvToggleButtonProps
 export const HvToggleButton = forwardRef<
   HTMLButtonElement,
   HvToggleButtonProps
->((props, ref) => {
+>(function HvToggleButton(props, ref) {
   const {
     defaultSelected,
     selected,

--- a/packages/core/src/Tooltip/Tooltip.tsx
+++ b/packages/core/src/Tooltip/Tooltip.tsx
@@ -67,7 +67,7 @@ export interface HvTooltipProps extends Omit<MuiTooltipProps, "classes"> {
  * If you are looking to wrap an icon only button with a tooltip, take a look at the `HvIconButton` component
  * which offers you thus behavior out of the box.
  */
-export const HvTooltip = forwardRef((props: HvTooltipProps, ref) => {
+export const HvTooltip = forwardRef<unknown, HvTooltipProps>((props, ref) => {
   const {
     className,
     classes: classesProp,

--- a/packages/core/src/Tooltip/Tooltip.tsx
+++ b/packages/core/src/Tooltip/Tooltip.tsx
@@ -67,7 +67,11 @@ export interface HvTooltipProps extends Omit<MuiTooltipProps, "classes"> {
  * If you are looking to wrap an icon only button with a tooltip, take a look at the `HvIconButton` component
  * which offers you thus behavior out of the box.
  */
-export const HvTooltip = forwardRef<unknown, HvTooltipProps>((props, ref) => {
+export const HvTooltip = forwardRef<
+  // no-indent
+  unknown,
+  HvTooltipProps
+>(function HvTooltip(props, ref) {
   const {
     className,
     classes: classesProp,

--- a/packages/core/src/TreeView/TreeItem/DefaultContent.tsx
+++ b/packages/core/src/TreeView/TreeItem/DefaultContent.tsx
@@ -41,7 +41,7 @@ export interface HvTreeContentProps extends React.HTMLAttributes<HTMLElement> {
  * Use this as a basis to create a custom component.
  */
 export const DefaultContent = forwardRef<HTMLDivElement, HvTreeContentProps>(
-  (props, ref) => {
+  function DefaultContent(props, ref) {
     const {
       classes: classesProp,
       className,

--- a/packages/core/src/TreeView/TreeItem/TreeItem.tsx
+++ b/packages/core/src/TreeView/TreeItem/TreeItem.tsx
@@ -74,7 +74,7 @@ export interface HvTreeItemProps extends React.HTMLAttributes<HTMLElement> {
 }
 
 export const HvTreeItem = forwardRef<HTMLLIElement, HvTreeItemProps>(
-  (props, ref) => {
+  function HvTreeItem(props, ref) {
     const {
       id: idProp,
       nodeId,

--- a/packages/core/src/VerticalNavigation/TreeView/TreeView.tsx
+++ b/packages/core/src/VerticalNavigation/TreeView/TreeView.tsx
@@ -79,7 +79,7 @@ function noopSelection() {
 export const HvVerticalNavigationTreeView = forwardRef<
   HTMLUListElement,
   HvVerticalNavigationTreeViewProps
->((props, ref) => {
+>(function HvVerticalNavigationTreeView(props, ref) {
   const {
     id: idProp,
     className,

--- a/packages/core/src/VerticalNavigation/VerticalNavigation.tsx
+++ b/packages/core/src/VerticalNavigation/VerticalNavigation.tsx
@@ -70,7 +70,7 @@ export interface HvVerticalNavigationProps extends HvBaseProps<HTMLDivElement> {
 export const HvVerticalNavigation = forwardRef<
   HTMLDivElement,
   HvVerticalNavigationProps
->((props, ref) => {
+>(function HvVerticalNavigation(props, ref) {
   const {
     id,
     className,


### PR DESCRIPTION
- add missing `forwardRef` in components
- add `function <componentName>` so that component's name isn't lost (in docs, devtools, etc.)

> [!WARNING]
> Please squash when merging