### PR TITLE
fix(CodeEditor): account for special characters inside tables and columns names

### DIFF
--- a/.config/test.setup.tsx
+++ b/.config/test.setup.tsx
@@ -31,25 +31,28 @@ beforeAll(() => {
     unobserve() {}
   }
 
-  window.ResizeObserver = ResizeObserver;
+  // Tests running in Node environment don't have access to the window global object
+  if (typeof window !== "undefined") {
+    window.ResizeObserver = ResizeObserver;
 
-  Object.defineProperty(window, "IntersectionObserver", {
-    writable: true,
-    configurable: true,
-    value: IntersectionObserver,
-  });
+    Object.defineProperty(window, "IntersectionObserver", {
+      writable: true,
+      configurable: true,
+      value: IntersectionObserver,
+    });
 
-  Object.defineProperty(window, "matchMedia", {
-    writable: true,
-    value: vi.fn().mockImplementation((query) => ({
-      matches: false,
-      media: query,
-      onchange: null,
-      addListener: vi.fn(), // Deprecated
-      removeListener: vi.fn(), // Deprecated
-      addEventListener: vi.fn(),
-      removeEventListener: vi.fn(),
-      dispatchEvent: vi.fn(),
-    })),
-  });
+    Object.defineProperty(window, "matchMedia", {
+      writable: true,
+      value: vi.fn().mockImplementation((query) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: vi.fn(), // Deprecated
+        removeListener: vi.fn(), // Deprecated
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })),
+    });
+  }
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -33199,9 +33199,12 @@
         "xmllint-wasm": "^4.0.2"
       },
       "devDependencies": {
+        "@testing-library/react": "^16.0.0",
+        "@testing-library/user-event": "^14.5.1",
         "@types/react": "^18.2.43",
         "@types/react-dom": "^18.2.17",
-        "vite": "^5.1.0"
+        "vite": "^5.1.0",
+        "vitest": "^2.0.4"
       },
       "peerDependencies": {
         "@emotion/react": "^11.11.1",
@@ -33209,6 +33212,362 @@
         "@mui/material": "^5.12.2",
         "react": "^17.0.0 || ^18.0.0",
         "react-dom": "^17.0.0 || ^18.0.0"
+      }
+    },
+    "packages/code-editor/node_modules/@testing-library/react": {
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.0.0.tgz",
+      "integrity": "sha512-guuxUKRWQ+FgNX0h0NS0FIq3Q3uLtWVpBzcLOggmfMoUpgBnzBzvLLd4fbm6yS8ydJd94cIfY4yP9qUQjM2KwQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0",
+        "@types/react-dom": "^18.0.0",
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "packages/code-editor/node_modules/@testing-library/user-event": {
+      "version": "14.5.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.5.1.tgz",
+      "integrity": "sha512-UCcUKrUYGj7ClomOo2SpNVvx4/fkd/2BbIHDCle8A0ax+P3bU7yJwDBDrS6ZwdTMARWTGODX1hEsCcO+7beJjg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
+    "packages/code-editor/node_modules/@vitest/expect": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.0.4.tgz",
+      "integrity": "sha512-39jr5EguIoanChvBqe34I8m1hJFI4+jxvdOpD7gslZrVQBKhh8H9eD7J/LJX4zakrw23W+dITQTDqdt43xVcJw==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/spy": "2.0.4",
+        "@vitest/utils": "2.0.4",
+        "chai": "^5.1.1",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "packages/code-editor/node_modules/@vitest/pretty-format": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.0.4.tgz",
+      "integrity": "sha512-RYZl31STbNGqf4l2eQM1nvKPXE0NhC6Eq0suTTePc4mtMQ1Fn8qZmjV4emZdEdG2NOWGKSCrHZjmTqDCDoeFBw==",
+      "dev": true,
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "packages/code-editor/node_modules/@vitest/runner": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.0.4.tgz",
+      "integrity": "sha512-Gk+9Su/2H2zNfNdeJR124gZckd5st4YoSuhF1Rebi37qTXKnqYyFCd9KP4vl2cQHbtuVKjfEKrNJxHHCW8thbQ==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/utils": "2.0.4",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "packages/code-editor/node_modules/@vitest/snapshot": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.0.4.tgz",
+      "integrity": "sha512-or6Mzoz/pD7xTvuJMFYEtso1vJo1S5u6zBTinfl+7smGUhqybn6VjzCDMhmTyVOFWwkCMuNjmNNxnyXPgKDoPw==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/pretty-format": "2.0.4",
+        "magic-string": "^0.30.10",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "packages/code-editor/node_modules/@vitest/spy": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.0.4.tgz",
+      "integrity": "sha512-uTXU56TNoYrTohb+6CseP8IqNwlNdtPwEO0AWl+5j7NelS6x0xZZtP0bDWaLvOfUbaYwhhWp1guzXUxkC7mW7Q==",
+      "dev": true,
+      "dependencies": {
+        "tinyspy": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "packages/code-editor/node_modules/@vitest/utils": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.0.4.tgz",
+      "integrity": "sha512-Zc75QuuoJhOBnlo99ZVUkJIuq4Oj0zAkrQ2VzCqNCx6wAwViHEh5Fnp4fiJTE9rA+sAoXRf00Z9xGgfEzV6fzQ==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/pretty-format": "2.0.4",
+        "estree-walker": "^3.0.3",
+        "loupe": "^3.1.1",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "packages/code-editor/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "packages/code-editor/node_modules/execa": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
+      "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^8.0.1",
+        "human-signals": "^5.0.0",
+        "is-stream": "^3.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^5.1.0",
+        "onetime": "^6.0.0",
+        "signal-exit": "^4.1.0",
+        "strip-final-newline": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.17"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "packages/code-editor/node_modules/get-stream": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
+      "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
+      "dev": true,
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/code-editor/node_modules/human-signals": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
+      "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=16.17.0"
+      }
+    },
+    "packages/code-editor/node_modules/is-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+      "dev": true,
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/code-editor/node_modules/mimic-fn": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+      "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/code-editor/node_modules/npm-run-path": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
+      "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
+      "dev": true,
+      "dependencies": {
+        "path-key": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/code-editor/node_modules/onetime": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+      "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+      "dev": true,
+      "dependencies": {
+        "mimic-fn": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/code-editor/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/code-editor/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/code-editor/node_modules/std-env": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.8.0.tgz",
+      "integrity": "sha512-Bc3YwwCB+OzldMxOXJIIvC6cPRWr/LxOp48CdQTOkPyk/t4JWWJbrilwBd7RJzKV8QW7tJkcgAmeuLLJugl5/w==",
+      "dev": true
+    },
+    "packages/code-editor/node_modules/strip-final-newline": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+      "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/code-editor/node_modules/vite-node": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.0.4.tgz",
+      "integrity": "sha512-ZpJVkxcakYtig5iakNeL7N3trufe3M6vGuzYAr4GsbCTwobDeyPJpE4cjDhhPluv8OvQCFzu2LWp6GkoKRITXA==",
+      "dev": true,
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.5",
+        "pathe": "^1.1.2",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "packages/code-editor/node_modules/vitest": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.0.4.tgz",
+      "integrity": "sha512-luNLDpfsnxw5QSW4bISPe6tkxVvv5wn2BBs/PuDRkhXZ319doZyLOBr1sjfB5yCEpTiU7xCAdViM8TNVGPwoog==",
+      "dev": true,
+      "dependencies": {
+        "@ampproject/remapping": "^2.3.0",
+        "@vitest/expect": "2.0.4",
+        "@vitest/pretty-format": "^2.0.4",
+        "@vitest/runner": "2.0.4",
+        "@vitest/snapshot": "2.0.4",
+        "@vitest/spy": "2.0.4",
+        "@vitest/utils": "2.0.4",
+        "chai": "^5.1.1",
+        "debug": "^4.3.5",
+        "execa": "^8.0.1",
+        "magic-string": "^0.30.10",
+        "pathe": "^1.1.2",
+        "std-env": "^3.7.0",
+        "tinybench": "^2.8.0",
+        "tinypool": "^1.0.0",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.0.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.0.4",
+        "@vitest/ui": "2.0.4",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
       }
     },
     "packages/config": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -486,10 +486,9 @@
       }
     },
     "apps/docs/node_modules/p-limit": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-6.1.0.tgz",
