### PR TITLE
ci: bump to node@22

### DIFF
--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -12,7 +12,7 @@ runs:
     - name: Install Node.js
       uses: actions/setup-node@v4
       with:
-        node-version: 18
+        node-version: 22
         cache: npm
 
     - name: Install dependencies

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 ![License](https://img.shields.io/badge/license-Apache%202-blue.svg)
 ![React](https://img.shields.io/badge/react-17|18-blue.svg)
-![Node](https://img.shields.io/badge/node-16|18-brightgreen.svg)
+![Node](https://img.shields.io/badge/node-16+-brightgreen.svg)
 [![Nightly](https://github.com/lumada-design/hv-uikit-react/actions/workflows/nightly.yml/badge.svg)](https://github.com/lumada-design/hv-uikit-react/actions/workflows/nightly.yml)
 
 </div>


### PR DESCRIPTION
- extend node version support to `16+` instead of explicitly `16` or `18`
  - this is just in docs, we actually don't enforce any node version in packages
- use `node@22` in CI