### PR TITLE
feat(FileUploader): add classes, label, accept props

### DIFF
--- a/apps/docs/src/components/code/Controls.tsx
+++ b/apps/docs/src/components/code/Controls.tsx
@@ -26,7 +26,7 @@ type ControlType =
 
 export type Control = {
   type?: ControlType;
-  defaultValue?: string;
+  defaultValue?: any;
   values?: string[];
 };
 
@@ -37,11 +37,21 @@ type ControlsProps = {
   onChange: (prop: string, value: unknown) => void;
 };
 
+const defaultMap: Record<string, ControlType> = {
+  string: "text",
+  number: "number",
+  boolean: "check",
+};
+
 export const Controls = ({ prop, state, control, onChange }: ControlsProps) => {
   const { colors } = useTheme();
   const { meta } = useData();
   const propMeta = meta.docgen.props[prop];
-  const type = control?.type || propMeta?.type?.name || "text";
+  const type: ControlType =
+    control?.type ||
+    defaultMap[typeof control.defaultValue] ||
+    defaultMap[propMeta?.type?.name] ||
+    "text";
 
   // Utility to clean up values (e.g., remove quotes)
   const cleanValue = (value: string) => value.replace(/"/g, "");

--- a/apps/docs/src/pages/components/file-uploader.mdx
+++ b/apps/docs/src/pages/components/file-uploader.mdx
@@ -1,0 +1,159 @@
+import {
+  fileUploaderClasses,
+  HvFileUploader,
+} from "@hitachivantara/uikit-react-core";
+
+import Playground from "@docs/components/code/Playground";
+import { Description } from "@docs/components/page/Description";
+import { Page } from "@docs/components/page/Page";
+import { getComponentData } from "@docs/utils/component";
+
+export const getStaticProps = async ({ params }) => {
+  const meta = await getComponentData(
+    "FileUploader",
+    "core",
+    fileUploaderClasses,
+    ["DropZone", "FileList"],
+  );
+  return { props: { ssg: { meta } } };
+};
+
+<Description />
+
+<Page>
+
+<Playground
+  Component={HvFileUploader}
+  componentName="HvFileUploader"
+  controls={{
+    label: { defaultValue: "Upload" },
+    accept: { defaultValue: "image/*" },
+    multiple: { defaultValue: true },
+    disabled: { defaultValue: false },
+  }}
+  componentProps={{
+    className: "w-full",
+  }}
+/>
+
+### Controlled
+
+`HvFileUploader` is limited to controlled behavior. Use the `fileList` prop to list the files, and listen to added/removed files with the `onFilesAdded` and `onFileRemoved` props respectively.
+
+```tsx live
+import { useState } from "react";
+
+export default function Demo() {
+  const [list, setList] = useState<HvFileData[]>([]);
+
+  return (
+    <HvFileUploader
+      className="w-full"
+      accept="image/*"
+      fileList={list}
+      onFilesAdded={(newFiles) => {
+        newFiles.forEach((newFile) => {
+          // simulate instant successful upload
+          // in a real scenario, you would upload the file to the server
+          // and update `.progress` and `.status` accordingly
+          newFile.status = "success";
+          newFile.progress = newFile.size;
+
+          setList((files) => [newFile, ...files]);
+        });
+      }}
+      onFileRemoved={(removedFile) => {
+        setList((files) => files.filter((file) => file !== removedFile));
+      }}
+    />
+  );
+}
+```
+
+### Preview
+
+The `fileList` supports a `preview` prop that can be used to render a custom `ReactNode` preview.
+
+```tsx live
+import { useState } from "react";
+
+export default function Demo() {
+  const [open, setOpen] = useState(false);
+  const [previewUrl, setPreviewUrl] = useState("");
+  const [previewTitle, setPreviewTitle] = useState("");
+
+  function openDialog(url: string, title: string) {
+    setPreviewUrl(url);
+    setPreviewTitle(title);
+    setOpen(true);
+  }
+
+  return (
+    <>
+      <HvFileUploader
+        className="w-full"
+        accept="image/*"
+        disabled
+        fileList={[
+          {
+            id: "1",
+            name: "already_here.jpg",
+            size: 5000,
+            status: "success",
+            preview: (
+              <HvFileUploaderPreview
+                aria-label="Open the bigger preview"
+                onClick={() =>
+                  openDialog(
+                    "https://i.imgur.com/YcVYmM0.jpg",
+                    "already_here.jpg",
+                  )
+                }
+              >
+                <img
+                  alt="Small preview of the uploaded file"
+                  src="https://i.imgur.com/YcVYmM0.jpg"
+                />
+              </HvFileUploaderPreview>
+            ),
+          },
+          {
+            id: "2",
+            name: "code.yaml",
+            size: 200,
+            status: "success",
+            preview: <Code />,
+          },
+          {
+            id: "3",
+            name: "letter.docx",
+            size: 2000,
+            status: "success",
+            preview: (
+              <HvFileUploaderPreview
+                aria-label="Open preview of the document (not!)"
+                onClick={() => {}}
+                disableOverlay
+              >
+                <DocWord />
+              </HvFileUploaderPreview>
+            ),
+          },
+        ]}
+      />
+      <HvDialog open={open} onClose={() => setOpen(false)}>
+        <HvDialogTitle>{previewTitle}</HvDialogTitle>
+        <HvDialogContent>
+          <img
+            alt="Preview of the uploaded file"
+            src={previewUrl}
+            style={{ maxWidth: "100%", maxHeight: "70vh" }}
+          />
+        </HvDialogContent>
+      </HvDialog>
+    </>
+  );
+}
+```
+
+</Page>

--- a/packages/core/src/FileUploader/DropZone/DropZone.styles.tsx
+++ b/packages/core/src/FileUploader/DropZone/DropZone.styles.tsx
@@ -10,17 +10,15 @@ export const { staticClasses, useClasses } = createClasses("HvDropZone", {
     display: "flex",
     border: `1px dashed ${theme.colors.secondary_60}`,
     cursor: "pointer",
-    background: theme.colors.atmo1,
+    backgroundColor: theme.colors.atmo1,
     borderRadius: theme.radii.round,
 
     "&:hover": {
-      background: `${theme.colors.atmo1}`,
-      border: `1px dashed ${theme.colors.secondary}`,
+      borderColor: theme.colors.secondary,
     },
 
     "&:focus-within": {
-      background: `${theme.colors.atmo1}`,
-      border: `1px dashed ${theme.colors.secondary}`,
+      borderColor: theme.colors.secondary,
       ...outlineStyles,
     },
   },
@@ -35,23 +33,16 @@ export const { staticClasses, useClasses } = createClasses("HvDropZone", {
     },
   },
   dragAction: {
-    background: `${theme.colors.atmo1}`,
-    border: `1px dashed ${theme.colors.primary}`,
+    backgroundColor: theme.colors.atmo1,
+    borderColor: theme.colors.primary,
   },
   dropZoneContainerDisabled: {
-    background: `${theme.colors.atmo3}`,
-    border: `1px dashed ${theme.colors.secondary_60}`,
+    color: theme.colors.secondary_60,
+    backgroundColor: theme.colors.atmo3,
+    borderColor: "currentcolor",
     cursor: "not-allowed",
     "&:hover": {
-      background: `${theme.colors.atmo3}`,
-      border: `1px dashed ${theme.colors.secondary_60}`,
-    },
-
-    "& $dragText": {
-      color: theme.colors.secondary_60,
-    },
-    "& $selectFilesText": {
-      color: theme.colors.secondary_60,
+      borderColor: "currentcolor",
     },
   },
   inputArea: {
@@ -67,7 +58,8 @@ export const { staticClasses, useClasses } = createClasses("HvDropZone", {
   },
   dropArea: {
     display: "flex",
-    margin: `${theme.space.md} auto`,
+    margin: theme.spacing("md", "auto"),
+    gap: theme.space.xs,
     minHeight: 48,
   },
   dropZoneAreaLabels: {
@@ -75,15 +67,10 @@ export const { staticClasses, useClasses } = createClasses("HvDropZone", {
     maxWidth: 120,
     margin: "auto",
   },
-  dropZoneAreaIcon: {
-    margin: "auto",
-    marginRight: theme.space.xs,
-  },
+  dropZoneAreaIcon: {},
   dropZoneLabel: {},
-  dragText: {
-    ...(theme.typography.body as React.CSSProperties),
-  },
+  dragText: {},
   selectFilesText: {
-    ...(theme.typography.label as React.CSSProperties),
+    fontWeight: theme.typography.label.fontWeight,
   },
 });

--- a/packages/core/src/FileUploader/FileUploader.stories.tsx
+++ b/packages/core/src/FileUploader/FileUploader.stories.tsx
@@ -11,7 +11,7 @@ import {
 } from "@hitachivantara/uikit-react-core";
 import { Code, DocWord } from "@hitachivantara/uikit-react-icons";
 
-import { cancelUpload, simulateUpload } from "./simulators";
+import { cancelUpload, simulateUpload } from "./stories/simulators";
 
 const meta: Meta<typeof HvFileUploader> = {
   title: "Widgets/File Uploader",
@@ -140,7 +140,7 @@ export const Basic: StoryObj<HvFileUploaderProps> = {
 
     return (
       <HvFileUploader
-        acceptedFiles={[".jpg", ".jpeg", ".png"]}
+        accept=".jpg,.jpeg,.png"
         labels={{ sizeWarning: "Maximum file size:" }}
         maxFileSize={1 * 1000 ** 2}
         fileList={list}
@@ -292,7 +292,7 @@ export const WithPreviewThumbnails: StoryObj<HvFileUploaderProps> = {
     return (
       <>
         <HvFileUploader
-          acceptedFiles={["image/*"]}
+          accept="image/*"
           labels={{
             sizeWarning: "Maximum file size:",
             acceptedFiles: "Pick an image",
@@ -378,7 +378,7 @@ export const SingleUpload: StoryObj<HvFileUploaderProps> = {
         onFileRemoved={(removedFile) => {
           removeFile(removedFile);
         }}
-        acceptedFiles={[".jpg", ".jpeg", ".png"]}
+        accept=".jpg,.jpeg,.png"
         maxFileSize={1 * 1000 ** 2}
         multiple={false}
         disabled={list.length === 1}
@@ -444,10 +444,7 @@ export const CustomizedFileTypes: StoryObj<HvFileUploaderProps> = {
         onFileRemoved={(removedFile) => {
           removeFile(removedFile);
         }}
-        acceptedFiles={[
-          "application/vnd.ms-excel",
-          "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
-        ]}
+        accept="application/vnd.ms-excel,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
         labels={{
           dropzone: "Upload your spreadsheets",
           acceptedFiles: "(excel files)",

--- a/packages/core/src/FileUploader/FileUploader.styles.ts
+++ b/packages/core/src/FileUploader/FileUploader.styles.ts
@@ -1,0 +1,5 @@
+import { createClasses } from "@hitachivantara/uikit-react-utils";
+
+export const { staticClasses, useClasses } = createClasses("HvFileUploader", {
+  root: {},
+});

--- a/packages/core/src/FileUploader/FileUploader.test.tsx
+++ b/packages/core/src/FileUploader/FileUploader.test.tsx
@@ -113,7 +113,7 @@ describe("FileUploader", () => {
             },
           ] as HvFileData[]
         }
-        acceptedFiles={["png"]}
+        accept=".png"
         maxFileSize={1}
       />,
     );
@@ -141,7 +141,7 @@ describe("FileUploader", () => {
             },
           ] as HvFileData[]
         }
-        acceptedFiles={["png"]}
+        accept=".png"
         maxFileSize={5 * 1000}
       />,
     );

--- a/packages/core/src/FileUploader/FileUploader.tsx
+++ b/packages/core/src/FileUploader/FileUploader.tsx
@@ -1,24 +1,34 @@
-import { useDefaultProps } from "@hitachivantara/uikit-react-utils";
+import {
+  ExtractNames,
+  useDefaultProps,
+} from "@hitachivantara/uikit-react-utils";
 
+import { HvFormElement, HvFormElementProps } from "../FormElement";
 import { useLabels } from "../hooks/useLabels";
-import { HvBaseProps } from "../types/generic";
 import { setId } from "../utils/setId";
-import { HvDropZone, HvDropZoneLabels } from "./DropZone";
+import { HvDropZone, HvDropZoneLabels, HvDropZoneProps } from "./DropZone";
 import { HvFileData, HvFileRemovedEvent, HvFilesAddedEvent } from "./File";
 import { HvFileList } from "./FileList";
+import { staticClasses, useClasses } from "./FileUploader.styles";
+
+export { staticClasses as fileUploaderClasses };
+
+export type HvFileUploaderClasses = ExtractNames<typeof useClasses>;
 
 export interface HvFileUploaderLabels extends HvDropZoneLabels {
-  /**
-   * Value of aria-label to apply to remove file button in FileList
-   * */
+  /** Value of aria-label to apply to remove file button in FileList */
   removeFileButtonLabel?: string;
 }
 
-export interface HvFileUploaderProps extends HvBaseProps {
+export interface HvFileUploaderProps extends HvFormElementProps {
   /**
    * An object containing all the labels.
    */
   labels?: HvFileUploaderLabels;
+  /**
+   * An object used to override or extend the styles applied to the component.
+   */
+  classes?: HvFileUploaderClasses;
   /**
    * The files to upload.
    */
@@ -35,9 +45,9 @@ export interface HvFileUploaderProps extends HvBaseProps {
    * Max upload size
    * */
   maxFileSize?: number;
-  /**
-   * Files extensions accepted for upload.
-   */
+  /** File types accepted for uploading. @see [HTML input file accept](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/file#accept) */
+  accept?: HvDropZoneProps["accept"];
+  /** Files extensions accepted for upload. @deprecated use `accept` instead */
   acceptedFiles?: string[];
   /**
    * Callback fired when files are added.
@@ -59,14 +69,7 @@ export interface HvFileUploaderProps extends HvBaseProps {
 
 // TODO: This component needs to adopt the Form element shape and deprecate its way of composing labels
 
-const DEFAULT_LABELS: HvFileUploaderLabels = {
-  dropzone: "Label",
-  sizeWarning: "Max. file size:",
-  drag: "Drop files here or",
-  selectFiles: "click to upload",
-  dropFiles: "Drop files here",
-  fileSizeError: "The file exceeds the maximum upload size",
-  fileTypeError: "File type not allowed for upload",
+const DEFAULT_LABELS = {
   removeFileButtonLabel: "Remove File",
 };
 
@@ -74,34 +77,38 @@ const DEFAULT_LABELS: HvFileUploaderLabels = {
  * Lets the user choose one or more files from their device storage. Once chosen,
  * the files can be uploaded to a server or manipulated on the client side.
  *
- * Accepted file types follow the format of the html input accept attribute. Please check https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/file for more details.
+ * Accepted file types follow the format of the html [input accept attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/file).
  */
 export const HvFileUploader = (props: HvFileUploaderProps) => {
   const {
     id,
     className,
+    classes: classesProp,
     labels: labelsProp,
     fileList,
     multiple = true,
-    disabled = false,
-    hideLabels = false,
+    label,
+    hideLabels,
     maxFileSize = Infinity,
     inputProps = {},
+    accept,
     acceptedFiles = [],
+    // TODO: consider adding/replacing with onFilesChange
     onFilesAdded,
     onFileRemoved,
     ...others
   } = useDefaultProps("HvFileUploader", props);
+  const { classes, cx } = useClasses(classesProp);
   const labels = useLabels(DEFAULT_LABELS, labelsProp);
 
   return (
-    <div id={id} className={className} {...others}>
+    <HvFormElement id={id} className={cx(classes.root, className)} {...others}>
       <HvDropZone
         id={setId(id, "dropzone")}
+        label={label}
         labels={labels}
         multiple={multiple}
-        disabled={disabled}
-        accept={acceptedFiles.join(",")}
+        accept={accept ?? acceptedFiles.join(",")}
         maxFileSize={maxFileSize}
         onFilesAdded={onFilesAdded}
         inputProps={inputProps}
@@ -113,6 +120,6 @@ export const HvFileUploader = (props: HvFileUploaderProps) => {
         onFileRemoved={onFileRemoved}
         removeFileButtonLabel={labels?.removeFileButtonLabel}
       />
-    </div>
+    </HvFormElement>
   );
 };

--- a/packages/core/src/FileUploader/stories/simulators.ts
+++ b/packages/core/src/FileUploader/stories/simulators.ts
@@ -1,4 +1,4 @@
-import { HvFileData } from "./File";
+import { HvFileData } from "../File";
 
 const uploadHandlers = new Map();
 

--- a/packages/core/src/FileUploader/utils.ts
+++ b/packages/core/src/FileUploader/utils.ts
@@ -1,6 +1,6 @@
 const units = ["B", "kB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"];
 
-export const findBestUnit = (bytes: number, base = 1000) => {
+const findBestUnit = (bytes: number, base = 1000) => {
   const i = bytes > 0 ? Math.floor(Math.log(bytes) / Math.log(base)) : 0;
   const si = Math.min(i, units.length - 1); // safe index
 


### PR DESCRIPTION
- align `label` with other form elements
- align `acceptedFiles` with the native `accept` attribute
- add missing `classes` and `fileUploaderClasses`
- refactor DropZone styles & classes
- add docs, using new `label` & `accept` props