### PR TITLE
chore: remove package path alias & baseUrl

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,20 +1,11 @@
 {
   "extends": "./tsconfig.build.json",
   "compilerOptions": {
-    "baseUrl": ".",
     "paths": {
-      "@hitachivantara/uikit-react-code-editor": ["packages/code-editor/src"],
-      "@hitachivantara/uikit-react-core": ["packages/core/src"],
-      "@hitachivantara/uikit-react-icons": ["packages/icons/src"],
-      "@hitachivantara/uikit-react-lab": ["packages/lab/src"],
-      "@hitachivantara/uikit-react-pentaho": ["packages/pentaho/src"],
-      "@hitachivantara/uikit-react-shared": ["packages/shared/src"],
-      "@hitachivantara/uikit-react-viz": ["packages/viz/src"],
-      "@hitachivantara/uikit-styles": ["packages/styles/src"],
-      "~/*": ["apps/app/src/*"],
-      "@docs/*": ["apps/docs/src/*"]
+      "~/*": ["./apps/app/src/*"],
+      "@docs/*": ["./apps/docs/src/*"]
     }
   },
   "include": [".config", ".storybook/**/*", "apps", "docs", "packages"],
-  "exclude": ["node_modules", "packages/*/dist"]
+  "exclude": ["node_modules", "packages/*/dist", "packages/*/package"]
 }


### PR DESCRIPTION
This isn't needed as the packages are "installed" under the root `node_modules`, which our monorepo (packages/*, apps/*) and storybook understands

<img width="294" alt="image" src="https://github.com/user-attachments/assets/f64b8073-6b95-4257-9b3c-c21187589546">

Follow up to https://github.com/lumada-design/hv-uikit-react/pull/4453, but this doesn't seem to be enough to made IDE's not suggest `packages/*/src` imports - see ([baseUrl](https://www.typescriptlang.org/tsconfig/#baseUrl))