### PR TITLE
chore(lint): update base plugins & rules

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -102,15 +102,16 @@
       // override for package source-code files
       "files": ["packages/*/src/**/*.ts?(x)"],
       "excludedFiles": [
-        "packages/**/*.stories.ts?(x)",
-        "packages/**/*.spec.ts?(x)",
-        "packages/**/*.test.ts?(x)",
-        "packages/**/stories/**/*.ts?(x)"
+        "*.stories.ts?(x)",
+        "*.spec.ts?(x)",
+        "*.test.ts?(x)",
+        "**/templates/**",
+        "**/stories/**"
       ],
       "extends": ["plugin:ssr-friendly/recommended"],
       "rules": {
         "no-restricted-imports": ["error", { "patterns": ["packages/**"] }],
-        // "react/display-name": "error", // TODO: enable
+        "react/display-name": "error",
         "import/no-cycle": "error",
         "import/no-extraneous-dependencies": "error"
       }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,20 +1,23 @@
 {
   "parser": "@typescript-eslint/parser",
+  "root": true,
   "parserOptions": {
     "project": "./tsconfig.json",
     "ecmaVersion": "latest",
     "sourceType": "module"
   },
   "extends": [
+    "eslint:recommended",
+    "plugin:@typescript-eslint/recommended",
     "plugin:import/recommended",
     "plugin:import/typescript",
-    "airbnb",
-    "airbnb/hooks",
-    "airbnb-typescript",
+    "plugin:jsx-a11y/recommended",
+    "plugin:react-hooks/recommended",
+    "plugin:react/recommended",
     "plugin:react/jsx-runtime",
     "prettier"
   ],
-  "plugins": ["@typescript-eslint", "import", "ssr-friendly"],
+  "plugins": [],
   "env": {
     "es2021": true,
     "browser": true,
@@ -24,6 +27,7 @@
   "rules": {
     "arrow-body-style": "off",
     "prefer-arrow-callback": "off",
+    "jsx-a11y/no-autofocus": "off",
     "react/jsx-key": "error",
     "react/prop-types": "off",
     "react/no-unused-prop-types": "off",
@@ -87,13 +91,29 @@
         ]
       }
     ],
-    "import/no-cycle": "error",
+    "import/no-cycle": "off",
+    "import/namespace": "off",
+    "import/no-unresolved": "off",
     "import/order": "off",
+    "no-restricted-syntax": [
+      "error",
+      {
+        "selector": "ImportDeclaration[source.value='react'][specifiers.0.type='ImportDefaultSpecifier']",
+        "message": "Default React import not allowed"
+      }
+    ],
     // TODO: review this
     "react/no-array-index-key": "off",
-    "no-restricted-syntax": "off", // loops are fine?
     "no-param-reassign": "off",
-    "consistent-return": "off"
+    "consistent-return": "off",
+    "@typescript-eslint/ban-types": "off",
+    "@typescript-eslint/ban-ts-comment": "off",
+    "@typescript-eslint/no-explicit-any": "off",
+    "@typescript-eslint/no-unused-vars": [
+      "error",
+      { "ignoreRestSiblings": true }
+    ],
+    "react/display-name": "off"
   },
   "overrides": [
     {
@@ -144,6 +164,9 @@
     }
   ],
   "settings": {
+    "react": {
+      "version": "detect"
+    },
     "import/parsers": {
       "@typescript-eslint/parser": [".ts", ".tsx"]
     },

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -13,11 +13,9 @@
     "plugin:import/typescript",
     "plugin:jsx-a11y/recommended",
     "plugin:react-hooks/recommended",
-    "plugin:react/recommended",
-    "plugin:react/jsx-runtime",
     "prettier"
   ],
-  "plugins": [],
+  "plugins": ["react"],
   "env": {
     "es2021": true,
     "browser": true,
@@ -25,18 +23,24 @@
   },
   "ignorePatterns": ["*.d.ts", "dist", "node_modules", "playwright.config.ts"],
   "rules": {
-    "arrow-body-style": "off",
-    "prefer-arrow-callback": "off",
+    // #region React
+    "react-hooks/exhaustive-deps": "error",
     "jsx-a11y/no-autofocus": "off",
+
     "react/jsx-key": "error",
-    "react/prop-types": "off",
-    "react/no-unused-prop-types": "off",
-    "react/require-default-props": "off",
-    "react/jsx-props-no-spreading": "off",
+    "react/jsx-no-comment-textnodes": "error",
+    "react/jsx-no-duplicate-props": "error",
+    "react/jsx-no-target-blank": "error",
+    "react/no-children-prop": "error",
+    "react/no-danger-with-children": "error",
+    "react/no-deprecated": "error",
+    "react/no-find-dom-node": "error",
+    "react/no-render-return-value": "error",
+    "react/no-unescaped-entities": "error",
     "react/function-component-definition": [
       "error",
       {
-        "namedComponents": "arrow-function",
+        "namedComponents": ["arrow-function", "function-declaration"],
         "unnamedComponents": "arrow-function"
       }
     ],
@@ -53,7 +57,13 @@
         "allowNamespace": true
       }
     ],
-    "no-nested-ternary": "off",
+    // #endregion
+
+    // #region Imports
+    "import/namespace": "off",
+    "import/no-unresolved": "off",
+    // #endregion
+
     "no-restricted-imports": [
       "error",
       {
@@ -68,33 +78,7 @@
         }
       }
     ],
-    "no-plusplus": [
-      "error",
-      {
-        "allowForLoopAfterthoughts": true
-      }
-    ],
-    "import/prefer-default-export": "off",
-    "import/no-extraneous-dependencies": [
-      "error",
-      {
-        "devDependencies": [
-          "apps/**",
-          "docs/**",
-          "templates/**",
-          "packages/icons/**",
-          "**/*.config.ts",
-          "**/*.stories.ts?(x)",
-          "**/stories/*.ts?(x)",
-          "**/*.spec.ts?(x)",
-          "**/*.test.ts?(x)"
-        ]
-      }
-    ],
-    "import/no-cycle": "off",
-    "import/namespace": "off",
-    "import/no-unresolved": "off",
-    "import/order": "off",
+
     "no-restricted-syntax": [
       "error",
       {
@@ -103,7 +87,6 @@
       }
     ],
     // TODO: review this
-    "react/no-array-index-key": "off",
     "no-param-reassign": "off",
     "consistent-return": "off",
     "@typescript-eslint/ban-types": "off",
