### PR TITLE
docs(Playground): fix children rendering & component name

### DIFF
--- a/apps/docs/src/components/code/Playground.tsx
+++ b/apps/docs/src/components/code/Playground.tsx
@@ -1,4 +1,4 @@
-import { isValidElement, useCallback, useState } from "react";
+import { Children, isValidElement, useCallback, useState } from "react";
 import jsxToString from "react-element-to-jsx-string";
 import { CodeEditor } from "react-live-runner";
 import useEditorTheme from "@docs/hooks/useEditorTheme";
@@ -14,10 +14,15 @@ type PlaygroundProps = {
   decorator?: (component: JSX.Element) => JSX.Element;
 };
 
+const parseChildren = (child: React.ReactNode) =>
+  (isValidElement(child) && jsxToString(child)) ||
+  (typeof child === "string" && child) ||
+  "";
+
 const generateCode = (
   componentName: string,
   componentProps: Record<string, unknown> = {},
-  children?: React.ReactNode,
+  children?: React.ReactNode | React.ReactNode[],
 ): string => {
   // Format props and componentProps into strings
   const parsedPropsString = Object.entries(componentProps)
@@ -33,10 +38,10 @@ const generateCode = (
   const componentPropsString = parsedPropsString && `\n${parsedPropsString}`;
 
   // Handle children content
-  const childrenString =
-    (isValidElement(children) && jsxToString(children)) ||
-    (children === "string" && children) ||
-    "";
+  const childrenString = Children.toArray(children)
+    .map(parseChildren)
+    .filter(Boolean)
+    .join("\n");
 
   // Generate and return the final code
   if (childrenString) {

--- a/apps/docs/src/pages/components/accordion.mdx
+++ b/apps/docs/src/pages/components/accordion.mdx
@@ -36,8 +36,9 @@ export const getStaticProps = async ({ params }) => {
     },
   }}
   componentProps={{ style: { width: "50%" } }}
-  children={<div>My accordion example content</div>}
-/>
+>
+  <div>My accordion example content</div>
+</Playground>
 
 <Callout type="info">
   You can use the `HvSection` component to create an accordion group that better

--- a/apps/docs/src/pages/components/input.mdx
+++ b/apps/docs/src/pages/components/input.mdx
@@ -260,7 +260,7 @@ Inputs not using the visual `label` prop should instead provide an `aria-label` 
 - [`HvFormElement`](/components/form-element)
 - [`HvTextArea`](/components/textarea)
 - [`HvSelect`](/components/select)
-- [`HvDatePicker`](/components/datepicker)
-- [`HvTimePicker`](/components/timepicker)
+- [`HvDatePicker`](/components/date-picker)
+- [`HvTimePicker`](/components/time-picker)
 
 </Page>

--- a/apps/docs/src/pages/components/loading-container.mdx
+++ b/apps/docs/src/pages/components/loading-container.mdx
@@ -34,22 +34,13 @@ export const getStaticProps = async ({ params }) => {
       defaultValue: 0.8,
     },
   }}
-  children={
-    <div
-      style={{
-        height: 200,
-        display: "flex",
-        alignItems: "center",
-        justifyContent: "center",
-        backgroundColor: "lightgray",
-      }}
-    >
-      My content
-    </div>
-  }
   componentProps={{
     style: { width: "100%" },
   }}
-/>
+>
+  <div className="flex items-center justify-center bg-gray h-200px">
+    My content
+  </div>
+</Playground>
 
 </Page>

--- a/apps/docs/src/pages/components/section.mdx
+++ b/apps/docs/src/pages/components/section.mdx
@@ -24,7 +24,7 @@ export const getStaticProps = async ({ params }) => {
   controls={{
     title: {
       type: "text",
-      defaultValue: "Section title - ",
+      defaultValue: "Section title",
     },
     expandable: {
       defaultValue: false,
@@ -33,12 +33,9 @@ export const getStaticProps = async ({ params }) => {
       defaultValue: false,
     },
   }}
-  children={
-    <div>
-      <p>My section example content</p>
-    </div>
-  }
-/>
+>
+  <div>My section example content</div>
+</Playground>
 
 ### Actions
 

--- a/apps/docs/src/pages/components/select.mdx
+++ b/apps/docs/src/pages/components/select.mdx
@@ -33,17 +33,14 @@ export const getStaticProps = async ({ params }) => {
   componentProps={{
     placeholder: "Select a value",
   }}
-  children={
-    <>
-      <HvOption value="ar">Argentina</HvOption>
-      <HvOption value="bg">Belgium</HvOption>
-      <HvOption value="pt">Portugal</HvOption>
-      <HvOption value="pl">Poland</HvOption>
-      <HvOption value="sp">Spain</HvOption>
-      <HvOption value="us">United States</HvOption>
-    </>
-  }
-/>
+>
+  <HvOption value="ar">Argentina</HvOption>
+  <HvOption value="bg">Belgium</HvOption>
+  <HvOption value="pt">Portugal</HvOption>
+  <HvOption value="pl">Poland</HvOption>
+  <HvOption value="sp">Spain</HvOption>
+  <HvOption value="us">United States</HvOption>
+</Playground>
 
 ### Form
 

--- a/apps/docs/src/pages/components/tooltip.mdx
+++ b/apps/docs/src/pages/components/tooltip.mdx
@@ -24,16 +24,15 @@ export const getStaticProps = async ({ params }) => {
   Component={HvTooltip}
   componentName="HvTooltip"
   controls={{
-
     enterDelay: { type: "text", defaultValue: 300 },
     placement: { defaultValue: "top" },
-
-}}
-componentProps={{
+  }}
+  componentProps={{
     title: "Tooltip text",
   }}
-children={<HvButton variant="primarySubtle">Hover or focus here</HvButton>}
-/>
+>
+  <HvButton variant="primarySubtle">Hover or focus here</HvButton>
+</Playground>
 
 <Callout type="info">
   `HvTooltip` uses Material UI's tooltip under the hood. You can find more


### PR DESCRIPTION
- fixes `children` rendering in `Playground`
  - we should use actual `children`, not `children={}` (requires fragments)
- this also seems to fix the `"No Display Name"` in children components