-      "integrity": "sha512-H0jc0q1vOzlEk0TqAKXKZxdl7kX3OFUzCnNVUnq5Pc3DGo0kpeaMuPqxQn235HibwBEb0/pm9dgKTjXy66fBkg==",
-      "license": "MIT",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-6.2.0.tgz",
+      "integrity": "sha512-kuUqqHNUqoIWp/c467RI4X6mmyuojY5jGutNU0wVTmEOOfcuwLqyMVoAi9MKi2Ak+5i9+nhmrK4ufZE8069kHA==",
       "dependencies": {
         "yocto-queue": "^1.1.1"
       },
@@ -4615,17 +4614,16 @@
       }
     },
     "node_modules/@mui/base/node_modules/@mui/utils": {
-      "version": "6.1.10",
-      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-6.1.10.tgz",
-      "integrity": "sha512-1ETuwswGjUiAf2dP9TkBy8p49qrw2wXa+RuAjNTRE5+91vtXJ1HKrs7H9s8CZd1zDlQVzUcUAPm9lpQwF5ogTw==",
-      "license": "MIT",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-6.3.0.tgz",
+      "integrity": "sha512-MkDBF08OPVwXhAjedyMykRojgvmf0y/jxkBWjystpfI/pasyTYrfdv4jic6s7j3y2+a+SJzS9qrD6X8ZYj/8AQ==",
       "dependencies": {
         "@babel/runtime": "^7.26.0",
-        "@mui/types": "^7.2.19",
-        "@types/prop-types": "^15.7.13",
+        "@mui/types": "^7.2.20",
+        "@types/prop-types": "^15.7.14",
         "clsx": "^2.1.1",
         "prop-types": "^15.8.1",
-        "react-is": "^18.3.1"
+        "react-is": "^19.0.0"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -4643,6 +4641,11 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@mui/base/node_modules/react-is": {
+      "version": "19.0.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.0.0.tgz",
+      "integrity": "sha512-H91OHcwjZsbq3ClIDHMzBShc1rotbfACdWENsmEf0IFvZ3FgGPtdHMcsv45bQ1hAbgdfiA8SnxTKfDS+x/8m2g=="
     },
     "node_modules/@mui/core-downloads-tracker": {
       "version": "5.16.7",
@@ -4799,10 +4802,9 @@
       }
     },
     "node_modules/@mui/types": {
-      "version": "7.2.19",
-      "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.2.19.tgz",
-      "integrity": "sha512-6XpZEM/Q3epK9RN8ENoXuygnqUQxE+siN/6rGRi2iwJPgBUR25mphYQ9ZI87plGh58YoZ5pp40bFvKYOCDJ3tA==",
-      "license": "MIT",
+      "version": "7.2.20",
+      "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.2.20.tgz",
+      "integrity": "sha512-straFHD7L8v05l/N5vcWk+y7eL9JF0C2mtph/y4BPm3gn2Eh61dDwDB65pa8DLss3WJfDXYC7Kx5yjP0EmXpgw==",
       "peerDependencies": {
         "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0"
       },
@@ -4813,17 +4815,16 @@
       }
     },
     "node_modules/@mui/utils": {
-      "version": "5.16.8",
-      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-5.16.8.tgz",
-      "integrity": "sha512-P/yb7BSWallQUeiNGxb+TM8epHteIUC8gzNTdPV2VfKhVY/EnGliHgt5np0GPkjQ7EzwDi/+gBevrAJtf+K94A==",
-      "license": "MIT",
+      "version": "5.16.13",
+      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-5.16.13.tgz",
+      "integrity": "sha512-35kLiShnDPByk57Mz4PP66fQUodCFiOD92HfpW6dK9lc7kjhZsKHRKeYPgWuwEHeXwYsCSFtBCW4RZh/8WT+TQ==",
       "dependencies": {
         "@babel/runtime": "^7.23.9",
         "@mui/types": "^7.2.15",
         "@types/prop-types": "^15.7.12",
         "clsx": "^2.1.1",
         "prop-types": "^15.8.1",
-        "react-is": "^18.3.1"
+        "react-is": "^19.0.0"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -4841,6 +4842,11 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@mui/utils/node_modules/react-is": {
+      "version": "19.0.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.0.0.tgz",
+      "integrity": "sha512-H91OHcwjZsbq3ClIDHMzBShc1rotbfACdWENsmEf0IFvZ3FgGPtdHMcsv45bQ1hAbgdfiA8SnxTKfDS+x/8m2g=="
     },
     "node_modules/@napi-rs/simple-git": {
       "version": "0.1.19",
@@ -7532,11 +7538,10 @@
       }
     },
     "node_modules/@storybook/csf": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/@storybook/csf/-/csf-0.1.12.tgz",