@@ -112,16 +95,24 @@
     "@typescript-eslint/no-unused-vars": [
       "error",
       { "ignoreRestSiblings": true }
-    ],
-    "react/display-name": "off"
+    ]
   },
   "overrides": [
     {
       // override for package source-code files
       "files": ["packages/*/src/**/*.ts?(x)"],
+      "excludedFiles": [
+        "packages/**/*.stories.ts?(x)",
+        "packages/**/*.spec.ts?(x)",
+        "packages/**/*.test.ts?(x)",
+        "packages/**/stories/**/*.ts?(x)"
+      ],
       "extends": ["plugin:ssr-friendly/recommended"],
       "rules": {
-        "no-restricted-imports": ["error", { "patterns": ["packages/**"] }]
+        "no-restricted-imports": ["error", { "patterns": ["packages/**"] }],
+        // "react/display-name": "error", // TODO: enable
+        "import/no-cycle": "error",
+        "import/no-extraneous-dependencies": "error"
       }
     },
     {
@@ -152,14 +143,7 @@
         "no-alert": "off",
         "no-console": "off",
         "no-multi-str": "off",
-        "import/no-duplicates": "off",
-        "import/no-extraneous-dependencies": "off"
-      }
-    },
-    {
-      "files": ["**/*.config.ts"],
-      "rules": {
-        "import/no-relative-packages": "off"
+        "import/no-duplicates": "off"
       }
     }
   ],

