### PR TITLE
feat(Button): support external icons

### DIFF
--- a/packages/core/src/Badge/Badge.styles.tsx
+++ b/packages/core/src/Badge/Badge.styles.tsx
@@ -2,7 +2,19 @@ import { createClasses } from "@hitachivantara/uikit-react-utils";
 import { theme } from "@hitachivantara/uikit-styles";
 
 export const { staticClasses, useClasses } = createClasses("HvBadge", {
-  root: { position: "relative", "&>*": { float: "left" } },
+  root: {
+    position: "relative",
+    "&>*": { float: "left" },
+    ":has($badgeIcon)": {
+      width: "fit-content",
+      height: "fit-content",
+      "&>div:first-child": {
+        minWidth: 32,
+        minHeight: 32,
+        "--icsize": "100%",
+      },
+    },
+  },
   /** class applied to the badge container when it has content */
   badgeContainer: {},
   /** class applied to the badge */

--- a/packages/core/src/Button/Button.stories.tsx
+++ b/packages/core/src/Button/Button.stories.tsx
@@ -1,4 +1,6 @@
 import { css } from "@emotion/css";
+import { faAdd } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { StoryObj } from "@storybook/react";
 import { HvButton, HvButtonProps } from "@hitachivantara/uikit-react-core";
 import {
@@ -374,10 +376,10 @@ export const Test: StoryObj = {
       </HvButton>
 
       <HvButton icon aria-label="Play">
-        <Play iconSize="M" />
+        <Play size="M" />
       </HvButton>
       <HvButton icon disabled aria-label="Stop">
-        <Play iconSize="M" />
+        <Play size="M" />
       </HvButton>
 
       <HvButton startIcon={<Play />} variant="primary" size="lg">
@@ -416,6 +418,15 @@ export const Test: StoryObj = {
       <HvButton startIcon={<Play />} color="lightcyan" variant="ghost">
         lightcyan
       </HvButton>
+
+      <HvButton icon variant="primary" aria-label="Add">
+        <FontAwesomeIcon icon={faAdd} />
+      </HvButton>
+      <HvButton startIcon={<FontAwesomeIcon icon={faAdd} />}>Add</HvButton>
+      <HvButton icon variant="primary" aria-label="Add">
+        <div className="i-ph-plus-bold" />
+      </HvButton>
+      <HvButton startIcon={<div className="i-ph-plus-bold" />}>Add</HvButton>
     </div>
   ),
 };

--- a/packages/core/src/Button/Button.styles.ts
+++ b/packages/core/src/Button/Button.styles.ts
@@ -33,20 +33,22 @@ export const { staticClasses, useClasses } = createClasses("HvButton", {
     borderRadius: `var(--radius, ${theme.radii.base})`,
     padding: theme.spacing(0, "sm"),
 
+    // remove icon container spacing
+    "--icsize": "auto",
+
     "& $startIcon, & $endIcon": {
       flexShrink: 0,
       lineHeight: 0,
-      marginTop: -1,
-      marginBottom: -1,
+      minWidth: 16,
     },
   },
   /** applied to the _left_ icon container */
   startIcon: {
-    marginLeft: theme.spacing(-1),
+    marginRight: 8,
   },
   /** applied to the _right_ icon container */
   endIcon: {
-    marginRight: theme.spacing(-1),
+    marginLeft: 8,
   },
   focusVisible: {},
   /** applied to the root element when disabled */

--- a/packages/core/src/DotPagination/DotPagination.stories.tsx
+++ b/packages/core/src/DotPagination/DotPagination.stories.tsx
@@ -21,7 +21,6 @@ const meta: Meta<typeof HvDotPagination> = {
 export default meta;
 
 const styles = {
-  container: css({ width: "100%", justifyContent: "center" }),
   page: css({ textAlign: "center" }),
 };
 
@@ -42,10 +41,8 @@ export const Main: StoryObj<HvDotPaginationProps> = {
     ];
 
     return (
-      <div className={styles.container}>
-        <div className={styles.page}>
-          <HvTypography>{pages[page]}</HvTypography>
-        </div>
+      <div>
+        <HvTypography className={styles.page}>{pages[page]}</HvTypography>
         <br />
         <HvDotPagination
           page={page}
@@ -110,10 +107,8 @@ export const CustomizedDotPagination: StoryObj<HvDotPaginationProps> = {
     };
 
     return (
-      <div className={styles.container}>
-        <div className={styles.page}>
-          <HvTypography>{pages[page]}</HvTypography>
-        </div>
+      <div>
+        <HvTypography className={styles.page}>{pages[page]}</HvTypography>
         <br />
         <HvDotPagination
           classes={dotpaginationStyle}

--- a/packages/core/src/InlineEditor/InlineEditor.styles.tsx
+++ b/packages/core/src/InlineEditor/InlineEditor.styles.tsx
@@ -53,7 +53,6 @@ export const { staticClasses, useClasses } = createClasses("HvInlineEditor", {
     cursor: "pointer",
     visibility: "hidden",
     alignSelf: "center",
-    height: 16,
   },
   iconVisible: {
     visibility: "visible",

--- a/packages/core/src/InlineEditor/InlineEditor.tsx
+++ b/packages/core/src/InlineEditor/InlineEditor.tsx
@@ -171,6 +171,7 @@ export const HvInlineEditor = fixedForwardRef(function HvInlineEditor<
           variant="secondaryGhost"
           endIcon={
             <HvIcon
+              compact
               name="Edit"
               color="textDisabled"
               className={cx(classes.icon, {

--- a/packages/core/src/QueryBuilder/RuleGroup/RuleGroup.tsx
+++ b/packages/core/src/QueryBuilder/RuleGroup/RuleGroup.tsx
@@ -51,7 +51,7 @@ export const RuleGroup = ({
             dispatchAction({ type: "add-rule", id });
           }}
           disabled={readOnly}
-          startIcon={<HvIcon name="Add" />}
+          startIcon={<HvIcon compact name="Add" />}
         >
           {level === 0 && labels.query?.addRule?.label != null
             ? labels.query?.addRule?.label
@@ -66,7 +66,7 @@ export const RuleGroup = ({
               dispatchAction({ type: "add-group", id });
             }}
             disabled={readOnly}
-            startIcon={<HvIcon name="Add" />}
+            startIcon={<HvIcon compact name="Add" />}
           >
             {level === 0 && labels.query?.addGroup?.label != null
               ? labels.query?.addGroup?.label

--- a/packages/core/src/VerticalNavigation/Actions/Action.styles.tsx
+++ b/packages/core/src/VerticalNavigation/Actions/Action.styles.tsx
@@ -10,7 +10,7 @@ export const { staticClasses, useClasses } = createClasses(
       height: "32px",
       color: "inherit",
       fontWeight: "inherit",
-      padding: 0,
+      padding: theme.spacing(0, "xs"),
       border: "none",
 
       // cursor
@@ -18,12 +18,10 @@ export const { staticClasses, useClasses } = createClasses(
         cursor: "pointer",
       },
     },
-    noIcon: {
-      paddingLeft: theme.space.xs,
-    },
+    noIcon: {},
     minimized: {
       justifyContent: "center",
-      paddingRight: 0,
+      padding: 0,
     },
   },
 );

--- a/packages/core/src/VerticalNavigation/Actions/Action.tsx
+++ b/packages/core/src/VerticalNavigation/Actions/Action.tsx
@@ -44,6 +44,7 @@ export const HvVerticalNavigationAction = (
       id={setId(id, "button")}
       variant="secondaryGhost"
       icon={!isOpen}
+      startIcon={isOpen && icon}
       className={cx(
         classes.action,
         {
@@ -55,7 +56,7 @@ export const HvVerticalNavigationAction = (
       {...(!isOpen && { "aria-label": label })}
       {...others}
     >
-      {icon}
+      {!isOpen && icon}
       {isOpen && label}
     </HvButton>
   );

--- a/packages/icons/src/IconBase.tsx
+++ b/packages/icons/src/IconBase.tsx
@@ -56,7 +56,7 @@ export interface IconBaseProps extends Omit<HvIconContainerProps, "color"> {
   /**
    * A color or array of colors to override the default icon colors.
    * Accepts any valid CSS color or color from the UI Kit palette.
-   * @example ["brand", "inherit"]
+   * @example "secondary" "brand" "atmo2" "#FF0000" "purple" "inherit"
    */
   color?: HvColorAny | HvColorAny[];
   /**

--- a/packages/icons/src/IconContainer.tsx
+++ b/packages/icons/src/IconContainer.tsx
@@ -23,9 +23,9 @@ const StyledIconContainer = styled("div")({
   display: "flex",
   flex: "0 0 auto", // ensure icon doesn't flex grow/shrink
   fontSize: 16,
-  // box has a minimum size of 32px (`xs` & `sm`)
-  width: "var(--size, 32px)",
-  height: "var(--size, 32px)",
+  // box has a default icon container size of 32px (`xs` & `sm`)
+  width: "var(--icsize, 32px)",
+  height: "var(--icsize, 32px)",
   transition: "rotate 0.2s ease",
   justifyContent: "center",
   alignItems: "center",

--- a/packages/icons/src/utils.ts
+++ b/packages/icons/src/utils.ts
@@ -64,6 +64,7 @@ export const getSizeStyles = (
 
   return {
     fontSize,
-    "--size": `${containerSize}px`,
+    /** icon container size. @private */
+    "--icsize": `${containerSize}px`,
   };
 };

--- a/packages/lab/src/StepNavigation/DefaultNavigation/Step/Step.styles.tsx
+++ b/packages/lab/src/StepNavigation/DefaultNavigation/Step/Step.styles.tsx
@@ -1,9 +1,10 @@
-import { createClasses } from "@hitachivantara/uikit-react-core";
+import { createClasses, theme } from "@hitachivantara/uikit-react-core";
 
 export const { staticClasses, useClasses } = createClasses("HvStep", {
   root: {
     width: "fit-content",
     height: "fit-content",
+    fontWeight: theme.fontWeights.semibold,
   },
   notCurrent: { margin: "-8px" },
   xs: {},

--- a/packages/lab/src/StepNavigation/DefaultNavigation/Step/Step.tsx
+++ b/packages/lab/src/StepNavigation/DefaultNavigation/Step/Step.tsx
@@ -2,8 +2,8 @@ import {
   ExtractNames,
   HvAvatar,
   HvBaseProps,
-  HvButton,
-  HvButtonProps,
+  HvButtonBase,
+  HvButtonBaseProps,
   HvSize,
 } from "@hitachivantara/uikit-react-core";
 import {
@@ -20,7 +20,7 @@ import { useClasses } from "./Step.styles";
 type HvStepClasses = ExtractNames<typeof useClasses>;
 
 export interface HvStepProps
-  extends Pick<HvButtonProps, "onClick">,
+  extends Pick<HvButtonBaseProps, "onClick">,
     Omit<HvBaseProps, "onClick"> {
   /** A Jss Object used to override or extend the styles applied to the empty state StepNavigation. */
   classes?: HvStepClasses;
@@ -92,18 +92,16 @@ export const HvStep = ({
 
   const backgroundColor = getColor(state);
 
-  const color = state === "Pending" ? "atmo2" : undefined;
-  const semantic = state !== "Pending" ? getSemantic(state) : undefined;
+  const color = state === "Pending" ? "atmo2" : getSemantic(state);
   const status = state === "Current" ? "secondary_60" : undefined;
   const IconComponent = iconStateObject[state];
 
   return (
-    <HvButton
+    <HvButtonBase
       className={cx(classes.root, className, {
         [classes.notCurrent]: state !== "Current",
       })}
       aria-label={title}
-      icon
       disabled={disabled ?? ["Current", "Disabled"].includes(state)}
       onClick={onClick}
     >
@@ -116,15 +114,13 @@ export const HvStep = ({
         {IconComponent ? (
           <IconComponent
             color={color}
-            semantic={semantic}
-            width={svgSize}
-            height={svgSize}
-            iconSize={iconSize}
+            style={{ fontSize: svgSize }}
+            size={iconSize}
           />
         ) : (
           number
         )}
       </HvAvatar>
-    </HvButton>
+    </HvButtonBase>
   );
 };

--- a/packages/lab/src/Wizard/WizardTitle/WizardTitle.styles.tsx
+++ b/packages/lab/src/Wizard/WizardTitle/WizardTitle.styles.tsx
@@ -13,10 +13,7 @@ export const { staticClasses, useClasses } = createClasses("HvWizardTitle", {
   messageContainer: {},
   /** @deprecated use `classes.root` */
   titleContainer: {},
-  summaryButton: {
-    width: 120,
-    paddingRight: 18,
-  },
+  summaryButton: {},
   /** @deprecated use `classes.summaryButton` */
   buttonWidth: {},
   /** @deprecated use `classes.summaryButton` */


### PR DESCRIPTION
Add support for external icons (that don't have a container box) to `HvButton` (and `HvAvatar`/`HvBadge`), by removing the icon internal padding & adding the correct padding in the components:

- rename internal `HvIconContainer` container sizing CSS variable to `--icsize` to avoid collisions
- change `--icsize` in button to "auto"
- make `<HvButton icon>` follow the icon sizes