### PR TITLE
fix: get text until cursor and not all text in SQL autocomplete

### DIFF
--- a/packages/code-editor/src/CodeEditor/languages/sql.ts
+++ b/packages/code-editor/src/CodeEditor/languages/sql.ts
@@ -79,11 +79,18 @@ const parseErrorMessage = (errorString: string) => {
 /**
  * Get the last keyword entered in the query.
  */
-function getLastKeyword(model: any) {
-  const content = model.getValue();
+function getLastKeyword(model: any, position: any) {
+  const textUntilCursor = String(
+    model.getValueInRange({
+      startLineNumber: 1,
+      startColumn: 1,
+      endLineNumber: position.lineNumber,
+      endColumn: position.column,
+    }),
+  );
 
   // This regex ignores punctuation and special characters
-  const words = content.split(/[\s,.!?;:()]+/);
+  const words = textUntilCursor.split(/[\s,.!?;:()]+/);
 
   for (let i = words.length - 1; i >= 0; i--) {
     let word = words[i];
@@ -121,7 +128,7 @@ export const hvSqlCompletionProvider = (monaco: Monaco, schema?: string) => {
   ];
 
   return {
-    provideCompletionItems: (model: any) => {
+    provideCompletionItems: (model: any, position: any) => {
       // If no text is typed, show a suggestion to select all columns from a table
       if (model.getValue() === "") {
         const emptySuggestions = {
@@ -142,7 +149,7 @@ export const hvSqlCompletionProvider = (monaco: Monaco, schema?: string) => {
         sortText: "1",
       }));
 
-      const lastKeyword = getLastKeyword(model);
+      const lastKeyword = getLastKeyword(model, position);
 
       if (lastKeyword === "FROM" || lastKeyword.includes("JOIN")) {
         const tableSuggestions = tablesNames.map((tableName) => ({


### PR DESCRIPTION
Sometimes the wrong suggestions are showing because instead of getting the text up until the cursor we are getting all the text in the code editor:

https://github.com/user-attachments/assets/33d6309f-8787-4cee-9942-c928e379a0c7

- In the video above, the suggestions given at the end are wrong. The tables are shown and not the columns because the code is taking into account the `FROM` keyword and not `SELECT`.