-      "integrity": "sha512-9/exVhabisyIVL0VxTCxo01Tdm8wefIXKXfltAPTSr8cbLn5JAxGQ6QV3mjdecLGEOucfoVhAKtJfVHxEK1iqw==",
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/@storybook/csf/-/csf-0.1.13.tgz",
+      "integrity": "sha512-7xOOwCLGB3ebM87eemep89MYRFTko+D8qE7EdAAq74lgdqRR5cOUtYWJLjO2dLtP94nqoOdHJo6MdLLKzg412Q==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "type-fest": "^2.19.0"
       }
@@ -8398,11 +8403,10 @@
       "license": "MIT"
     },
     "node_modules/@testing-library/react": {
-      "version": "16.0.1",
-      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.0.1.tgz",
-      "integrity": "sha512-dSmwJVtJXmku+iocRhWOUFbrERC76TX2Mnf0ATODz8brzAZrMBbzLwQixlBSanZxR6LddK3eiwpSFZgDET1URg==",
+      "version": "16.1.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.1.0.tgz",
+      "integrity": "sha512-Q2ToPvg0KsVL0ohND9A3zLJWcOXXcO8IDu3fj11KhNt0UlCWyFyvnCIBkd12tidB2lkiVRG8VFqdhcqhqnAQtg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.12.5"
       },
@@ -8411,10 +8415,10 @@
       },
       "peerDependencies": {
         "@testing-library/dom": "^10.0.0",
-        "@types/react": "^18.0.0",
-        "@types/react-dom": "^18.0.0",
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
       },
       "peerDependenciesMeta": {
         "@types/react": {
@@ -9132,10 +9136,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "20.17.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.9.tgz",
-      "integrity": "sha512-0JOXkRyLanfGPE2QRCwgxhzlBAvaRdCNMcvbd7jFfpmD4eEXll7LRwy5ymJmyeZqk7Nh7eD2LeUyQ68BbndmXw==",
-      "license": "MIT",
+      "version": "20.17.11",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.11.tgz",
+      "integrity": "sha512-Ept5glCK35R8yeyIeYlRIZtX6SLRyqMhOFTgj5SOkMpLTdw3SEHI9fHx60xaUZ+V1aJxQJODE+7/j5ocZydYTg==",
       "dependencies": {
         "undici-types": "~6.19.2"
       }
@@ -9160,10 +9163,9 @@
       "license": "MIT"
     },
     "node_modules/@types/prop-types": {
-      "version": "15.7.13",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.13.tgz",
-      "integrity": "sha512-hCZTSvwbzWGvhqxp/RqVqwU999pBf2vp7hzIjiYOsl8wqOmUxkQ6ddw1cV3l8811+kdUFus/q4d1Y3E3SyEifA==",
-      "license": "MIT"
+      "version": "15.7.14",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.14.tgz",
+      "integrity": "sha512-gNMvNH49DJ7OJYv+KAKn0Xp45p8PLl6zo2YnvDIbTd4J6MER2BmWN49TG7n9LvkyihINxeKW8+3bfS2yDC9dzQ=="
     },
     "node_modules/@types/react": {
       "version": "18.3.12",
@@ -10060,13 +10062,12 @@
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.4.tgz",
-      "integrity": "sha512-Ky/O1Lc0QBbutJdW0rqLeFNbuLEyS+mIPiNdlVlp2/yhJ0SbyYqObS5IHdhferJud8MbbwMnexg4jordE5cCoQ==",
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.8.tgz",
+      "integrity": "sha512-7guJ/47I6uqfttp33mgo6ga5Gr1VnL58rcqYKyShoRK9ebu8T5Rs6HN3s1NABiBeVTdWNrwUMcHH54uXZBN4zA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "2.1.4",
+        "@vitest/spy": "2.1.8",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.12"
       },
@@ -10087,11 +10088,10 @@
       }
     },
     "node_modules/@vitest/mocker/node_modules/@vitest/spy": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.4.tgz",