--- a/apps/app/src/generator/GeneratorContext.tsx
+++ b/apps/app/src/generator/GeneratorContext.tsx
@@ -1,4 +1,4 @@
-import React, {
+import {
   createContext,
   Dispatch,
   SetStateAction,

--- a/apps/docs/src/components/code/Live.tsx
+++ b/apps/docs/src/components/code/Live.tsx
@@ -1,4 +1,5 @@
-import React, { useMemo, useState } from "react";
+import * as React from "react";
+import { useMemo, useState } from "react";
 import {
   CodeEditor,
   LiveError,

--- a/apps/docs/src/components/home/CardsSection.tsx
+++ b/apps/docs/src/components/home/CardsSection.tsx
@@ -1,4 +1,4 @@
-import clsx from "clsx";
+import { clsx } from "clsx";
 
 import { ApiUsage } from "./cards/ApiUsage";
 import { DataConfig } from "./cards/DataConfig";

--- a/apps/docs/src/components/home/HeroSection.tsx
+++ b/apps/docs/src/components/home/HeroSection.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from "react";
 import { ArrowRight } from "@phosphor-icons/react";
-import clsx from "clsx";
+import { clsx } from "clsx";
 import { HvButton } from "@hitachivantara/uikit-react-core";
 
 const SlideText = () => {

--- a/apps/docs/src/components/home/Home.tsx
+++ b/apps/docs/src/components/home/Home.tsx
@@ -1,4 +1,4 @@
-import clsx from "clsx";
+import { clsx } from "clsx";
 
 import { CardsSection } from "./CardsSection";
 import { HeroSection } from "./HeroSection";

--- a/apps/docs/src/components/home/cards/Card.tsx
+++ b/apps/docs/src/components/home/cards/Card.tsx
@@ -1,4 +1,4 @@
-import clsx from "clsx";
+import { clsx } from "clsx";
 import {
   HvCard,
   HvCardContent,

--- a/docs/foundation/colors/Colors.stories.tsx
+++ b/docs/foundation/colors/Colors.stories.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from "react";
+import { Fragment, useMemo } from "react";
 import { css } from "@emotion/css";
 import { Meta } from "@storybook/react";
 import {
@@ -12,10 +12,8 @@ import { themeColors } from "./themeColors";
 
 function groupColors(colorsJson?: HvThemeColorModeStructure) {
   const colorsMap = new Map<string, string>();
-  for (const key in colorsJson) {
-    if (Object.hasOwn(colorsJson, key)) {
-      colorsMap.set(key, colorsJson[key as keyof typeof colorsJson]);
-    }
+  for (const [key, value] of Object.entries(colorsJson || {})) {
+    colorsMap.set(key, value);
   }
   return colorsMap;
 }
@@ -70,12 +68,12 @@ const ColorsGroup = ({
               <div className={classes.colors}>
                 {Object.values(themeColors[selectedTheme][group]).map(
                   (color, idx) => (
-                    <React.Fragment key={color as string}>
+                    <Fragment key={color}>
                       <div
                         style={{
                           width: 0,
                           flexBasis:
-                            (color as string).includes("cat") &&
+                            color.includes("cat") &&
                             selectedTheme === "ds5" &&
                             idx !== 0 &&
                             idx % 9 === 0
@@ -87,19 +85,17 @@ const ColorsGroup = ({
                         <div
                           className={classes.colorSquare}
                           style={{
-                            backgroundColor: colors.get(color as string),
+                            backgroundColor: colors.get(color),
                           }}
                         />
                         <span className={classes.colorName}>
-                          <HvTypography variant="label">
-                            {color as string}
-                          </HvTypography>
+                          <HvTypography variant="label">{color}</HvTypography>
                           <HvTypography variant="caption1">
-                            {colors.get(color as string)}
+                            {colors.get(color)}
                           </HvTypography>
                         </span>
                       </div>
-                    </React.Fragment>
+                    </Fragment>
                   ),
                 )}
               </div>

--- a/docs/guides/dnd/types.ts
+++ b/docs/guides/dnd/types.ts
@@ -1,5 +1,3 @@
-import React from "react";
-
 export type Column = {
   id: string;
   title?: string;

--- a/package-lock.json
+++ b/package-lock.json
@@ -64,8 +64,6 @@
         "echarts": "^5.4.3",
         "echarts-for-react": "^3.0.2",
         "eslint": "^8.55.0",
-        "eslint-config-airbnb": "^19.0.4",
-        "eslint-config-airbnb-typescript": "^18.0.0",
         "eslint-config-prettier": "^9.1.0",
         "eslint-import-resolver-typescript": "^3.6.1",
         "eslint-plugin-import": "^2.29.0",
@@ -12697,13 +12695,6 @@
       "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
       "license": "MIT"
     },
-    "node_modules/confusing-browser-globals": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/confusing-browser-globals/-/confusing-browser-globals-1.0.11.tgz",
-      "integrity": "sha512-JsPKdmh8ZkmnHxDk55FZ1TqVLvEQTvoByJZRN9jzI0UjxK/QgAmsphz7PGtqgPieQZ/CQcHWXCR7ATDNhGe+YA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/consola": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/consola/-/consola-3.2.3.tgz",
@@ -15144,73 +15135,6 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/eslint-config-airbnb": {
-      "version": "19.0.4",
-      "resolved": "https://registry.npmjs.org/eslint-config-airbnb/-/eslint-config-airbnb-19.0.4.tgz",
-      "integrity": "sha512-T75QYQVQX57jiNgpF9r1KegMICE94VYwoFQyMGhrvc+lB8YF2E/M/PYDaQe1AJcWaEgqLE+ErXV1Og/+6Vyzew==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "eslint-config-airbnb-base": "^15.0.0",
-        "object.assign": "^4.1.2",
-        "object.entries": "^1.1.5"
-      },
-      "engines": {
-        "node": "^10.12.0 || ^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "peerDependencies": {
-        "eslint": "^7.32.0 || ^8.2.0",
-        "eslint-plugin-import": "^2.25.3",
-        "eslint-plugin-jsx-a11y": "^6.5.1",
-        "eslint-plugin-react": "^7.28.0",
-        "eslint-plugin-react-hooks": "^4.3.0"
-      }
-    },
-    "node_modules/eslint-config-airbnb-base": {
-      "version": "15.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-airbnb-base/-/eslint-config-airbnb-base-15.0.0.tgz",
-      "integrity": "sha512-xaX3z4ZZIcFLvh2oUNvcX5oEofXda7giYmuplVxoOg5A7EXJMrUyqRgR+mhDhPK8LZ4PttFOBvCYDbX3sUoUig==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "confusing-browser-globals": "^1.0.10",
-        "object.assign": "^4.1.2",
-        "object.entries": "^1.1.5",
-        "semver": "^6.3.0"
-      },
-      "engines": {
-        "node": "^10.12.0 || >=12.0.0"
-      },
-      "peerDependencies": {
-        "eslint": "^7.32.0 || ^8.2.0",
-        "eslint-plugin-import": "^2.25.2"
-      }
-    },
-    "node_modules/eslint-config-airbnb-base/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/eslint-config-airbnb-typescript": {
-      "version": "18.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-airbnb-typescript/-/eslint-config-airbnb-typescript-18.0.0.tgz",
-      "integrity": "sha512-oc+Lxzgzsu8FQyFVa4QFaVKiitTYiiW3frB9KYW5OWdPrqFc7FzxgB20hP4cHMlr+MBzGcLl3jnCOVOydL9mIg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "eslint-config-airbnb-base": "^15.0.0"
-      },
-      "peerDependencies": {
-        "@typescript-eslint/eslint-plugin": "^7.0.0",
-        "@typescript-eslint/parser": "^7.0.0",
-        "eslint": "^8.56.0"
       }
     },
     "node_modules/eslint-config-prettier": {

--- a/package.json
+++ b/package.json
@@ -92,8 +92,6 @@
     "echarts": "^5.4.3",
     "echarts-for-react": "^3.0.2",
     "eslint": "^8.55.0",
-    "eslint-config-airbnb": "^19.0.4",
-    "eslint-config-airbnb-typescript": "^18.0.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-import-resolver-typescript": "^3.6.1",
     "eslint-plugin-import": "^2.29.0",

--- a/packages/cli/src/baselines/vite/src/main.tsx
+++ b/packages/cli/src/baselines/vite/src/main.tsx
@@ -1,8 +1,8 @@
 import { Suspense } from "react";
-import ReactDOM from "react-dom/client";
+import { createRoot } from "react-dom/client";
 import App from "./App";
 
-const root = ReactDOM.createRoot(document.getElementById("hv-root")!);
+const root = createRoot(document.getElementById("hv-root")!);
 
 root.render(
   <Suspense fallback>

--- a/packages/cli/src/templates/Canvas/TreeView.tsx
+++ b/packages/cli/src/templates/Canvas/TreeView.tsx
@@ -69,7 +69,7 @@ const data = [
 ] satisfies Data[];
 
 export const TreeItem = forwardRef<HTMLLIElement, TreeItemProps>(
-  (props, ref) => {
+  function TreeItem(props, ref) {
     const {
       className,
       isDragging,

--- a/packages/cli/src/templates/Canvas/index.tsx
+++ b/packages/cli/src/templates/Canvas/index.tsx
@@ -86,19 +86,17 @@ const Page = () => {
   const { selectedTable, openedTables, setOpenedTables, setSelectedTable } =
     useCanvasContext();
 
-  const bottomTabs: HvCanvasBottomPanelProps["tabs"] = useMemo(
-    () =>
-      openedTables?.map((table) => ({
-        id: table.id,
-        title: (overflowing) => (
-          <div className={classes.titleRoot}>
-            {!overflowing && <Table />}
-            <HvOverflowTooltip data={table.label} />
-          </div>
-        ),
-      })) ?? [],
-    [openedTables],
-  );
+  const bottomTabs = useMemo(() => {
+    return (openedTables || []).map((table) => ({
+      id: table.id,
+      title: (overflowing) => (
+        <div className={classes.titleRoot}>
+          {!overflowing && <Table />}
+          <HvOverflowTooltip data={table.label} />
+        </div>
+      ),
+    })) satisfies HvCanvasBottomPanelProps["tabs"];
+  }, [openedTables]);
 
   const handleCloseTab = (value: string | number) => {
     const newOpenedTables = openedTables?.filter((x) => x.id !== value) ?? [];
@@ -277,10 +275,7 @@ const Page = () => {
             onClose={() => setFullscreen((prev) => !prev)}
           >
             <HvDialogTitle className={classes.dialogTitle}>
-              {(
-                bottomTabs?.find((x) => x.id === selectedTable)
-                  ?.title as Function
-              )(false)}
+              {bottomTabs.find((x) => x.id === selectedTable)?.title(false)}
             </HvDialogTitle>
             <HvDialogContent>
               <DataTable id={selectedTable} />

--- a/packages/code-editor/src/CodeEditor/languages/xml.ts
+++ b/packages/code-editor/src/CodeEditor/languages/xml.ts
@@ -280,7 +280,7 @@ export const hvXmlValidator = async (
     const errors = String(error?.message).split("parser error :");
     const lastError = errors[errors.length - 1].trim();
     const lineNumberParts = lastError.match(/(line) ([0-9]+)/);
-    const errorLine = Number(lineNumberParts?.[2]) ?? 1;
+    const errorLine = Number(lineNumberParts?.[2]) || 1;
     const cleanedError = lastError.replace(lineNumberParts?.[0] ?? "", "");
 
     return [

--- a/packages/code-editor/src/CodeEditor/stories/Xml/utils.tsx
+++ b/packages/code-editor/src/CodeEditor/stories/Xml/utils.tsx
@@ -120,7 +120,7 @@ interface SimpleTreeItemProps extends HvTreeItemProps {
 }
 
 const SimpleTreeItem = forwardRef<HTMLLIElement, SimpleTreeItemProps>(
-  (props, ref) => {
+  function SimpleTreeItem(props, ref) {
     const { children, nodeId, label, attributes, ...others } = props;
     return (
       <HvTreeItem

--- a/packages/core/src/BaseDropdown/BaseDropdown.tsx
+++ b/packages/core/src/BaseDropdown/BaseDropdown.tsx
@@ -132,7 +132,7 @@ const BaseDropdown = forwardRef<
     HvBaseDropdownProps,
     "popperProps" | "variableWidth" | "placement" | "onContainerCreation"
   >
->((props, ref) => {
+>(function BaseDropdown(props, ref) {
   const {
     id: idProp,
     className,

--- a/packages/core/src/Card/Card.tsx
+++ b/packages/core/src/Card/Card.tsx
@@ -41,7 +41,7 @@ export const HvCard = forwardRef<
   // no-indent
   React.ComponentRef<"div">,
   HvCardProps
->((props, ref) => {
+>(function HvCard(props, ref) {
   const {
     classes: classesProp,
     style,

--- a/packages/core/src/Controls/context/ControlsContext.ts
+++ b/packages/core/src/Controls/context/ControlsContext.ts
@@ -1,6 +1,6 @@
-import React from "react";
+import { createContext } from "react";
 
-export const HvControlsContext = React.createContext<{
+export const HvControlsContext = createContext<{
   onSearch?: any;
   onSort?: any;
 }>({});

--- a/packages/core/src/Dialog/Dialog.tsx
+++ b/packages/core/src/Dialog/Dialog.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo } from "react";
+import { useCallback, useMemo } from "react";
 import MuiDialog, { DialogProps as MuiDialogProps } from "@mui/material/Dialog";
 import { Close } from "@hitachivantara/uikit-react-icons";
 import {

--- a/packages/core/src/DropDownMenu/DropDownMenu.tsx
+++ b/packages/core/src/DropDownMenu/DropDownMenu.tsx
@@ -86,7 +86,7 @@ export interface HvDropDownMenuProps
 }
 
 const HeaderComponent = forwardRef<HTMLButtonElement, HvDropdownButtonProps>(
-  (props, ref) => {
+  function HeaderComponent(props, ref) {
     const { open, icon, disabled, ...others } = props;
     const { popperPlacement } = useBaseDropdownContext();
 

--- a/packages/core/src/Dropdown/stories/CustomDropdown.tsx
+++ b/packages/core/src/Dropdown/stories/CustomDropdown.tsx
@@ -62,7 +62,7 @@ const treeDataObject = {
 } satisfies TreeData;
 
 const SimpleTreeItem = forwardRef<HTMLLIElement, HvTreeItemProps>(
-  (props, ref) => {
+  function SimpleTreeItem(props, ref) {
     const { children, nodeId, label, ...others } = props;
     const Icon = children ? Folders : Doc;
 

--- a/packages/core/src/EmptyState/EmptyState.tsx
+++ b/packages/core/src/EmptyState/EmptyState.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef } from "react";
+import { forwardRef } from "react";
 import { useTheme } from "@mui/material/styles";
 import useMediaQuery from "@mui/material/useMediaQuery";
 import {

--- a/packages/core/src/FormElement/Adornment/Adornment.tsx
+++ b/packages/core/src/FormElement/Adornment/Adornment.tsx
@@ -50,7 +50,7 @@ export interface HvAdornmentProps
 export const HvAdornment = forwardRef<
   HTMLDivElement | HTMLButtonElement,
   HvAdornmentProps
->((props, ref) => {
+>(function HvAdornment(props, ref) {
   const {
     id,
     classes: classesProp,

--- a/packages/core/src/FormElement/Suggestions/Suggestions.tsx
+++ b/packages/core/src/FormElement/Suggestions/Suggestions.tsx
@@ -58,7 +58,7 @@ export const HvSuggestions = forwardRef<
   // no-indent
   unknown,
   HvSuggestionsProps
->((props, extRef) => {
+>(function HvSuggestions(props, extRef) {
   const {
     id: idProp,
     className,

--- a/packages/core/src/GlobalActions/GlobalActions.tsx
+++ b/packages/core/src/GlobalActions/GlobalActions.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef } from "react";
+import { forwardRef } from "react";
 import { useTheme as useMuiTheme } from "@mui/material/styles";
 import useMediaQuery from "@mui/material/useMediaQuery";
 import {

--- a/packages/core/src/Grid/Grid.tsx
+++ b/packages/core/src/Grid/Grid.tsx
@@ -210,7 +210,11 @@ function getContainerProps(
   return containerProps;
 }
 
-const WidthGrid = forwardRef<HTMLDivElement, HvGridProps>((props, ref) => {
+const WidthGrid = forwardRef<
+  // no-indent
+  HTMLDivElement,
+  HvGridProps
+>(function WidthGrid(props, ref) {
   const { container, spacing, rowSpacing, columnSpacing, columns, ...others } =
     props;
 

--- a/packages/core/src/InlineEditor/InlineEditor.tsx
+++ b/packages/core/src/InlineEditor/InlineEditor.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from "react";
+import { useRef, useState } from "react";
 import { Edit } from "@hitachivantara/uikit-react-icons";
 import {
   useDefaultProps,

--- a/packages/core/src/List/List.tsx
+++ b/packages/core/src/List/List.tsx
@@ -326,6 +326,7 @@ export const HvList = (props: HvListProps) => {
   const ariaMultiSelectable = (role === "listbox" && multiSelect) || undefined;
 
   const ListContainer = useMemo(() => {
+    // eslint-disable-next-line react/display-name
     return forwardRef<HTMLUListElement, HvListContainerProps>(
       ({ ...rest }, ref) => (
         <HvListContainer

--- a/packages/core/src/ListContainer/ListContext/ListContext.ts
+++ b/packages/core/src/ListContainer/ListContext/ListContext.ts
@@ -1,6 +1,6 @@
-import React from "react";
+import { createContext } from "react";
 
-const ListContext = React.createContext<{
+const ListContext = createContext<{
   interactive?: boolean;
   nesting?: number;
   condensed?: boolean;

--- a/packages/core/src/Pagination/Pagination.tsx
+++ b/packages/core/src/Pagination/Pagination.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, useCallback, useEffect, useState } from "react";
+import { forwardRef, useCallback, useEffect, useState } from "react";
 import { useMediaQuery, useTheme } from "@mui/material";
 import {
   Backwards,

--- a/packages/core/src/Select/Select.tsx
+++ b/packages/core/src/Select/Select.tsx
@@ -9,7 +9,7 @@ import {
 } from "@mui/base/useSelect";
 import { useControlled, useForkRef } from "@mui/material/utils";
 import type { Placement } from "@popperjs/core";
-import clsx from "clsx";
+import { clsx, type ClassValue } from "clsx";
 import {
   useDefaultProps,
   useTheme,
@@ -45,7 +45,7 @@ function defaultRenderValue<Value>(
   return options?.label ?? null;
 }
 
-const mergeIds = (...ids: clsx.ClassValue[]) => clsx(ids) || undefined;
+const mergeIds = (...ids: ClassValue[]) => clsx(ids) || undefined;
 
 export { staticClasses as selectClasses };
 

--- a/packages/core/src/Slider/Slider.tsx
+++ b/packages/core/src/Slider/Slider.tsx
@@ -145,7 +145,11 @@ export interface HvSliderProps
 /**
  * Sliders reflect a range of values along a bar, from which users may select a single value. They are ideal for adjusting settings such as volume, brightness, or applying image filters.
  */
-export const HvSlider = forwardRef<SliderRef, HvSliderProps>((props, ref) => {
+export const HvSlider = forwardRef<
+  // no-indent
+  SliderRef,
+  HvSliderProps
+>(function HvSlider(props, ref) {
   const {
     id,
     className,
@@ -336,7 +340,7 @@ export const HvSlider = forwardRef<SliderRef, HvSliderProps>((props, ref) => {
           minPointValue,
           stepValue,
         );
-      }, this);
+      });
 
       return {
         knobsPosition: newKnobsPosition,

--- a/packages/core/src/Snackbar/SnackbarContent/SnackbarContent.tsx
+++ b/packages/core/src/Snackbar/SnackbarContent/SnackbarContent.tsx
@@ -50,7 +50,7 @@ export interface HvSnackbarContentProps
 export const HvSnackbarContent = forwardRef<
   HTMLDivElement,
   HvSnackbarContentProps
->((props: HvSnackbarContentProps, ref) => {
+>(function HvSnackbarContent(props, ref) {
   const {
     className,
     id,

--- a/packages/core/src/SnackbarProvider/SnackbarProvider.tsx
+++ b/packages/core/src/SnackbarProvider/SnackbarProvider.tsx
@@ -55,7 +55,7 @@ export interface HvNotistackSnackMessageProps extends OptionsObject {
 const HvNotistackSnackMessage = forwardRef<
   HTMLDivElement,
   HvNotistackSnackMessageProps
->((props, ref) => {
+>(function HvNotistackSnackMessage(props, ref) {
   const { id, message, variant = "success", snackbarContentProps } = props;
 
   return (

--- a/packages/core/src/Table/TableBody/TableBody.tsx
+++ b/packages/core/src/Table/TableBody/TableBody.tsx
@@ -5,7 +5,10 @@ import {
   useContext,
   useRef,
 } from "react";
-import { type ExtractNames } from "@hitachivantara/uikit-react-utils";
+import {
+  useDefaultProps,
+  type ExtractNames,
+} from "@hitachivantara/uikit-react-utils";
 
 import { HvFocus } from "../../Focus";
 import { useForkRef } from "../../hooks/useForkRef";
@@ -50,17 +53,15 @@ const defaultComponent = "tbody";
  * `HvTableCell` and `HvTableRow` elements in it inherit body-specific styles
  */
 export const HvTableBody = forwardRef<HTMLElement, HvTableBodyProps>(
-  (
-    {
+  function HvTableBody(props, externalRef) {
+    const {
       classes: classesProp,
       className,
       component,
       children,
       withNavigation = false,
       ...others
-    },
-    externalRef,
-  ) => {
+    } = useDefaultProps("HvTableBody", props);
     const { classes, cx } = useClasses(classesProp);
 
     const tableContext = useContext(TableContext);

--- a/packages/core/src/Table/TableCell/TableCell.tsx
+++ b/packages/core/src/Table/TableCell/TableCell.tsx
@@ -58,7 +58,7 @@ const defaultComponent = "td";
  * `HvTableCell` acts as a `td` element and inherits styles from its context
  */
 export const HvTableCell = forwardRef<HTMLElement, HvTableCellProps>(
-  (props, externalRef) => {
+  function HvTableCell(props, ref) {
     const {
       children,
       component,
@@ -91,7 +91,7 @@ export const HvTableCell = forwardRef<HTMLElement, HvTableCellProps>(
 
     return (
       <Component
-        ref={externalRef}
+        ref={ref}
         role={Component === defaultComponent ? null : "cell"}
         style={style}
         className={cx(

--- a/packages/core/src/Table/TableContainer/TableContainer.tsx
+++ b/packages/core/src/Table/TableContainer/TableContainer.tsx
@@ -1,5 +1,8 @@
 import { forwardRef } from "react";
-import { type ExtractNames } from "@hitachivantara/uikit-react-utils";
+import {
+  useDefaultProps,
+  type ExtractNames,
+} from "@hitachivantara/uikit-react-utils";
 
 import { HvBaseProps } from "../../types/generic";
 import { staticClasses, useClasses } from "./TableContainer.styles";
@@ -27,14 +30,20 @@ export interface HvTableContainerProps
  * HvTableContainer is a container for the HvTable
  */
 export const HvTableContainer = forwardRef<HTMLElement, HvTableContainerProps>(
-  ({ classes: classesProp, className, component, ...others }, externalRef) => {
+  function HvTableContainer(props, ref) {
+    const {
+      classes: classesProp,
+      className,
+      component,
+      ...others
+    } = useDefaultProps("HvTableContainer", props);
     const { classes, cx } = useClasses(classesProp);
 
     const Component = component || "div";
 
     return (
       <Component
-        ref={externalRef}
+        ref={ref}
         className={cx(classes.root, className)}
         {...others}
       />

--- a/packages/core/src/Table/TableHead/TableHead.tsx
+++ b/packages/core/src/Table/TableHead/TableHead.tsx
@@ -1,5 +1,8 @@
 import { forwardRef, useContext } from "react";
-import { type ExtractNames } from "@hitachivantara/uikit-react-utils";
+import {
+  useDefaultProps,
+  type ExtractNames,
+} from "@hitachivantara/uikit-react-utils";
 
 import { HvBaseProps } from "../../types/generic";
 import TableContext from "../TableContext";
@@ -43,10 +46,14 @@ const defaultComponent = "thead";
  * `HvTableCell` and `HvTableRow` elements in it inherit header-specific styles
  */
 export const HvTableHead = forwardRef<HTMLElement, HvTableHeadProps>(
-  (
-    { classes: classesProp, className, component, stickyHeader, ...others },
-    externalRef,
-  ) => {
+  function HvTableHead(props, ref) {
+    const {
+      classes: classesProp,
+      className,
+      component,
+      stickyHeader,
+      ...others
+    } = useDefaultProps("HvTableHead", props);
     const { classes, cx } = useClasses(classesProp);
 
     const tableContext = useContext(TableContext);
@@ -62,7 +69,7 @@ export const HvTableHead = forwardRef<HTMLElement, HvTableHeadProps>(
             { [classes.stickyHeader]: stickyHeader },
             className,
           )}
-          ref={externalRef}
+          ref={ref}
           role={Component === defaultComponent ? null : "rowgroup"}
           {...others}
         />

--- a/packages/core/src/Table/TableHeader/TableHeader.tsx
+++ b/packages/core/src/Table/TableHeader/TableHeader.tsx
@@ -71,7 +71,7 @@ const defaultComponent = "th";
  * `HvTableHeader` acts as a `th` element and inherits styles from its context
  */
 export const HvTableHeader = forwardRef<HTMLElement, HvTableHeaderProps>(
-  (props, externalRef) => {
+  function HvTableHeader(props, ref) {
     const {
       children,
       component,
@@ -130,7 +130,7 @@ export const HvTableHeader = forwardRef<HTMLElement, HvTableHeaderProps>(
 
     return (
       <Component
-        ref={externalRef}
+        ref={ref}
         role={role}
         scope={scope}
         style={style}

--- a/packages/core/src/Table/TableRow/TableRow.tsx
+++ b/packages/core/src/Table/TableRow/TableRow.tsx
@@ -37,7 +37,7 @@ const defaultComponent = "tr";
  * `HvTableRow` acts as a `tr` element and inherits styles from its context
  */
 export const HvTableRow = forwardRef<HTMLElement, HvTableRowProps>(
-  (props, externalRef) => {
+  function HvTableRow(props, ref) {
     const {
       classes: classesProp,
       className,
@@ -63,7 +63,7 @@ export const HvTableRow = forwardRef<HTMLElement, HvTableRowProps>(
 
     return (
       <Component
-        ref={externalRef}
+        ref={ref}
         className={cx(
           tableSectionContext.filterClassName,
           classes.root,

--- a/packages/core/src/TagsInput/TagsInput.tsx
+++ b/packages/core/src/TagsInput/TagsInput.tsx
@@ -1,4 +1,4 @@
-import React, {
+import {
   forwardRef,
   useCallback,
   useEffect,

--- a/packages/core/src/TreeView/internals/utils/EventManager.ts
+++ b/packages/core/src/TreeView/internals/utils/EventManager.ts
@@ -85,7 +85,7 @@ export class EventManager {
   }
 
   once(eventName: string, listener: EventListener): void {
-    // eslint-disable-next-line consistent-this
+    // eslint-disable-next-line @typescript-eslint/no-this-alias
     const that = this;
     this.on(eventName, function oneTimeListener(...args) {
       that.removeListener(eventName, oneTimeListener);

--- a/packages/core/src/TreeView/stories/AsyncLoading.tsx
+++ b/packages/core/src/TreeView/stories/AsyncLoading.tsx
@@ -23,7 +23,7 @@ interface CustomTreeItemProps extends HvTreeItemProps {
 }
 
 const LoadingItem = forwardRef<HTMLLIElement, CustomTreeItemProps>(
-  (props, ref) => {
+  function LoadingItem(props, ref) {
     const { children, nodeId, label, onOpen, onClick, ...others } = props;
     const { expanded, disabled } = useHvTreeItem(nodeId);
     const Icon = children ? Folders : Doc;

--- a/packages/core/src/TreeView/stories/DataObject.tsx
+++ b/packages/core/src/TreeView/stories/DataObject.tsx
@@ -48,7 +48,7 @@ const treeDataObject = {
 } satisfies TreeData;
 
 const SimpleTreeItem = forwardRef<HTMLLIElement, HvTreeItemProps>(
-  (props, ref) => {
+  function SimpleTreeItem(props, ref) {
     const { children, nodeId, label, ...others } = props;
     const Icon = children ? Folders : Doc;
 

--- a/packages/core/src/TreeView/stories/VerticalNavigation.tsx
+++ b/packages/core/src/TreeView/stories/VerticalNavigation.tsx
@@ -37,7 +37,7 @@ const classes = {
 };
 
 const NavigationItem = forwardRef<HTMLLIElement, CustomTreeItemProps>(
-  (props, ref) => {
+  function NavigationItem(props, ref) {
     const { children, nodeId, label, onOpen, onClick, ...others } = props;
     const { disabled, expanded, level } = useHvTreeItem(nodeId);
 

--- a/packages/core/src/VerticalNavigation/TreeView/TreeViewItem.tsx
+++ b/packages/core/src/VerticalNavigation/TreeView/TreeViewItem.tsx
@@ -116,7 +116,10 @@ const preventSelection = (event: any, disabled: any) => {
 };
 
 export const HvVerticalNavigationTreeViewItem = forwardRef(
-  (props: HvVerticalNavigationTreeViewItemProps, ref) => {
+  function HvVerticalNavigationTreeViewItem(
+    props: HvVerticalNavigationTreeViewItemProps,
+    ref,
+  ) {
     const {
       id: idProp,
       className,

--- a/packages/core/src/hocs/withTooltip.tsx
+++ b/packages/core/src/hocs/withTooltip.tsx
@@ -21,6 +21,7 @@ export const withTooltip =
     tooltipProps?: Partial<HvTooltipProps>,
     tooltipContainerProps?: HvBaseProps,
   ) =>
+  // eslint-disable-next-line react/display-name
   (props: any) => {
     const [isHoverDisabled, setIsHoverDisabled] = useState<boolean | undefined>(
       false,

--- a/packages/core/src/hooks/useIsMounted.ts
+++ b/packages/core/src/hooks/useIsMounted.ts
@@ -1,9 +1,9 @@
-import React from "react";
+import { useEffect, useRef } from "react";
 
 export const useIsMounted = () => {
-  const isMounted = React.useRef(false);
+  const isMounted = useRef(false);
 
-  React.useEffect(() => {
+  useEffect(() => {
     isMounted.current = true;
 
     return () => {

--- a/packages/core/src/utils/deepMerge.ts
+++ b/packages/core/src/utils/deepMerge.ts
@@ -1,6 +1,6 @@
 import { DeepPartial } from "../types/generic";
 
-const isObject = (val: any): val is Object =>
+const isObject = (val: any): val is object =>
   val && typeof val === "object" && !Array.isArray(val);
 
 function merge<T>(target: T, source?: DeepPartial<T>) {

--- a/packages/lab/src/Flow/DroppableFlow.tsx
+++ b/packages/lab/src/Flow/DroppableFlow.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useRef, useState } from "react";
 import { DragEndEvent, useDndMonitor, useDroppable } from "@dnd-kit/core";
 import { Global } from "@emotion/react";
-import ReactFlow, {
+import {
   addEdge,
   applyEdgeChanges,
   applyNodeChanges,
@@ -11,6 +11,7 @@ import ReactFlow, {
   MarkerType,
   Node,
   NodeChange,
+  ReactFlow,
   ReactFlowProps,
 } from "reactflow";
 import { uid } from "uid";

--- a/packages/lab/src/Flow/Sidebar/SidebarGroup/SidebarGroupItem/SidebarGroupItem.tsx
+++ b/packages/lab/src/Flow/Sidebar/SidebarGroup/SidebarGroupItem/SidebarGroupItem.tsx
@@ -24,7 +24,7 @@ export interface HvFlowSidebarGroupItemProps extends HvBaseProps {
 export const HvFlowSidebarGroupItem = forwardRef<
   HTMLDivElement,
   HvFlowSidebarGroupItemProps
->((props, ref) => {
+>(function HvFlowSidebarGroupItem(props, ref) {
   const {
     label,
     isDragging,

--- a/packages/lab/src/Flow/stories/SubFlow/Level.tsx
+++ b/packages/lab/src/Flow/stories/SubFlow/Level.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { css, cx } from "@emotion/css";
 import {
   HvButton,

--- a/packages/pentaho/src/Canvas/BottomPanel/BottomPanel.tsx
+++ b/packages/pentaho/src/Canvas/BottomPanel/BottomPanel.tsx
@@ -72,7 +72,7 @@ export interface HvCanvasBottomPanelProps extends HvBaseProps {
 export const HvCanvasBottomPanel = forwardRef<
   HTMLDivElement,
   HvCanvasBottomPanelProps
->((props, ref) => {
+>(function HvCanvasBottomPanel(props, ref) {
   const {
     id: idProp,
     className,

--- a/packages/pentaho/src/Canvas/PanelTab/PanelTab.tsx
+++ b/packages/pentaho/src/Canvas/PanelTab/PanelTab.tsx
@@ -22,7 +22,7 @@ export interface HvCanvasPanelTabProps extends TabProps {
 export const HvCanvasPanelTab = forwardRef<
   HTMLButtonElement,
   HvCanvasPanelTabProps
->((props, ref) => {
+>(function HvCanvasPanelTab(props, ref) {
   const {
     classes: classesProp,
     className,

--- a/packages/pentaho/src/Canvas/PanelTabs/PanelTabs.tsx
+++ b/packages/pentaho/src/Canvas/PanelTabs/PanelTabs.tsx
@@ -23,7 +23,7 @@ export interface HvCanvasPanelTabsProps extends TabsProps {
 export const HvCanvasPanelTabs = forwardRef<
   HTMLDivElement,
   HvCanvasPanelTabsProps
->((props, ref) => {
+>(function HvCanvasPanelTabs(props, ref) {
   const {
     selectionFollowsFocus = true,
     children,

--- a/packages/pentaho/src/Canvas/SidePanel/SidePanel.tsx
+++ b/packages/pentaho/src/Canvas/SidePanel/SidePanel.tsx
@@ -71,7 +71,7 @@ export interface HvCanvasSidePanelProps
 export const HvCanvasSidePanel = forwardRef<
   HTMLDivElement,
   HvCanvasSidePanelProps
->((props, ref) => {
+>(function HvCanvasSidePanel(props, ref) {
   const {
     id: idProp,
     tab: tabProp,

--- a/packages/pentaho/src/Canvas/Toolbar/Toolbar.tsx
+++ b/packages/pentaho/src/Canvas/Toolbar/Toolbar.tsx
@@ -42,7 +42,7 @@ export interface HvCanvasToolbarProps
  * A toolbar component to use in a canvas context.
  */
 export const HvCanvasToolbar = forwardRef<HTMLDivElement, HvCanvasToolbarProps>(
-  (props, ref) => {
+  function HvCanvasToolbar(props, ref) {
     const {
       title: titleProp,
       backButton,

--- a/packages/pentaho/src/Canvas/ToolbarTabs/ToolbarTabs.tsx
+++ b/packages/pentaho/src/Canvas/ToolbarTabs/ToolbarTabs.tsx
@@ -86,7 +86,7 @@ export interface HvCanvasToolbarTabsProps
 export const HvCanvasToolbarTabs = forwardRef<
   HTMLDivElement,
   HvCanvasToolbarTabsProps
->((props, ref) => {
+>(function HvCanvasToolbarTabs(props, ref) {
   const {
     children,
     className,

--- a/packages/styles/src/index.ts
+++ b/packages/styles/src/index.ts
@@ -1,4 +1,6 @@
-import * as themes from "./themes";
+import ds3 from "./themes/ds3";
+import ds5 from "./themes/ds5";
+import pentahoPlus from "./themes/pentahoPlus";
 
 export * from "./types";
 export * from "./theme";
@@ -8,5 +10,5 @@ export * from "./tokens";
 export * from "./CssBaseline";
 
 // Export each theme individually and a bundle of themes
-export { ds3, ds5, pentahoPlus } from "./themes";
-export { themes };
+export { ds3, ds5, pentahoPlus };
+export const themes = { ds3, ds5, pentahoPlus };

--- a/packages/styles/src/themes/index.ts
+++ b/packages/styles/src/themes/index.ts
@@ -1,3 +1,0 @@
-export { default as ds3 } from "./ds3";
-export { default as ds5 } from "./ds5";
-export { default as pentahoPlus } from "./pentahoPlus";

--- a/packages/utils/src/hooks/useCss.ts
+++ b/packages/utils/src/hooks/useCss.ts
@@ -1,7 +1,7 @@
 import { useMemo } from "react";
 import { serializeStyles, type RegisteredCache } from "@emotion/serialize";
 import { getRegisteredStyles, insertStyles } from "@emotion/utils";
-import clsx from "clsx";
+import { clsx } from "clsx";
 import { useEmotionCache } from "@hitachivantara/uikit-react-shared";
 
 type CSS = any;

--- a/packages/utils/src/utils/classes.ts
+++ b/packages/utils/src/utils/classes.ts
@@ -8,7 +8,7 @@ export type ExtractNames<
 > = Partial<ReturnType<T>["classes"]>;
 
 /** Maps over an object, preserving the original keys */
-function mapObject<T extends Record<string, any>, Value extends any>(
+function mapObject<T extends Record<string, any>, Value>(
   /** Input object to convert */
   inputObject: T,
   /** Function to map over each entry */

--- a/packages/viz/src/BarChart/BarChart.tsx
+++ b/packages/viz/src/BarChart/BarChart.tsx
@@ -62,7 +62,7 @@ export interface HvBarChartProps
  * A bar chart is a chart or graph that presents categorical data with rectangular bars.
  */
 export const HvBarChart = forwardRef<ReactECharts, HvBarChartProps>(
-  (props, ref) => {
+  function HvBarChart(props, ref) {
     const {
       yAxis,
       xAxis,

--- a/packages/viz/src/BaseChart/BaseChart.tsx
+++ b/packages/viz/src/BaseChart/BaseChart.tsx
@@ -24,7 +24,7 @@ export interface HvBaseChartProps extends Pick<HvChartCommonProps, "onEvents"> {
  * Base chart.
  */
 export const HvBaseChart = forwardRef<ReactECharts, HvBaseChartProps>(
-  (props, ref) => {
+  function HvBaseChart(props, ref) {
     const { option, width, height, onEvents, ...others } = props;
 
     const { theme, activeTheme } = useVizTheme();

--- a/packages/viz/src/Boxplot/Boxplot.tsx
+++ b/packages/viz/src/Boxplot/Boxplot.tsx
@@ -50,7 +50,7 @@ export interface HvBoxplotProps
  * A Boxplot chart visually summarizes the distribution of a dataset by depicting key statistical measures such as the median, quartiles, and outliers.
  */
 export const HvBoxplot = forwardRef<ReactECharts, HvBoxplotProps>(
-  (props, ref) => {
+  function HvBoxplot(props, ref) {
     const {
       name,
       data,

--- a/packages/viz/src/ConfusionMatrix/ConfusionMatrix.tsx
+++ b/packages/viz/src/ConfusionMatrix/ConfusionMatrix.tsx
@@ -89,7 +89,7 @@ export interface HvConfusionMatrixProps
 export const HvConfusionMatrix = forwardRef<
   ReactECharts,
   HvConfusionMatrixProps
->((props, ref) => {
+>(function HvConfusionMatrix(props, ref) {
   const {
     legend,
     groupBy,

--- a/packages/viz/src/DonutChart/DonutChart.tsx
+++ b/packages/viz/src/DonutChart/DonutChart.tsx
@@ -50,7 +50,7 @@ export interface HvDonutChartProps extends HvChartCommonProps {
  * the most recognizable chart types for representing proportions in business and data statistics.
  */
 export const HvDonutChart = forwardRef<ReactECharts, HvDonutChartProps>(
-  (props, ref) => {
+  function HvDonutChart(props, ref) {
     const {
       data,
       groupBy,

--- a/packages/viz/src/Heatmap/Heatmap.tsx
+++ b/packages/viz/src/Heatmap/Heatmap.tsx
@@ -55,7 +55,7 @@ export interface HvHeatmapProps
  * A Heatmap uses color gradients to represent data intensity across a surface.
  */
 export const HvHeatmap = forwardRef<ReactECharts, HvHeatmapProps>(
-  (props, ref) => {
+  function HvHeatmap(props, ref) {
     const {
       name,
       data,

--- a/packages/viz/src/LineChart/LineChart.tsx
+++ b/packages/viz/src/LineChart/LineChart.tsx
@@ -67,7 +67,7 @@ export interface HvLineChartProps
  * connected by straight line segments. It is a basic type of chart common in many fields.
  */
 export const HvLineChart = forwardRef<ReactECharts, HvLineChartProps>(
-  (props, ref) => {
+  function HvLineChart(props, ref) {
     const {
       area = false,
       emptyCellMode = "void",

--- a/packages/viz/src/ScatterPlot/ScatterPlot.tsx
+++ b/packages/viz/src/ScatterPlot/ScatterPlot.tsx
@@ -61,7 +61,7 @@ export interface HvScatterPlotProps
  * This type of chart is used to determine the relationship between two variables.
  */
 export const HvScatterPlot = forwardRef<ReactECharts, HvScatterPlotProps>(
-  (props, ref) => {
+  function HvScatterPlot(props, ref) {
     const {
       yAxis,
       xAxis,

--- a/packages/viz/src/Treemap/Treemap.tsx
+++ b/packages/viz/src/Treemap/Treemap.tsx
@@ -46,7 +46,7 @@ export interface HvTreemapChartProps
  * A tree map chart visually represents hierarchical data using nested rectangles, with each rectangle's size proportional to the value it represents.
  */
 export const HvTreemapChart = forwardRef<ReactECharts, HvTreemapChartProps>(
-  (props, ref) => {
+  function HvTreemapChart(props, ref) {
     const {
       name,
       data,


### PR DESCRIPTION
- rename to the standard [`.eslintrc.json`](https://eslint.org/docs/v8.x/use/configure/configuration-files) format
- add an `overrides` section for our exported `pacakges/*/src` code for rules that aren't necessary project-wide
  -  eg. `ssr-friendly`, `import/no-cycle` (disabled for performance reasons)
- replace `airbnb` config with the "standard" `eslint` & `@typescript-eslint` configs, as well as its `jsx-a11y` & `react-hooks`'s recommendations.
  - `airbnb` rules are strict and [outdated](https://react.dev/blog/2024/04/25/react-19-upgrade-guide#removed-proptypes-and-defaultprops), and the maintainers are unwilling to update (eg. `react/default-props`, `react/prop-types`).
  - Allegedly, Airbnb doesn't even use their own config anymore 😅 
- replace `react`'s config with react plugin, and inline the rules. most of the rules configuration are useless, the configuration is really outdated and there seems to be no plan to update. most rules in the configuration either:
  - address only class components
  - are already checked by TypeScript
  - we're disabling in our own config (.eg `react/prop-types`)
- disallow [deprecated](https://github.com/jsx-eslint/eslint-plugin-react/issues/2628#issuecomment-736680314) `import React from "react"` namespace import
- enable `react/display-name` in package, ensuring components are named
- update code according to new rules