### PR TITLE
docs: fix component urls

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -67,7 +67,8 @@
     "no-restricted-imports": [
       "error",
       {
-        "patterns": ["@hitachivantara/*/*"]
+        "patterns": ["@hitachivantara/*/*"],
+        "paths": ["..", "../.."]
       }
     ],
     "no-restricted-exports": [

--- a/apps/docs/src/pages/components/loading.mdx
+++ b/apps/docs/src/pages/components/loading.mdx
@@ -88,7 +88,7 @@ function LoadingButton({ onClick, children, ...others }: HvButtonProps) {
 
 ### Related components
 
-- [`HvLoadingContainer`](/components/loadingContainer)
+- [`HvLoadingContainer`](/components/loading-container)
 - [`HvSkeleton`](/components/skeleton)
 
 </Page>

--- a/apps/docs/src/pages/components/skeleton.mdx
+++ b/apps/docs/src/pages/components/skeleton.mdx
@@ -89,6 +89,6 @@ You can use custom CSS animations with the skeleton component by defining your o
 ### Related components
 
 - [`HvLoading`](/components/loading)
-- [`HvLoadingContainer`](/components/loadingContainer)
+- [`HvLoadingContainer`](/components/loading-container)
 
 </Page>

--- a/apps/docs/src/pages/components/tooltip.mdx
+++ b/apps/docs/src/pages/components/tooltip.mdx
@@ -41,7 +41,7 @@ export const getStaticProps = async ({ params }) => {
 </Callout>
 <Callout type="info">
   If you're looking for a tooltip on overflowing content, check out the
-  [`HvOverflowTooltip`](/components/overflowTooltip) component.
+  [`HvOverflowTooltip`](/components/overflow-tooltip) component.
 </Callout>
 
 ### Disabled
@@ -141,6 +141,6 @@ A Tooltip will grow to the size of its content. Keep in mind that the Tooltip `t
 
 ### Related components
 
-- [`HvOverflowTooltip`](/components/overflowTooltip)
+- [`HvOverflowTooltip`](/components/overflow-tooltip)
 
 </Page>

--- a/packages/core/src/Drawer/Drawer.test.tsx
+++ b/packages/core/src/Drawer/Drawer.test.tsx
@@ -3,7 +3,8 @@ import { render } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { vi } from "vitest";
 
-import { HvButton, HvDialogActions, HvDialogContent, HvDialogTitle } from "..";
+import { HvButton } from "../Button";
+import { HvDialogActions, HvDialogContent, HvDialogTitle } from "../Dialog";
 import { HvDrawer } from "./Drawer";
 
 const Sample = ({
@@ -17,13 +18,13 @@ const Sample = ({
 
   return (
     <div>
-      <HvButton
+      <button
         id="openDialog"
         aria-label="openDialog"
         onClick={() => setOpen(true)}
       >
         Open dialog
-      </HvButton>
+      </button>
       <HvDrawer
         id="drawer-test"
         open={open}

--- a/packages/core/src/TimeAgo/TimeAgo.test.tsx
+++ b/packages/core/src/TimeAgo/TimeAgo.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
-import { HvButton } from "..";
+import { HvButton } from "../Button";
 import { HvTimeAgo } from "./TimeAgo";
 
 const EM_DASH = "—";

--- a/packages/viz/src/utils/index.ts
+++ b/packages/viz/src/utils/index.ts
@@ -10,7 +10,7 @@ import type {
   HvConfusionMatrixMeasure,
   HvDonutChartMeasure,
   HvLineChartMeasures,
-} from "..";
+} from "../types";
 import { HvChartCommonProps } from "../types/common";
 import { HvChartLegendIcon } from "../types/legend";
 import { HvScatterPlotMeasure } from "../types/measures";


### PR DESCRIPTION
- fix `loading-container` & `overflow-tooltip` links (missing `-`)
- disallow parent barrel file imports (for performance & circular dependency imports)