-      "integrity": "sha512-4JOxa+UAizJgpZfaCPKK2smq9d8mmjZVPMt2kOsg/R8QkoRzydHH1qHxIYNvr1zlEaFj4SXiaaJWxq/LPLKaLg==",
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.8.tgz",
+      "integrity": "sha512-5swjf2q95gXeYPevtW0BLk6H8+bPlMb4Vw/9Em4hFxDcaOxS+e0LOX4yqNxoHzMR2akEB2xfpnWUzkZokmgWDg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "tinyspy": "^3.0.2"
       },
@@ -10104,7 +10104,6 @@
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
       "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0"
       }
@@ -10123,29 +10122,65 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.4.tgz",
-      "integrity": "sha512-sKRautINI9XICAMl2bjxQM8VfCMTB0EbsBc/EDFA57V6UQevEKY/TOPOF5nzcvCALltiLfXWbq4MaAwWx/YxIA==",
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.8.tgz",
+      "integrity": "sha512-17ub8vQstRnRlIU5k50bG+QOMLHRhYPAna5tw8tYbj+jzjcspnwnwtPtiOlkuKC4+ixDPTuLZiqiWWQ2PSXHVg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "2.1.4",
+        "@vitest/utils": "2.1.8",
         "pathe": "^1.1.2"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
-    "node_modules/@vitest/snapshot": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.4.tgz",
-      "integrity": "sha512-3Kab14fn/5QZRog5BPj6Rs8dc4B+mim27XaKWFWHWA87R56AKjHTGcBFKpvZKDzC4u5Wd0w/qKsUIio3KzWW4Q==",
+    "node_modules/@vitest/runner/node_modules/@vitest/pretty-format": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.8.tgz",
+      "integrity": "sha512-9HiSZ9zpqNLKlbIDRWOnAWqgcA7xu+8YxXSekhr0Ykab7PAYFkhkwoqVArPOtJhPmYeE2YHgKZlj3CP36z2AJQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "2.1.4",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner/node_modules/@vitest/utils": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.8.tgz",
+      "integrity": "sha512-dwSoui6djdwbfFmIgbIjX2ZhIoG7Ex/+xpxyiEgIGzjliY8xGkcpITKTlp6B4MgtGkF2ilvm97cPM96XZaAgcA==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.8",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.8.tgz",
+      "integrity": "sha512-20T7xRFbmnkfcmgVEz+z3AU/3b0cEzZOt/zmnvZEctg64/QZbSDJEVm9fLnnlSi74KibmRsO9/Qabi+t0vCRPg==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.8",
         "magic-string": "^0.30.12",
         "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot/node_modules/@vitest/pretty-format": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.8.tgz",
+      "integrity": "sha512-9HiSZ9zpqNLKlbIDRWOnAWqgcA7xu+8YxXSekhr0Ykab7PAYFkhkwoqVArPOtJhPmYeE2YHgKZlj3CP36z2AJQ==",
+      "dev": true,
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
@@ -14481,11 +14516,10 @@
       "license": "(MPL-2.0 OR Apache-2.0)"
     },
     "node_modules/domutils": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.1.0.tgz",
-      "integrity": "sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.1.tgz",
+      "integrity": "sha512-xWXmuRnN9OMP6ptPd2+H0cCbcYBULa5YDTbMm/2lvkWvNA3O4wcW+GvzooqBuNM8yy6pl3VIAeJTUUWUbfI5Fw==",
       "dev": true,
-      "license": "BSD-2-Clause",
       "dependencies": {
         "dom-serializer": "^2.0.0",
         "domelementtype": "^2.3.0",
@@ -14909,6 +14943,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.6.0.tgz",
+      "integrity": "sha512-qqnD1yMU6tk/jnaMosogGySTZP8YtUgAffA9nMN+E/rjxcfRQ6IEk7IiozUjgxKoFHBGjTLnrHB/YC45r/59EQ==",
+      "dev": true
     },
     "node_modules/es-object-atoms": {
       "version": "1.0.0",
@@ -18593,10 +18633,9 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.15.1",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.15.1.tgz",
-      "integrity": "sha512-z0vtXSwucUJtANQWldhbtbt7BnL0vxiFjIdDLAatwhDYty2bad6s+rijD6Ri4YuYJubLzIJLUidCh09e1djEVQ==",
-      "license": "MIT",
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
       "dependencies": {
         "hasown": "^2.0.2"
       },
@@ -20314,11 +20353,10 @@
       }
     },
     "node_modules/jest-watch-typeahead/node_modules/chalk": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
-      "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.1.tgz",
+      "integrity": "sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
@@ -22244,10 +22282,9 @@
       }
     },
     "node_modules/magic-string": {
-      "version": "0.30.15",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.15.tgz",
-      "integrity": "sha512-zXeaYRgZ6ldS1RJJUrMrYgNJ4fdwnyI6tVqoiIhyCyv5IVTK9BU8Ic2l253GGETQHxI4HNUwhJ3fjDhKqEoaAw==",
-      "license": "MIT",
+      "version": "0.30.17",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
+      "integrity": "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0"
       }
