### PR TITLE
docs: review components' JSDoc

### DIFF
--- a/apps/docs/src/pages/components/radio-group.mdx
+++ b/apps/docs/src/pages/components/radio-group.mdx
@@ -121,6 +121,7 @@ export default function Demo() {
 ### Related components
 
 - [`HvFormElement`](/components/form-element)
+- [`HvSelectionList`](/components/selection-list)
 - [`HvRadio`](/components/radio)
 
 </Page>

--- a/apps/docs/src/pages/components/select.mdx
+++ b/apps/docs/src/pages/components/select.mdx
@@ -118,7 +118,6 @@ The value and open states of `HvSelect` can be controlled by using the `value`/`
 
 ```tsx live
 import { useState } from "react";
-import { HvButton, HvOption, HvSelect } from "@hitachivantara/uikit-react-core";
 
 export default function Demo() {
   const [selection, setSelection] = useState<string[]>([]);

--- a/apps/docs/src/pages/components/snackbar-provider.mdx
+++ b/apps/docs/src/pages/components/snackbar-provider.mdx
@@ -1,3 +1,4 @@
+import { Callout } from "nextra/components";
 import { snackbarProviderClasses } from "@hitachivantara/uikit-react-core";
 
 import Playground from "@docs/components/code/Playground";
@@ -18,28 +19,22 @@ export const getStaticProps = async ({ params }) => {
 
 <Page>
 
-The UI Kit library provides a snackbar provider to control the stacking of multiple snackbars in the app.
-
-The provider is not meant to be 100% feature complete, but instead, ease the majority of use-cases we have been encountering. If you need any customization or extension to the behavior, please feel free to copy and customize it.
-
-This feature needs both the HvSnackbarProvider provider and the hook useHvSnackbar. The provider and the hook are wrappers of the [Notistack](https://github.com/iamhosseindhv/notistack) API.
-
-Ideally the `HvSnackbarProvider` should be at the top of the component tree of your application. This will allow the snackbar to be triggered in any page. For more information of the provider API check the [notistack documentation](https://iamhosseindhv.com/notistack/api).
+<Callout type="info">
+  The provider is not meant to be 100% feature complete, but instead, ease the
+  majority of use-cases we have been encountering. If you need any customization
+  or extension to the behavior, please feel free to copy and customize it.
+</Callout>
 
 ```tsx
-import { HvSnackbarProvider } from "@hitachivantara/uikit-react-core";
+import {
+  HvSnackbarProvider,
+  useHvSnackbar,
+} from "@hitachivantara/uikit-react-core";
 ```
 
 After adding the provider at the root of your app, you can call the `useHvSnackbar` at any component inside your app. This hook will allow you to request the rendering of a snackbar through the use of the `enqueueSnackbar` function or close one with `closeSnackbar`.
 
 ```tsx live
-import {
-  HvButton,
-  HvOverflowTooltip,
-  HvSnackbarProvider,
-  useHvSnackbar,
-} from "@hitachivantara/uikit-react-core";
-
 export default function Demo() {
   return (
     <HvSnackbarProvider autoHideDuration={3000}>
@@ -96,13 +91,6 @@ Internally, the `HvSnackbarProvider` uses the `HvSnackbarContent` to render the 
 Check the [`HvSnackbar`](/components/snackbar) documentation for more information.
 
 ```tsx live
-import {
-  HvButton,
-  HvOverflowTooltip,
-  HvSnackbarProvider,
-  useHvSnackbar,
-} from "@hitachivantara/uikit-react-core";
-
 export default function Demo() {
   return (
     <HvSnackbarProvider autoHideDuration={3000}>
@@ -145,13 +133,6 @@ Note, though, that you shouldn't have long messages displayed in a snackbar as i
 be dismissed automically after a some time.
 
 ```tsx live
-import {
-  HvButton,
-  HvOverflowTooltip,
-  HvSnackbarProvider,
-  useHvSnackbar,
-} from "@hitachivantara/uikit-react-core";
-
 export default function Demo() {
   return (
     <HvSnackbarProvider autoHideDuration={3000}>

--- a/packages/core/src/CheckBox/CheckBox.tsx
+++ b/packages/core/src/CheckBox/CheckBox.tsx
@@ -59,7 +59,7 @@ export interface HvCheckBoxProps extends Omit<HvBaseCheckBoxProps, "classes"> {
  * A Checkbox is a mechanism that allows the user to select one or more options.
  *
  * Usually used in a Checkbox Group to present the user with a range of options from
- * which the user <b>may select any number of options</b> to complete their task.
+ * which the user **may select any number of options** to complete their task.
  *
  * It can also be used individually to represent the toggle of a single option, when
  * the Toggle Switch and Toggle Button aren't more appropriate.

--- a/packages/core/src/Dialog/Dialog.tsx
+++ b/packages/core/src/Dialog/Dialog.tsx
@@ -54,6 +54,9 @@ export interface HvDialogProps
   component?: MuiDialogProps["component"];
 }
 
+/**
+ * A Dialog is a graphical control element in the form of a small panel that communicates information and prompts for a response.
+ */
 export const HvDialog = (props: HvDialogProps) => {
   const {
     variant,

--- a/packages/core/src/Radio/Radio.tsx
+++ b/packages/core/src/Radio/Radio.tsx
@@ -126,7 +126,7 @@ export interface HvRadioProps
  * A Radio Button is a mechanism that allows user to select just an option from a group of options.
  *
  * It should used in a Radio Button Group to present the user with a range of options from
- * which the user <b>may select just one option</b> to complete their task.
+ * which the user **may select just one option** to complete their task.
  *
  * Individual use of radio buttons, at least uncontrolled, is unadvised as React state management doesn't
  * respond to the browser's native management of radio inputs checked state.

--- a/packages/core/src/RadioGroup/RadioGroup.tsx
+++ b/packages/core/src/RadioGroup/RadioGroup.tsx
@@ -120,8 +120,6 @@ const getValueFromSelectedChildren = (children: React.ReactNode) => {
 };
 
 /**
- * A group of radio buttons.
- *
  * A radio group is a type of selection list that can only have a single entry checked at any one time.
  */
 export const HvRadioGroup = forwardRef<HTMLDivElement, HvRadioGroupProps>(

--- a/packages/core/src/Snackbar/Snackbar.tsx
+++ b/packages/core/src/Snackbar/Snackbar.tsx
@@ -78,9 +78,9 @@ export interface HvSnackbarProps
  * A Snackbar provides brief messages about app processes.
  * It is dismissed automatically after a given interval.
  *
- * Snackbar can be built with two different components.
- * One is the HvSnackbar, which wraps all the positioning, transition, auto hide, etc.
- * The other is the HvSnackbarContent, which allows a finer control and customization of the content of the Snackbar.
+ * Snackbar can be built with two different components:
+ * - `HvSnackbar`, which wraps all the positioning, transition, auto hide, etc.
+ * - `HvSnackbarContent`, which allows a finer control and customization of the content of the Snackbar.
  */
 export const HvSnackbar = forwardRef<
   React.ComponentRef<typeof MuiSnackbar>,

--- a/packages/core/src/SnackbarProvider/SnackbarProvider.tsx
+++ b/packages/core/src/SnackbarProvider/SnackbarProvider.tsx
@@ -114,6 +114,12 @@ export const useHvSnackbar = () => {
   );
 };
 
+/**
+ * A snackbar provider to control the stacking of multiple snackbars in the app.
+ *
+ * This component uses of the [Notistack](https://github.com/iamhosseindhv/notistack) library.
+ * Please refer to its [API Reference](https://notistack.com/v2.x/api-reference) for more complex usage scenarios.
+ */
 export const HvSnackbarProvider = ({
   children,
   notistackClassesOverride,

--- a/packages/core/src/Switch/Switch.tsx
+++ b/packages/core/src/Switch/Switch.tsx
@@ -121,10 +121,9 @@ const isSemantical = (color: HvColorAny) =>
   ["positive", "negative", "warning"].includes(color);
 
 /**
- * A Switch is <b>binary</b> and work as a digital on/off button.
+ * A Switch is **binary** and works as a digital on/off button.
  *
- * Use when two states are <b>opposite</b> and to trigger immediate
- * changes in the system.
+ * Use when two states are **opposite** and to trigger immediate changes in the system.
  */
 export const HvSwitch = forwardRef<HTMLButtonElement, HvSwitchProps>(
   function HvSwitch(props, ref) {

--- a/packages/core/src/Tag/Tag.tsx
+++ b/packages/core/src/Tag/Tag.tsx
@@ -65,7 +65,7 @@ export interface HvTagProps
  * Use tags to highlight an item's status for quick recognition and navigation
  * Use color to indicate meanings that users can learn and recognize across products
  *
- * It leverages the Chip component from Material UI
+ * It leverages the [MUI Chip](https://mui.com/material-ui/react-chip/) component
  */
 export const HvTag = forwardRef<
   // no-indent

--- a/packages/core/src/ToggleButton/ToggleButton.tsx
+++ b/packages/core/src/ToggleButton/ToggleButton.tsx
@@ -24,6 +24,9 @@ export interface HvToggleButtonProps
   ) => void;
 }
 
+/**
+ * Use when two instances are opposite and the on/off analogy doesn’t apply. Only well-known icons should be used, otherwise, use a single checkbox for the same situation.
+ */
 export const HvToggleButton = forwardRef<
   HTMLButtonElement,
   HvToggleButtonProps

--- a/packages/core/src/TreeView/TreeView.tsx
+++ b/packages/core/src/TreeView/TreeView.tsx
@@ -34,7 +34,7 @@ export interface HvTreeViewProps<Multiple extends boolean | undefined>
  * Tree structures are built through composing the `HvTreeItem` component,
  * or a custom variation of it.
  *
- * It is based on MUI's [TreeView](https://mui.com/x/react-tree-view) component.
+ * It is based on the [MUI X TreeView](https://mui.com/x/react-tree-view) component.
  *
  * @example
  * ```tsx

--- a/packages/lab/src/StepNavigation/StepNavigation.tsx
+++ b/packages/lab/src/StepNavigation/StepNavigation.tsx
@@ -27,7 +27,7 @@ export { staticClasses as stepNavigationClasses };
 export type HvStepNavigationClasses = ExtractNames<typeof useClasses>;
 
 export interface HvStepNavigationProps extends HvBaseProps {
-  /** Type of step navigation. Values = {"Simple", "Default"} */
+  /** Type of step navigation. */
   type?: "Simple" | "Default";
   /** Steps to show on the component. */
   steps: Array<
@@ -41,9 +41,12 @@ export interface HvStepNavigationProps extends HvBaseProps {
       titleClassName?: string;
     }
   >;
-  /** Sets one of the standard sizes of the steps. */
+  /** Sets one of the standard sizes of the steps. @default useWidth()  */
   stepSize?: "xs" | "sm" | "md" | "lg" | "xl";
-  /** Width of the component element on each breakpoint screen resolution. */
+  /**
+   * Width of the component element on each breakpoint screen resolution.
+   * If undefined and the step component has no title, the width of the separator element will be 100px.
+   * */
   width?: { [breakpoint in HvBreakpoints]?: number };
   /** Defines either show a title or only a tooltip on each step component. */
   showTitles?: boolean;
@@ -54,22 +57,10 @@ export interface HvStepNavigationProps extends HvBaseProps {
 /**
  * Navigation page with steps.
  *
- * You need to define the <b>steps<b/> displayed on the component so that itself can be drawn on the UI.
- * On each step, you need to define a <b>state</b> - 'Pending', 'Failed', 'Completed', 'Current', 'Disabled' -
- * and a <b>title</b> to be shown as a tooltip or a text above of the step. You can also:
- * * Define a <b>className</b> on each step element;
- * * Define a <b>separatorClassName</b> to specify a className for the separator element. The default height
- * values of the separator element are 2px/3px on 'Simple'/'Default' layouts respectively;
- * * Define a <b>titleClassName</b> to specify a className for the title above each step element.
+ * You need to define the `steps` displayed on the component so that itself can be drawn on the UI.
+ * On each step, you need to define a `state` - 'Pending', 'Failed', 'Completed', 'Current', 'Disabled' -
+ * and a `title` to be shown as a tooltip or a text above of the step. You can also defined `className`, `separatorClassName`, and `titleClassName` to override the default styles.
  *
- * For the root element, you can:
- * * Define a <b>className</b>;
- * * Choose a <b>type</b> of layout: 'Simple' or 'Default';
- * * Choose the <b>stepSize</b> of the step component: "xs", "sm", "md", "lg", "xl". The default size will be
- * correspondent to the current media breakpoint;
- * * Choose either you want to <b>showTitles</b> near to each step component or a tooltip on hover;
- * * Define a <b>width</b> of the component. If you don't define any value and the step component has no title
- * displayed above, the width of the separator element will be 100px.
  * If the step component has titles, each one will have 215px of width by default.
  */
 export const HvStepNavigation = ({


### PR DESCRIPTION
- convert component docs from HTML to MD (ie. `<b>` -> `**`)
- add JSDoc to (documented) components without them
- minor doc reviews