### PR TITLE
docs: add `OverflowTooltip` documentation

### DIFF
--- a/apps/docs/src/components/code/Playground.tsx
+++ b/apps/docs/src/components/code/Playground.tsx
@@ -11,6 +11,7 @@ type PlaygroundProps = {
   componentProps?: Record<string, unknown>;
   controls: Record<string, Control>;
   children?: React.ReactNode;
+  decorator?: (component: JSX.Element) => JSX.Element;
 };
 
 const generateCode = (
@@ -53,6 +54,7 @@ const Playground = ({
   componentProps,
   controls = {},
   children,
+  decorator,
 }: PlaygroundProps) => {
   const editorTheme = useEditorTheme();
 
@@ -85,15 +87,19 @@ const Playground = ({
     children,
   );
 
+  const componentElement = (
+    <Component {...componentProps} {...dynamicProps}>
+      {children}
+    </Component>
+  );
+
   return (
     <>
       {/* Component preview and controls */}
       <div className="grid grid-cols-[2fr_1fr] border border-[var(--uikit-colors-atmo4)] rounded-t-round">
         {/* Preview Area */}
         <div className="flex justify-center items-center p-sm">
-          <Component {...componentProps} {...dynamicProps}>
-            {children}
-          </Component>
+          {decorator ? decorator(componentElement) : componentElement}
         </div>
 
         {/* Controls Area */}

--- a/apps/docs/src/pages/components/overflow-tooltip.mdx
+++ b/apps/docs/src/pages/components/overflow-tooltip.mdx
@@ -1,0 +1,47 @@
+import { Callout } from "nextra/components";
+import {
+  HvOverflowTooltip,
+  overflowTooltipClasses,
+} from "@hitachivantara/uikit-react-core";
+
+import Playground from "@docs/components/code/Playground";
+import { Description } from "@docs/components/page/Description";
+import { Page } from "@docs/components/page/Page";
+import { getComponentData } from "@docs/utils/component";
+
+export const getStaticProps = async ({ params }) => {
+  const meta = await getComponentData(
+    "OverflowTooltip",
+    "core",
+    overflowTooltipClasses,
+  );
+  return { props: { ssg: { meta: meta } } };
+};
+
+<Description />
+
+<Page>
+
+<Callout type="info">
+  Check out the [`HvTooltip`](/components/tooltip) component for our regular
+  tooltip component.
+</Callout>
+
+<br />
+
+<Playground
+  Component={HvOverflowTooltip}
+  componentName="HvOverflowTooltip"
+  controls={{
+    placement: { defaultValue: "top" },
+    paragraphOverflow: { defaultValue: false },
+    data: {
+      type: "text",
+      defaultValue:
+        "This is a very long text that should be cut because it so long that it doesn't fit",
+    },
+  }}
+  decorator={(component) => <div className="max-w-160px">{component}</div>}
+/>
+
+</Page>


### PR DESCRIPTION
- This also adds the possibility of passing a decorator to the playground to be used around the component