@@ -28295,17 +28332,19 @@
       "license": "MIT"
     },
     "node_modules/resolve": {
-      "version": "1.22.8",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
-      "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
-      "license": "MIT",
+      "version": "1.22.10",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
+      "integrity": "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==",
       "dependencies": {
-        "is-core-module": "^2.13.0",
+        "is-core-module": "^2.16.0",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
       },
       "bin": {
         "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -29484,11 +29523,10 @@
       "license": "MIT"
     },
     "node_modules/std-env": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.7.0.tgz",
-      "integrity": "sha512-JPbdCEQLj1w5GilpiHAx3qJvFndqybBysA3qUOnznweH4QbNYUsW/ea8QzSrnh0vNsezMMw5bcVool8lM0gwzg==",
-      "dev": true,
-      "license": "MIT"
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.8.0.tgz",
+      "integrity": "sha512-Bc3YwwCB+OzldMxOXJIIvC6cPRWr/LxOp48CdQTOkPyk/t4JWWJbrilwBd7RJzKV8QW7tJkcgAmeuLLJugl5/w==",
+      "dev": true
     },
     "node_modules/storybook": {
       "version": "8.4.1",
@@ -31660,14 +31698,14 @@
       }
     },
     "node_modules/vite-node": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.4.tgz",
-      "integrity": "sha512-kqa9v+oi4HwkG6g8ufRnb5AeplcRw8jUF6/7/Qz1qRQOXHImG8YnLbB+LLszENwFnoBl9xIf9nVdCFzNd7GQEg==",
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.8.tgz",
+      "integrity": "sha512-uPAwSr57kYjAUux+8E2j0q0Fxpn8M9VoyfGiRI8Kfktz9NcYMCenwY5RnZxnF1WTu3TGiYipirIzacLL3VVGFg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "cac": "^6.7.14",
         "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
         "pathe": "^1.1.2",
         "vite": "^5.0.0"
       },
@@ -32162,31 +32200,30 @@
       }
     },
     "node_modules/vitest": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.4.tgz",
-      "integrity": "sha512-eDjxbVAJw1UJJCHr5xr/xM86Zx+YxIEXGAR+bmnEID7z9qWfoxpHw0zdobz+TQAFOLT+nEXz3+gx6nUJ7RgmlQ==",
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.8.tgz",
+      "integrity": "sha512-1vBKTZskHw/aosXqQUlVWWlGUxSJR8YtiyZDJAFeW2kPAeX6S3Sool0mjspO+kXLuxVWlEDDowBAeqeAQefqLQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "2.1.4",
-        "@vitest/mocker": "2.1.4",
-        "@vitest/pretty-format": "^2.1.4",
-        "@vitest/runner": "2.1.4",
-        "@vitest/snapshot": "2.1.4",
-        "@vitest/spy": "2.1.4",
-        "@vitest/utils": "2.1.4",
+        "@vitest/expect": "2.1.8",
+        "@vitest/mocker": "2.1.8",
+        "@vitest/pretty-format": "^2.1.8",
+        "@vitest/runner": "2.1.8",
+        "@vitest/snapshot": "2.1.8",
+        "@vitest/spy": "2.1.8",
+        "@vitest/utils": "2.1.8",
         "chai": "^5.1.2",
         "debug": "^4.3.7",
         "expect-type": "^1.1.0",
         "magic-string": "^0.30.12",
         "pathe": "^1.1.2",
-        "std-env": "^3.7.0",
+        "std-env": "^3.8.0",
         "tinybench": "^2.9.0",
         "tinyexec": "^0.3.1",
         "tinypool": "^1.0.1",
         "tinyrainbow": "^1.2.0",
         "vite": "^5.0.0",
-        "vite-node": "2.1.4",
+        "vite-node": "2.1.8",
         "why-is-node-running": "^2.3.0"
       },
       "bin": {
@@ -32201,8 +32238,8 @@
       "peerDependencies": {
         "@edge-runtime/vm": "*",
         "@types/node": "^18.0.0 || >=20.0.0",
-        "@vitest/browser": "2.1.4",
-        "@vitest/ui": "2.1.4",
+        "@vitest/browser": "2.1.8",
+        "@vitest/ui": "2.1.8",
         "happy-dom": "*",
         "jsdom": "*"
       },
@@ -32228,14 +32265,13 @@
       }
     },
     "node_modules/vitest/node_modules/@vitest/expect": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.4.tgz",
-      "integrity": "sha512-DOETT0Oh1avie/D/o2sgMHGrzYUFFo3zqESB2Hn70z6QB1HrS2IQ9z5DfyTqU8sg4Bpu13zZe9V4+UTNQlUeQA==",
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.8.tgz",
+      "integrity": "sha512-8ytZ/fFHq2g4PJVAtDX57mayemKgDR6X3Oa2Foro+EygiOJHUXhCqBAAKQYYajZpFoIfvBCF1j6R6IYRSIUFuw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "2.1.4",
-        "@vitest/utils": "2.1.4",
+        "@vitest/spy": "2.1.8",
+        "@vitest/utils": "2.1.8",
         "chai": "^5.1.2",
         "tinyrainbow": "^1.2.0"
       },
@@ -32243,14 +32279,39 @@
         "url": "https://opencollective.com/vitest"
       }
     },
-    "node_modules/vitest/node_modules/@vitest/spy": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.4.tgz",
-      "integrity": "sha512-4JOxa+UAizJgpZfaCPKK2smq9d8mmjZVPMt2kOsg/R8QkoRzydHH1qHxIYNvr1zlEaFj4SXiaaJWxq/LPLKaLg==",
+    "node_modules/vitest/node_modules/@vitest/pretty-format": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.8.tgz",
+      "integrity": "sha512-9HiSZ9zpqNLKlbIDRWOnAWqgcA7xu+8YxXSekhr0Ykab7PAYFkhkwoqVArPOtJhPmYeE2YHgKZlj3CP36z2AJQ==",
       "dev": true,
