### PR TITLE
feat(Dialog): add `fullHeight` & fix styles on large heights

### DIFF
--- a/apps/docs/src/pages/components/dialog.mdx
+++ b/apps/docs/src/pages/components/dialog.mdx
@@ -316,6 +316,7 @@ export default function Demo() {
       <pre>{JSON.stringify(postData, null, 2)}</pre>
       <HvDialog
         disableBackdropClick
+        fullHeight
         open={open}
         onClose={() => setOpen(false)}
         aria-describedby={descId}

--- a/packages/core/src/Dialog/Actions/Actions.styles.tsx
+++ b/packages/core/src/Dialog/Actions/Actions.styles.tsx
@@ -3,12 +3,12 @@ import { theme } from "@hitachivantara/uikit-styles";
 
 export const { staticClasses, useClasses } = createClasses("HvDialog-Action", {
   root: {
-    margin: "0",
+    margin: 0,
     padding: theme.space.sm,
+    backgroundColor: "inherit",
     borderTop: `3px solid ${theme.colors.atmo2}`,
     height: 65,
     maxHeight: 65,
-    flex: 1,
   },
   fullscreen: { position: "fixed", width: "100%", bottom: 0, left: 0 },
   spacing: {

--- a/packages/core/src/Dialog/Actions/Actions.tsx
+++ b/packages/core/src/Dialog/Actions/Actions.tsx
@@ -30,7 +30,7 @@ export const HvDialogActions = (props: HvDialogActionsProps) => {
     ...others
   } = useDefaultProps("HvDialogActions", props);
   const context = useDialogContext();
-  const fullscreen = fullScreenProp ?? context.fullscreen;
+  const fullScreen = fullScreenProp ?? context.fullScreen;
 
   const { classes, cx } = useClasses(classesProp);
 
@@ -38,7 +38,7 @@ export const HvDialogActions = (props: HvDialogActionsProps) => {
     <MuiDialogActions
       className={className}
       classes={{
-        root: cx(classes.root, { [classes.fullscreen]: fullscreen }),
+        root: cx(classes.root, { [classes.fullscreen]: fullScreen }),
         spacing: classes.spacing,
       }}
       {...others}

--- a/packages/core/src/Dialog/Content/Content.styles.tsx
+++ b/packages/core/src/Dialog/Content/Content.styles.tsx
@@ -3,13 +3,11 @@ import { theme } from "@hitachivantara/uikit-styles";
 
 export const { staticClasses, useClasses } = createClasses("HvDialog-Content", {
   root: {
-    padding: `0 ${theme.space.sm} ${theme.space.sm} ${theme.space.sm}`,
-    flex: "none",
+    padding: theme.spacing(0, "sm", "sm"),
   },
   textContent: {
     marginLeft: "42px",
     paddingRight: "62px",
-    flex: 1,
     overflowY: "auto",
   },
 });

--- a/packages/core/src/Dialog/Dialog.stories.tsx
+++ b/packages/core/src/Dialog/Dialog.stories.tsx
@@ -48,14 +48,6 @@ export const Main: StoryObj<HvDialogProps> = {
     docs: {
       source: { code: MainStoryRaw },
     },
-    ...setupChromatic(["DS3 dawn", "DS5 dawn", "Pentaho+ dawn"]),
-  },
-  // For visual testing and a11y
-  play: async ({ canvasElement }) => {
-    const canvas = within(canvasElement);
-    const button = canvas.getByRole("button", { name: /open dialog/i });
-    await userEvent.click(button);
-    await expect(canvas.getByRole("dialog")).toBeInTheDocument();
   },
   render: (args) => <MainStory {...args} />,
 };
@@ -105,6 +97,18 @@ export const Form: StoryObj<HvDialogProps> = {
           Accessibility-wise, `HvDialogTitle` automatically labels the dialog. A `aria-describedby` can be used to describe the content.",
       },
     },
+    chromatic: {
+      modes: {
+        md: { viewport: 1200 },
+      },
+    },
+  },
+  // For visual testing and a11y
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const button = canvas.getByRole("button", { name: /create a post/i });
+    await userEvent.click(button);
+    await expect(canvas.getByRole("dialog")).toBeInTheDocument();
   },
   decorators: [(Story) => <div style={{ minHeight: 440 }}>{Story()}</div>],
   render: () => <FormStory />,

--- a/packages/core/src/Dialog/Dialog.styles.tsx
+++ b/packages/core/src/Dialog/Dialog.styles.tsx
@@ -7,10 +7,14 @@ export const { staticClasses, useClasses } = createClasses("HvDialog", {
   paper: {
     color: theme.colors.secondary,
     backgroundColor: theme.colors.atmo1,
-    boxShadow: ["none", theme.colors.shadow],
+    boxShadow: theme.colors.shadow,
+    borderColor: theme.colors.atmo4,
     borderRadius: theme.radii.round,
   },
   fullscreen: {},
+  fullHeight: {
+    height: "100%",
+  },
   closeButton: {
     padding: 0,
     minWidth: "auto",
@@ -24,15 +28,14 @@ export const { staticClasses, useClasses } = createClasses("HvDialog", {
     borderTopLeftRadius: 0,
     borderTopRightRadius: 0,
     borderTopWidth: 4,
-    borderTopStyle: "solid",
   },
   success: {
-    borderTopColor: theme.colors.positive,
+    borderColor: theme.colors.positive,
   },
   error: {
-    borderTopColor: theme.colors.negative,
+    borderColor: theme.colors.negative,
   },
   warning: {
-    borderTopColor: theme.colors.warning,
+    borderColor: theme.colors.warning,
   },
 });

--- a/packages/core/src/Dialog/Dialog.tsx
+++ b/packages/core/src/Dialog/Dialog.tsx
@@ -30,6 +30,8 @@ export interface HvDialogProps
   maxWidth?: MuiDialogProps["maxWidth"];
   /** @inheritdoc */
   fullWidth?: MuiDialogProps["fullWidth"];
+  /** If true, the dialog stretches vertically, limited by the margins. @default false */
+  fullHeight?: boolean;
   /**
    * Element id that should be focus when the Dialog opens.
    * Auto-focusing elements can cause usability issues, so this should be avoided.
@@ -63,12 +65,13 @@ export const HvDialog = (props: HvDialogProps) => {
     onClose,
     firstFocusable,
     buttonTitle = "Close",
-    fullscreen = false,
+    fullHeight,
+    fullscreen: fullScreen = false, // TODO: rename to `fullScreen` in v6
     disableBackdropClick = false,
     ...others
   } = useDefaultProps("HvDialog", props);
 
-  const { classes, css, cx } = useClasses(classesProp);
+  const { classes, cx } = useClasses(classesProp);
   const { rootId } = useTheme();
 
   const measuredRef = useCallback(() => {
@@ -78,17 +81,24 @@ export const HvDialog = (props: HvDialogProps) => {
     element?.focus();
   }, [firstFocusable]);
 
-  const contextValue = useMemo(() => ({ fullscreen }), [fullscreen]);
+  const contextValue = useMemo(() => ({ fullScreen }), [fullScreen]);
 
   return (
     <MuiDialog
       container={getElementById(rootId)}
-      className={cx(classes.root, className)}
-      classes={{ container: css({ position: "relative" }) }}
+      className={className}
+      classes={{
+        root: classes.root,
+        paper: cx(classes.paper, classes[variant!], {
+          [classes.fullHeight]: fullHeight,
+          [classes.statusBar]: !!variant,
+          [classes.fullscreen]: fullScreen,
+        }),
+      }}
       id={id}
       ref={measuredRef}
       open={open}
-      fullScreen={fullscreen}
+      fullScreen={fullScreen}
       onClose={(event, reason) => {
         // `disableBackdropClick` property was removed in MUI5
         // and we want to maintain that functionality
@@ -103,27 +113,13 @@ export const HvDialog = (props: HvDialogProps) => {
           },
         },
       }}
-      PaperProps={{
-        classes: {
-          root: cx(
-            css({ position: "absolute" }),
-            classes.paper,
-            variant && cx(classes.statusBar, classes[variant]),
-            {
-              [classes.fullscreen]: fullscreen,
-            },
-          ),
-        },
-      }}
       {...others}
     >
-      <HvIconButton
+      <HvIconButton<"button">
         title={buttonTitle}
         id={setId(id, "close")}
         className={classes.closeButton}
-        onClick={(event: React.MouseEvent<HTMLButtonElement>) =>
-          onClose?.(event, undefined)
-        }
+        onClick={(event) => onClose?.(event, undefined)}
       >
         <Close />
       </HvIconButton>

--- a/packages/core/src/Dialog/Title/Title.styles.tsx
+++ b/packages/core/src/Dialog/Title/Title.styles.tsx
@@ -3,21 +3,18 @@ import { theme } from "@hitachivantara/uikit-styles";
 
 export const { staticClasses, useClasses } = createClasses("HvDialog-Title", {
   root: {
-    fontFamily: theme.fontFamily.body, // override MUI font
     padding: theme.space.sm,
-    margin: 0,
-  },
-  fullscreen: {},
-  messageContainer: {
+    paddingRight: 32 + 16, // close icon padding
+    backgroundColor: "inherit",
     display: "flex",
     alignItems: "center",
+    gap: theme.space.xs,
   },
-  textWithIcon: {
-    marginLeft: theme.space.xs,
-    // 32px is the icon width
-    marginRight: `calc(32px + ${theme.space.xs})`,
-  },
-  titleText: {
-    ...theme.typography.title4,
-  },
+  fullscreen: {},
+  /** @deprecated use `classes.root` instead  */
+  messageContainer: {},
+  // TODO: consider deprecating
+  textWithIcon: {},
+  /** @deprecated use `classes.root` instead */
+  titleText: {},
 });

--- a/packages/core/src/Dialog/Title/Title.tsx
+++ b/packages/core/src/Dialog/Title/Title.tsx
@@ -6,6 +6,7 @@ import {
   type ExtractNames,
 } from "@hitachivantara/uikit-react-utils";
 
+import { HvTypography } from "../../Typography";
 import { iconVariant } from "../../utils/iconVariant";
 import { useDialogContext } from "../context";
 import { staticClasses, useClasses } from "./Title.styles";
@@ -40,40 +41,33 @@ export const HvDialogTitle = (props: HvDialogTitleProps) => {
     children,
     variant = "default",
     showIcon = true,
-    customIcon = null,
+    customIcon,
     ...others
   } = useDefaultProps("HvDialogTitle", props);
 
-  const { classes, css, cx } = useClasses(classesProp);
-  const { fullscreen } = useDialogContext();
-
-  const isString = typeof children === "string";
+  const { classes, cx } = useClasses(classesProp);
+  const { fullScreen } = useDialogContext();
 
   const icon = customIcon || (showIcon && iconVariant(variant));
 
   return (
-    <MuiDialogTitle
+    <HvTypography
+      component={MuiDialogTitle}
+      variant="title4"
       className={cx(
-        !fullscreen && css({ flex: 1 }),
         classes.root,
+        classes.messageContainer,
         {
-          [classes.fullscreen]: fullscreen,
+          [classes.fullscreen]: fullScreen,
+          [classes.textWithIcon]: icon,
+          [classes.titleText]: typeof children === "string",
         },
         className,
       )}
       {...others}
     >
-      <div className={classes.messageContainer}>
-        {icon}
-        <div
-          className={cx({
-            [classes.textWithIcon]: !!icon,
-            [classes.titleText]: isString,
-          })}
-        >
-          {children}
-        </div>
-      </div>
-    </MuiDialogTitle>
+      {icon}
+      {children}
+    </HvTypography>
   );
 };

