### PR TITLE
feat(Badge): support children prop

### DIFF
--- a/apps/docs/src/pages/components/badge.mdx
+++ b/apps/docs/src/pages/components/badge.mdx
@@ -57,16 +57,28 @@ Use the `maxCount` prop to specify the maximum value to be displayed. Above that
 
 ### Text
 
-To display text with the badge you can use the `text` prop along with the `textVariant` prop to specify the typography variant to use.
+To display a badge on any content, wrap the `children` content with the badge component.
 
 ```tsx live
 <>
-  <HvBadge count={0} text="Events" textVariant="label" />
-  <HvBadge count={1} text="Events" textVariant="label" />
-  <HvBadge showCount count={8} text="Events" textVariant="title4" />
-  <HvBadge showCount count={88} text="Events" textVariant="title4" />
-  <HvBadge showCount count={888} text="Events" textVariant="title3" />
-  <HvBadge label="100%" text="Events" textVariant="title2" />
+  <HvBadge label={0}>
+    <HvTypography variant="label">Events</HvTypography>
+  </HvBadge>
+  <HvBadge label={1}>
+    <HvTypography variant="label">Events</HvTypography>
+  </HvBadge>
+  <HvBadge showCount label={8}>
+    <HvTypography variant="title4">Events</HvTypography>
+  </HvBadge>
+  <HvBadge showCount label={88}>
+    <HvTypography variant="title4">Events</HvTypography>
+  </HvBadge>
+  <HvBadge showCount label={888}>
+    <HvTypography variant="title3">Events</HvTypography>
+  </HvBadge>
+  <HvBadge label="100%">
+    <HvTypography variant="title2">Events</HvTypography>
+  </HvBadge>
 </>
 ```
 
@@ -84,7 +96,7 @@ export default function Demo() {
   return (
     <>
       <HvButton onClick={addCount}>Double Value</HvButton>
-      <HvBadge showCount count={count} text="Events" textVariant="title4" />
+      <HvBadge showCount count={count} icon={<Alert />} />
     </>
   );
 }
@@ -92,14 +104,13 @@ export default function Demo() {
 
 ### Accessibility
 
-If you want to specify a custom aria-label, use the `role` prop.
+If you want to specify a custom aria-label, ensure the badge has a `role`.
 
 ```tsx live
 <HvBadge
   showCount
   count={25}
-  text="Events"
-  textVariant="title4"
+  icon={<Alert />}
   role="status"
   aria-label="25 unread notifications"
 />

--- a/packages/core/src/Badge/Badge.stories.tsx
+++ b/packages/core/src/Badge/Badge.stories.tsx
@@ -5,6 +5,7 @@ import {
   HvBadge,
   HvBadgeProps,
   HvButton,
+  HvTypography,
 } from "@hitachivantara/uikit-react-core";
 import { Alert } from "@hitachivantara/uikit-react-icons";
 
@@ -77,12 +78,24 @@ export const WithText: StoryObj<HvBadgeProps> = {
   render: () => {
     return (
       <>
-        <HvBadge label={0} text="Events" textVariant="label" />
-        <HvBadge label={1} text="Events" textVariant="label" />
-        <HvBadge showCount label={8} text="Events" textVariant="title4" />
-        <HvBadge showCount label={88} text="Events" textVariant="title4" />
-        <HvBadge showCount label={888} text="Events" textVariant="title3" />
-        <HvBadge label="100%" text="Events" textVariant="title2" />
+        <HvBadge label={0}>
+          <HvTypography variant="label">Events</HvTypography>
+        </HvBadge>
+        <HvBadge label={1}>
+          <HvTypography variant="label">Events</HvTypography>
+        </HvBadge>
+        <HvBadge showCount label={8}>
+          <HvTypography variant="title4">Events</HvTypography>
+        </HvBadge>
+        <HvBadge showCount label={88}>
+          <HvTypography variant="title4">Events</HvTypography>
+        </HvBadge>
+        <HvBadge showCount label={888}>
+          <HvTypography variant="title3">Events</HvTypography>
+        </HvBadge>
+        <HvBadge label="100%">
+          <HvTypography variant="title2">Events</HvTypography>
+        </HvBadge>
       </>
     );
   },
@@ -103,7 +116,7 @@ export const WithState: StoryObj<HvBadgeProps> = {
     return (
       <>
         <HvButton onClick={addCount}>Double Value</HvButton>
-        <HvBadge showCount label={count} text="Events" textVariant="title4" />
+        <HvBadge showCount label={count} icon={<Alert />} />
       </>
     );
   },
@@ -121,8 +134,7 @@ export const Accessibility: StoryObj<HvBadgeProps> = {
     <HvBadge
       showCount
       label={25}
-      text="Events"
-      textVariant="title4"
+      icon={<Alert />}
       role="status"
       aria-label="25 unread notifications"
     />
@@ -142,7 +154,9 @@ export const Test: StoryObj = {
       <HvBadge count={0} text="Events" textVariant="label" />
       <HvBadge label={10} text="Events" />
       <HvBadge showCount label={10} maxCount={5} text="Events" />
-      <HvBadge showCount label={8} text="Events" textVariant="title4" />
+      <HvBadge showCount label={8}>
+        <HvTypography variant="title4">Events</HvTypography>
+      </HvBadge>
     </div>
   ),
 };

--- a/packages/core/src/Badge/Badge.tsx
+++ b/packages/core/src/Badge/Badge.tsx
@@ -36,9 +36,9 @@ export interface HvBadgeProps extends HvBaseProps {
   label?: React.ReactNode;
   /** Icon which the notification will be attached. */
   icon?: React.ReactNode;
-  /** Text which the notification will be attached. */
+  /** Text which the notification will be attached. @deprecated use `children` instead. */
   text?: string;
-  /** Text variant. */
+  /** Text variant. @deprecated use a `HvTypography` on `children` instead. */
   textVariant?: HvTypographyVariants;
   /** A Jss Object used to override or extend the styles applied to the component. */
   classes?: HvBadgeClasses;
@@ -62,6 +62,7 @@ export const HvBadge = forwardRef<
     icon,
     text,
     textVariant,
+    children: childrenProp,
     ...others
   } = useDefaultProps("HvBadge", props);
 
@@ -77,7 +78,9 @@ export const HvBadge = forwardRef<
   const renderedCountOrLabel =
     label && typeof label !== "number" ? label : renderedCount;
   const children =
-    icon || (text && <HvTypography variant={textVariant}>{text}</HvTypography>);
+    childrenProp ||
+    icon ||
+    (text && <HvTypography variant={textVariant}>{text}</HvTypography>);
 
   return (
     <div ref={ref} className={cx(classes.root, className)} {...others}>


### PR DESCRIPTION
- add support `children` prop (already in typings)
- deprecate `text`/`textVariant` props