-      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/spy": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.8.tgz",
+      "integrity": "sha512-5swjf2q95gXeYPevtW0BLk6H8+bPlMb4Vw/9Em4hFxDcaOxS+e0LOX4yqNxoHzMR2akEB2xfpnWUzkZokmgWDg==",
+      "dev": true,
       "dependencies": {
         "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/utils": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.8.tgz",
+      "integrity": "sha512-dwSoui6djdwbfFmIgbIjX2ZhIoG7Ex/+xpxyiEgIGzjliY8xGkcpITKTlp6B4MgtGkF2ilvm97cPM96XZaAgcA==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.8",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
@@ -33175,10 +33236,9 @@
       }
     },
     "packages/cli/node_modules/chalk": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
-      "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
-      "license": "MIT",
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.1.tgz",
+      "integrity": "sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==",
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
@@ -33465,12 +33525,6 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
-    },
-    "packages/code-editor/node_modules/std-env": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.8.0.tgz",
-      "integrity": "sha512-Bc3YwwCB+OzldMxOXJIIvC6cPRWr/LxOp48CdQTOkPyk/t4JWWJbrilwBd7RJzKV8QW7tJkcgAmeuLLJugl5/w==",
-      "dev": true
     },
     "packages/code-editor/node_modules/strip-final-newline": {
       "version": "3.0.0",

--- a/packages/code-editor/package.json
+++ b/packages/code-editor/package.json
@@ -26,6 +26,8 @@
   },
   "scripts": {
     "build": "npm run clean && vite build",
+    "test": "vitest",
+    "test:ui": "vitest --ui",
     "clean": "npx rimraf dist package",
     "prepublishOnly": "npm run build && npx clean-publish"
   },
