### PR TITLE
fix(Canvas): panel button position

### DIFF
--- a/packages/pentaho/src/Canvas/SidePanel/SidePanel.styles.tsx
+++ b/packages/pentaho/src/Canvas/SidePanel/SidePanel.styles.tsx
@@ -37,7 +37,7 @@ export const { staticClasses, useClasses } = createClasses(
       borderRadius: "0px 16px 16px 0px",
       position: "absolute",
       transition: "left 0.3s ease",
-      top: "calc(50% - 86px)",
+      top: "calc(50% - 44px)", // subtract handle's full height
       "&$handleOpen": {
         left: 320,
       },


### PR DESCRIPTION
alignment is to the top of the button (like `align: "start"`), so there's less chance of button overlap

![image](https://github.com/user-attachments/assets/5ab5c90c-8437-43fd-9b32-c2ece4224528)
