### PR TITLE
fix(Select): merge HvOption events

### DIFF
--- a/packages/core/src/Select/Option.tsx
+++ b/packages/core/src/Select/Option.tsx
@@ -66,8 +66,7 @@ export const HvOption = fixedForwardRef(function HvOption<
       className={cx(classes.root, className, {
         [classes.highlighted]: highlighted,
       })}
-      {...getRootProps()}
-      {...others}
+      {...getRootProps(others)}
     >
       {children}
     </HvListItem>

--- a/packages/core/src/Select/Select.test.tsx
+++ b/packages/core/src/Select/Select.test.tsx
@@ -69,8 +69,12 @@ describe("Select", () => {
           <HvOption value="opt3">Option3</HvOption>
         </HvOptionGroup>
         <HvOptionGroup label="Group2">
-          <HvOption value="opt4">Option4</HvOption>
-          <HvOption value="opt5">Option5</HvOption>
+          <HvOption value="opt4" onClick={() => {}}>
+            Option4
+          </HvOption>
+          <HvOption value="opt5" onClick={() => {}}>
+            Option5
+          </HvOption>
         </HvOptionGroup>
       </HvSelect>,
     );


### PR DESCRIPTION
The `...others` spread in `HvOption` is squashing the internal `useOption` event handlers