@@ -45,9 +47,12 @@
     "xmllint-wasm": "^4.0.2"
   },
   "devDependencies": {
+    "@testing-library/react": "^16.0.0",
+    "@testing-library/user-event": "^14.5.1",
     "@types/react": "^18.2.43",
     "@types/react-dom": "^18.2.17",
-    "vite": "^5.1.0"
+    "vite": "^5.1.0",
+    "vitest": "^2.0.4"
   },
   "files": [
     "dist"

--- a/packages/code-editor/src/CodeEditor/languages/sql.test.tsx
+++ b/packages/code-editor/src/CodeEditor/languages/sql.test.tsx
@@ -1,3 +1,6 @@
+// @vitest-environment node
+import { describe, expect, it } from "vitest";
+
 import { getColumnNames, getTablesNames } from "./sql";
 
 const dbSchema = `

--- a/packages/code-editor/src/CodeEditor/languages/sql.test.tsx
+++ b/packages/code-editor/src/CodeEditor/languages/sql.test.tsx
@@ -1,0 +1,88 @@
+import { getColumnNames, getTablesNames } from "./sql";
+
+const dbSchema = `
+CREATE DATABASE OnlineStore;
+
+CREATE TABLE "My, test @ test test Customers" (
+    "Customer ID" INT PRIMARY KEY AUTO_INCREMENT,
+    [First Name] VARCHAR(50) NOT NULL,
+    \`Last Name\` VARCHAR(50) NOT NULL,
+    Email VARCHAR(100) UNIQUE NOT NULL,
+    DateOfBirth DATE,
+    Gender CHAR(1) CHECK (Gender IN ('M', 'F')),
+    CreatedAt TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE [Products 123] (
+    ProductID INT PRIMARY KEY AUTO_INCREMENT,
+    ProductName VARCHAR(100) NOT NULL,
+    Price DECIMAL(10, 2) NOT NULL CHECK (Price >= 0),
+    StockQuantity INT NOT NULL CHECK (StockQuantity >= 0),
+    CreatedAt TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE \`Orders @ test\` (
+    OrderID INT PRIMARY KEY AUTO_INCREMENT,
+    CustomerID INT NOT NULL,
+    OrderDate DATE NOT NULL,
+    TotalAmount DECIMAL(10, 2) NOT NULL CHECK (TotalAmount >= 0),
+    FOREIGN KEY (CustomerID) REFERENCES Customers(CustomerID)
+);
+
+CREATE TABLE @OrderItems (
+    OrderItemID INT PRIMARY KEY AUTO_INCREMENT,
+    OrderID INT NOT NULL,
+    ProductID INT NOT NULL,
+    Quantity INT NOT NULL CHECK (Quantity > 0),
+    UnitPrice DECIMAL(10, 2) NOT NULL CHECK (UnitPrice >= 0),
+    FOREIGN KEY (OrderID) REFERENCES Orders(OrderID),
+    FOREIGN KEY (ProductID) REFERENCES Products(ProductID)
+);
+
+CREATE TABLE OrderItems (
+    OrderItemID INT PRIMARY KEY AUTO_INCREMENT,
+    OrderID INT NOT NULL
+);
+`;
+
+describe("SQL", () => {
+  it("should return the table names with and without enclosing delimiters", () => {
+    const result = getTablesNames(dbSchema);
+    expect(result).toEqual([
+      "My, test @ test test Customers",
+      "Products 123",
+      "Orders @ test",
+      "@OrderItems",
+      "OrderItems",
+    ]);
+  });
+
+  it("should return the column names with and without enclosing delimiters", () => {
+    const result = getColumnNames(dbSchema);
+    expect(result).toEqual([
+      "My, test @ test test Customers.Customer ID",
+      "My, test @ test test Customers.First Name",
+      "My, test @ test test Customers.Last Name",
+      "My, test @ test test Customers.Email",
+      "My, test @ test test Customers.DateOfBirth",
+      "My, test @ test test Customers.Gender",
+      "My, test @ test test Customers.CreatedAt",
+      "Products 123.ProductID",
+      "Products 123.ProductName",
+      "Products 123.Price",
+      "Products 123.StockQuantity",
+      "Products 123.CreatedAt",
+      "Orders @ test.OrderID",
+      "Orders @ test.CustomerID",
+      "Orders @ test.OrderDate",
+      "Orders @ test.TotalAmount",
+      "@OrderItems.OrderItemID",
+      "@OrderItems.OrderID",
+      "@OrderItems.ProductID",
+      "@OrderItems.Quantity",
+      "@OrderItems.UnitPrice",
+      "OrderItems.OrderItemID",
+      "OrderItems.OrderID",
+    ]);
+  });
+});

--- a/packages/core/src/Banner/Banner.stories.tsx
+++ b/packages/core/src/Banner/Banner.stories.tsx
@@ -14,7 +14,6 @@ import { Info } from "@hitachivantara/uikit-react-icons";
 export default {
   title: "Components/Banner",
   component: HvBanner,
-  // @ts-expect-error https://github.com/storybookjs/storybook/issues/20782
   subcomponents: { HvBannerContent },
 } satisfies Meta<typeof HvBanner>;
 

--- a/packages/core/src/Card/Card.stories.tsx
+++ b/packages/core/src/Card/Card.stories.tsx
@@ -21,7 +21,6 @@ import VariantsRaw from "./stories/Variants?raw";
 const meta: Meta<typeof HvCard> = {
   title: "Components/Card",
   component: HvCard,
-  // @ts-expect-error https://github.com/storybookjs/storybook/issues/20782
   subcomponents: { HvCardHeader, HvCardContent, HvCardMedia },
   decorators: [(Story) => <div style={{ margin: 20 }}>{Story()}</div>],
 };

--- a/packages/core/src/Carousel/Carousel.stories.tsx
+++ b/packages/core/src/Carousel/Carousel.stories.tsx
@@ -16,7 +16,6 @@ import {
 export default {
   title: "Widgets/Carousel",
   component: HvCarousel,
-  // @ts-expect-error https://github.com/storybookjs/storybook/issues/20782
   subcomponents: { HvCarouselSlide },
 } satisfies Meta<typeof HvCarousel>;
 

--- a/packages/core/src/CheckBox/CheckBox.stories.tsx
+++ b/packages/core/src/CheckBox/CheckBox.stories.tsx
@@ -23,7 +23,6 @@ const StyledDecorator = styled("div")({
 const meta: Meta<typeof HvCheckBox> = {
   title: "Components/Checkbox/Checkbox",
   component: HvCheckBox,
-  // @ts-expect-error https://github.com/storybookjs/storybook/issues/20782
   subcomponents: { HvBaseCheckBox },
   decorators: [(Story) => <StyledDecorator>{Story()}</StyledDecorator>],
 };

--- a/packages/core/src/Controls/Controls.stories.tsx
+++ b/packages/core/src/Controls/Controls.stories.tsx
@@ -18,7 +18,6 @@ import { setupChromatic } from ".storybook/setupChromatic";
 const meta: Meta<typeof HvControls> = {
   title: "Widgets/Controls",
   component: HvControls,
-  // @ts-expect-error https://github.com/storybookjs/storybook/issues/20782
   subcomponents: { HvLeftControl, HvRightControl },
 };
 

--- a/packages/core/src/DatePicker/DatePicker.stories.tsx
+++ b/packages/core/src/DatePicker/DatePicker.stories.tsx
@@ -35,7 +35,6 @@ const unsetDecorator: Decorator = (Story) => (
 const meta: Meta<typeof HvDatePicker> = {
   title: "Components/Date Picker",
   // TODO: HvCalendar should have its own docs
-  // @ts-expect-error https://github.com/storybookjs/storybook/issues/20782
   subcomponents: { HvCalendar },
   component: HvDatePicker,
   decorators: [containerDecorator],

--- a/packages/core/src/Dialog/Dialog.stories.tsx
+++ b/packages/core/src/Dialog/Dialog.stories.tsx
@@ -23,7 +23,6 @@ import { setupChromatic } from ".storybook/setupChromatic";
 const meta: Meta<typeof HvDialog> = {
   title: "Components/Dialog",
   component: HvDialog,
-  // @ts-expect-error https://github.com/storybookjs/storybook/issues/20782
   subcomponents: { HvDialogTitle, HvDialogContent, HvDialogActions },
   decorators: [
     (Story) => (

--- a/packages/core/src/Dropdown/stories/Dropdown.stories.tsx
+++ b/packages/core/src/Dropdown/stories/Dropdown.stories.tsx
@@ -28,7 +28,6 @@ const widthDecorator: Decorator = (Story) => (
 export default {
   title: "Components/Dropdown",
   component: HvDropdown,
-  // @ts-expect-error https://github.com/storybookjs/storybook/issues/20782
   subcomponents: { HvBaseDropdown },
 } satisfies Meta<typeof HvDropdown>;
 

--- a/packages/core/src/FileUploader/FileUploader.stories.tsx
+++ b/packages/core/src/FileUploader/FileUploader.stories.tsx
@@ -16,7 +16,6 @@ import { cancelUpload, simulateUpload } from "./stories/simulators";
 const meta: Meta<typeof HvFileUploader> = {
   title: "Widgets/File Uploader",
   component: HvFileUploader,
-  // @ts-expect-error https://github.com/storybookjs/storybook/issues/20782
   subcomponents: { HvFileUploaderPreview },
 };
 

--- a/packages/core/src/Header/Header.stories.tsx
+++ b/packages/core/src/Header/Header.stories.tsx
@@ -84,7 +84,6 @@ const navigationDataMain = [
 export default {
   title: "Widgets/Header",
   component: HvHeader,
-  // @ts-expect-error https://github.com/storybookjs/storybook/issues/20782
   subcomponents: { HvHeaderBrand, HvHeaderNavigation, HvHeaderActions },
 } satisfies Meta<typeof HvHeader>;
 

--- a/packages/core/src/Input/Input.stories.tsx
+++ b/packages/core/src/Input/Input.stories.tsx
@@ -39,7 +39,6 @@ const showcaseDecorator: Decorator = (Story) => (
 const meta: Meta<typeof HvInput> = {
   title: "Components/Input",
   component: HvInput,
-  // @ts-expect-error https://github.com/storybookjs/storybook/issues/20782
   subcomponents: { HvBaseInput },
 };
 export default meta;

--- a/packages/core/src/ListContainer/ListContainer.stories.tsx
+++ b/packages/core/src/ListContainer/ListContainer.stories.tsx
@@ -21,7 +21,6 @@ import {
 const meta: Meta<typeof HvListContainer> = {
   title: "Components/List/List",
   component: HvListContainer,
-  // @ts-expect-error https://github.com/storybookjs/storybook/issues/20782
   subcomponents: { HvListItem },
 };
 export default meta;

--- a/packages/core/src/Radio/Radio.stories.tsx
+++ b/packages/core/src/Radio/Radio.stories.tsx
@@ -14,7 +14,6 @@ import {
 const meta: Meta<typeof HvRadio> = {
   title: "Components/Radio/Radio",
   component: HvRadio,
-  // @ts-expect-error https://github.com/storybookjs/storybook/issues/20782
   subcomponents: { HvBaseRadio },
 };
 export default meta;

--- a/packages/core/src/Select/Select.stories.tsx
+++ b/packages/core/src/Select/Select.stories.tsx
@@ -20,7 +20,6 @@ const decorator: Decorator = (Story) => (
 export default {
   title: "Components/Select",
   component: HvSelect,
-  // @ts-expect-error https://github.com/storybookjs/storybook/issues/20782
   subcomponents: { HvOption, HvOptionGroup },
 } satisfies Meta<typeof HvSelect>;
 

--- a/packages/core/src/Snackbar/Snackbar.stories.tsx
+++ b/packages/core/src/Snackbar/Snackbar.stories.tsx
@@ -11,7 +11,6 @@ import { Deploy, Info } from "@hitachivantara/uikit-react-icons";
 const meta: Meta<typeof HvSnackbar> = {
   title: "Components/Snackbar",
   component: HvSnackbar,
-  // @ts-expect-error https://github.com/storybookjs/storybook/issues/20782
   subcomponents: { HvSnackbarContent },
   decorators: [(Story) => <div style={{ minHeight: 60 }}>{Story()}</div>],
   args: {

--- a/packages/core/src/Switch/Switch.stories.tsx
+++ b/packages/core/src/Switch/Switch.stories.tsx
@@ -29,7 +29,6 @@ const decorator: Decorator = (Story) => (
 const meta: Meta<typeof HvSwitch> = {
   title: "Components/Switch",
   component: HvSwitch,
-  // @ts-expect-error https://github.com/storybookjs/storybook/issues/20782
   subcomponents: { HvBaseSwitch },
 };
 

--- a/packages/core/src/Tabs/Tabs.stories.tsx
+++ b/packages/core/src/Tabs/Tabs.stories.tsx
@@ -23,7 +23,6 @@ import {
 const meta: Meta<typeof HvTabs> = {
   title: "Components/Tabs",
   component: HvTabs,
-  // @ts-expect-error https://github.com/storybookjs/storybook/issues/20782
   subcomponents: { HvTab },
 };
 export default meta;

--- a/packages/core/src/TreeView/stories/TreeView.stories.tsx
+++ b/packages/core/src/TreeView/stories/TreeView.stories.tsx
@@ -28,7 +28,6 @@ export default {
   title: "Components/Tree View",
   component: HvTreeView,
   argTypes: {},
-  // @ts-expect-error
   subcomponents: { HvTreeItem },
 } satisfies Meta<typeof HvTreeView>;
 

--- a/packages/core/src/VerticalNavigation/VerticalNavigation.stories.tsx
+++ b/packages/core/src/VerticalNavigation/VerticalNavigation.stories.tsx
@@ -35,19 +35,12 @@ const meta: Meta<typeof HvVerticalNavigation> = {
   title: "Widgets/Vertical Navigation",
   component: HvVerticalNavigation,
   subcomponents: {
-    // @ts-expect-error https://github.com/storybookjs/storybook/issues/20782
     HvVerticalNavigationHeader,
-    // @ts-expect-error
     HvVerticalNavigationTree,
-    // @ts-expect-error
     HvVerticalNavigationActions,
-    // @ts-expect-error
     HvVerticalNavigationAction,
-    // @ts-expect-error
     HvVerticalNavigationTreeView,
-    // @ts-expect-error
     HvVerticalNavigationTreeViewItem,
-    // @ts-expect-error
     HvVerticalNavigationSlider,
   },
   decorators: [


### PR DESCRIPTION
The Sql suggestions were not taking into account that the tables and columns names can be enclosed in delimiters when they contain special characters. The possible delimiters are double quotes, backticks and square brackets depending on the database.