### PR TITLE
feat(icons): inline core icons & make them customisable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33569,7 +33569,6 @@
       "dependencies": {
         "@emotion/cache": "^11.11.0",
         "@emotion/serialize": "^1.1.2",
-        "@hitachivantara/uikit-react-icons": "^5.14.5",
         "@hitachivantara/uikit-react-shared": "^5.3.30",
         "@hitachivantara/uikit-react-utils": "^0.2.31",
         "@hitachivantara/uikit-styles": "^5.44.3",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -41,7 +41,6 @@
   "dependencies": {
     "@emotion/cache": "^11.11.0",
     "@emotion/serialize": "^1.1.2",
-    "@hitachivantara/uikit-react-icons": "^5.14.5",
     "@hitachivantara/uikit-react-shared": "^5.3.30",
     "@hitachivantara/uikit-react-utils": "^0.2.31",
     "@hitachivantara/uikit-styles": "^5.44.3",

--- a/packages/core/src/Accordion/Accordion.tsx
+++ b/packages/core/src/Accordion/Accordion.tsx
@@ -1,5 +1,4 @@
 import { forwardRef, useCallback, useMemo } from "react";
-import { DropUpXS } from "@hitachivantara/uikit-react-icons";
 import {
   useDefaultProps,
   type ExtractNames,
@@ -7,6 +6,7 @@ import {
 
 import { HvButtonBase } from "../ButtonBase";
 import { useExpandable } from "../hooks/useExpandable";
+import { HvIcon } from "../icons";
 import { HvBaseProps } from "../types/generic";
 import { HvTypography, HvTypographyVariants } from "../Typography";
 import { staticClasses, useClasses } from "./Accordion.styles";
@@ -98,7 +98,7 @@ export const HvAccordion = forwardRef<
         onClick={handleClick}
         variant={labelVariant}
       >
-        <DropUpXS rotate={!isOpen} />
+        <HvIcon name="CaretDown" rotate={isOpen} size="xs" />
         {label}
       </HvTypography>
     );

--- a/packages/core/src/ActionsGeneric/ActionsGeneric.tsx
+++ b/packages/core/src/ActionsGeneric/ActionsGeneric.tsx
@@ -1,5 +1,4 @@
 import { forwardRef, isValidElement } from "react";
-import { MoreOptionsVertical } from "@hitachivantara/uikit-react-icons";
 import {
   useDefaultProps,
   type ExtractNames,
@@ -8,6 +7,7 @@ import {
 import { HvButton, HvButtonProps, HvButtonVariant } from "../Button";
 import { HvDropDownMenu, HvDropDownMenuProps } from "../DropDownMenu";
 import { HvIconButton } from "../IconButton";
+import { HvIcon } from "../icons";
 import { HvBaseProps } from "../types/generic";
 import { setId } from "../utils/setId";
 import { staticClasses, useClasses } from "./ActionsGeneric.styles";
@@ -164,7 +164,7 @@ export const HvActionsGeneric = forwardRef<
             icon: classes.dropDownMenuButton,
             iconSelected: classes.dropDownMenuButtonSelected,
           }}
-          icon={<MoreOptionsVertical color={iconColor} />}
+          icon={<HvIcon name="DotsVertical" color={iconColor} />}
           placement="left"
           onClick={(event, action) => {
             handleCallback(event, idProp || "", action as HvActionGeneric);

--- a/packages/core/src/AppSwitcher/Action/Action.tsx
+++ b/packages/core/src/AppSwitcher/Action/Action.tsx
@@ -1,10 +1,10 @@
 import { useCallback, useState } from "react";
-import { Info } from "@hitachivantara/uikit-react-icons";
-import { type ExtractNames } from "@hitachivantara/uikit-react-utils";
+import type { ExtractNames } from "@hitachivantara/uikit-react-utils";
 import { getColor, HvColorAny } from "@hitachivantara/uikit-styles";
 
 import { HvAvatar } from "../../Avatar";
 import { useUniqueId } from "../../hooks/useUniqueId";
+import { HvIcon } from "../../icons";
 import { HvListItem } from "../../ListContainer";
 import { HvOverflowTooltip } from "../../OverflowTooltip";
 import { HvTooltip } from "../../Tooltip";
@@ -159,7 +159,12 @@ export const HvAppSwitcherAction = ({
 
         {description && (
           <HvTooltip title={description}>
-            <Info className={classes.iconInfo} id={descriptionElementId} />
+            <HvIcon
+              name="Info"
+              compact
+              className={classes.iconInfo}
+              id={descriptionElementId}
+            />
           </HvTooltip>
         )}
       </HvTypography>

--- a/packages/core/src/Avatar/Avatar.tsx
+++ b/packages/core/src/Avatar/Avatar.tsx
@@ -1,6 +1,5 @@
 import { forwardRef } from "react";
 import MuiAvatar, { AvatarProps as MuiAvatarProps } from "@mui/material/Avatar";
-import { User } from "@hitachivantara/uikit-react-icons";
 import {
   useDefaultProps,
   type ExtractNames,
@@ -9,6 +8,7 @@ import { getColor, HvColorAny, HvSize } from "@hitachivantara/uikit-styles";
 
 import { useAvatarGroupContext } from "../AvatarGroup/AvatarGroupContext";
 import { useImageLoaded } from "../hooks/useImageLoaded";
+import { HvIcon } from "../icons";
 import { HvBaseProps } from "../types/generic";
 import { staticClasses, useClasses } from "./Avatar.styles";
 
@@ -122,7 +122,8 @@ export const HvAvatar = forwardRef<
     [children] = alt;
   } else {
     children = (
-      <User
+      <HvIcon
+        name="User"
         color={color}
         size={decreaseSizeMap[size]}
         className={classes.fallback}

--- a/packages/core/src/BaseDropdown/BaseDropdown.tsx
+++ b/packages/core/src/BaseDropdown/BaseDropdown.tsx
@@ -11,7 +11,6 @@ import { PopperProps, usePopper } from "react-popper";
 import type { ClickAwayListenerProps } from "@mui/material/ClickAwayListener";
 import { useForkRef } from "@mui/material/utils";
 import { detectOverflow, Options, Placement } from "@popperjs/core";
-import { DropDownXS, DropUpXS } from "@hitachivantara/uikit-react-icons";
 import {
   useDefaultProps,
   type ExtractNames,
@@ -19,6 +18,7 @@ import {
 
 import { useControlled } from "../hooks/useControlled";
 import { useUniqueId } from "../hooks/useUniqueId";
+import { HvIcon } from "../icons";
 import { HvBaseProps } from "../types/generic";
 import { HvTypography } from "../Typography";
 import { getFirstAndLastFocus } from "../utils/focusableElementFinder";
@@ -235,8 +235,6 @@ const BaseDropdown = forwardRef<
     [isOpen, disabled, setIsOpen, onToggle, referenceElement],
   );
 
-  const ExpanderComponent = isOpen ? DropUpXS : DropDownXS;
-
   const defaultHeaderElement = (
     <div
       id={setId(id, "header")}
@@ -272,9 +270,10 @@ const BaseDropdown = forwardRef<
       </div>
       <div className={classes.arrowContainer}>
         {adornment || (
-          <ExpanderComponent
-            iconSize="XS"
-            color={disabled ? "textDisabled" : undefined}
+          <HvIcon
+            name="CaretDown"
+            size="xs"
+            rotate={isOpen}
             className={classes.arrow}
           />
         )}

--- a/packages/core/src/BreadCrumb/PathElement/PathElement.tsx
+++ b/packages/core/src/BreadCrumb/PathElement/PathElement.tsx
@@ -1,6 +1,6 @@
-import { DropRightXS } from "@hitachivantara/uikit-react-icons";
 import { type ExtractNames } from "@hitachivantara/uikit-react-utils";
 
+import { HvIcon } from "../../icons";
 import { staticClasses, useClasses } from "./PathElement.styles";
 
 export { staticClasses as pathElementClasses };
@@ -24,7 +24,9 @@ export const HvPathElement = ({
     <li className={classes.centerContainer}>
       {children}
       {!last && (
-        <DropRightXS
+        <HvIcon
+          name="CaretRight"
+          size="xs"
           className={classes.separatorContainer}
           color="textDisabled"
         />

--- a/packages/core/src/BreadCrumb/utils.tsx
+++ b/packages/core/src/BreadCrumb/utils.tsx
@@ -1,6 +1,5 @@
-import { MoreOptionsHorizontal } from "@hitachivantara/uikit-react-icons";
-
 import { HvDropDownMenu, HvDropDownMenuProps } from "../DropDownMenu";
+import { HvIcon } from "../icons";
 import { setId } from "../utils/setId";
 
 export const removeExtension = (label: string) =>
@@ -27,7 +26,7 @@ export const pathWithSubMenu = (
     nbrElemToSubMenu,
     <HvDropDownMenu
       id={setId(id, "submenu")}
-      icon={<MoreOptionsHorizontal iconSize="S" color="text" />}
+      icon={<HvIcon name="DotsHorizontal" />}
       dataList={subMenuList}
       {...dropDownMenuProps}
       onClick={onClick != null ? handleClick : undefined}

--- a/packages/core/src/Calendar/CalendarNavigation/Navigation/Navigation.tsx
+++ b/packages/core/src/Calendar/CalendarNavigation/Navigation/Navigation.tsx
@@ -1,10 +1,7 @@
-import {
-  DropLeftXS as DropLeftIcon,
-  DropRightXS as DropRightIcon,
-} from "@hitachivantara/uikit-react-icons";
 import { type ExtractNames } from "@hitachivantara/uikit-react-utils";
 
 import { HvButton } from "../../../Button";
+import { HvIcon } from "../../../icons";
 import { HvBaseProps } from "../../../types/generic";
 import { setId } from "../../../utils/setId";
 import { staticClasses, useClasses } from "./Navigation.styles";
@@ -37,7 +34,7 @@ export const Navigation = ({
         })}
         onClick={onNavigatePrevious}
       >
-        <DropLeftIcon />
+        <HvIcon name="CaretRight" size="xs" rotate />
       </HvButton>
 
       <HvButton
@@ -62,7 +59,7 @@ export const Navigation = ({
         })}
         onClick={onNavigateNext}
       >
-        <DropRightIcon />
+        <HvIcon name="CaretRight" size="xs" />
       </HvButton>
     </div>
   );

--- a/packages/core/src/Carousel/Carousel.tsx
+++ b/packages/core/src/Carousel/Carousel.tsx
@@ -8,12 +8,6 @@ import {
 } from "react";
 import useCarousel from "embla-carousel-react";
 import {
-  Backwards,
-  Close,
-  Forwards,
-  Fullscreen,
-} from "@hitachivantara/uikit-react-icons";
-import {
   clamp,
   useDefaultProps,
   useTheme,
@@ -24,6 +18,7 @@ import { HvButton } from "../Button";
 import { HvContainer } from "../Container";
 import { useLabels } from "../hooks/useLabels";
 import { HvIconButton, HvIconButtonProps } from "../IconButton";
+import { HvIcon } from "../icons";
 import { HvBaseProps } from "../types/generic";
 import { HvTypography } from "../Typography";
 import { staticClasses, useClasses } from "./Carousel.styles";
@@ -217,7 +212,7 @@ export const HvCarousel = forwardRef<
           onClick={handleFullscreen}
           className={classes.closeButton}
         >
-          {isFullscreen ? <Close /> : <Fullscreen />}
+          <HvIcon name={isFullscreen ? "Close" : "Fullscreen"} />
         </HvIconButton>
       )}
     </div>
@@ -294,7 +289,7 @@ export const HvCarousel = forwardRef<
               aria-label={labels.backwards}
               onClick={handlePrevious}
             >
-              <Backwards iconSize="XS" />
+              <HvIcon name="Backwards" size="xs" />
             </HvButton>
             <HvButton
               icon
@@ -303,7 +298,7 @@ export const HvCarousel = forwardRef<
               aria-label={labels.forwards}
               onClick={handleNext}
             >
-              <Forwards iconSize="XS" />
+              <HvIcon name="Forwards" size="xs" />
             </HvButton>
           </div>
         )}

--- a/packages/core/src/Carousel/CarouselControls.tsx
+++ b/packages/core/src/Carousel/CarouselControls.tsx
@@ -1,4 +1,3 @@
-import { Backwards, Forwards } from "@hitachivantara/uikit-react-icons";
 import {
   useDefaultProps,
   type ExtractNames,
@@ -6,6 +5,7 @@ import {
 
 import { HvButton } from "../Button";
 import { useLabels } from "../hooks/useLabels";
+import { HvIcon } from "../icons";
 import { HvPaginationProps } from "../Pagination";
 import { HvBaseProps } from "../types/generic";
 import { useClasses } from "./Carousel.styles";
@@ -69,7 +69,7 @@ export const HvCarouselControls = (props: HvCarouselControlsProps) => {
             aria-label={labels.backwards}
             onClick={onPreviousClick}
           >
-            <Backwards iconSize="XS" />
+            <HvIcon name="Backwards" size="xs" />
           </HvButton>
           <div className={classes.pageCounter}>
             {`${selectedIndex + 1} / ${numSlides}`}
@@ -80,7 +80,7 @@ export const HvCarouselControls = (props: HvCarouselControlsProps) => {
             aria-label={labels.forwards}
             onClick={onNextClick}
           >
-            <Forwards iconSize="XS" />
+            <HvIcon name="Forwards" size="xs" />
           </HvButton>
         </>
       )}

--- a/packages/core/src/ColorPicker/ColorPicker.styles.tsx
+++ b/packages/core/src/ColorPicker/ColorPicker.styles.tsx
@@ -37,8 +37,10 @@ export const { staticClasses, useClasses } = createClasses("HvColorPicker", {
     },
   },
   dropdownRootIconOnly: {
-    width: 32,
-    height: 32,
+    "&,& .HvBaseDropdown-arrowContainer": {
+      width: 32,
+      height: 32,
+    },
     "& .HvBaseDropdown-selection": {
       padding: 0,
     },

--- a/packages/core/src/ColorPicker/ColorPicker.tsx
+++ b/packages/core/src/ColorPicker/ColorPicker.tsx
@@ -1,6 +1,5 @@
 import { forwardRef } from "react";
 import { ColorState } from "react-color";
-import { ColorPicker } from "@hitachivantara/uikit-react-icons";
 import {
   useDefaultProps,
   type ExtractNames,
@@ -13,6 +12,7 @@ import { HvFormElement, HvInfoMessage, HvLabel } from "../FormElement";
 import { useControlled } from "../hooks/useControlled";
 import { useLabels } from "../hooks/useLabels";
 import { useUniqueId } from "../hooks/useUniqueId";
+import { HvIcon } from "../icons";
 import { HvPanel } from "../Panel";
 import { HvTypography } from "../Typography";
 import { setId } from "../utils/setId";
@@ -267,7 +267,7 @@ export const HvColorPicker = forwardRef<HTMLDivElement, HvColorPickerProps>(
                 )}
               />
             ) : dropdownIcon === "colorPicker" ? (
-              <ColorPicker className={classes.colorPickerIcon} />
+              <HvIcon name="ColorPicker" className={classes.colorPickerIcon} />
             ) : undefined
           }
           placeholder={

--- a/packages/core/src/ColorPicker/SavedColors/SavedColors.styles.tsx
+++ b/packages/core/src/ColorPicker/SavedColors/SavedColors.styles.tsx
@@ -43,16 +43,5 @@ export const { staticClasses, useClasses } = createClasses(name, {
   removeButton: {
     height: 16,
     width: 16,
-    minWidth: 16,
-    minHeight: 16,
-    padding: 0,
-    margin: 0,
-
-    "& div > span": {
-      height: 16,
-      width: 16,
-
-      "& > div": { height: 16, width: 16 },
-    },
   },
 });

--- a/packages/core/src/ColorPicker/SavedColors/SavedColors.tsx
+++ b/packages/core/src/ColorPicker/SavedColors/SavedColors.tsx
@@ -1,13 +1,12 @@
-// @types/react-color seems to be broken
-// @ts-ignore
+// @ts-expect-error: @types/react-color seems to be broken
 import { Swatch } from "react-color/lib/components/common";
-import { Add, CloseXS } from "@hitachivantara/uikit-react-icons";
 import {
   useDefaultProps,
   type ExtractNames,
 } from "@hitachivantara/uikit-react-utils";
 
 import { HvIconButton } from "../../IconButton";
+import { HvIcon } from "../../icons";
 import { staticClasses, useClasses } from "./SavedColors.styles";
 
 export { staticClasses as colorPickerSavedColorsClasses };
@@ -51,7 +50,7 @@ export const SavedColors = (props: SavedColorsProps) => {
         onClick={onAddColor}
         title={addButtonAriaLabel}
       >
-        <Add aria-hidden />
+        <HvIcon name="Add" compact />
       </HvIconButton>
       {colors.map((color, index) => (
         <div
@@ -74,7 +73,7 @@ export const SavedColors = (props: SavedColorsProps) => {
               onClick={() => onRemoveColor(color, index)}
               title={deleteButtonAriaLabel}
             >
-              <CloseXS aria-hidden iconSize="XS" />
+              <HvIcon name="Close" compact size="xs" />
             </HvIconButton>
           </div>
         </div>

--- a/packages/core/src/DatePicker/DatePicker.tsx
+++ b/packages/core/src/DatePicker/DatePicker.tsx
@@ -1,6 +1,5 @@
 import { forwardRef, useEffect, useRef } from "react";
 import { useForkRef } from "@mui/material/utils";
-import { Calendar } from "@hitachivantara/uikit-react-icons";
 import {
   useDefaultProps,
   type ExtractNames,
@@ -23,6 +22,7 @@ import {
 import { useControlled } from "../hooks/useControlled";
 import { useLabels } from "../hooks/useLabels";
 import { useUniqueId } from "../hooks/useUniqueId";
+import { HvIcon } from "../icons";
 import { setId } from "../utils/setId";
 import { useSavedState } from "../utils/useSavedState";
 import { staticClasses, useClasses } from "./DatePicker.styles";
@@ -489,7 +489,7 @@ export const HvDatePicker = forwardRef<HTMLDivElement, HvDatePickerProps>(
           onClickOutside={handleCalendarClose}
           onContainerCreation={focusOnContainer}
           placeholder={dateString || placeholder || ""}
-          adornment={<Calendar className={classes.icon} />}
+          adornment={<HvIcon name="Calendar" className={classes.icon} />}
           popperProps={{
             modifiers: [
               { name: "preventOverflow", enabled: escapeWithReference },

--- a/packages/core/src/Dialog/Dialog.tsx
+++ b/packages/core/src/Dialog/Dialog.tsx
@@ -1,6 +1,5 @@
 import { useCallback, useMemo } from "react";
 import MuiDialog, { DialogProps as MuiDialogProps } from "@mui/material/Dialog";
-import { Close } from "@hitachivantara/uikit-react-icons";
 import {
   useDefaultProps,
   useTheme,
@@ -8,6 +7,7 @@ import {
 } from "@hitachivantara/uikit-react-utils";
 
 import { HvIconButton } from "../IconButton";
+import { HvIcon } from "../icons";
 import { getElementById } from "../utils/document";
 import { setId } from "../utils/setId";
 import { DialogContext } from "./context";
@@ -124,7 +124,7 @@ export const HvDialog = (props: HvDialogProps) => {
         className={classes.closeButton}
         onClick={(event) => onClose?.(event, undefined)}
       >
-        <Close />
+        <HvIcon name="Close" compact />
       </HvIconButton>
       <DialogContext.Provider value={contextValue}>
         {children}

--- a/packages/core/src/Drawer/Drawer.tsx
+++ b/packages/core/src/Drawer/Drawer.tsx
@@ -1,12 +1,12 @@
 import { forwardRef } from "react";
 import MuiDrawer, { DrawerProps as MuiDrawerProps } from "@mui/material/Drawer";
-import { Close } from "@hitachivantara/uikit-react-icons";
 import {
   useDefaultProps,
   type ExtractNames,
 } from "@hitachivantara/uikit-react-utils";
 
 import { HvIconButton } from "../IconButton";
+import { HvIcon } from "../icons";
 import { setId } from "../utils/setId";
 import { staticClasses, useClasses } from "./Drawer.styles";
 
@@ -133,7 +133,7 @@ export const HvDrawer = forwardRef<
         onClick={onClose}
         title={buttonTitle}
       >
-        <Close />
+        <HvIcon name="Close" />
       </HvIconButton>
       {children}
     </MuiDrawer>

--- a/packages/core/src/DropDownMenu/DropDownMenu.styles.tsx
+++ b/packages/core/src/DropDownMenu/DropDownMenu.styles.tsx
@@ -2,7 +2,12 @@ import { createClasses } from "@hitachivantara/uikit-react-utils";
 import { theme } from "@hitachivantara/uikit-styles";
 
 export const { staticClasses, useClasses } = createClasses("HvDropDownMenu", {
-  root: {},
+  root: {
+    flexShrink: 0,
+    "& > div": {
+      height: "inherit",
+    },
+  },
   /** @deprecated use `classes.root` instead */
   container: {},
   baseContainer: {

--- a/packages/core/src/DropDownMenu/DropDownMenu.tsx
+++ b/packages/core/src/DropDownMenu/DropDownMenu.tsx
@@ -1,5 +1,4 @@
 import { forwardRef, useMemo } from "react";
-import { MoreOptionsVertical } from "@hitachivantara/uikit-react-icons";
 import {
   useDefaultProps,
   type ExtractNames,
@@ -13,6 +12,7 @@ import { HvDropdownButton, HvDropdownButtonProps } from "../DropdownButton";
 import { useControlled } from "../hooks/useControlled";
 import { useLabels } from "../hooks/useLabels";
 import { useUniqueId } from "../hooks/useUniqueId";
+import { HvIcon } from "../icons";
 import { HvList, HvListProps, HvListValue } from "../List";
 import { HvBaseProps } from "../types/generic";
 import { getPrevNextFocus } from "../utils/focusableElementFinder";
@@ -101,7 +101,7 @@ const HeaderComponent = forwardRef<HTMLButtonElement, HvDropdownButtonProps>(
         placement={popperPlacement}
         {...others}
       >
-        {icon || <MoreOptionsVertical role="presentation" />}
+        {icon || <HvIcon name="DotsVertical" />}
       </HvDropdownButton>
     );
   },

--- a/packages/core/src/DropdownButton/DropdownButton.tsx
+++ b/packages/core/src/DropdownButton/DropdownButton.tsx
@@ -1,12 +1,12 @@
 import { forwardRef } from "react";
 import type { Placement } from "@popperjs/core";
-import { DropDownXS } from "@hitachivantara/uikit-react-icons";
 import {
   useDefaultProps,
   type ExtractNames,
 } from "@hitachivantara/uikit-react-utils";
 
 import { HvButton, HvButtonProps } from "../Button";
+import { HvIcon } from "../icons";
 import { staticClasses, useClasses } from "./DropdownButton.styles";
 
 export { staticClasses as dropdownButtonClasses };
@@ -42,14 +42,21 @@ export const HvDropdownButton = forwardRef<
     open,
     icon,
     readOnly,
-    children,
+    children: childrenProp,
     variant,
     ...others
   } = useDefaultProps("HvDropdownButton", props);
 
   const { classes, cx } = useClasses(classesProp, false);
 
-  const endIcon = icon ? undefined : <DropDownXS size="XS" rotate={open} />;
+  const endIcon = !icon && <HvIcon name="CaretDown" size="xs" rotate={open} />;
+
+  const children =
+    childrenProp && typeof childrenProp === "string" ? (
+      <div className={classes.placeholder}>{childrenProp}</div>
+    ) : (
+      childrenProp
+    );
 
   return (
     <HvButton
@@ -71,13 +78,7 @@ export const HvDropdownButton = forwardRef<
       variant={open ? "secondarySubtle" : variant}
       {...others}
     >
-      <div className={cx({ [classes.selection]: !icon })}>
-        {children && typeof children === "string" ? (
-          <div className={classes.placeholder}>{children}</div>
-        ) : (
-          children
-        )}
-      </div>
+      {icon ? children : <div className={classes.selection}>{children}</div>}
     </HvButton>
   );
 });

--- a/packages/core/src/FileUploader/DropZone/DropZone.tsx
+++ b/packages/core/src/FileUploader/DropZone/DropZone.tsx
@@ -1,5 +1,4 @@
 import { useContext, useRef, useState } from "react";
-import { Doc } from "@hitachivantara/uikit-react-icons";
 import {
   useDefaultProps,
   type ExtractNames,
@@ -13,6 +12,7 @@ import {
 } from "../../FormElement";
 import { useLabels } from "../../hooks/useLabels";
 import { useUniqueId } from "../../hooks/useUniqueId";
+import { HvIcon } from "../../icons";
 import { uniqueId } from "../../utils/helpers";
 import { setId } from "../../utils/setId";
 import { HvFileData, HvFilesAddedEvent } from "../File";
@@ -236,7 +236,11 @@ export const HvDropZone = (props: HvDropZoneProps) => {
             </div>
           ) : (
             <>
-              <Doc size="M" className={classes.dropZoneAreaIcon} />
+              <HvIcon
+                name="Doc"
+                size="md"
+                className={classes.dropZoneAreaIcon}
+              />
               <div className={classes.dropZoneAreaLabels}>
                 <div className={classes.dragText}>
                   {labels?.drag}

--- a/packages/core/src/FileUploader/File/File.tsx
+++ b/packages/core/src/FileUploader/File/File.tsx
@@ -1,10 +1,10 @@
-import { Close, Fail, Success } from "@hitachivantara/uikit-react-icons";
 import {
   useDefaultProps,
   type ExtractNames,
 } from "@hitachivantara/uikit-react-utils";
 
 import { HvIconButton } from "../../IconButton";
+import { HvIcon } from "../../icons";
 import { HvProgressBar } from "../../ProgressBar";
 import { HvTypography } from "../../Typography";
 import { convertUnits } from "../utils";
@@ -78,9 +78,11 @@ const getStatusIcon = (
 ) => {
   switch (status) {
     case "success":
-      return <Success className={classes?.icon} color="positive" />;
+      return (
+        <HvIcon name="Success" className={classes?.icon} color="positive" />
+      );
     case "fail":
-      return <Fail className={classes?.icon} color="negative" />;
+      return <HvIcon name="Fail" className={classes?.icon} color="negative" />;
     default:
       return <div className={classes?.icon} />;
   }
@@ -174,7 +176,7 @@ export const HvFile = (props: HvFileProps) => {
         className={classes.removeButton}
         onClick={() => onFileRemoved?.(data)}
       >
-        <Close iconSize="XS" />
+        <HvIcon name="Close" size="xs" />
       </HvIconButton>
     </li>
   );

--- a/packages/core/src/FileUploader/Preview/Preview.tsx
+++ b/packages/core/src/FileUploader/Preview/Preview.tsx
@@ -1,11 +1,11 @@
 import { useEffect } from "react";
-import { Preview } from "@hitachivantara/uikit-react-icons";
 import {
   useDefaultProps,
   type ExtractNames,
 } from "@hitachivantara/uikit-react-utils";
 
 import { HvButton, HvButtonProps } from "../../Button";
+import { EyeIcon } from "../../Input/icons";
 import { staticClasses, useClasses } from "./Preview.styles";
 
 export { staticClasses as fileUploaderPreviewClasses };
@@ -69,7 +69,7 @@ export const HvFileUploaderPreview = (props: HvFileUploaderPreviewProps) => {
         {children}
         {!disableOverlay && (
           <div className={classes.overlay} aria-hidden="true">
-            <Preview
+            <EyeIcon
               className={css({
                 position: "absolute",
                 left: "50%",

--- a/packages/core/src/FilterGroup/FilterContent/FilterContent.tsx
+++ b/packages/core/src/FilterGroup/FilterContent/FilterContent.tsx
@@ -1,5 +1,4 @@
 import { forwardRef, useContext, useMemo, useRef, useState } from "react";
-import { Filters } from "@hitachivantara/uikit-react-icons";
 import {
   useDefaultProps,
   useTheme,
@@ -10,6 +9,7 @@ import { HvActionBar } from "../../ActionBar";
 import { HvBaseDropdown, HvBaseDropdownProps } from "../../BaseDropdown";
 import { HvButton, HvButtonVariant } from "../../Button";
 import { HvFormStatus } from "../../FormElement";
+import { HvIcon } from "../../icons";
 import { HvTypography } from "../../Typography";
 import { setId } from "../../utils/setId";
 import { HvFilterGroupCounter } from "../Counter";
@@ -124,7 +124,7 @@ export const HvFilterGroupContent = forwardRef<
   const Header = useMemo(
     () => (
       <>
-        <Filters />
+        <HvIcon name="Filters" />
         <HvTypography variant="label">{labels?.placeholder}</HvTypography>
       </>
     ),

--- a/packages/core/src/FormElement/WarningText/WarningText.styles.tsx
+++ b/packages/core/src/FormElement/WarningText/WarningText.styles.tsx
@@ -6,7 +6,7 @@ export const { staticClasses, useClasses } = createClasses("HvWarningText", {
     display: "none",
     color: theme.form.errorColor,
   },
-  defaultIcon: { minWidth: "24px", width: "24px", height: "24px" },
+  defaultIcon: { margin: 6 },
   warningText: {
     ...theme.typography.caption1,
     color: "inherit",

--- a/packages/core/src/FormElement/WarningText/WarningText.tsx
+++ b/packages/core/src/FormElement/WarningText/WarningText.tsx
@@ -1,10 +1,10 @@
 import { useContext } from "react";
-import { Fail } from "@hitachivantara/uikit-react-icons";
 import {
   useDefaultProps,
   type ExtractNames,
 } from "@hitachivantara/uikit-react-utils";
 
+import { HvIcon } from "../../icons";
 import { HvBaseProps } from "../../types/generic";
 import { setId } from "../../utils/setId";
 import { HvFormElementContext } from "../context";
@@ -60,7 +60,7 @@ export const HvWarningText = (props: HvWarningTextProps) => {
   const id = idProp ?? setId(context.id, "error");
   const showWarning = visible && !disabled;
   const adornment = adornmentProp || (
-    <Fail size="xs" className={classes.defaultIcon} />
+    <HvIcon name="Fail" size="xs" className={classes.defaultIcon} />
   );
 
   return (

--- a/packages/core/src/InlineEditor/InlineEditor.tsx
+++ b/packages/core/src/InlineEditor/InlineEditor.tsx
@@ -1,5 +1,4 @@
 import { useRef, useState } from "react";
-import { Edit } from "@hitachivantara/uikit-react-icons";
 import {
   useDefaultProps,
   useTheme,
@@ -9,6 +8,7 @@ import {
 import { HvButton, HvButtonProps } from "../Button";
 import { useControlled } from "../hooks/useControlled";
 import { useEnhancedEffect } from "../hooks/useEnhancedEffect";
+import { HvIcon } from "../icons";
 import { HvInput, HvInputProps } from "../Input";
 import { HvTooltip } from "../Tooltip";
 import {
@@ -170,7 +170,8 @@ export const HvInlineEditor = fixedForwardRef(function HvInlineEditor<
         <HvButton
           variant="secondaryGhost"
           endIcon={
-            <Edit
+            <HvIcon
+              name="Edit"
               color="textDisabled"
               className={cx(classes.icon, {
                 [classes.iconVisible]: showIcon,

--- a/packages/core/src/Input/Input.tsx
+++ b/packages/core/src/Input/Input.tsx
@@ -8,7 +8,6 @@ import {
   useState,
 } from "react";
 import { useForkRef } from "@mui/material/utils";
-import { CloseXS, Search, Success } from "@hitachivantara/uikit-react-icons";
 import {
   useDefaultProps,
   type ExtractNames,
@@ -46,6 +45,7 @@ import { useControlled } from "../hooks/useControlled";
 import { useIsMounted } from "../hooks/useIsMounted";
 import { useLabels } from "../hooks/useLabels";
 import { useUniqueId } from "../hooks/useUniqueId";
+import { HvIcon } from "../icons";
 import { HvTooltip } from "../Tooltip";
 import { fixedForwardRef } from "../types/generic";
 import { isKey } from "../utils/keyboardUtils";
@@ -583,7 +583,7 @@ export const HvInput = fixedForwardRef(function HvInput<
         onClick={handleClear}
         aria-label={labels?.clearButtonLabel}
         aria-controls={setId(elementId, "input")}
-        icon={<CloseXS />}
+        icon={<HvIcon name="Close" size="xs" />}
       />
     );
   }, [
@@ -613,7 +613,7 @@ export const HvInput = fixedForwardRef(function HvInput<
           onEnter &&
           ((evt) => onEnter?.(evt as any, inputRef.current?.value ?? ""))
         }
-        icon={<Search title={labels.searchButtonLabel} />}
+        icon={<HvIcon name="Search" title={labels.searchButtonLabel} />}
       />
     );
   }, [
@@ -659,7 +659,7 @@ export const HvInput = fixedForwardRef(function HvInput<
     if (!showValidationIcon) return null;
     if (!isValid(validationState)) return null;
 
-    return <Success color="positive" className={classes.icon} />;
+    return <HvIcon name="Success" color="positive" className={classes.icon} />;
   }, [showValidationIcon, validationState, classes.icon]);
 
   // useMemo to avoid repetitive cloning of the custom icon

--- a/packages/core/src/Input/icons.tsx
+++ b/packages/core/src/Input/icons.tsx
@@ -1,7 +1,10 @@
 import { SvgBase } from "../icons";
 
-export const EyeIcon = ({ selected }: { selected: boolean }) => (
-  <SvgBase viewBox="0 0 16 16" style={{ margin: 8 }}>
+export const EyeIcon = ({
+  selected,
+  ...others
+}: { selected?: boolean } & React.SVGProps<SVGSVGElement>) => (
+  <SvgBase viewBox="0 0 16 16" style={{ margin: 8 }} {...others}>
     <path d="M11 8a3 3 0 1 1-3-3 3 3 0 0 1 3 3m5 0s-3.58 6-8 6-8-6-8-6 4-6 8-6 8 6 8 6m-1.2.03a22 22 0 0 0-2-2.32C11.01 3.94 9.35 3 8 3s-3 .93-4.77 2.68a22 22 0 0 0-2.02 2.35 18 18 0 0 0 1.85 2.28C4.25 11.53 6.08 13 8 13s3.73-1.45 4.91-2.67a18 18 0 0 0 1.88-2.3z" />
     <rect
       style={{ transition: "width 0.2s ease" }}

--- a/packages/core/src/List/List.tsx
+++ b/packages/core/src/List/List.tsx
@@ -7,13 +7,13 @@ import {
   useRef,
 } from "react";
 import { FixedSizeList } from "react-window";
-import { DropRightXS } from "@hitachivantara/uikit-react-icons";
 import {
   useDefaultProps,
   type ExtractNames,
 } from "@hitachivantara/uikit-react-utils";
 
 import { HvCheckBox } from "../CheckBox";
+import { HvIcon } from "../icons";
 import { HvLink } from "../Link";
 import {
   HvListContainer,
@@ -264,7 +264,7 @@ export const HvList = (props: HvListProps) => {
         startAdornment={startAdornment}
         endAdornment={
           item.showNavIcon && (
-            <DropRightXS className={classes.box} iconSize="XS" />
+            <HvIcon name="CaretRight" className={classes.box} size="xs" />
           )
         }
         {...otherProps}

--- a/packages/core/src/Pagination/Pagination.tsx
+++ b/packages/core/src/Pagination/Pagination.tsx
@@ -1,12 +1,6 @@
 import { forwardRef, useCallback, useEffect, useState } from "react";
 import { useMediaQuery, useTheme } from "@mui/material";
 import {
-  Backwards,
-  End,
-  Forwards,
-  Start,
-} from "@hitachivantara/uikit-react-icons";
-import {
   clamp,
   useDefaultProps,
   type ExtractNames,
@@ -14,6 +8,7 @@ import {
 
 import { useLabels } from "../hooks/useLabels";
 import { HvIconButton } from "../IconButton";
+import { HvIcon } from "../icons";
 import { HvInput, HvInputProps } from "../Input";
 import { HvBaseProps } from "../types/generic";
 import { HvTypography } from "../Typography";
@@ -223,7 +218,7 @@ export const HvPagination = forwardRef<
           onClick={() => changePage(0)}
           title={labels?.firstPage || labels?.paginationFirstPageTitle}
         >
-          <Start className={classes.icon} iconSize="XS" />
+          <HvIcon name="Start" className={classes.icon} size="xs" />
         </HvIconButton>
         <HvIconButton
           id={setId(id, "previousPage-button")}
@@ -232,7 +227,7 @@ export const HvPagination = forwardRef<
           onClick={() => changePage(page - 1)}
           title={labels?.previousPage || labels?.paginationPreviousPageTitle}
         >
-          <Backwards className={classes.icon} iconSize="XS" />
+          <HvIcon name="Backwards" className={classes.icon} size="xs" />
         </HvIconButton>
         <div className={classes.pageInfo}>
           {showPageJump ? (
@@ -258,7 +253,7 @@ export const HvPagination = forwardRef<
           onClick={() => changePage(page + 1)}
           title={labels?.nextPage || labels?.paginationNextPageTitle}
         >
-          <Forwards className={classes.icon} iconSize="XS" />
+          <HvIcon name="Forwards" className={classes.icon} size="xs" />
         </HvIconButton>
         <HvIconButton
           id={setId(id, "lastPage-button")}
@@ -267,7 +262,7 @@ export const HvPagination = forwardRef<
           onClick={() => changePage(pages - 1)}
           title={labels?.lastPage || labels?.paginationLastPageTitle}
         >
-          <End className={classes.icon} iconSize="XS" />
+          <HvIcon name="End" className={classes.icon} size="xs" />
         </HvIconButton>
       </div>
     </div>

--- a/packages/core/src/QueryBuilder/Rule/Rule.tsx
+++ b/packages/core/src/QueryBuilder/Rule/Rule.tsx
@@ -1,7 +1,6 @@
 import { useMemo } from "react";
 import { useTheme } from "@mui/material/styles";
 import useMediaQuery from "@mui/material/useMediaQuery";
-import { Delete } from "@hitachivantara/uikit-react-icons";
 import {
   useDefaultProps,
   type ExtractNames,
@@ -9,6 +8,7 @@ import {
 
 import { HvGrid } from "../../Grid";
 import { HvIconButton } from "../../IconButton";
+import { HvIcon } from "../../icons";
 import { useQueryBuilderContext } from "../Context";
 import { Attribute } from "./Attribute";
 import { Operator } from "./Operator";
@@ -123,7 +123,7 @@ export const Rule = (props: RuleProps) => {
           }
           disabled={readOnly}
         >
-          <Delete />
+          <HvIcon name="Delete" />
         </HvIconButton>
       </HvGrid>
     </HvGrid>

--- a/packages/core/src/QueryBuilder/RuleGroup/RuleGroup.tsx
+++ b/packages/core/src/QueryBuilder/RuleGroup/RuleGroup.tsx
@@ -1,10 +1,10 @@
 import { useCallback } from "react";
-import { Add, Delete, Info } from "@hitachivantara/uikit-react-icons";
 import { type ExtractNames } from "@hitachivantara/uikit-react-utils";
 
 import { HvButton } from "../../Button";
 import { HvEmptyState } from "../../EmptyState";
 import { HvIconButton } from "../../IconButton";
+import { HvIcon } from "../../icons";
 import { HvMultiButton } from "../../MultiButton";
 import { HvTypography } from "../../Typography";
 import { useQueryBuilderContext } from "../Context";
@@ -51,7 +51,7 @@ export const RuleGroup = ({
             dispatchAction({ type: "add-rule", id });
           }}
           disabled={readOnly}
-          startIcon={<Add />}
+          startIcon={<HvIcon name="Add" />}
         >
           {level === 0 && labels.query?.addRule?.label != null
             ? labels.query?.addRule?.label
@@ -66,7 +66,7 @@ export const RuleGroup = ({
               dispatchAction({ type: "add-group", id });
             }}
             disabled={readOnly}
-            startIcon={<Add />}
+            startIcon={<HvIcon name="Add" />}
           >
             {level === 0 && labels.query?.addGroup?.label != null
               ? labels.query?.addGroup?.label
@@ -135,7 +135,8 @@ export const RuleGroup = ({
           }
           disabled={readOnly}
         >
-          <Delete
+          <HvIcon
+            name="Delete"
             className={cx({ [classes.topRemoveButtonDisabled]: readOnly })}
           />
         </HvIconButton>
@@ -224,7 +225,7 @@ export const RuleGroup = ({
               )}
             </>
           }
-          icon={<Info />}
+          icon={<HvIcon name="Info" />}
         />
       )}
       <div

--- a/packages/core/src/Section/Section.tsx
+++ b/packages/core/src/Section/Section.tsx
@@ -1,5 +1,4 @@
 import { forwardRef } from "react";
-import { DropDownXS } from "@hitachivantara/uikit-react-icons";
 import {
   useDefaultProps,
   type ExtractNames,
@@ -7,6 +6,7 @@ import {
 
 import { HvButton, HvButtonProps } from "../Button";
 import { useExpandable } from "../hooks/useExpandable";
+import { HvIcon } from "../icons";
 import { HvBaseProps } from "../types/generic";
 import { staticClasses, useClasses } from "./Section.styles";
 
@@ -94,7 +94,7 @@ export const HvSection = forwardRef<HTMLDivElement, HvSectionProps>(
                 {...buttonProps}
                 {...expandButtonProps}
               >
-                <DropDownXS rotate={isOpen} />
+                <HvIcon name="CaretDown" size="xs" rotate={isOpen} />
               </HvButton>
             )}
             {title}

--- a/packages/core/src/Table/TableHeader/TableHeader.tsx
+++ b/packages/core/src/Table/TableHeader/TableHeader.tsx
@@ -5,6 +5,7 @@ import {
 } from "@hitachivantara/uikit-react-utils";
 
 import { HvButton, HvButtonProps } from "../../Button";
+import { HvIcon } from "../../icons";
 import { HvTypography, HvTypographyProps } from "../../Typography";
 import { capitalize } from "../../utils/helpers";
 import {
@@ -15,7 +16,7 @@ import {
 import TableContext from "../TableContext";
 import { TableSectionContext } from "../TableSectionContext";
 import { staticClasses, useClasses } from "./TableHeader.styles";
-import { getSortIcon, isParagraph } from "./utils";
+import { getSortIconName, isParagraph } from "./utils";
 
 export { staticClasses as tableHeaderClasses };
 
@@ -107,11 +108,6 @@ export const HvTableHeader = forwardRef<HTMLElement, HvTableHeaderProps>(
 
     const scope = scopeProp ?? (isHeadCell ? "col" : "row");
 
-    const Sort = useMemo(
-      () => getSortIcon(sorted && sortDirection),
-      [sorted, sortDirection],
-    );
-
     const Component =
       component || tableContext?.components?.Th || defaultComponent;
 
@@ -169,7 +165,10 @@ export const HvTableHeader = forwardRef<HTMLElement, HvTableHeaderProps>(
               aria-label="Sort"
               {...sortButtonProps}
             >
-              <Sort className={classes.sortIcon} />
+              <HvIcon
+                name={getSortIconName(sorted && sortDirection)}
+                className={classes.sortIcon}
+              />
             </HvButton>
           )}
           <HvTypography

--- a/packages/core/src/Table/TableHeader/utils.ts
+++ b/packages/core/src/Table/TableHeader/utils.ts
@@ -1,20 +1,13 @@
-import {
-  SortAscendingXS,
-  SortDescendingXS,
-  SortXS,
-} from "@hitachivantara/uikit-react-icons";
-
-export const getSortIcon = (dir?: string | false) => {
+export const getSortIconName = (dir?: string | false) => {
   switch (dir) {
     case "ascending":
-      return SortAscendingXS;
+      return "SortAsc";
     case "descending":
-      return SortDescendingXS;
+      return "SortDesc";
     default:
-      return SortXS;
+      return "Sort";
   }
 };
-
 export const isParagraph = (children: React.ReactNode) => {
   return typeof children === "string" && /\s/.test(children);
 };

--- a/packages/core/src/Table/hooks/useHvRowExpand.tsx
+++ b/packages/core/src/Table/hooks/useHvRowExpand.tsx
@@ -3,10 +3,10 @@ import type {
   TableExpandedToggleProps,
   UseExpandedRowProps,
 } from "react-table";
-import { DropDownXS } from "@hitachivantara/uikit-react-icons";
 
 import { HvButton } from "../../Button";
 import { useLabels } from "../../hooks/useLabels";
+import { HvIcon } from "../../icons";
 import { HvTypography } from "../../Typography";
 import type { HvCellProps, HvColumnInstance } from "./useHvTable";
 
@@ -63,7 +63,7 @@ const CellWithExpandButton = ({
         aria-expanded={row.isExpanded}
         onClick={rowProps?.onClick}
       >
-        <DropDownXS rotate={row.isExpanded} />
+        <HvIcon name="CaretDown" size="xs" rotate={row.isExpanded} />
       </HvButton>
       {cell?.value && (
         <HvTypography variant="label" component="span">

--- a/packages/core/src/Table/renderers/renderers.tsx
+++ b/packages/core/src/Table/renderers/renderers.tsx
@@ -1,9 +1,9 @@
 import { ClassNames } from "@emotion/react";
-import { DropDownXS, DropUpXS } from "@hitachivantara/uikit-react-icons";
 
 import { HvBaseSwitchProps } from "../../BaseSwitch";
 import { HvButton } from "../../Button";
 import { HvDropdownProps } from "../../Dropdown";
+import { HvIcon } from "../../icons";
 import { HvListValue } from "../../List";
 import {
   HvOverflowTooltip,
@@ -94,8 +94,8 @@ export function hvExpandColumn<
   expandRowButtonAriaLabel: string,
   collapseRowButtonAriaLabel: string,
   getCanRowExpand?: (row: HvRowInstance<D, H>) => boolean,
-  ExpandedIcon: React.ReactNode = <DropUpXS />,
-  CollapsedIcon: React.ReactNode = <DropDownXS />,
+  ExpandedIcon: React.ReactNode = <HvIcon name="CaretDown" size="xs" rotate />,
+  CollapsedIcon: React.ReactNode = <HvIcon name="CaretDown" size="xs" />,
 ): HvTableColumnConfig<D, H> {
   return {
     Cell: (cellProps: HvCellProps<D, H>) => {

--- a/packages/core/src/Tag/Tag.styles.tsx
+++ b/packages/core/src/Tag/Tag.styles.tsx
@@ -17,6 +17,11 @@ export const { staticClasses, useClasses } = createClasses("HvTag", {
     "&,:hover,:focus-visible": {
       backgroundColor: "var(--tagColor)",
     },
+    "& div:has($deleteIcon)": {
+      // ensure icon container doesn't grow into $label
+      width: "max-content",
+      lineHeight: 0,
+    },
   },
   hasIcon: {
     paddingLeft: 2,
@@ -66,9 +71,9 @@ export const { staticClasses, useClasses } = createClasses("HvTag", {
     color: "inherit",
   },
   deleteIcon: {
-    width: 16,
-    height: 16,
-    "&:hover": {
+    margin: 0,
+    padding: 2,
+    ":hover": {
       backgroundColor: theme.colors.bgHover,
     },
   },

--- a/packages/core/src/Tag/Tag.tsx
+++ b/packages/core/src/Tag/Tag.tsx
@@ -1,5 +1,4 @@
 import { cloneElement, forwardRef, isValidElement } from "react";
-import { CloseXS } from "@hitachivantara/uikit-react-icons";
 import {
   mergeStyles,
   useDefaultProps,
@@ -15,6 +14,7 @@ import {
 import { HvCheckBoxIcon } from "../BaseCheckBox/CheckBoxIcon";
 import { HvButtonBase, HvButtonBaseProps } from "../ButtonBase";
 import { useControlled } from "../hooks/useControlled";
+import { HvIcon } from "../icons";
 import { HvTypography } from "../Typography";
 import { isDeleteKey } from "../utils/keyboardUtils";
 import { staticClasses, useClasses } from "./Tag.styles";
@@ -132,12 +132,15 @@ export const HvTag = forwardRef<
         onClick: handleDeleteClick,
       })
     ) : (
-      <CloseXS
-        size="XS"
-        onClick={handleDeleteClick}
-        className={cx(classes.deleteIcon, classes.button, classes.tagButton)}
-        {...deleteButtonProps}
-      />
+      <div>
+        <HvIcon
+          compact
+          name="Close"
+          onClick={handleDeleteClick as any}
+          className={cx(classes.deleteIcon, classes.button, classes.tagButton)}
+          {...(deleteButtonProps as any)}
+        />
+      </div>
     );
 
   return (

--- a/packages/core/src/TagsInput/TagsInput.test.tsx
+++ b/packages/core/src/TagsInput/TagsInput.test.tsx
@@ -38,7 +38,7 @@ describe("TagsInput examples", () => {
       expect(clickableButtons.length).toBe(5);
 
       const lastTag = clickableButtons[4];
-      fireEvent.click(lastTag.querySelector("[data-name=CloseXS]")!);
+      fireEvent.click(lastTag.querySelector("[data-name=Close]")!);
 
       expect((await screen.findAllByRole("button")).length).toBe(4);
       expect(tagsInput).toHaveValue(uncommittedText);
@@ -120,7 +120,7 @@ describe("TagsInput Component", () => {
     const clickableButtons = screen.getAllByRole("button");
     expect(clickableButtons.length).toBe(2);
     const [, tag2] = clickableButtons;
-    fireEvent.click(tag2.querySelector("[data-name=CloseXS]")!);
+    fireEvent.click(tag2.querySelector("[data-name=Close]")!);
 
     const remainingButtons = await screen.findAllByRole("button");
     expect(onChangeSpy).toHaveBeenCalledWith(expect.any(Object), [
@@ -241,7 +241,7 @@ describe("TagsInput Component", () => {
     expect(clickableButtons.length).toBe(0);
 
     // in readonly mode the button shouldn't have the close icon
-    expect(document.querySelector("[data-name=CloseXS]")).toBeNull();
+    expect(document.querySelector("[data-name=Close]")).toBeNull();
   });
 
   it("should call the suggestions callback when the input is changed", () => {

--- a/packages/core/src/TimePicker/TimePicker.tsx
+++ b/packages/core/src/TimePicker/TimePicker.tsx
@@ -6,7 +6,6 @@ import {
   useTimeFieldState,
   type TimeFieldStateOptions,
 } from "@react-stately/datepicker";
-import { Time as TimeIcon } from "@hitachivantara/uikit-react-icons";
 import {
   useDefaultProps,
   type ExtractNames,
@@ -24,6 +23,7 @@ import {
 } from "../FormElement";
 import { useControlled } from "../hooks/useControlled";
 import { useUniqueId } from "../hooks/useUniqueId";
+import { HvIcon } from "../icons";
 import { setId } from "../utils/setId";
 import { Placeholder, PlaceholderProps } from "./Placeholder";
 import { staticClasses, useClasses } from "./TimePicker.styles";
@@ -285,12 +285,7 @@ export const HvTimePicker = forwardRef<HTMLDivElement, HvTimePickerProps>(
             headerOpen: classes.dropdownHeaderOpen,
           }}
           placement="right"
-          adornment={
-            <TimeIcon
-              color={disabled ? "textDisabled" : undefined}
-              className={classes.icon}
-            />
-          }
+          adornment={<HvIcon name="Time" className={classes.icon} />}
           expanded={open}
           onToggle={(evt, newOpen) => {
             if (disableExpand) return;

--- a/packages/core/src/TimePicker/Unit/Unit.tsx
+++ b/packages/core/src/TimePicker/Unit/Unit.tsx
@@ -1,12 +1,9 @@
 import { DateFieldState, DateSegment } from "@react-stately/datepicker";
-import {
-  DropUpXS as AddTimeIcon,
-  DropDownXS as SubtractTimeIcon,
-} from "@hitachivantara/uikit-react-icons";
 import { theme } from "@hitachivantara/uikit-styles";
 
 import { HvBaseInput, HvBaseInputProps } from "../../BaseInput";
 import { HvButton } from "../../Button";
+import { HvIcon } from "../../icons";
 import { useClasses } from "./Unit.styles";
 
 interface UnitProps {
@@ -37,7 +34,9 @@ export const Unit = ({
 
   return (
     <div className={classes.root}>
-      {type !== "literal" && <AddTimeIcon onClick={onAdd} />}
+      {type !== "literal" && (
+        <HvIcon name="CaretDown" size="xs" rotate onClick={onAdd} />
+      )}
       {type === "literal" && <div className={classes.separator}>{text}</div>}
       {type === "dayPeriod" && (
         <HvButton icon className={classes.periodToggle} onClick={onAdd}>
@@ -68,7 +67,9 @@ export const Unit = ({
           inputProps={{ autoComplete: "off", type: "number" }}
         />
       )}
-      {type !== "literal" && <SubtractTimeIcon onClick={onSub} />}
+      {type !== "literal" && (
+        <HvIcon name="CaretDown" size="xs" onClick={onSub} />
+      )}
     </div>
   );
 };

--- a/packages/core/src/TreeView/TreeView.tsx
+++ b/packages/core/src/TreeView/TreeView.tsx
@@ -1,10 +1,10 @@
 import { useSlotProps } from "@mui/base/utils";
-import { DropDownXS, DropRightXS } from "@hitachivantara/uikit-react-icons";
 import {
   useDefaultProps,
   type ExtractNames,
 } from "@hitachivantara/uikit-react-utils";
 
+import { HvIcon } from "../icons";
 import { fixedForwardRef, HvBaseProps } from "../types/generic";
 import {
   DEFAULT_TREE_VIEW_PLUGINS,
@@ -59,8 +59,8 @@ export const HvTreeView = fixedForwardRef(function HvTreeView<
     selected,
     defaultSelected,
     disableSelection,
-    defaultCollapseIcon = <DropDownXS />,
-    defaultExpandIcon = <DropRightXS />,
+    defaultCollapseIcon = <HvIcon name="CaretDown" size="xs" />,
+    defaultExpandIcon = <HvIcon name="CaretRight" size="xs" />,
     defaultEndIcon,
     defaultParentIcon,
     onNodeSelect,

--- a/packages/core/src/VerticalNavigation/Header/Header.tsx
+++ b/packages/core/src/VerticalNavigation/Header/Header.tsx
@@ -1,11 +1,11 @@
 import { useContext, useMemo } from "react";
-import { Backwards, Forwards, Menu } from "@hitachivantara/uikit-react-icons";
 import {
   useDefaultProps,
   type ExtractNames,
 } from "@hitachivantara/uikit-react-utils";
 
 import { HvButton, HvButtonProps } from "../../Button";
+import { HvIcon } from "../../icons";
 import { HvBaseProps } from "../../types/generic";
 import { HvTypography } from "../../Typography";
 import { VerticalNavigationContext } from "../VerticalNavigationContext";
@@ -67,8 +67,10 @@ export const HvVerticalNavigationHeader = (
 
   if (!shouldShowTitle) return null;
 
-  const openIcon = openIconProp ?? (!useIcons ? <Menu /> : <Forwards />);
-  const closeIcon = closeIconProp ?? <Backwards />;
+  const openIcon = openIconProp ?? (
+    <HvIcon name={useIcons ? "Forwards" : "Menu"} />
+  );
+  const closeIcon = closeIconProp ?? <HvIcon name="Backwards" />;
 
   const handleClickBack = () => navigateToParentHandler?.();
 
@@ -94,7 +96,7 @@ export const HvVerticalNavigationHeader = (
           aria-label="Back"
           {...otherBackButtonProps}
         >
-          <Backwards iconSize="XS" />
+          <HvIcon name="Backwards" size="xs" />
         </HvButton>
       )}
       {isOpen && (

--- a/packages/core/src/VerticalNavigation/NavigationSlider/NavigationSlider.tsx
+++ b/packages/core/src/VerticalNavigation/NavigationSlider/NavigationSlider.tsx
@@ -1,10 +1,10 @@
-import { DropRightXS } from "@hitachivantara/uikit-react-icons";
 import {
   useDefaultProps,
   type ExtractNames,
 } from "@hitachivantara/uikit-react-utils";
 
 import { HvButton } from "../../Button";
+import { HvIcon } from "../../icons";
 import {
   HvListContainer,
   HvListContainerProps,
@@ -99,7 +99,7 @@ export const HvVerticalNavigationSlider = (
                 className={classes.forwardButton}
                 aria-label={forwardButtonAriaLabel}
               >
-                <DropRightXS />
+                <HvIcon name="CaretRight" size="xs" />
               </HvButton>
             ) : undefined
           }

--- a/packages/core/src/VerticalNavigation/TreeView/TreeViewItem.styles.tsx
+++ b/packages/core/src/VerticalNavigation/TreeView/TreeViewItem.styles.tsx
@@ -143,7 +143,7 @@ export const { staticClasses, useClasses } = createClasses(
         marginLeft: "var(--icon-margin-left)",
       },
       "> div:nth-of-type(2)": {
-        width: "14px",
+        width: "12px",
         marginLeft: "auto",
       },
       [`&& .${avatarClasses.root}`]: {

--- a/packages/core/src/VerticalNavigation/TreeView/TreeViewItem.tsx
+++ b/packages/core/src/VerticalNavigation/TreeView/TreeViewItem.tsx
@@ -7,7 +7,6 @@ import {
   useRef,
   useState,
 } from "react";
-import { DropDownXS, Forwards } from "@hitachivantara/uikit-react-icons";
 import {
   mergeStyles,
   useDefaultProps,
@@ -16,6 +15,7 @@ import {
 
 import { HvAvatar } from "../../Avatar";
 import { useForkRef } from "../../hooks/useForkRef";
+import { HvIcon } from "../../icons";
 import { HvOverflowTooltip } from "../../OverflowTooltip";
 import { HvTooltip } from "../../Tooltip";
 import {
@@ -507,7 +507,7 @@ export const HvVerticalNavigationTreeViewItem = forwardRef(
                 useIcons && icon
               )}
               {hasChildren && !isOpen ? (
-                <Forwards iconSize="XS" />
+                <HvIcon name="Forwards" size="xs" compact />
               ) : (
                 hasAnyChildWithData && !isOpen && <div />
               )}
@@ -524,7 +524,9 @@ export const HvVerticalNavigationTreeViewItem = forwardRef(
               </div>
             )}
 
-            {isOpen && expandable && <DropDownXS rotate={expanded} />}
+            {isOpen && expandable && (
+              <HvIcon name="CaretDown" size="xs" rotate={expanded} />
+            )}
           </HvTypography>
         </HvTooltip>
       );

--- a/packages/core/src/icons.tsx
+++ b/packages/core/src/icons.tsx
@@ -1,4 +1,24 @@
+import { forwardRef, memo, useMemo } from "react";
 import styled from "@emotion/styled";
+import { useTheme } from "@hitachivantara/uikit-react-utils";
+import { getColor, HvColorAny, HvSize } from "@hitachivantara/uikit-styles";
+
+/** sizes for the <svg> icon */
+const svgSizeMap = {
+  xs: 12,
+  sm: 16,
+  md: 32,
+  lg: 96,
+  xl: 112,
+} satisfies Record<HvSize, number>;
+
+interface SvgProps extends Omit<React.SVGProps<SVGSVGElement>, "rotate"> {
+  size?: HvSize | number;
+  color?: HvColorAny;
+  compact?: boolean;
+  title?: string;
+  rotate?: boolean;
+}
 
 export const SvgBase = styled("svg")({
   display: "inline-block",
@@ -9,3 +29,87 @@ export const SvgBase = styled("svg")({
   flexShrink: 0,
   transition: "rotate 0.2s ease",
 });
+
+const Svg = styled(SvgBase)<SvgProps>(({ size, color, compact, rotate }) => ({
+  rotate: rotate ? "180deg" : undefined,
+  margin: compact ? 0 : size === "xs" ? 10 : 8,
+  color: getColor(color) ?? "inherit",
+  fontSize: svgSizeMap[size as HvSize] ?? size ?? svgSizeMap.sm,
+}));
+
+const defaultIconPathMap = {
+  // Semantic icons
+  Success:
+    "M6.39 12 4 9.61l.7-.7 1.62 1.6 4.65-5.57.77.64zM8 15a7 7 0 0 1-4.94-2.06A7.02 7.02 0 1 1 8 15m8-7a8 8 0 1 0-8 8 8 8 0 0 0 8-8",
+  Caution: "M7.5 6h1v4h-1zm0 7h1v-1h-1zm8.5 2H0L8 1zM1.72 14h12.56L8 3.02z",
+  Fail: "M7.5 4h1v6h-1zm0 8h1v-1h-1zM16 8a8 8 0 1 0-8 8 8 8 0 0 0 8-8m-1 0a7 7 0 1 1-7-7 7 7 0 0 1 7 7",
+  Info: "M8 16a8 8 0 1 1 8-8 8 8 0 0 1-8 8M8 1a6.96 6.96 0 0 0-7 6.91V8a6.96 6.96 0 0 0 6.91 7H8a6.96 6.96 0 0 0 7-6.91V8a6.96 6.96 0 0 0-6.91-7zm-.5 11h1V6h-1zm0-7h1V4h-1z",
+  // Arrows/Navigation
+  CaretDown: "m8 11.53-6.13-6.13.93-.93L8 9.67l5.2-5.2.93.93z",
+  CaretRight: "m5.4 14.13-.93-.93L9.67 8l-5.2-5.2.93-.93L11.53 8z",
+  DotsHorizontal: "M9.1 7v2h-2V7zM2 7v2h2V7zm10 0v2h2V7z",
+  DotsVertical: "M7 6.9h2v2H7zM7 4h2V2H7zm0 10h2v-2H7z",
+  Start:
+    "M2.99 16.05H2v-16h.99zm2.97-8 7.34 7.41.7-.7-6.64-6.71L14 1.33l-.7-.7z",
+  Backwards: "M11.3 15.5 4 8 11.3.5l.7.8L5.38 8 12 14.8z",
+  Forwards: "M4.79 15.5 4 14.8 10.62 8 4 1.3l.79-.8L12 8z",
+  End: "M13 0h1v16h-1zM2.58.58l-.7.7L8.57 8l-6.7 6.71.7.71L10 8z",
+  // Others
+  Add: "M16 8.5H8.5V16h-1V8.5H0v-1h7.5V0h1v7.5H16z",
+  Close:
+    "m8.7 8 5.3 5.3-.7.7L8 8.7 2.7 14l-.7-.7L7.3 8 2 2.7l.7-.7L8 7.3 13.3 2l.7.7z",
+  Search:
+    "M15.07 14.52 10.5 9.95a5.96 5.96 0 1 0-.72.7l4.58 4.58zM5.9 11A4.95 4.95 0 0 1 1 6v-.1A4.95 4.95 0 0 1 6 1h.1A4.95 4.95 0 0 1 11 6v.1A4.95 4.95 0 0 1 6 11z",
+  SortAsc: "M.08 6.07 6.5.01l6.42 6.06Zm0 0",
+  SortDesc: "M1.76 5 6 .76 10.24 5z",
+  Sort: "M10.24 7 6 11.24 1.76 7zM1.76 5 6 .76 10.24 5z",
+  // single-use icons in Widgets
+  Calendar:
+    "M10.5 2V0h-1v2h-3V0h-1v2H0v14h16V2zM15 15H1V3h14zM3 6h2v2H3zm4 0h2v2H7zm4 0h2v2h-2zm-8 4h2v2H3zm4 0h2v2H7zm4 0h2v2h-2z",
+  ColorPicker:
+    "M15.41.57a2.05 2.05 0 0 0-2.82 0l-2.12 2.12-1.42-1.42-.7.71L14 7.64l.7-.7-1.4-1.42 2.1-2.12a2 2 0 0 0 0-2.83zm-.69 2.11L12.59 4.8l-1.42-1.42 2.12-2.12a1 1 0 0 1 1.42 1.42zM0 13v3h3l9-9-3-3zm2.59 2H1v-1.58l8-8L10.59 7z",
+  CurrentStep: "M16 8a8 8 0 0 1-8 8 8 8 0 0 1-8-8 8 8 0 0 1 8-8 8 8 0 0 1 8 8",
+  Delete: "M12 1H4V0h8zm4 1v1h-2.1L13 16H3L2.1 3H0V2zm-3 1H3.1L4 15h8.1z",
+  Doc: "M9 0H2v16h12V5zm3.6 5H9V1.4zm.4 10H3V1h5v5h5z",
+  Edit: "M13.17 7.07 8.93 2.83 11.76 0 16 4.24zm-2.83-4.24 2.83 2.83 1.42-1.42-2.83-2.83zm-2.7 2.7L1 12.16V15h2.83l6.65-6.65-2.83-2.83m-.01-1.4 4.24 4.24L4.24 16H0v-4.24z",
+  Filters: "M1 2v1.6l6 6.1V14h2V9.7l6-6.1V2zM0 1h16v3l-6 6v5H6v-4.9L0 4z",
+  Fullscreen:
+    "M16 0v4.5h-1V1.7l-4.65 4.65-.7-.7L14.29 1H11.5V0zM4.5 1V0H0v4.5h1V1.7l4.65 4.65.7-.7L1.71 1zM15 14.3l-4.65-4.65-.7.7L14.29 15H11.5v1H16v-4.5h-1zM5.65 9.64 1 14.29V11.5H0V16h4.5v-1H1.7l4.65-4.65z",
+  Menu: "M1 2v1.6l6 6.1V14h2V9.7l6-6.1V2zM0 1h16v3l-6 6v5H6v-4.9L0 4z",
+  OtherStep: "M12 8a4 4 0 0 1-4 4 4 4 0 0 1-4-4 4 4 0 0 1 4-4 4 4 0 0 1 4 4",
+  Time: "M8 15a7.02 7.02 0 1 0-4.94-2.06A7 7 0 0 0 8 15m0 1a8 8 0 1 1 8-8 8 8 0 0 1-8 8m2.65-4.65L7.5 8.21V3h1v4.8l2.85 2.85z",
+  User: "M9.6 8.7A4.5 4.5 0 0 0 8.04 0H8a4.5 4.5 0 0 0-4.5 4.46v.04a4.6 4.6 0 0 0 2.9 4.2A7.7 7.7 0 0 0 .5 16h1a6.5 6.5 0 0 1 6.47-6.5H8a6.5 6.5 0 0 1 6.5 6.47V16h1a7.5 7.5 0 0 0-5.9-7.3M4.5 4.5A3.54 3.54 0 0 1 8 1a3.54 3.54 0 0 1 3.5 3.5A3.54 3.54 0 0 1 8 8a3.54 3.54 0 0 1-3.5-3.5",
+} satisfies Record<string, string>;
+
+function HvIconInternal(
+  props: SvgProps & { name: keyof typeof defaultIconPathMap },
+  ref: React.Ref<SVGSVGElement>,
+) {
+  const { name, title, "aria-label": ariaLabel, children, ...others } = props;
+  const { activeTheme } = useTheme();
+
+  const iconsPathMap = useMemo(
+    () => ({ ...defaultIconPathMap, ...activeTheme?.icons }),
+    [activeTheme?.icons],
+  );
+
+  const isDefaultIcon = iconsPathMap[name] === defaultIconPathMap[name];
+
+  return (
+    // @ts-expect-error `rotate` is fine
+    <Svg
+      ref={ref}
+      data-name={name}
+      viewBox={(!isDefaultIcon && activeTheme?.icons?.viewBox) || "0 0 16 16"}
+      focusable={false}
+      aria-label={ariaLabel}
+      role={title || ariaLabel ? "img" : "none"}
+      {...others}
+    >
+      {title ? <title>{title}</title> : null}
+      <path d={iconsPathMap[name]} />
+    </Svg>
+  );
+}
+
+export const HvIcon = memo(forwardRef(HvIconInternal));

--- a/packages/core/src/utils/Callout.tsx
+++ b/packages/core/src/utils/Callout.tsx
@@ -3,7 +3,6 @@ import type { SnackbarProps as MuiSnackbarProps } from "@mui/material/Snackbar";
 import SnackbarContent, {
   type SnackbarContentProps as MuiSnackbarContentProps,
 } from "@mui/material/SnackbarContent";
-import { Close } from "@hitachivantara/uikit-react-icons";
 import {
   createClasses,
   useDefaultProps,
@@ -14,6 +13,7 @@ import { theme } from "@hitachivantara/uikit-styles";
 
 import { HvActionsGeneric, HvActionsGenericProps } from "../ActionsGeneric";
 import { HvButton, HvButtonProps } from "../Button";
+import { HvIcon } from "../icons";
 import { iconVariant } from "./iconVariant";
 
 const { useClasses } = createClasses("HvCallout", {
@@ -52,7 +52,9 @@ const { useClasses } = createClasses("HvCallout", {
     overflow: "hidden",
     wordBreak: "break-word",
   },
-  messageIcon: {},
+  messageIcon: {
+    lineHeight: 0,
+  },
   messageTitle: {
     display: "block",
     fontWeight: theme.fontWeights.semibold,
@@ -196,7 +198,7 @@ export const HvCallout = forwardRef<
                 onClick={(evt) => onClose?.(evt, "clickaway")}
                 {...actionProps}
               >
-                <Close size="XS" />
+                <HvIcon size="xs" name="Close" />
               </HvButton>
             )}
             {showCustomActions && actionsContent}

--- a/packages/core/src/utils/iconVariant.tsx
+++ b/packages/core/src/utils/iconVariant.tsx
@@ -1,27 +1,17 @@
-import {
-  Caution,
-  Fail,
-  IconBaseProps,
-  Info,
-  Success,
-} from "@hitachivantara/uikit-react-icons";
+import { HvColorAny } from "@hitachivantara/uikit-styles";
 
+import { HvIcon } from "../icons";
 import type { HvCalloutVariant } from "./Callout";
 
-export const iconVariant = (
-  variant: HvCalloutVariant,
-  color?: IconBaseProps["color"],
-) => {
-  switch (variant) {
-    case "success":
-      return <Success color={color} />;
-    case "warning":
-      return <Caution color={color} />;
-    case "error":
-      return <Fail color={color} />;
-    case "info":
-      return <Info color={color} />;
-    default:
-      return null;
-  }
+const variantIconMap = {
+  success: "Success",
+  warning: "Caution",
+  error: "Fail",
+  info: "Info",
+} as const;
+
+export const iconVariant = (variant: HvCalloutVariant, color?: HvColorAny) => {
+  if (variant === "default" || variant === "accent") return null;
+
+  return <HvIcon name={variantIconMap[variant]} color={color} />;
 };

--- a/packages/styles/src/themes/ds3.ts
+++ b/packages/styles/src/themes/ds3.ts
@@ -1015,10 +1015,9 @@ const ds3 = makeTheme((theme) => ({
           [`&& .HvPagination-pageSizeInputRoot`]: {
             height: 32,
           },
-          [`& .HvPagination-icon > svg`]: {
-            width: 16,
-            height: 16,
-          },
+        },
+        icon: {
+          fontSize: 16,
         },
         pageSizeOptions: {
           height: 32,
@@ -1426,13 +1425,8 @@ const ds3 = makeTheme((theme) => ({
         },
         topGutter: { paddingTop: "8px" },
         defaultIcon: {
-          minWidth: "32px",
-          width: "32px",
-          height: "32px",
-          "& svg": {
-            height: "16px",
-            width: "16px",
-          },
+          fontSize: 16,
+          margin: 8,
         },
       },
     },

--- a/packages/styles/src/types.ts
+++ b/packages/styles/src/types.ts
@@ -21,6 +21,8 @@ export type HvThemeTokens = typeof flattenTokens;
 export type HvThemeComponentsProps<ComponentNames extends string = string> = {
   /** Component properties to override */
   components?: Record<ComponentNames, Record<string, any>>;
+  /** Record of icon names and their path, to override the default icons */
+  icons?: Record<string, string> & { viewBox: string };
 };
 
 /** Theme components */


### PR DESCRIPTION
- remove `uikit-react-icons` dependency on `uikit-react-core`
- inline used icons (Close, Chevron, Success/Caution/Fail, etc.) in core, and make them theme-customisable

usage (internal):
```tsx
<HvIcon name="Success" />
```