--- a/packages/core/src/Dialog/context.ts
+++ b/packages/core/src/Dialog/context.ts
@@ -1,5 +1,5 @@
 import { createContext, useContext } from "react";
 
-export const DialogContext = createContext({ fullscreen: false });
+export const DialogContext = createContext({ fullScreen: false });
 
 export const useDialogContext = () => useContext(DialogContext);

--- a/packages/core/src/Dialog/stories/FormStory.tsx
+++ b/packages/core/src/Dialog/stories/FormStory.tsx
@@ -39,11 +39,14 @@ export const FormStory = () => {
       <pre>{JSON.stringify(postData, null, 2)}</pre>
       <HvDialog
         disableBackdropClick
+        fullHeight
         open={open}
         onClose={() => setOpen(false)}
         aria-describedby={descId}
       >
-        <HvDialogTitle>Create a new post</HvDialogTitle>
+        <HvDialogTitle>
+          <span>Create a new post</span>
+        </HvDialogTitle>
         <HvDialogContent>
           <div id={descId} style={{ marginBottom: 10 }}>
             Fill the following form to create a post.

--- a/packages/core/src/Section/Section.stories.tsx
+++ b/packages/core/src/Section/Section.stories.tsx
@@ -22,6 +22,7 @@ export default meta;
 export const Main: StoryObj<HvSectionProps> = {
   args: {
     title: "Section Title",
+    raisedHeader: false,
     expandable: false,
     defaultExpanded: true,
   },

--- a/packages/core/src/Section/Section.styles.tsx
+++ b/packages/core/src/Section/Section.styles.tsx
@@ -14,6 +14,7 @@ export const { staticClasses, useClasses } = createClasses("HvSection", {
   header: {
     display: "flex",
     alignItems: "center",
+    borderColor: "inherit",
     position: "relative",
     minHeight: theme.sizes.sm,
     padding: theme.space.sm,
@@ -36,6 +37,7 @@ export const { staticClasses, useClasses } = createClasses("HvSection", {
   raisedHeader: {
     "& $header": {
       zIndex: 1,
+      borderBottomWidth: 1,
       boxShadow: theme.colors.shadow,
     },
     "& $content": {

--- a/packages/core/src/Section/Section.tsx
+++ b/packages/core/src/Section/Section.tsx
@@ -1,5 +1,5 @@
 import { forwardRef } from "react";
-import { Down } from "@hitachivantara/uikit-react-icons";
+import { DropDownXS } from "@hitachivantara/uikit-react-icons";
 import {
   useDefaultProps,
   type ExtractNames,
@@ -94,7 +94,7 @@ export const HvSection = forwardRef<HTMLDivElement, HvSectionProps>(
                 {...buttonProps}
                 {...expandButtonProps}
               >
-                <Down rotate={isOpen} />
+                <DropDownXS rotate={isOpen} />
               </HvButton>
             )}
             {title}

--- a/packages/core/src/TableSection/TableSection.styles.tsx
+++ b/packages/core/src/TableSection/TableSection.styles.tsx
@@ -13,7 +13,6 @@ export const { staticClasses, useClasses } = createClasses("HvTableSection", {
   header: {
     // Only apply the border to divide the header and content when both are displayed
     "+ div": {
-      borderTop: `1px solid ${theme.colors.atmo3}`,
       borderTopLeftRadius: 0,
       borderTopRightRadius: 0,
     },

--- a/packages/lab/src/Flow/Node/Node.tsx
+++ b/packages/lab/src/Flow/Node/Node.tsx
@@ -11,7 +11,7 @@ import {
   theme,
   useLabels,
 } from "@hitachivantara/uikit-react-core";
-import { Down, Info, Up } from "@hitachivantara/uikit-react-icons";
+import { DropDownXS, Info } from "@hitachivantara/uikit-react-icons";
 
 import { useFlowContext, useFlowNode, useFlowNodeUtils } from "../hooks";
 import { HvFlowNodeParam } from "../types";
@@ -137,11 +137,7 @@ export const HvFlowNode = ({
               }
               {...expandParamsButtonProps}
             >
-              {showParams ? (
-                <Up color="base_dark" />
-              ) : (
-                <Down color="base_dark" />
-              )}
+              <DropDownXS rotate={showParams} color="base_dark" />
             </HvButton>
           )}
         </>

--- a/packages/lab/src/Flow/Sidebar/SidebarGroup/SidebarGroup.tsx
+++ b/packages/lab/src/Flow/Sidebar/SidebarGroup/SidebarGroup.tsx
@@ -5,7 +5,7 @@ import {
   HvButtonProps,
   HvTypography,
 } from "@hitachivantara/uikit-react-core";
-import { Down, Up } from "@hitachivantara/uikit-react-icons";
+import { DropDownXS } from "@hitachivantara/uikit-react-icons";
 import { getColor } from "@hitachivantara/uikit-styles";
 
 import { useFlowContext } from "../../hooks";
@@ -76,7 +76,7 @@ export const HvFlowSidebarGroup = ({
           aria-expanded={opened}
           {...expandButtonProps}
         >
-          {opened ? <Up /> : <Down />}
+          <DropDownXS rotate={opened} />
         </HvButton>
       </div>
       {description && (

--- a/packages/lab/src/Wizard/WizardContainer/WizardContainer.styles.tsx
+++ b/packages/lab/src/Wizard/WizardContainer/WizardContainer.styles.tsx
@@ -4,11 +4,7 @@ export const { staticClasses, useClasses } = createClasses(
   "HvWizardContainer",
   {
     root: {},
-    paper: {
-      width: "80%",
-      maxWidth: "80%",
-      maxHeight: "calc(100% - (2 * 80px))",
-    },
+    paper: {},
     closeButton: {
       display: "none",
     },

--- a/packages/lab/src/Wizard/WizardContainer/WizardContainer.tsx
+++ b/packages/lab/src/Wizard/WizardContainer/WizardContainer.tsx
@@ -40,6 +40,7 @@ export const HvWizardContainer = (props: HvWizardContainerProps) => {
         paper: classes.paper,
       }}
       onClose={handleClose}
+      fullWidth
       maxWidth="lg"
       {...others}
     >

--- a/packages/lab/src/Wizard/WizardTitle/WizardTitle.styles.tsx
+++ b/packages/lab/src/Wizard/WizardTitle/WizardTitle.styles.tsx
@@ -2,32 +2,25 @@ import { createClasses } from "@hitachivantara/uikit-react-core";
 import { theme } from "@hitachivantara/uikit-styles";
 
 export const { staticClasses, useClasses } = createClasses("HvWizardTitle", {
-  messageContainer: {
-    "& > div": {
-      width: "100%",
-    },
-  },
-  titleContainer: {
-    display: "flex",
-    alignItems: "center",
+  root: {
+    backgroundColor: theme.colors.atmo2,
     justifyContent: "space-between",
-    gap: theme.spacing(1),
-    width: "100%",
+    paddingRight: theme.space.sm,
   },
-  buttonWidth: {
+  /** @deprecated use `classes.root` */
+  headerContainer: {},
+  /** @deprecated use `classes.root` */
+  messageContainer: {},
+  /** @deprecated use `classes.root` */
+  titleContainer: {},
+  summaryButton: {
     width: 120,
-  },
-  rootSummaryButton: {
     paddingRight: 18,
   },
-  headerContainer: {
-    backgroundColor: theme.colors.atmo2,
-    "& h6": {
-      fontSize: "16px",
-      fontWeight: "bold",
-      letterSpacing: 0,
-    },
-  },
+  /** @deprecated use `classes.summaryButton` */
+  buttonWidth: {},
+  /** @deprecated use `classes.summaryButton` */
+  rootSummaryButton: {},
   stepContainer: {
     margin: "auto",
   },

--- a/packages/lab/src/Wizard/WizardTitle/WizardTitle.tsx
+++ b/packages/lab/src/Wizard/WizardTitle/WizardTitle.tsx
@@ -56,7 +56,7 @@ export const HvWizardTitle = ({
 }: HvWizardTitleProps) => {
   const { context, setSummary, tab, setTab } = useContext(HvWizardContext);
 
-  const { classes } = useClasses(classesProp);
+  const { classes, cx } = useClasses(classesProp);
 
   const [steps, setSteps] = useState<HvStepProps[]>([]);
 
@@ -88,47 +88,48 @@ export const HvWizardTitle = ({
 
   return (
     <HvDialogTitle
-      className={classes.headerContainer}
-      classes={{
-        messageContainer: classes.messageContainer,
-      }}
+      className={cx(
+        classes.root,
+        classes.headerContainer,
+        classes.messageContainer,
+        classes.titleContainer,
+      )}
     >
-      <div className={classes.titleContainer}>
-        {title && (
-          <HvTypography variant="title3" component="h3">
-            {title}
-          </HvTypography>
-        )}
-        {!!steps.length && (
-          <HvStepNavigation
-            className={classes.stepContainer}
-            steps={steps}
-            type="Default"
-            stepSize="xs"
-            width={{
-              xs: 200,
-              sm: 350,
-              md: 600,
-              lg: 800,
-              xl: 1000,
-            }}
-            {...customStep}
-          />
-        )}
-        {hasSummary && (
-          <HvButton
-            variant="secondarySubtle"
-            className={classes.buttonWidth}
-            classes={{
-              root: classes.rootSummaryButton,
-            }}
-            onClick={toggleSummary}
-            startIcon={<Report />}
-          >
-            {`${labels.summary ?? "Summary"}`}
-          </HvButton>
-        )}
-      </div>
+      {title && (
+        <HvTypography variant="title3" component="div">
+          {title}
+        </HvTypography>
+      )}
+      {!!steps.length && (
+        <HvStepNavigation
+          className={classes.stepContainer}
+          steps={steps}
+          type="Default"
+          stepSize="xs"
+          width={{
+            xs: 200,
+            sm: 350,
+            md: 600,
+            lg: 800,
+            xl: 1000,
+          }}
+          {...customStep}
+        />
+      )}
+      {hasSummary && (
+        <HvButton
+          variant="secondarySubtle"
+          className={cx(
+            classes.summaryButton,
+            classes.buttonWidth,
+            classes.rootSummaryButton,
+          )}
+          onClick={toggleSummary}
+          startIcon={<Report />}
+        >
+          {`${labels.summary ?? "Summary"}`}
+        </HvButton>
+      )}
     </HvDialogTitle>
   );
 };


### PR DESCRIPTION
- add `fullHeight` prop to make it easier to build full-height Dialogs
  - very useful to prevent layout shifts in "complex" dialogs
  - currently user has to do `classes={{paper: "w-full"}}`, which is a bit obscure
- fix styles when `HvDialog` is larger/100%
  - Title/Actions is flexing, instead of content
- fix Title styles when custom `children` content
- make `HvDialogActions` using `HvDialog`'s `backgroundColor`
- apply new props/fixes to the `Form` example & use it in Chromatic
- align chevron icon usage (`Down` -> `DropDownXS`)
- fix section border