### PR TITLE
fix(Input): extend HvBaseInput types

### DIFF
--- a/packages/core/src/BaseInput/BaseInput.tsx
+++ b/packages/core/src/BaseInput/BaseInput.tsx
@@ -1,10 +1,6 @@
 import { forwardRef, useContext } from "react";
 import { css as emotionCss, Global } from "@emotion/react";
-import MuiInput, { InputProps as MuiInputProps } from "@mui/material/Input";
-import {
-  InputBaseProps,
-  InputBaseComponentProps as MuiInputBaseComponentProps,
-} from "@mui/material/InputBase";
+import MuiInputBase, { InputBaseProps } from "@mui/material/InputBase";
 import { useForkRef } from "@mui/material/utils";
 import {
   useDefaultProps,
@@ -53,13 +49,16 @@ const baseInputStyles = emotionCss({
 });
 
 export interface HvBaseInputProps
-  extends Omit<MuiInputProps, "onChange" | "classes" | "ref"> {
+  extends Omit<
+    InputBaseProps,
+    "onChange" | "classes" | "ref" | "color" | "size"
+  > {
   /** The input name. */
   name?: string;
   /** The value of the input, when controlled. */
-  value?: string;
+  value?: React.InputHTMLAttributes<HTMLInputElement>["value"];
   /** The initial value of the input, when uncontrolled. */
-  defaultValue?: string;
+  defaultValue?: React.InputHTMLAttributes<HTMLInputElement>["value"];
   /** If `true` the input is disabled. */
   disabled?: boolean;
   /** Indicates that the input is not editable. */
@@ -72,19 +71,16 @@ export interface HvBaseInputProps
     event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
     value: string,
   ) => void;
-  /** The input type. */
-  type?: string;
-  /** Label inside the input used to help user. */
-  placeholder?: string;
   /** If true, a textarea element will be rendered. */
   multiline?: boolean;
   /** If true and multiline is also true the textarea element will be resizable. */
   resizable?: boolean;
   /** Denotes if the input is in an invalid state. */
   invalid?: boolean;
-  /** Attributes applied to the input element. */
-  inputProps?: MuiInputBaseComponentProps;
-  /** Allows passing a ref to the underlying input */
+  /**
+   * Allows passing a ref to the underlying input
+   * @deprecated Use `ref` directly instead
+   * */
   inputRef?: InputBaseProps["inputRef"];
   /** A Jss Object used to override or extend the styles applied to the component. */
   classes?: HvBaseInputClasses;
@@ -96,7 +92,7 @@ export interface HvBaseInputProps
  */
 export const HvBaseInput = forwardRef<
   // no-indent
-  unknown,
+  React.ElementRef<"input">,
   HvBaseInputProps
 >(function HvBaseInput(props, ref) {
   const {
@@ -143,10 +139,6 @@ export const HvBaseInput = forwardRef<
     id,
   );
 
-  const onChangeHandler: MuiInputProps["onChange"] = (event) => {
-    onChange?.(event, event.target.value);
-  };
-
   return (
     <>
       <Global styles={baseInputStyles} />
@@ -158,7 +150,7 @@ export const HvBaseInput = forwardRef<
           [classes.readOnly]: formElementProps.readOnly,
         })}
       >
-        <MuiInput
+        <MuiInputBase
           id={id}
           name={formElementProps.name}
           value={value}
@@ -167,7 +159,7 @@ export const HvBaseInput = forwardRef<
           placeholder={placeholder}
           readOnly={!!formElementProps.readOnly}
           disabled={formElementProps.disabled}
-          onChange={onChangeHandler}
+          onChange={(event) => onChange?.(event, event.target.value)}
           className={cx({
             [classes.inputRootInvalid]: localInvalid,
             [classes.inputRootReadOnly]: formElementProps.readOnly,

--- a/packages/core/src/ColorPicker/ColorPicker.test.tsx
+++ b/packages/core/src/ColorPicker/ColorPicker.test.tsx
@@ -21,9 +21,9 @@ describe("ColorPicker", () => {
     );
 
     expect(screen.getByText("#de2beb")).toBeInTheDocument();
-    expect(screen.getByRole("textbox", { name: "R" })).toBeInTheDocument();
-    expect(screen.getByRole("textbox", { name: "G" })).toBeInTheDocument();
-    expect(screen.getByRole("textbox", { name: "B" })).toBeInTheDocument();
+    expect(screen.getByRole("spinbutton", { name: "R" })).toBeInTheDocument();
+    expect(screen.getByRole("spinbutton", { name: "G" })).toBeInTheDocument();
+    expect(screen.getByRole("spinbutton", { name: "B" })).toBeInTheDocument();
   });
 
   it("should render recommended colors", () => {

--- a/packages/core/src/ColorPicker/Fields/Fields.tsx
+++ b/packages/core/src/ColorPicker/Fields/Fields.tsx
@@ -144,7 +144,7 @@ export const Fields = (props: FieldsProps) => {
         ref={redInputRef}
         className={classes.single}
         label="R"
-        value={`${internalRed}`}
+        value={internalRed}
         onChange={(event, value) => onChangeRbg(event, value, "r")}
         onBlur={() => setInternalRed(rgb?.r)}
         disableClear
@@ -153,7 +153,7 @@ export const Fields = (props: FieldsProps) => {
         ref={greenInputRef}
         className={classes.single}
         label="G"
-        value={`${internalGreen}`}
+        value={internalGreen}
         onChange={(event, value) => onChangeRbg(event, value, "g")}
         onBlur={() => setInternalGreen(rgb?.g)}
         disableClear
@@ -162,7 +162,7 @@ export const Fields = (props: FieldsProps) => {
         ref={blueInputRef}
         className={classes.single}
         label="B"
-        value={`${internalBlue}`}
+        value={internalBlue}
         onChange={(event, value) => onChangeRbg(event, value, "b")}
         onBlur={() => setInternalBlue(rgb?.b)}
         disableClear

--- a/packages/core/src/ColorPicker/Fields/Fields.tsx
+++ b/packages/core/src/ColorPicker/Fields/Fields.tsx
@@ -147,6 +147,7 @@ export const Fields = (props: FieldsProps) => {
         value={internalRed}
         onChange={(event, value) => onChangeRbg(event, value, "r")}
         onBlur={() => setInternalRed(rgb?.r)}
+        inputProps={{ type: "number", min: 0, max: 255 }}
         disableClear
       />
       <HvInput
@@ -156,6 +157,7 @@ export const Fields = (props: FieldsProps) => {
         value={internalGreen}
         onChange={(event, value) => onChangeRbg(event, value, "g")}
         onBlur={() => setInternalGreen(rgb?.g)}
+        inputProps={{ type: "number", min: 0, max: 255 }}
         disableClear
       />
       <HvInput
@@ -165,6 +167,7 @@ export const Fields = (props: FieldsProps) => {
         value={internalBlue}
         onChange={(event, value) => onChangeRbg(event, value, "b")}
         onBlur={() => setInternalBlue(rgb?.b)}
+        inputProps={{ type: "number", min: 0, max: 255 }}
         disableClear
       />
     </div>

--- a/packages/core/src/TextArea/TextArea.tsx
+++ b/packages/core/src/TextArea/TextArea.tsx
@@ -251,7 +251,7 @@ export const HvTextArea = forwardRef<
   const performValidation = useCallback(() => {
     const inputValidity = validateInput(
       inputRef.current,
-      value,
+      String(value),
       required,
       minCharQuantity,
       maxCharQuantity,
@@ -303,7 +303,7 @@ export const HvTextArea = forwardRef<
 
     const inputValidity = performValidation();
 
-    onBlur?.(event as any, value, inputValidity);
+    onBlur?.(event as any, String(value), inputValidity);
   };
 
   /**
@@ -334,7 +334,7 @@ export const HvTextArea = forwardRef<
     // Reset validation status to standBy (only when status is uncontrolled)
     setValidationState(validationStates.standBy);
 
-    onFocus?.(event as any, value);
+    onFocus?.(event as any, String(value));
   };
 
   const isScrolledDown = useCallback(() => {
@@ -456,7 +456,7 @@ export const HvTextArea = forwardRef<
           id={setId(elementId, "charCounter")}
           className={classes.characterCounter}
           separator={middleCountLabel}
-          currentCharQuantity={value.length}
+          currentCharQuantity={String(value).length}
           maxCharQuantity={maxCharQuantity}
           {...countCharProps}
         />


### PR DESCRIPTION
- align `HvInput` & `HvBaseInput` types
  - and align them with the underlying `<input>` (eg. `value`/`defaultValue`)
- add `HvInput` generics so we can specify when it's a `textarea` (when needed)
- `HvBaseInput` extends from MUI's `InputBase`