### PR TITLE
fix(DatePicker): input locale & align input/label values

### DIFF
--- a/packages/core/src/Calendar/Calendar.tsx
+++ b/packages/core/src/Calendar/Calendar.tsx
@@ -12,24 +12,20 @@ import { setId } from "../utils/setId";
 import { staticClasses, useClasses } from "./Calendar.styles";
 import { HvSingleCalendar } from "./SingleCalendar";
 import { DateRangeProp, VisibilitySelectorActions } from "./types";
-import { isRange } from "./utils";
+import { DEFAULT_LOCALE, isRange } from "./utils";
 
 export { staticClasses as calendarClasses };
 
 export type HvCalendarClasses = ExtractNames<typeof useClasses>;
 
-export interface HvCalendarProps {
+export interface HvCalendarProps
+  extends Omit<React.HTMLAttributes<HTMLDivElement>, "onChange"> {
   /**
    * Styles applied from the theme.
    */
   classes?: HvCalendarClasses;
   /**
-   * Identifier.
-   */
-  id?: string;
-  /**
-   * The calendar locale. If undefined, it defaults to en-US
-   *
+   * The calendar locale.
    */
   locale?: string;
   /**
@@ -113,7 +109,7 @@ export const HvCalendar = (props: HvCalendarProps) => {
   const {
     classes: classesProp,
     id: idProp,
-    locale = "en-US",
+    locale = DEFAULT_LOCALE,
     value: valueProp,
     visibleMonth,
     visibleYear,

--- a/packages/core/src/Calendar/CalendarHeader/CalendarHeader.tsx
+++ b/packages/core/src/Calendar/CalendarHeader/CalendarHeader.tsx
@@ -17,8 +17,15 @@ import { HvInput, HvInputProps } from "../../Input";
 import { HvTypography } from "../../Typography";
 import { isKey } from "../../utils/keyboardUtils";
 import { setId } from "../../utils/setId";
+import type { HvSingleCalendarProps } from "../SingleCalendar";
 import { DateRangeProp } from "../types";
-import { formatToLocale, isDate, isRange, isSameDay } from "../utils";
+import {
+  DEFAULT_LOCALE,
+  formatToLocale,
+  isDate,
+  isRange,
+  isSameDay,
+} from "../utils";
 import { staticClasses, useClasses } from "./CalendarHeader.styles";
 
 export { staticClasses as calendarHeaderClasses };
@@ -33,7 +40,7 @@ export const HvCalendarHeader = (props: HvCalendarHeaderProps) => {
   const {
     id: idProp,
     value,
-    locale = "en-US",
+    locale = DEFAULT_LOCALE,
     classes: classesProp,
     onChange,
     showEndDate,
@@ -187,32 +194,21 @@ export const HvCalendarHeader = (props: HvCalendarHeaderProps) => {
 // TODO: refactor this out
 HvCalendarHeader.formElementType = "HvCalendarHeader";
 
-export interface HvCalendarHeaderProps {
+export interface HvCalendarHeaderProps
+  extends Pick<
+    HvSingleCalendarProps,
+    | "id"
+    | "value"
+    | "locale"
+    | "onChange"
+    | "showEndDate"
+    | "showDayOfWeek"
+    | "invalidDateLabel"
+  > {
   /**
    * A Jss Object used to override or extend the component styles.
    */
   classes?: HvCalendarHeaderClasses;
-  /**
-   * Identifier.
-   */
-  id?: string;
-  /**
-   * The text to be shown on the main part of the header.
-   */
-  value?: string | Date | DateRangeProp;
-  /**
-   * Locale to be used by the calendar.
-   */
-  locale?: string;
-  /**
-   * Callback to define the input date.
-   */
-  onChange?: (
-    event:
-      | React.ChangeEvent<HTMLTextAreaElement | HTMLInputElement>
-      | undefined,
-    value: Date | DateRangeProp,
-  ) => void;
   /**
    * Callback to handle input onFocus.
    */
@@ -220,16 +216,4 @@ export interface HvCalendarHeaderProps {
     event: React.FocusEvent<HTMLTextAreaElement | HTMLInputElement>,
     formattedDate: string | null,
   ) => void;
-  /**
-   * Indicates if header should display end date in a date range.
-   */
-  showEndDate?: boolean;
-  /**
-   * Indicates if header should display the day of week.
-   */
-  showDayOfWeek?: boolean;
-  /**
-   * Label shown when date is invalid.
-   */
-  invalidDateLabel?: string;
 }

--- a/packages/core/src/Calendar/CalendarUtils.test.tsx
+++ b/packages/core/src/Calendar/CalendarUtils.test.tsx
@@ -13,22 +13,7 @@ import {
   isSameDay,
   isSameMonth,
   makeUTCDate,
-  zeroPad,
 } from "./utils";
-
-describe("Calendar utils - zeroPad", () => {
-  it("should return 01 when the input is 1 and the length is 2", () => {
-    expect(zeroPad(1, 2)).toBe("01");
-  });
-
-  it("should return 3 when the input is 3 and the length is 0", () => {
-    expect(zeroPad(3, 0)).toBe("3");
-  });
-
-  it("should return 005 when the input is 5 and the length is 3", () => {
-    expect(zeroPad(5, 3)).toBe("005");
-  });
-});
 
 describe("Calendar utils - getMonthDays", () => {
   it("should return 31 days for January", () => {
@@ -113,9 +98,6 @@ describe("Calendar utils - getDateISO", () => {
   it("should return the received date in ISO format (YYYY-MM-DD)", () => {
     expect(getDateISO(new Date(2019, 0, 1))).toBe("2019-01-01");
   });
-  it("should return `null` if the received date is invalid", () => {
-    expect(getDateISO(undefined)).toBe(null);
-  });
 });
 
 describe("Calendar utils - getPreviousMonth", () => {
@@ -172,7 +154,7 @@ describe("Calendar utils - getMonthName", () => {
 
 describe("Calendar utils - getFormattedDate", () => {
   it("should return a date as a string with the format `14 Aug, 2019`", () => {
-    expect(getFormattedDate(new Date(2019, 7, 14), "en-US")).toBe(
+    expect(getFormattedDate(new Date("2019-08-14"), "en-GB")).toBe(
       "14 Aug 2019",
     );
   });

--- a/packages/core/src/Calendar/SingleCalendar/SingleCalendar.tsx
+++ b/packages/core/src/Calendar/SingleCalendar/SingleCalendar.tsx
@@ -5,12 +5,13 @@ import { HvPanel } from "../../Panel";
 import { HvTypography } from "../../Typography";
 import { isKey } from "../../utils/keyboardUtils";
 import { setId } from "../../utils/setId";
+import type { HvCalendarProps } from "../Calendar";
 import { HvCalendarHeader } from "../CalendarHeader/CalendarHeader";
 import { HvComposedNavigation, HvMonthSelector } from "../CalendarNavigation";
 import { ViewMode } from "../enums";
 import { generateCalendarModel } from "../model";
-import { DateRangeProp, VisibilitySelectorActions } from "../types";
-import { getWeekdayNamesList, isDate, isRange } from "../utils";
+import type { DateRangeProp } from "../types";
+import { DEFAULT_LOCALE, getWeekdayNamesList, isDate, isRange } from "../utils";
 import { HvCalendarCell } from "./CalendarCell";
 import { staticClasses, useClasses } from "./SingleCalendar.styles";
 
@@ -22,7 +23,7 @@ export const HvSingleCalendar = ({
   classes: classesProp,
   className,
   id,
-  locale = "en-US",
+  locale = DEFAULT_LOCALE,
   value,
   visibleMonth,
   visibleYear,
@@ -136,6 +137,7 @@ export const HvSingleCalendar = ({
       <HvCalendarHeader
         id={setId(id, "header")}
         locale={locale}
+        value={value}
         onChange={handleInputChange}
         showEndDate={showEndDate && !isDateSelectionMode}
         showDayOfWeek={showDayOfWeek}
@@ -175,50 +177,12 @@ export const HvSingleCalendar = ({
   );
 };
 
-export interface HvSingleCalendarProps {
+export interface HvSingleCalendarProps
+  extends Omit<HvCalendarProps, "classes"> {
   /**
    * Styles applied from the theme.
    */
   classes?: HvSingleCalendarClasses;
-  /**
-   * Identifier.
-   */
-  id?: string;
-  /**
-   * The class name to add at the root of the single calendar
-   */
-  className?: string;
-  /**
-   * The calendar locale.
-   *
-   */
-  locale: string;
-  /**
-   * Date that the calendar would show.
-   */
-  value?: string | Date | DateRangeProp;
-  /**
-   * Date that will be used to know which month and year should be displayed on the calendar. The value of the day is
-   * irrelevant.
-   */
-  visibleDate?: Date;
-  /**
-   * Controls the visible month of the Calendar
-   */
-  visibleMonth?: number;
-  /**
-   * Controls the visible month of the Calendar
-   */
-  visibleYear?: number;
-  /**
-   * Callback function to be triggered when the selected date has changed.
-   */
-  onChange?: (
-    event:
-      | React.ChangeEvent<HTMLTextAreaElement | HTMLInputElement>
-      | undefined,
-    value: Date | DateRangeProp,
-  ) => void;
   /**
    * Callback function to be triggered when the selected date input has changed.
    */
@@ -232,37 +196,11 @@ export interface HvSingleCalendarProps {
     position?: "left" | "right",
   ) => void;
   /**
-   * Callback function to be triggered when visible date has changed.
-   */
-  onVisibleDateChange?: (
-    event:
-      | React.ChangeEvent<HTMLTextAreaElement | HTMLInputElement>
-      | undefined,
-    action: VisibilitySelectorActions,
-    value?: Date | DateRangeProp | number,
-  ) => void;
-  /**
-   * The maximum selectable date after this all values are disabled.
-   */
-  maximumDate?: Date;
-  /**
-   * The minimum selectable date before this all values are disabled.
-   */
-  minimumDate?: Date;
-  /**
    * Indicates if header should display end date in a date range.
    */
   showEndDate?: boolean;
   /**
-   * Indicates if header should display the day of week.
-   */
-  showDayOfWeek?: boolean;
-  /**
    * Content on the upper part of the calendar.
    */
   children?: React.ReactNode;
-  /**
-   * Label shown when date is invalid.
-   */
-  invalidDateLabel?: string;
 }

--- a/packages/core/src/Calendar/utils.tsx
+++ b/packages/core/src/Calendar/utils.tsx
@@ -3,16 +3,11 @@ import dayjs from "dayjs";
 import { capitalize } from "../utils/helpers";
 import { DateRangeProp } from "./types";
 
-/**
- * Constant with the number of weeks to be displayed on the calendar.
- */
+/** number of weeks to be displayed on the calendar. */
 export const CALENDAR_WEEKS = 6;
 
-/**
- * Constant with the default locale that should be used as the default.
- */
+/** default locale used in the date-aware components */
 export const DEFAULT_LOCALE = "en";
-
 /**
  * Pads a string value with leading zeroes(0) until length is reached.
  *

--- a/packages/core/src/DatePicker/DatePicker.stories.tsx
+++ b/packages/core/src/DatePicker/DatePicker.stories.tsx
@@ -141,10 +141,7 @@ export const Localized: StoryObj<HvDatePickerProps> = {
     },
   },
   render: () => {
-    // Locales must be imported beforehand:
-    // import "dayjs/locale/pt";
-    const initialLocale = "pt";
-    const [locale, setLocale] = useState(initialLocale);
+    const [locale, setLocale] = useState("pt");
 
     return (
       <>
@@ -152,17 +149,18 @@ export const Localized: StoryObj<HvDatePickerProps> = {
           <HvRadioGroup
             orientation="horizontal"
             value={locale}
-            onChange={(event, value) => {
-              setLocale(value);
-            }}
+            onChange={(event, value) => setLocale(value)}
           >
-            <HvRadio label="English" value="en" />
-            <HvRadio label="French" value="fr" />
-            <HvRadio label="Portuguese" value="pt" />
+            <HvRadio label="🇺🇸" value="en-US" />
+            <HvRadio label="🇬🇧" value="en-GB" />
+            <HvRadio label="🇫🇷" value="fr" />
+            <HvRadio label="🇵🇹" value="pt" />
+            <HvRadio label="🇯🇵" value="ja" />
           </HvRadioGroup>
         </div>
         <HvDatePicker
           placeholder={`Select a date in ${locale}`}
+          value={new Date("2020-02-10")}
           locale={locale}
           aria-label="Date"
         />

--- a/packages/core/src/DatePicker/DatePicker.test.tsx
+++ b/packages/core/src/DatePicker/DatePicker.test.tsx
@@ -52,7 +52,7 @@ describe("HvDatePicker", () => {
       const calendarButtons = screen.queryAllByRole("button");
       const firstDayOfTheMonth = screen.queryAllByText("1");
       const datePickerDropdown = screen.getByRole("combobox");
-      const datePickerDropdownValue = screen.getByText("1 Jan 2019");
+      const datePickerDropdownValue = screen.getByText("Jan 1, 2019");
       const dateInput = screen.queryByDisplayValue("Jan 1, 2019");
 
       expect(datePickerDropdown).toBeInTheDocument();
@@ -63,16 +63,14 @@ describe("HvDatePicker", () => {
     });
     it("should render a calendar component with a value", async () => {
       render(
-        <HvDatePicker value={makeUTCDate(2019, 0, 1, 12)} locale="en-US" />,
+        <HvDatePicker value={makeUTCDate(2019, 0, 1, 12)} locale="en-GB" />,
       );
       let calendarButtons = screen.queryAllByRole("button");
       let firstDayOfTheMonth = screen.queryAllByText("1");
       const datePickerDropdown = screen.getByRole("combobox");
-      let datePickerDropdownValue: HTMLElement | HTMLElement[] =
-        screen.getByText("1 Jan 2019");
 
       expect(datePickerDropdown).toBeInTheDocument();
-      expect(datePickerDropdownValue).toBeInTheDocument();
+      expect(screen.getByText("1 Jan 2019")).toBeInTheDocument();
       expect(screen.queryByDisplayValue("Jan 1, 2019")).not.toBeInTheDocument();
       expect(calendarButtons.length).toBe(0);
       expect(firstDayOfTheMonth.length).toBe(0);
@@ -81,8 +79,8 @@ describe("HvDatePicker", () => {
 
       calendarButtons = await screen.findAllByRole("button");
       firstDayOfTheMonth = await screen.findAllByText("1");
-      datePickerDropdownValue = await screen.findAllByText("1 Jan 2019");
-      const dateInput = screen.getByDisplayValue("Jan 1, 2019");
+      const datePickerDropdownValue = await screen.findAllByText("1 Jan 2019");
+      const dateInput = screen.getByDisplayValue("1 Jan 2019");
       expect(calendarButtons.length).toBe(42 + 5);
       expect(firstDayOfTheMonth.length).toBe(2);
       expect(datePickerDropdownValue.length).toBe(1);

--- a/packages/core/src/DatePicker/DatePicker.tsx
+++ b/packages/core/src/DatePicker/DatePicker.tsx
@@ -10,7 +10,7 @@ import { HvActionBar } from "../ActionBar";
 import { HvBaseDropdown, HvBaseDropdownProps } from "../BaseDropdown";
 import { HvButton } from "../Button";
 import { HvCalendar, HvCalendarProps } from "../Calendar";
-import { isDate } from "../Calendar/utils";
+import { DEFAULT_LOCALE, isDate } from "../Calendar/utils";
 import {
   HvFormElement,
   HvFormElementProps,
@@ -180,7 +180,7 @@ export const HvDatePicker = forwardRef<HTMLDivElement, HvDatePickerProps>(
       rangeMode = false,
       startAdornment,
       horizontalPlacement = "right",
-      locale: localeProp,
+      locale = DEFAULT_LOCALE,
       showActions,
       showClear,
       disablePortal = true,
@@ -201,8 +201,6 @@ export const HvDatePicker = forwardRef<HTMLDivElement, HvDatePickerProps>(
     );
 
     const [validationMessage] = useControlled(statusMessage, "Required");
-
-    const locale = localeProp || "en-US";
 
     const [calendarOpen, setCalendarOpen] = useControlled(
       expanded,

--- a/packages/core/src/DatePicker/utils.tsx
+++ b/packages/core/src/DatePicker/utils.tsx
@@ -1,4 +1,4 @@
-import { DateRangeProp } from "../Calendar";
+import type { DateRangeProp } from "../Calendar";
 import {
   getFormattedDate,
   getMonthName,
@@ -8,16 +8,12 @@ import {
 
 export const validateDate = (date: any) => (isDate(date) && date) || new Date();
 
-export const getFormattedDateRange = (
-  date: DateRangeProp,
-  locale: string,
-  rep: Intl.DateTimeFormatOptions["month"] = "short",
-) => {
+export const getFormattedDateRange = (date: DateRangeProp, locale: string) => {
   const { startDate, endDate } = date;
   const monthYear = `${getMonthName(
     startDate,
     locale,
-    rep,
+    "short",
   )} ${startDate.getFullYear()}`;
   return `${startDate.getDate()} - ${endDate?.getDate()} ${monthYear}`;
 };

--- a/packages/core/src/TimeAgo/TimeAgo.tsx
+++ b/packages/core/src/TimeAgo/TimeAgo.tsx
@@ -3,6 +3,7 @@ import {
   type ExtractNames,
 } from "@hitachivantara/uikit-react-utils";
 
+import { DEFAULT_LOCALE } from "../Calendar/utils";
 import {
   fixedForwardRef,
   PolymorphicComponentRef,
@@ -59,7 +60,7 @@ export const HvTimeAgo = fixedForwardRef(function HvTimeAgo<
     classes: classesProp,
     className,
     timestamp,
-    locale = "en",
+    locale = DEFAULT_LOCALE,
     component: Component = HvTypography,
     emptyElement = "—",
     disableRefresh = false,

--- a/packages/core/src/TimePicker/TimePicker.test.tsx
+++ b/packages/core/src/TimePicker/TimePicker.test.tsx
@@ -62,7 +62,7 @@ describe("TimePicker", () => {
     expect(inputs).toHaveLength(7);
     assertTime(inputs, { ...defaultValue, hours: 7 });
 
-    const amPmButton = screen.getByRole("button", { name: "PM" });
+    const amPmButton = screen.getByRole("button", { name: /PM/i });
     expect(amPmButton).toBeInTheDocument();
   });
 

--- a/packages/core/src/TimePicker/TimePicker.tsx
+++ b/packages/core/src/TimePicker/TimePicker.tsx
@@ -13,6 +13,7 @@ import {
 } from "@hitachivantara/uikit-react-utils";
 
 import { HvBaseDropdown, HvBaseDropdownProps } from "../BaseDropdown";
+import { DEFAULT_LOCALE } from "../Calendar/utils";
 import {
   HvFormElement,
   HvFormElementProps,
@@ -144,7 +145,7 @@ export const HvTimePicker = forwardRef<HTMLDivElement, HvTimePickerProps>(
       timeFormat,
       showSeconds,
       disableExpand,
-      locale = "en",
+      locale = DEFAULT_LOCALE,
 
       onToggle,
       onChange,


### PR DESCRIPTION
- align DatePicker/Calendar input & label values
- fix forced locale format
- remove `dayjs` dependency in favour on `Intl` in DatePicker/Calendar
- reuse `DEFAULT_LOCALE`
- dedupe type definitions in `HvCalendar` sub-components
- improve typings