### PR TITLE
docs: improve number control/rendering

### DIFF
--- a/apps/docs/src/components/code/Controls.tsx
+++ b/apps/docs/src/components/code/Controls.tsx
@@ -15,7 +15,14 @@ type OptionType = {
   value: string;
 };
 
-type ControlType = "check" | "color" | "radio" | "select" | "slider" | "text";
+type ControlType =
+  | "check"
+  | "color"
+  | "number"
+  | "radio"
+  | "select"
+  | "slider"
+  | "text";
 
 export type Control = {
   type?: ControlType;
@@ -137,6 +144,18 @@ export const Controls = ({ prop, state, control, onChange }: ControlsProps) => {
     />
   );
 
+  // Render number input for default text types
+  const renderNumberInputControl = () => (
+    <HvInput
+      key={prop}
+      label={propLabel}
+      inputProps={{ type: "number" }}
+      value={state[prop] ?? control.defaultValue}
+      onChange={(e, value) => onChange(prop, Number(value))}
+      className="w-full"
+    />
+  );
+
   // Render color picker for color types
   const renderColorControl = () => (
     <HvColorPicker
@@ -161,6 +180,7 @@ export const Controls = ({ prop, state, control, onChange }: ControlsProps) => {
     check: renderCheckboxControl,
     boolean: renderCheckboxControl,
     color: renderColorControl,
+    number: renderNumberInputControl,
     text: renderInputControl,
     enum: renderSelectControl,
   };

--- a/apps/docs/src/components/code/Playground.tsx
+++ b/apps/docs/src/components/code/Playground.tsx
@@ -29,8 +29,10 @@ const generateCode = (
     .filter(([key]) => key !== "style")
     .map(([key, value]) => {
       if (typeof value === "string") return `${key}="${value}"`;
+      if (isValidElement(value)) return `${key}={${jsxToString(value)}}`;
+      if (typeof value === "object") return `${key}={${JSON.stringify(value)}}`;
       if (typeof value === "boolean") return value ? key : `${key}={false}`;
-      return `${key}={${JSON.stringify(value)}}`;
+      return `${key}={${value}}`;
     })
     .filter(Boolean)
     .map((str) => `  ${str}\n`)

--- a/apps/docs/src/pages/components/accordion.mdx
+++ b/apps/docs/src/pages/components/accordion.mdx
@@ -13,7 +13,7 @@ import { getComponentData } from "@docs/utils/component";
 
 export const getStaticProps = async ({ params }) => {
   const meta = await getComponentData("Accordion", "core", accordionClasses);
-  return { props: { ssg: { meta: meta } } };
+  return { props: { ssg: { meta } } };
 };
 
 <Description />
@@ -50,7 +50,7 @@ export const getStaticProps = async ({ params }) => {
 
 You can control the state of `HvAccordion` by using the `expanded`/`onChange` props.
 
-```jsx live
+```tsx live
 import { useState } from "react";
 
 export default function Demo() {
@@ -78,7 +78,7 @@ export default function Demo() {
 
 If you need an accordion group, you can use multiple `HvAccordion` components.
 
-```jsx live
+```tsx live
 <div className="w-full flex flex-col w-1/2">
   <HvTypography className="pb-1" variant="title3">
     UI Kit

--- a/apps/docs/src/pages/components/avatar.mdx
+++ b/apps/docs/src/pages/components/avatar.mdx
@@ -7,7 +7,7 @@ import { getComponentData } from "@docs/utils/component";
 
 export const getStaticProps = async ({ params }) => {
   const meta = await getComponentData("Avatar", "core", avatarClasses);
-  return { props: { ssg: { meta: meta } } };
+  return { props: { ssg: { meta } } };
 };
 
 <Description />
@@ -41,7 +41,7 @@ export const getStaticProps = async ({ params }) => {
 
 Image avatars can be created by passing the src or srcSet props to the component.
 
-```jsx live
+```tsx live
 <>
   <HvAvatar alt="Ben" src="https://i.imgur.com/56Eeg1g.png" />
   <HvAvatar alt="Beatrice" src="https://i.imgur.com/bE7vg3N.png" />
@@ -54,7 +54,7 @@ Image avatars can be created by passing the src or srcSet props to the component
 
 Avatars containing simple characters can be created by passing a string as children.
 
-```jsx live
+```tsx live
 <>
   <HvAvatar>BM</HvAvatar>
   <HvAvatar backgroundColor="sema19">W</HvAvatar>
@@ -66,7 +66,7 @@ Avatars containing simple characters can be created by passing a string as child
 
 Icon avatars are created by passing an icon as children. Its size and color aren't Avatar's responsibility.
 
-```jsx live
+```tsx live
 <>
   <HvAvatar>
     <LogIn color="atmo1" iconSize="XS" />
@@ -87,7 +87,7 @@ Icon avatars are created by passing an icon as children. Its size and color aren
 
 If there is an error loading the avatar image, the component falls back to an alternative in the following order: the provided children, the first letter of the alt text and finally the generic User icon.
 
-```jsx live
+```tsx live
 <>
   <HvAvatar alt="Clara Soul" src="/broken-image.jpg">
     CS
@@ -101,7 +101,7 @@ If there is an error loading the avatar image, the component falls back to an al
 
 You can configure the `size` and `variant` of an avatar. When using an icon, set its `iconSize` to the size immediately below the avatar size.
 
-```jsx live
+```tsx live
 <>
   <HvAvatar size="xs" />
   <HvAvatar size="xs" variant="square" />
@@ -125,7 +125,7 @@ You can configure the `size` and `variant` of an avatar. When using an icon, set
 
 An avatar can have a status, represented by either the status colored border or by the badge dot. The color can be from the theme palette or custom.
 
-```jsx live
+```tsx live
 <>
   <HvAvatar size="xs" status="positive">
     AB
@@ -149,7 +149,7 @@ An avatar can have a status, represented by either the status colored border or 
 
 An avatar should be interacted with by wrapping it in an interactable element, such as an `HvButton` or a link. Make sure the elements are labelled accordingly.
 
-```jsx live
+```tsx live
 <>
   <HvButton
     icon

--- a/apps/docs/src/pages/components/badge.mdx
+++ b/apps/docs/src/pages/components/badge.mdx
@@ -1,23 +1,38 @@
-import { badgeClasses } from "@hitachivantara/uikit-react-core";
+import { badgeClasses, HvBadge } from "@hitachivantara/uikit-react-core";
+import { Alert } from "@hitachivantara/uikit-react-icons";
 
+import Playground from "@docs/components/code/Playground";
 import { Description } from "@docs/components/page/Description";
 import { Page } from "@docs/components/page/Page";
 import { getComponentData } from "@docs/utils/component";
 
 export const getStaticProps = async ({ params }) => {
   const meta = await getComponentData("Badge", "core", badgeClasses);
-  return { props: { ssg: { meta: meta } } };
+  return { props: { ssg: { meta } } };
 };
 
 <Description />
 
 <Page>
 
+<Playground
+  Component={HvBadge}
+  componentName="HvBadge"
+  controls={{
+    showCount: { defaultValue: true },
+    count: { type: "number", defaultValue: 2 },
+    maxCount: { type: "number", defaultValue: 99 },
+  }}
+  componentProps={{
+    icon: <Alert />,
+  }}
+/>
+
 ### Icon
 
 Use the `icon` prop to specify a icon to use with the badge.
 
-```jsx live
+```tsx live
 <>
   <HvBadge count={0} icon={<Alert />} />
   <HvBadge count={1} icon={<Alert />} />
@@ -32,7 +47,7 @@ Use the `icon` prop to specify a icon to use with the badge.
 
 Use the `maxCount` prop to specify the maximum value to be displayed. Above that value a '+' sign is displayed.
 
-```jsx live
+```tsx live
 <>
   <HvBadge showCount count={10} maxCount={9} />
   <HvBadge showCount count={100} maxCount={99} />
@@ -44,7 +59,7 @@ Use the `maxCount` prop to specify the maximum value to be displayed. Above that
 
 To display text with the badge you can use the `text` prop along with the `textVariant` prop to specify the typography variant to use.
 
-```jsx live
+```tsx live
 <>
   <HvBadge count={0} text="Events" textVariant="label" />
   <HvBadge count={1} text="Events" textVariant="label" />
@@ -59,7 +74,7 @@ To display text with the badge you can use the `text` prop along with the `textV
 
 A badge sample using react hooks to set the number of events.
 
-```jsx live
+```tsx live
 import { useState } from "react";
 
 export default function Demo() {
@@ -79,7 +94,7 @@ export default function Demo() {
 
 If you want to specify a custom aria-label, use the `role` prop.
 
-```jsx live
+```tsx live
 <HvBadge
   showCount
   count={25}

--- a/apps/docs/src/pages/components/banner.mdx
+++ b/apps/docs/src/pages/components/banner.mdx
@@ -8,7 +8,7 @@ import { getComponentData } from "@docs/utils/component";
 
 export const getStaticProps = async ({ params }) => {
   const meta = await getComponentData("Banner", "core", bannerClasses);
-  return { props: { ssg: { meta: meta } } };
+  return { props: { ssg: { meta } } };
 };
 
 <Description />
@@ -39,7 +39,7 @@ export const getStaticProps = async ({ params }) => {
 
 You can add a set of actions to the banner by specifying the `actions` prop. The `onAction` prop is a callback function that is called when an action is clicked.
 
-```jsx live
+```tsx live
 <HvBanner
   open
   offset={0}
@@ -58,7 +58,7 @@ You can add a set of actions to the banner by specifying the `actions` prop. The
 
 You can pass a custom icon to the banner by using the `customIcon` prop.
 
-```jsx live
+```tsx live
 <HvBanner
   open
   offset={0}

--- a/apps/docs/src/pages/components/button.mdx
+++ b/apps/docs/src/pages/components/button.mdx
@@ -2,7 +2,6 @@ import {
   buttonClasses,
   buttonVariant,
   HvButton,
-  HvSize,
 } from "@hitachivantara/uikit-react-core";
 
 import Playground from "@docs/components/code/Playground";
@@ -12,7 +11,7 @@ import { getComponentData } from "@docs/utils/component";
 
 export const getStaticProps = async ({ params }) => {
   const meta = await getComponentData("Button", "core", buttonClasses);
-  return { props: { ssg: { meta: meta } } };
+  return { props: { ssg: { meta } } };
 };
 
 <Description />
@@ -44,7 +43,7 @@ export const getStaticProps = async ({ params }) => {
 
 ### Sizes
 
-```jsx live
+```tsx live
 <>
   <HvButton size="sm">Small</HvButton>
   <HvButton size="md">Medium</HvButton>
@@ -66,7 +65,7 @@ You can also use the `icon` prop and pass icon directly to `children` of the `Hv
 When using icon-only buttons (`icon` prop), it's preferable to use the `HvIconButton` component instead,
 as it wraps the button in an `HvTooltip` component and requires a `title` label.
 
-```jsx live
+```tsx live
 <>
   <HvButton startIcon={<Play />} variant="primary">
     Play
@@ -118,7 +117,7 @@ interface MyLinkProps extends HvButtonProps<"a"> {
 
 If you need a button that exists on a semantic container you can set the `variant` prop to `semantic`.
 
-```jsx live
+```tsx live
 <div className="flex flex-wrap gap-sm p-sm text-base_dark bg-neutral_20">
   <HvButton variant="semantic" startIcon={<Favorite />}>
     Favorite
@@ -140,7 +139,7 @@ If you need a button that exists on a semantic container you can set the `varian
 If you still need the button to be focusable when disabled for accessibility purposes, you can set the `focusableWhenDisabled` property to `true`.
 When using this property, the buttons will continue to be read by screen readers when disabled.
 
-```jsx live
+```tsx live
 <HvButton disabled focusableWhenDisabled>
   Primary
 </HvButton>

--- a/apps/docs/src/pages/components/card.mdx
+++ b/apps/docs/src/pages/components/card.mdx
@@ -11,14 +11,14 @@ export const getStaticProps = async ({ params }) => {
     "Content",
     "Media",
   ]);
-  return { props: { ssg: { meta: meta } } };
+  return { props: { ssg: { meta } } };
 };
 
 <Description />
 
 <Page>
 
-```jsx live
+```tsx live
 <HvCard
   className="w-380px"
   bgcolor="atmo1"
@@ -57,7 +57,7 @@ export const getStaticProps = async ({ params }) => {
 
 You can place an image on your card using the `HvCardMedia` component. It will adapt to the location of the card it is placed on.
 
-```jsx live
+```tsx live
 <HvCard className="w-240px" bgcolor="atmo1">
   <HvCardMedia
     component="img"
@@ -78,7 +78,7 @@ You can place an image on your card using the `HvCardMedia` component. It will a
 
 If you want to add actions to the card, you can use the `HvActionBar` component.
 
-```jsx live
+```tsx live
 <>
   <HvCard className="w-380px" bgcolor="atmo1">
     <HvCardHeader

--- a/apps/docs/src/pages/components/checkbox.mdx
+++ b/apps/docs/src/pages/components/checkbox.mdx
@@ -1,8 +1,4 @@
-import {
-  checkBoxClasses,
-  HvCheckBox,
-  theme,
-} from "@hitachivantara/uikit-react-core";
+import { checkBoxClasses, HvCheckBox } from "@hitachivantara/uikit-react-core";
 
 import Playground from "@docs/components/code/Playground";
 import { Description } from "@docs/components/page/Description";
@@ -11,7 +7,7 @@ import { getComponentData } from "@docs/utils/component";
 
 export const getStaticProps = async ({ params }) => {
   const meta = await getComponentData("CheckBox", "core", checkBoxClasses);
-  return { props: { ssg: { meta: meta } } };
+  return { props: { ssg: { meta } } };
 };
 
 <Description />
@@ -45,7 +41,7 @@ export const getStaticProps = async ({ params }) => {
 
 ### States
 
-```jsx live
+```tsx live
 <div className="flex gap-xs items-start">
   <HvCheckBox label="Checkbox" />
   <HvCheckBox required label="Required" />
@@ -60,7 +56,7 @@ export const getStaticProps = async ({ params }) => {
 
 Controlled checkbox. Clicking the Checkbox 1 does nothing, while clicking Checkbox 2 changes both inputs.
 
-```jsx live
+```tsx live
 import { useState } from "react";
 
 export default function Demo() {

--- a/apps/docs/src/pages/components/date-picker.mdx
+++ b/apps/docs/src/pages/components/date-picker.mdx
@@ -1,7 +1,6 @@
 import {
   datePickerClasses,
   HvDatePicker,
-  theme,
 } from "@hitachivantara/uikit-react-core";
 
 import Playground from "@docs/components/code/Playground";
@@ -49,7 +48,7 @@ Use the `showActions` property to display Apply/Cancel buttons at the bottom.
 
 Use the `labels` object to customize the internal labels of the date picker.
 
-```jsx live
+```tsx live
 <HvDatePicker
   showActions
   label="This is the title for the date picker"
@@ -105,7 +104,7 @@ export default function Demo() {
 
 Use `rangeMode` to enable the selection of a range of dates. When doing so, use `startValue` and `endValue` to set the initial values, instead of the `value` prop.
 
-```jsx live
+```tsx live
 <HvDatePicker
   label="Date"
   placeholder="Select a range"
@@ -119,7 +118,7 @@ Use `rangeMode` to enable the selection of a range of dates. When doing so, use 
 
 You can restrict the selection of dates by setting the `minimumDate` and `maximumDate` properties.
 
-```jsx live
+```tsx live
 <HvDatePicker
   label="Date"
   placeholder="Select date"

--- a/apps/docs/src/pages/components/form-element.mdx
+++ b/apps/docs/src/pages/components/form-element.mdx
@@ -7,7 +7,6 @@ import {
   HvInfoMessage,
   HvLabel,
   HvWarningText,
-  theme,
 } from "@hitachivantara/uikit-react-core";
 import { Fail, Success } from "@hitachivantara/uikit-react-icons";
 

--- a/apps/docs/src/pages/components/input.mdx
+++ b/apps/docs/src/pages/components/input.mdx
@@ -1,4 +1,4 @@
-import { HvInput, inputClasses, theme } from "@hitachivantara/uikit-react-core";
+import { HvInput, inputClasses } from "@hitachivantara/uikit-react-core";
 
 import Playground from "@docs/components/code/Playground";
 import { Description } from "@docs/components/page/Description";
@@ -7,7 +7,7 @@ import { getComponentData } from "@docs/utils/component";
 
 export const getStaticProps = async ({ params }) => {
   const meta = await getComponentData("Input", "core", inputClasses);
-  return { props: { ssg: { meta: meta } } };
+  return { props: { ssg: { meta } } };
 };
 
 <Description />
@@ -30,7 +30,7 @@ export const getStaticProps = async ({ params }) => {
 
 You can control the value of the `HvInput` by using the `value`/`onChange` props, similarly to the `<input>` element.
 
-```jsx live
+```tsx live
 import { useState } from "react";
 
 export default function Demo() {
@@ -61,7 +61,7 @@ export default function Demo() {
 
 ### Validation
 
-```jsx live
+```tsx live
 <HvInput
   label="Greeting"
   description="You must input `hello`"
@@ -87,7 +87,7 @@ export default function Demo() {
 
 Use `inputProps` to inject custom props to the underlying `<input>` element.
 
-```jsx live
+```tsx live
 <HvInput
   label="Description"
   placeholder="Insert a short description"
@@ -149,7 +149,7 @@ export default function Demo() {
 
 Inputs are form elements and oftentimes used within a form. You can use the `form` prop to associate the input with a form.
 
-```jsx live
+```tsx live
 export default function Demo() {
   return (
     <form
@@ -175,7 +175,7 @@ export default function Demo() {
 
 If you need to apply a custom layout, e.g. for providing a prefix or suffix, you can and should externalize both the label (`HvLabel`) and description (`HvInfoMessage`).
 
-```jsx live
+```tsx live
 <div className="w-400px">
   <div className="flex items-start">
     <HvLabel label="Subdomain" htmlFor="subdomain-input" />
@@ -203,7 +203,7 @@ If you need to apply a custom layout, e.g. for providing a prefix or suffix, you
 
 Inputs can have a autocomplete suggestons using the `suggestionListCallback`.
 
-```jsx live
+```tsx live
 import { useState } from "react";
 
 export default function Demo() {
@@ -251,7 +251,7 @@ const animalsStartingWithA = [
 
 Inputs not using the visual `label` prop should instead provide an `aria-label` property.
 
-```jsx live
+```tsx live
 <HvInput aria-label="First name" placeholder="Insert first name" />
 ```
 

--- a/apps/docs/src/pages/components/loading-container.mdx
+++ b/apps/docs/src/pages/components/loading-container.mdx
@@ -14,7 +14,7 @@ export const getStaticProps = async ({ params }) => {
     "core",
     loadingContainerClasses,
   );
-  return { props: { ssg: { meta: meta } } };
+  return { props: { ssg: { meta } } };
 };
 
 <Description />

--- a/apps/docs/src/pages/components/loading.mdx
+++ b/apps/docs/src/pages/components/loading.mdx
@@ -7,7 +7,7 @@ import { getComponentData } from "@docs/utils/component";
 
 export const getStaticProps = async ({ params }) => {
   const meta = await getComponentData("Loading", "core", loadingClasses);
-  return { props: { ssg: { meta: meta } } };
+  return { props: { ssg: { meta } } };
 };
 
 <Description />
@@ -36,7 +36,7 @@ export const getStaticProps = async ({ params }) => {
 
 You can change the default color of the loader by passing a color name from the UI Kit color palette, a CSS color name or a hex color code.
 
-```jsx live
+```tsx live
 <>
   <HvLoading color="positive" />
   <HvLoading color="cat2" />
@@ -49,17 +49,13 @@ You can change the default color of the loader by passing a color name from the 
 
 You can easily create a custom `LoadingButton` component to handle async submission operations.
 
-```jsx live
+```tsx live
 import { useState } from "react";
 
 const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
 export default function Demo() {
-  return (
-    <LoadingButton onClick={() => delay(3000)}>
-      Submit
-    </LoadingButton>
-  );
+  return <LoadingButton onClick={() => delay(3000)}>Submit</LoadingButton>;
 }
 
 function LoadingButton({ onClick, children, ...others }: HvButtonProps) {
@@ -83,7 +79,7 @@ function LoadingButton({ onClick, children, ...others }: HvButtonProps) {
       )}
     </HvButton>
   );
-};
+}
 ```
 
 ### Related components

--- a/apps/docs/src/pages/components/overflow-tooltip.mdx
+++ b/apps/docs/src/pages/components/overflow-tooltip.mdx
@@ -15,7 +15,7 @@ export const getStaticProps = async ({ params }) => {
     "core",
     overflowTooltipClasses,
   );
-  return { props: { ssg: { meta: meta } } };
+  return { props: { ssg: { meta } } };
 };
 
 <Description />

--- a/apps/docs/src/pages/components/radio-group.mdx
+++ b/apps/docs/src/pages/components/radio-group.mdx
@@ -2,7 +2,6 @@ import {
   HvRadio,
   HvRadioGroup,
   radioGroupClasses,
-  theme,
 } from "@hitachivantara/uikit-react-core";
 
 import Playground from "@docs/components/code/Playground";
@@ -12,7 +11,7 @@ import { getComponentData } from "@docs/utils/component";
 
 export const getStaticProps = async ({ params }) => {
   const meta = await getComponentData("RadioGroup", "core", radioGroupClasses);
-  return { props: { ssg: { meta: meta } } };
+  return { props: { ssg: { meta } } };
 };
 
 <Description />
@@ -49,7 +48,7 @@ export const getStaticProps = async ({ params }) => {
 
 ### States
 
-```jsx live
+```tsx live
 <div className="flex gap-xs items-start">
   <HvRadioGroup required label="Required">
     <HvRadio label="Radio 1" value="1" />
@@ -83,11 +82,11 @@ export const getStaticProps = async ({ params }) => {
 
 Controlled radio button group. Choosing the first option will result in an invalid state of the Radio group.
 
-```jsx live
-import { useState } from "react";
+```tsx live
+import { useState } from "react";
 
 export default function Demo() {
- const [value, setValue] = useState<string>("2");
+  const [value, setValue] = useState<string>("2");
   const [status, setStatus] = useState<HvFormStatus>("standBy");
 
   const handleOnChange = (

--- a/apps/docs/src/pages/components/radio.mdx
+++ b/apps/docs/src/pages/components/radio.mdx
@@ -1,4 +1,4 @@
-import { HvRadio, radioClasses, theme } from "@hitachivantara/uikit-react-core";
+import { HvRadio, radioClasses } from "@hitachivantara/uikit-react-core";
 
 import Playground from "@docs/components/code/Playground";
 import { Description } from "@docs/components/page/Description";
@@ -7,7 +7,7 @@ import { getComponentData } from "@docs/utils/component";
 
 export const getStaticProps = async ({ params }) => {
   const meta = await getComponentData("Radio", "core", radioClasses);
-  return { props: { ssg: { meta: meta } } };
+  return { props: { ssg: { meta } } };
 };
 
 <Description />
@@ -41,7 +41,7 @@ export const getStaticProps = async ({ params }) => {
 
 ### States
 
-```jsx live
+```tsx live
 <div className="flex gap-xs items-start">
   <HvRadio label="Radio" />
   <HvRadio required label="Required" />
@@ -56,7 +56,7 @@ export const getStaticProps = async ({ params }) => {
 
 Controlled radio button. Clicking the Radio button 1 does nothing, while clicking Radio button 2 changes both inputs.
 
-```jsx live
+```tsx live
 import { useState } from "react";
 
 export default function Demo() {

--- a/apps/docs/src/pages/components/section.mdx
+++ b/apps/docs/src/pages/components/section.mdx
@@ -11,7 +11,7 @@ import { getComponentData } from "@docs/utils/component";
 
 export const getStaticProps = async ({ params }) => {
   const meta = await getComponentData("Section", "core", sectionClasses);
-  return { props: { ssg: { meta: meta } } };
+  return { props: { ssg: { meta } } };
 };
 
 <Description />
@@ -41,7 +41,7 @@ export const getStaticProps = async ({ params }) => {
 
 You can add actions to the section header by using the `actions` prop which can accept any component.
 
-```jsx live
+```tsx live
 <HvSection
   actions={<HvButton variant="primarySubtle">Explore Insights</HvButton>}
   title={

--- a/apps/docs/src/pages/components/select.mdx
+++ b/apps/docs/src/pages/components/select.mdx
@@ -47,7 +47,7 @@ export const getStaticProps = async ({ params }) => {
 To integrate `HvSelect` in a form, make sure you're giving it a `name`.
 The value result will be the selected option's `value`, or a JSON of the selected values when multi-select is enabled. The value can be customized via the `getSerializedValue` prop.
 
-```jsx live
+```tsx live
 <form
   onSubmit={(evt) => {
     evt.preventDefault();
@@ -82,7 +82,7 @@ The value result will be the selected option's `value`, or a JSON of the selecte
 
 The value and open states of `HvSelect` can be controlled by using the `value`/`onChange` and `open`/`onOpenChange` props respectively.
 
-```jsx live
+```tsx live
 import { useState } from "react";
 import { HvButton, HvOption, HvSelect } from "@hitachivantara/uikit-react-core";
 
@@ -123,7 +123,7 @@ export default function Demo() {
       </HvButton>
     </>
   );
-};
+}
 
 const options = [
   { value: "ar", label: "Argentina", flag: "🇦🇷" },

--- a/apps/docs/src/pages/components/skeleton.mdx
+++ b/apps/docs/src/pages/components/skeleton.mdx
@@ -13,7 +13,7 @@ import { getComponentData } from "@docs/utils/component";
 
 export const getStaticProps = async ({ params }) => {
   const meta = await getComponentData("Skeleton", "core", skeletonClasses);
-  return { props: { ssg: { meta: meta } } };
+  return { props: { ssg: { meta } } };
 };
 
 <Description />

--- a/apps/docs/src/pages/components/tag.mdx
+++ b/apps/docs/src/pages/components/tag.mdx
@@ -7,7 +7,7 @@ import { getComponentData } from "@docs/utils/component";
 
 export const getStaticProps = async ({ params }) => {
   const meta = await getComponentData("Tag", "core", tagClasses);
-  return { props: { ssg: { meta: meta } } };
+  return { props: { ssg: { meta } } };
 };
 
 <Description />
@@ -39,7 +39,7 @@ export const getStaticProps = async ({ params }) => {
 
 You can change the default color of the tag by passing a color name from the UI Kit color palette, a CSS color name or a hex color code.
 
-```jsx live
+```tsx live
 <>
   <HvTag label="Tag Label" color="positive" />
   <HvTag label="Tag Label" color="cat2" />
@@ -52,7 +52,7 @@ You can change the default color of the tag by passing a color name from the UI 
 
 The tag component will automatically truncate the text if it is too long to fit in the container. You can add a tooltip to show the full text when the user hovers over the tag.
 
-```jsx live
+```tsx live
 <HvTag
   label={
     <HvOverflowTooltip data="This is an example of a extremely long tag" />
@@ -67,7 +67,7 @@ Tags can have click actions.
 - Use the `onClick` prop to add an action to the tag.
 - Use the `onDelete` prop to add a delete button to the tag.
 
-```jsx live
+```tsx live
 <HvTag
   label="Click me!"
   onClick={() => alert("Clicked!")}
@@ -79,7 +79,7 @@ Tags can have click actions.
 
 To use the selectable tags in a controlled way, set the `selected` prop to `true` of `false`.
 
-```jsx live
+```tsx live
 import { useState } from "react";
 
 const tags = ["Asset 1", "Asset 2", "Asset 3", "Asset 4"];

--- a/apps/docs/src/pages/components/textarea.mdx
+++ b/apps/docs/src/pages/components/textarea.mdx
@@ -1,9 +1,5 @@
 import { Callout } from "nextra/components";
-import {
-  HvTextArea,
-  textAreaClasses,
-  theme,
-} from "@hitachivantara/uikit-react-core";
+import { HvTextArea, textAreaClasses } from "@hitachivantara/uikit-react-core";
 
 import Playground from "@docs/components/code/Playground";
 import { Description } from "@docs/components/page/Description";
@@ -12,7 +8,7 @@ import { getComponentData } from "@docs/utils/component";
 
 export const getStaticProps = async ({ params }) => {
   const meta = await getComponentData("TextArea", "core", textAreaClasses);
-  return { props: { ssg: { meta: meta } } };
+  return { props: { ssg: { meta } } };
 };
 
 <Description />
@@ -51,7 +47,7 @@ The `maxCharQuantity` prop can be used to limit the number of allowed characters
 - By default, the limited can be exceeded, but you can set the `blockMax` prop to prevent this.
 - The `middleCountLabel` allows customizing the count separator (`/`).
 
-```jsx live
+```tsx live
 <>
   <HvTextArea
     label="You can write past the limit"
@@ -74,7 +70,7 @@ The `maxCharQuantity` prop can be used to limit the number of allowed characters
 
 Use the `autoScroll` prop to automatically scroll to bottom. Auto-scroll stops once the user scrolls up, and resumes once the user scrolls back to the bottom.
 
-```jsx live
+```tsx live
 import { useEffect, useState } from "react";
 
 export default function Demo() {

--- a/apps/docs/src/pages/components/time-picker.mdx
+++ b/apps/docs/src/pages/components/time-picker.mdx
@@ -1,6 +1,5 @@
 import {
   HvTimePicker,
-  theme,
   timePickerClasses,
 } from "@hitachivantara/uikit-react-core";
 
@@ -39,7 +38,7 @@ export const getStaticProps = async ({ params }) => {
 A Time Picker usage inside a `form` element. Give `HvTimePicker` a `name`, and it will be included in the form data,
 following the time [`input` format](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/time) specification.
 
-```jsx live
+```tsx live
 <form
   onSubmit={(event) => {
     event.preventDefault();

--- a/apps/docs/src/pages/components/tooltip.mdx
+++ b/apps/docs/src/pages/components/tooltip.mdx
@@ -2,7 +2,6 @@ import { Callout } from "nextra/components";
 import {
   HvButton,
   HvTooltip,
-  theme,
   tooltipClasses,
 } from "@hitachivantara/uikit-react-core";
 
@@ -13,7 +12,7 @@ import { getComponentData } from "@docs/utils/component";
 
 export const getStaticProps = async ({ params }) => {
   const meta = await getComponentData("Tooltip", "core", tooltipClasses);
-  return { props: { ssg: { meta: meta } } };
+  return { props: { ssg: { meta } } };
 };
 
 <Description />


### PR DESCRIPTION
uniformize samples
- remove hanging `theme`, which is always unused
- always use tsx syntax
- meta shorthand