### PR TITLE
docs: review container layout & components docs

### DIFF
--- a/apps/docs/src/components/code/ExpandableLayout.tsx
+++ b/apps/docs/src/components/code/ExpandableLayout.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { CodeEditor, useLiveRunner, type Scope } from "react-live-runner";
 import useEditorTheme from "@docs/hooks/useEditorTheme";
+import { clsx } from "clsx";
 
 import { ExpandableControls } from "./ExpandableControls";
 
@@ -17,54 +18,56 @@ export const ExpandableLayout = ({ scope, code }: ExpandableLayoutProps) => {
   const editorTheme = useEditorTheme();
   const [isExpanded, setIsExpanded] = useState(false);
 
+  const initialCode = Object.values(code)[0];
+
   const {
     element,
     code: editorCode,
     error: liveError,
     onChange,
   } = useLiveRunner({
-    initialCode: Object.values(code)[0],
+    initialCode,
     scope: scope || {},
   });
 
-  const resetCode = () => onChange(Object.values(code)[0]);
-
   return (
-    <div className="relative mt-3">
+    <section className="relative mt-md rounded-round [&>*]:border-[var(--uikit-colors-atmo4)]">
       {/* Compact Controls */}
       <ExpandableControls
         onToggle={() => setIsExpanded((prev) => !prev)}
         isExpanded={isExpanded}
         code={editorCode}
-        onReset={resetCode}
+        onReset={() => onChange(initialCode)}
       />
 
       {/* Preview Section */}
       <div
-        className={[
-          "p-4 pt-5 [&_tr]:table-row gap-2 bg-[var(--uikit-colors-atmo2)] overflow-hidden",
-          "border rounded-round border-[var(--uikit-colors-atmo4)]",
-          isExpanded ? "rounded-b-0" : "",
-        ].join(" ")}
+        className={clsx(
+          "p-md pt-lg bg-[var(--uikit-colors-atmo2)] border rounded-inherit",
+          isExpanded && "rounded-b-0",
+        )}
       >
-        {liveError ? <div className="text-red-500">{liveError}</div> : element}
+        {liveError ? (
+          <div className="text-red-500">{liveError}</div>
+        ) : (
+          <div>{element}</div>
+        )}
       </div>
 
       {/* Code Editor Section */}
       <div
-        className="max-h-[300px] overflow-auto rounded-b-round mt-[-4px]"
+        className="max-h-300px overflow-auto rounded-b-inherit -mt-xxs transition-max-height"
         style={{
-          maxHeight: isExpanded ? "300px" : "0px",
-          transition: "max-height 0.2s ease-in-out",
+          maxHeight: isExpanded ? 300 : 0,
         }}
       >
         <CodeEditor
           value={editorCode}
           onChange={onChange}
           theme={editorTheme}
-          className="font-mono text-[.85em] rounded-b-round border border-[var(--uikit-colors-atmo4)]"
+          className="font-mono text-[.85em] rounded-b-inherit border border-color-inherit"
         />
       </div>
-    </div>
+    </section>
   );
 };

--- a/apps/docs/src/components/code/Playground.tsx
+++ b/apps/docs/src/components/code/Playground.tsx
@@ -11,7 +11,7 @@ type PlaygroundProps = {
   componentProps?: Record<string, unknown>;
   controls: Record<string, Control>;
   children?: React.ReactNode;
-  decorator?: (component: JSX.Element) => JSX.Element;
+  decorator?: (children: React.ReactNode) => React.ReactNode;
 };
 
 const parseChildren = (child: React.ReactNode) =>
@@ -101,16 +101,19 @@ const Playground = ({
   );
 
   return (
-    <>
+    <section
+      className="[&>*]:border-[var(--uikit-colors-atmo4)]"
+      aria-label="Playground"
+    >
       {/* Component preview and controls */}
-      <div className="grid grid-cols-[2fr_1fr] border border-[var(--uikit-colors-atmo4)] rounded-t-round">
+      <div className="grid grid-cols-[2fr_1fr] border rounded-t-round">
         {/* Preview Area */}
-        <div className="flex justify-center items-center p-sm overflow-auto">
+        <div className={"grid place-items-center p-sm"}>
           {decorator ? decorator(componentElement) : componentElement}
         </div>
 
         {/* Controls Area */}
-        <div className="grid gap-xs border-l border-[var(--uikit-colors-atmo4)] p-sm pl-xs">
+        <div className="flex flex-col gap-xs border-l border-color-inherit py-sm px-xs">
           {Object.entries(controls).map(([prop, control]) => {
             if (!control) return null;
 
@@ -128,7 +131,7 @@ const Playground = ({
       </div>
 
       {/* Code editor */}
-      <div className="max-h-72 overflow-auto rounded-b-round border border-[var(--uikit-colors-atmo4)] border-t-0 max-h-250px">
+      <div className="max-h-72 overflow-auto rounded-b-round border border-t-0 max-h-250px">
         <CodeEditor
           readOnly
           className="font-mono text-sm leading-2.2"
@@ -136,7 +139,7 @@ const Playground = ({
           theme={editorTheme}
         />
       </div>
-    </>
+    </section>
   );
 };
 

--- a/apps/docs/src/pages/components/accordion.mdx
+++ b/apps/docs/src/pages/components/accordion.mdx
@@ -54,19 +54,14 @@ export default function Demo() {
   const [expanded, setExpanded] = useState(false);
 
   return (
-    <div className="flex flex-col w-full">
-      <HvButton className="w-150px" onClick={() => setExpanded((p) => !p)}>
-        Open
-      </HvButton>
-      <HvAccordion
-        expanded={expanded}
-        onChange={(e, isExpanded) => setExpanded(isExpanded)}
-        label="Accordion label"
-        labelVariant="label"
-      >
-        <div>My accordion content</div>
-      </HvAccordion>
-    </div>
+    <HvAccordion
+      expanded={expanded}
+      onChange={(evt, isExpanded) => setExpanded(!isExpanded)}
+      label="Accordion label"
+      labelVariant="label"
+    >
+      <div>My accordion content</div>
+    </HvAccordion>
   );
 }
 ```
@@ -76,30 +71,24 @@ export default function Demo() {
 If you need an accordion group, you can use multiple `HvAccordion` components.
 
 ```tsx live
-<div className="w-full flex flex-col w-1/2">
-  <HvTypography className="pb-1" variant="title3">
+<>
+  <HvTypography className="pb-xs" variant="title3">
     UI Kit
   </HvTypography>
 
   <HvAccordion label="Components" labelVariant="title4">
-    <HvPanel>
-      UI Building blocks that can be used in various combinations to create a
-      larger user interface
-    </HvPanel>
+    UI Building blocks that can be used in various combinations to create a
+    larger user interface
   </HvAccordion>
   <HvAccordion label="Widgets" labelVariant="title4">
-    <HvPanel>
-      Specialized components that address specific use cases and can be used as
-      base to support other scenarios.
-    </HvPanel>
+    Specialized components that address specific use cases and can be used as
+    base to support other scenarios.
   </HvAccordion>
   <HvAccordion label="Templates" labelVariant="title4">
-    <HvPanel>
-      Pre-designed layouts that address common UI patterns and can be used to
-      quickly create a consistent design.
-    </HvPanel>
+    Pre-designed layouts that address common UI patterns and can be used to
+    quickly create a consistent design.
   </HvAccordion>
-</div>
+</>
 ```
 
 ### Related components

--- a/apps/docs/src/pages/components/action-bar.mdx
+++ b/apps/docs/src/pages/components/action-bar.mdx
@@ -18,18 +18,11 @@ export const getStaticProps = async ({ params }) => {
 ### Usage
 
 ```tsx live
-<HvActionBar className="gapxds">
-  <HvButton variant="secondaryGhost">Cancel</HvButton>
-  <div className="flex-1" aria-hidden="true">
-    &nbsp;
-  </div>
-  <HvButton variant="secondaryGhost">Save</HvButton>
-  <HvDropDownMenu
-    dataList={[
-      { id: "export", label: "Export" },
-      { id: "preview", label: "Preview" },
-    ]}
-  />
+<HvActionBar className="gap-xs">
+  <HvButton variant="secondaryGhost">Reset</HvButton>
+  <div className="flex-1" aria-hidden="true" />
+  <HvButton variant="primary">Save</HvButton>
+  <HvButton variant="subtle">Cancel</HvButton>
 </HvActionBar>
 ```
 

--- a/apps/docs/src/pages/components/app-switcher.mdx
+++ b/apps/docs/src/pages/components/app-switcher.mdx
@@ -25,18 +25,9 @@ export const getStaticProps = async ({ params }) => {
   Component={HvAppSwitcher}
   componentName="HvAppSwitcher"
   controls={{
-    layout: {
-      defaultValue: "single",
-    },
-    title: {
-      defaultValue: "My Apps",
-    },
-    header: {
-      defaultValue: "",
-    },
-    footer: {
-      defaultValue: "Footer",
-    },
+    layout: { defaultValue: "single" },
+    title: { defaultValue: "My Apps" },
+    footer: { defaultValue: "Footer" },
   }}
   componentProps={{
     applications: [
@@ -81,18 +72,19 @@ When there are many entries, the AppSwitcher will scroll vertically. Use the `is
 ```tsx live
 export default function Demo() {
   return (
-    <div className="flex h-360px">
-      <HvAppSwitcher
-        layout="dual"
-        title="Big list of applications"
-        applications={getDummyApplicationsList()}
-      />
-    </div>
+    <HvAppSwitcher
+      className="max-h-360px"
+      layout="dual"
+      title="Big list of applications"
+      applications={applicationList}
+      isActionSelectedCallback={(app) => app.id === "app_5"}
+    />
   );
 }
 
-const getDummyApplicationsList = () => {
-  return [...Array(100).keys()].map<HvAppSwitcherActionApplication>((i) => ({
+const applicationList = Array(100)
+  .keys()
+  .map<HvAppSwitcherActionApplication>((i) => ({
     id: `app_${i}`,
     name:
       i % 3 === 0
@@ -104,6 +96,6 @@ const getDummyApplicationsList = () => {
         : undefined,
     url: "https://github.com/lumada-design/hv-uikit-react",
     target: i % 2 === 0 ? "_top" : "_blank",
-  }));
-};
+  }))
+  .toArray();
 ```

--- a/apps/docs/src/pages/components/avatar-group.mdx
+++ b/apps/docs/src/pages/components/avatar-group.mdx
@@ -59,25 +59,22 @@ is the number of avatars that are not visible. The `overflowComponent` prop allo
 displayed in this scenario.
 
 ```tsx live
-export default function Demo() {
-  const overflowComponent = (overflowCount: number) => (
+<HvAvatarGroup
+  maxVisible={3}
+  overflowComponent={(overflowCount) => (
     <HvTooltip title={`+${overflowCount}`}>
       <HvAvatar backgroundColor="brand" color="atmo1" role="img" />
     </HvTooltip>
-  );
-
-  return (
-    <HvAvatarGroup overflowComponent={overflowComponent} maxVisible={3}>
-      <HvAvatar alt="Ben" src="https://i.imgur.com/56Eeg1g.png" />
-      <HvAvatar alt="Beatrice" src="https://i.imgur.com/bE7vg3N.png" />
-      <HvAvatar alt="Wayne" src="https://i.imgur.com/ea22egF.png" />
-      <HvAvatar alt="Clara" src="https://i.imgur.com/6sYhSb6.png" />
-      <HvAvatar alt="Steve" src="https://i.imgur.com/8we9311.jpeg" />
-      <HvAvatar alt="Sarah" src="https://i.imgur.com/2aJYRLM.jpeg" />
-      <HvAvatar alt="Cristina" src="https://i.imgur.com/fj50fND.jpeg" />
-    </HvAvatarGroup>
-  );
-}
+  )}
+>
+  <HvAvatar alt="Ben" src="https://i.imgur.com/56Eeg1g.png" />
+  <HvAvatar alt="Beatrice" src="https://i.imgur.com/bE7vg3N.png" />
+  <HvAvatar alt="Wayne" src="https://i.imgur.com/ea22egF.png" />
+  <HvAvatar alt="Clara" src="https://i.imgur.com/6sYhSb6.png" />
+  <HvAvatar alt="Steve" src="https://i.imgur.com/8we9311.jpeg" />
+  <HvAvatar alt="Sarah" src="https://i.imgur.com/2aJYRLM.jpeg" />
+  <HvAvatar alt="Cristina" src="https://i.imgur.com/fj50fND.jpeg" />
+</HvAvatarGroup>
 ```
 
 ### With tooltip
@@ -86,13 +83,6 @@ The `HvAvatarGroup` component expects `HvAvatar` as children but you can wrap th
 
 ```tsx live
 export default function Demo() {
-  const users = [
-    { name: "Ben", img: "https://i.imgur.com/56Eeg1g.png" },
-    { name: "Beatrice", img: "https://i.imgur.com/bE7vg3N.png" },
-    { name: "Wayne", img: "https://i.imgur.com/ea22egF.png" },
-    { name: "Clara", img: "https://i.imgur.com/6sYhSb6.png" },
-  ];
-
   return (
     <HvAvatarGroup maxVisible={4} size="lg" highlight>
       {users.map((u) => (
@@ -103,4 +93,11 @@ export default function Demo() {
     </HvAvatarGroup>
   );
 }
+
+const users = [
+  { name: "Ben", img: "https://i.imgur.com/56Eeg1g.png" },
+  { name: "Beatrice", img: "https://i.imgur.com/bE7vg3N.png" },
+  { name: "Wayne", img: "https://i.imgur.com/ea22egF.png" },
+  { name: "Clara", img: "https://i.imgur.com/6sYhSb6.png" },
+];
 ```

--- a/apps/docs/src/pages/components/avatar.mdx
+++ b/apps/docs/src/pages/components/avatar.mdx
@@ -39,12 +39,12 @@ export const getStaticProps = async ({ params }) => {
 Image avatars can be created by passing the src or srcSet props to the component.
 
 ```tsx live
-<>
+<div className="flex gap-xs">
   <HvAvatar alt="Ben" src="https://i.imgur.com/56Eeg1g.png" />
   <HvAvatar alt="Beatrice" src="https://i.imgur.com/bE7vg3N.png" />
   <HvAvatar alt="Wayne" src="https://i.imgur.com/ea22egF.png" />
   <HvAvatar alt="Clara Soul" src="https://i.imgur.com/6sYhSb6.png" />
-</>
+</div>
 ```
 
 ### Letter Avatars
@@ -52,11 +52,11 @@ Image avatars can be created by passing the src or srcSet props to the component
 Avatars containing simple characters can be created by passing a string as children.
 
 ```tsx live
-<>
+<div className="flex gap-xs">
   <HvAvatar>BM</HvAvatar>
   <HvAvatar backgroundColor="sema19">W</HvAvatar>
   <HvAvatar backgroundColor="sema6">CS</HvAvatar>
-</>
+</div>
 ```
 
 ### Icon Avatars
@@ -64,20 +64,20 @@ Avatars containing simple characters can be created by passing a string as child
 Icon avatars are created by passing an icon as children. Its size and color aren't Avatar's responsibility.
 
 ```tsx live
-<>
+<div className="flex gap-xs">
   <HvAvatar>
-    <LogIn color="atmo1" iconSize="XS" />
+    <LogIn color="atmo1" size="XS" />
   </HvAvatar>
   <HvAvatar backgroundColor="positive">
-    <Archives color="atmo1" iconSize="XS" />
+    <Archives color="atmo1" size="XS" />
   </HvAvatar>
   <HvAvatar backgroundColor="neutral">
-    <Search color="atmo1" iconSize="XS" />
+    <Search color="atmo1" size="XS" />
   </HvAvatar>
   <HvAvatar backgroundColor="warning">
-    <Bookmark color="atmo1" iconSize="XS" />
+    <Bookmark color="atmo1" size="XS" />
   </HvAvatar>
-</>
+</div>
 ```
 
 ### Fallbacks
@@ -85,28 +85,28 @@ Icon avatars are created by passing an icon as children. Its size and color aren
 If there is an error loading the avatar image, the component falls back to an alternative in the following order: the provided children, the first letter of the alt text and finally the generic User icon.
 
 ```tsx live
-<>
+<div className="flex gap-xs">
   <HvAvatar alt="Clara Soul" src="/broken-image.jpg">
     CS
   </HvAvatar>
   <HvAvatar alt="Clara Soul" src="/broken-image.jpg" />
   <HvAvatar src="/broken-image.jpg" />
-</>
+</div>
 ```
 
 ### Variants
 
-You can configure the `size` and `variant` of an avatar. When using an icon, set its `iconSize` to the size immediately below the avatar size.
+You can configure the `size` and `variant` of an avatar. When using an icon, set its `size` to the size immediately below the avatar size.
 
 ```tsx live
-<>
+<div className="flex gap-xs">
   <HvAvatar size="xs" />
   <HvAvatar size="xs" variant="square" />
   <HvAvatar backgroundColor="sema6" size="sm">
     NA
   </HvAvatar>
   <HvAvatar size="lg" backgroundColor="warning">
-    <Bookmark iconSize="M" color={["base_light", "base_dark"]} />
+    <Bookmark size="M" color={["base_light", "base_dark"]} />
   </HvAvatar>
   <HvAvatar size="xl" alt="Beatrice" src="https://i.imgur.com/bE7vg3N.png" />
   <HvAvatar
@@ -115,7 +115,7 @@ You can configure the `size` and `variant` of an avatar. When using an icon, set
     alt="Beatrice"
     src="https://i.imgur.com/bE7vg3N.png"
   />
-</>
+</div>
 ```
 
 ### Status
@@ -123,7 +123,7 @@ You can configure the `size` and `variant` of an avatar. When using an icon, set
 An avatar can have a status, represented by either the status colored border or by the badge dot. The color can be from the theme palette or custom.
 
 ```tsx live
-<>
+<div className="flex gap-xs">
   <HvAvatar size="xs" status="positive">
     AB
   </HvAvatar>
@@ -139,7 +139,7 @@ An avatar can have a status, represented by either the status colored border or 
   <HvAvatar size="xl" status="#8CEB34" badge="#8CEB34">
     AB
   </HvAvatar>
-</>
+</div>
 ```
 
 ### Actions
@@ -147,32 +147,21 @@ An avatar can have a status, represented by either the status colored border or 
 An avatar should be interacted with by wrapping it in an interactable element, such as an `HvButton` or a link. Make sure the elements are labelled accordingly.
 
 ```tsx live
-<>
-  <HvButton
-    icon
-    overrideIconColors={false}
-    component="a"
-    href="#profile-url"
-    aria-label="External link"
-  >
+<div className="flex gap-xs">
+  <HvButton icon component="a" href="#profile-url" aria-label="External link">
     <HvAvatar size="md">
-      <Bookmark color="atmo1" />
+      <Bookmark />
     </HvAvatar>
   </HvButton>
-  <HvButton icon overrideIconColors={false} aria-label="Open the user profile">
+  <HvButton icon aria-label="Open the user profile">
     <HvAvatar size="md" />
   </HvButton>
-  <HvButton icon overrideIconColors={false} aria-label="Business Manager">
+  <HvButton icon aria-label="Business Manager">
     <HvAvatar backgroundColor="sema19" size="md" badge="negative">
       BM
     </HvAvatar>
   </HvButton>
-  <HvButton
-    icon
-    overrideIconColors={false}
-    aria-label="Business Manager"
-    radius="none"
-  >
+  <HvButton icon aria-label="Business Manager" radius="none">
     <HvAvatar
       backgroundColor="sema19"
       size="md"
@@ -182,7 +171,7 @@ An avatar should be interacted with by wrapping it in an interactable element, s
       BM
     </HvAvatar>
   </HvButton>
-  <HvButton icon overrideIconColors={false} aria-label="Clara Soul profile">
+  <HvButton icon aria-label="Clara Soul profile">
     <HvAvatar
       alt="Clara Soul"
       src="https://i.imgur.com/6sYhSb6.png"
@@ -190,12 +179,7 @@ An avatar should be interacted with by wrapping it in an interactable element, s
       status="positive"
     />
   </HvButton>
-  <HvButton
-    icon
-    overrideIconColors={false}
-    aria-label="Clara Soul profile"
-    radius="none"
-  >
+  <HvButton icon aria-label="Clara Soul profile" radius="none">
     <HvAvatar
       alt="Clara Soul"
       src="https://i.imgur.com/6sYhSb6.png"
@@ -204,5 +188,5 @@ An avatar should be interacted with by wrapping it in an interactable element, s
       status="positive"
     />
   </HvButton>
-</>
+</div>
 ```

--- a/apps/docs/src/pages/components/badge.mdx
+++ b/apps/docs/src/pages/components/badge.mdx
@@ -17,7 +17,7 @@ export const getStaticProps = async ({ params }) => {
   componentName="HvBadge"
   controls={{
     showCount: { defaultValue: true },
-    count: { type: "number", defaultValue: 2 },
+    label: { type: "number", defaultValue: 2 },
     maxCount: { type: "number", defaultValue: 99 },
   }}
   componentProps={{
@@ -30,14 +30,14 @@ export const getStaticProps = async ({ params }) => {
 Use the `icon` prop to specify a icon to use with the badge.
 
 ```tsx live
-<>
-  <HvBadge count={0} icon={<Alert />} />
-  <HvBadge count={1} icon={<Alert />} />
-  <HvBadge showCount count={8} icon={<Alert />} />
-  <HvBadge showCount count={88} icon={<Alert />} />
-  <HvBadge showCount count={888} icon={<Alert />} />
+<div className="flex gap-sm">
+  <HvBadge label={0} icon={<Alert />} />
+  <HvBadge label={1} icon={<Alert />} />
+  <HvBadge showCount label={8} icon={<Alert />} />
+  <HvBadge showCount label={88} icon={<Alert />} />
+  <HvBadge showCount label={888} icon={<Alert />} />
   <HvBadge label="100%" icon={<Alert />} />
-</>
+</div>
 ```
 
 ### Maximum value
@@ -45,11 +45,11 @@ Use the `icon` prop to specify a icon to use with the badge.
 Use the `maxCount` prop to specify the maximum value to be displayed. Above that value a '+' sign is displayed.
 
 ```tsx live
-<>
-  <HvBadge showCount count={10} maxCount={9} />
-  <HvBadge showCount count={100} maxCount={99} />
-  <HvBadge showCount count={1000} maxCount={999} />
-</>
+<div className="flex gap-sm">
+  <HvBadge showCount label={10} maxCount={9} />
+  <HvBadge showCount label={100} maxCount={99} />
+  <HvBadge showCount label={1000} maxCount={999} />
+</div>
 ```
 
 ### Text
@@ -57,7 +57,7 @@ Use the `maxCount` prop to specify the maximum value to be displayed. Above that
 To display a badge on any content, wrap the `children` content with the badge component.
 
 ```tsx live
-<>
+<div className="flex gap-lg">
   <HvBadge label={0}>
     <HvTypography variant="label">Events</HvTypography>
   </HvBadge>
@@ -76,7 +76,7 @@ To display a badge on any content, wrap the `children` content with the badge co
   <HvBadge label="100%">
     <HvTypography variant="title2">Events</HvTypography>
   </HvBadge>
-</>
+</div>
 ```
 
 ### Controlled count
@@ -88,13 +88,12 @@ import { useState } from "react";
 
 export default function Demo() {
   const [count, setCount] = useState(1);
-  const addCount = () => setCount(count * 2);
 
   return (
-    <>
-      <HvButton onClick={addCount}>Double Value</HvButton>
-      <HvBadge showCount count={count} icon={<Alert />} />
-    </>
+    <div className="flex gap-md">
+      <HvButton onClick={() => setCount(count * 2)}>Double Value</HvButton>
+      <HvBadge showCount label={count} icon={<Alert />} />
+    </div>
   );
 }
 ```
@@ -105,8 +104,9 @@ If you want to specify a custom aria-label, ensure the badge has a `role`.
 
 ```tsx live
 <HvBadge
+  className="flex"
   showCount
-  count={25}
+  label={25}
   icon={<Alert />}
   role="status"
   aria-label="25 unread notifications"

--- a/apps/docs/src/pages/components/banner.mdx
+++ b/apps/docs/src/pages/components/banner.mdx
@@ -17,18 +17,12 @@ export const getStaticProps = async ({ params }) => {
   Component={HvBanner}
   componentName="HvBanner"
   controls={{
-    label: {
-      defaultValue: "This is an informational message.",
-    },
-    variant: {
-      defaultValue: "default",
-    },
-    showIcon: {
-      defaultValue: true,
-    },
+    label: { defaultValue: "This is a success message." },
+    variant: { defaultValue: "success" },
+    showIcon: { defaultValue: true },
+    open: { defaultValue: true },
   }}
   componentProps={{
-    open: true,
     style: { position: "relative", top: 0 },
   }}
 />
@@ -43,12 +37,12 @@ You can add a set of actions to the banner by specifying the `actions` prop. The
   offset={0}
   label="This is a banner."
   showIcon
+  className="relative"
   actions={[
     { id: "action_1", label: "Action 1", disabled: false },
     { id: "action_2", label: "Action 2", disabled: false },
   ]}
   onAction={(event, action) => console.log("Clicked", action)}
-  style={{ position: "relative", top: 0 }}
 />
 ```
 
@@ -61,8 +55,8 @@ You can pass a custom icon to the banner by using the `customIcon` prop.
   open
   offset={0}
   label="This is a banner with a custom icon."
+  className="relative"
   customIcon={<LightOn color="base_dark" />}
-  style={{ position: "relative", top: 0 }}
 />
 ```
 
@@ -73,15 +67,26 @@ Controlled banner. Click the buttons to display different banners.
 ```tsx live
 import { useState } from "react";
 
-const SimpleBanner = ({ variant, ...others }: Omit<HvBannerProps, "open">) => {
+export default function Demo() {
+  return (
+    <div className="flex gap-sm">
+      <BannerButton variant="default" label="This is a banner." />
+      <BannerButton variant="success" label="This is a success banner." />
+      <BannerButton variant="warning" label="This is a warning banner." />
+      <BannerButton variant="error" label="This is an error banner." />
+    </div>
+  );
+}
+
+const BannerButton = ({ variant, ...others }: Omit<HvBannerProps, "open">) => {
   const [open, setOpen] = useState(false);
 
   return (
     <>
       <HvButton
         onClick={() => setOpen(true)}
-        color="primary"
-        style={{ width: "150px", textTransform: "capitalize", margin: 10 }}
+        variant={buttonVariantMap[variant]}
+        className="capitalize w-120px"
       >
         {variant}
       </HvButton>
@@ -105,13 +110,10 @@ const SimpleBanner = ({ variant, ...others }: Omit<HvBannerProps, "open">) => {
   );
 };
 
-export default function Demo() {
-  return (
-    <>
-      <SimpleBanner variant="default" label="This is a banner." />
-      <SimpleBanner variant="success" label="This is a success banner." />
-      <SimpleBanner variant="error" label="This is an error banner." />
-    </>
-  );
-}
+const buttonVariantMap = {
+  default: "secondarySubtle",
+  success: "positiveSubtle",
+  warning: "warningSubtle",
+  error: "negativeSubtle",
+};
 ```

--- a/apps/docs/src/pages/components/blade.mdx
+++ b/apps/docs/src/pages/components/blade.mdx
@@ -39,21 +39,17 @@ export const getStaticProps = async ({ params }) => {
 
 ### Content
 
-The blade can have any content as it's label or children.
+The blade can have any content as its `label` or `children`.
 
 ```tsx live
 <HvBlade
+  className="w-fit"
   label={
     <div className="px-xs flex items-center">
       <HvTypography>Show Tags</HvTypography>
-      <DropRight />
+      <DropRightXS />
     </div>
   }
-  classes={{
-    root: "min-w-min",
-    button: "flex justify-center items-center",
-    container: "flex items-center",
-  }}
 >
   <div className="p-xs flex items-center gap-xs">
     <HvTag label="Tag 1" color="positive_20" />
@@ -69,30 +65,26 @@ The blade can have any content as it's label or children.
 import { useState } from "react";
 
 export default function Demo() {
-  const [expandedState, setExpandedState] = useState(false);
-
-  const handleToggle = (newState?: boolean) => {
-    setExpandedState(newState ?? ((oldState) => !oldState));
-  };
+  const [expanded, setExpanded] = useState(false);
 
   return (
     <>
       <div className="flex gap-xs mb-xs">
-        <HvButton variant="secondarySubtle" onClick={() => handleToggle()}>
+        <HvButton variant="subtle" onClick={() => setExpanded((s) => !s)}>
           Toggle
         </HvButton>
-        <HvButton variant="secondarySubtle" onClick={() => handleToggle(true)}>
+        <HvButton variant="subtle" onClick={() => setExpanded(true)}>
           Open
         </HvButton>
-        <HvButton variant="secondarySubtle" onClick={() => handleToggle(false)}>
+        <HvButton variant="subtle" onClick={() => setExpanded(false)}>
           Close
         </HvButton>
       </div>
       <div className="flex w-full">
         <HvBlade
           label="Show answer"
-          onChange={(e, state) => handleToggle(state)}
-          expanded={expandedState}
+          onChange={(e, state) => setExpanded(state)}
+          expanded={expanded}
         >
           <div className="p-xs">The answer to all things is 42.</div>
         </HvBlade>

--- a/apps/docs/src/pages/components/bulk-actions.mdx
+++ b/apps/docs/src/pages/components/bulk-actions.mdx
@@ -51,48 +51,39 @@ Sample of the `HvBulkActions` component with content.
 import { useState } from "react";
 
 export default function Demo() {
-  const addEntry = (i: number) => ({
-    id: `val${i + 1}`,
-    value: `Value ${i + 1}`,
-    checked: false,
-  });
+  const [data, setData] = useState(() =>
+    [...Array(12).keys()].map((id) => ({ id, checked: false })),
+  );
 
-  const [data, setData] = useState(() => [...Array(8).keys()].map(addEntry));
-
-  const handleSelectAll = (_: any, checked = false) => {
+  const handleSelectAll = (checked = false) => {
     setData(data.map((el) => ({ ...el, checked })));
   };
 
-  const handleSelectAllPages: HvBulkActionsProps["onSelectAllPages"] = (e) =>
-    handleSelectAll(e, true);
-
-  const handleChange: SampleComponentProps["onChange"] = (_, i, checked) => {
-    const newData = [...data];
-    newData[i].checked = checked;
-    setData(newData);
-  };
-
   return (
-    <div className="w-full">
+    <>
       <HvBulkActions
         numTotal={data.length}
         numSelected={data.filter((el) => el.checked).length}
-        onSelectAll={handleSelectAll}
-        onSelectAllPages={handleSelectAllPages}
+        onSelectAll={(evt, checked) => handleSelectAll(checked)}
+        onSelectAllPages={(evt) => handleSelectAll(true)}
         maxVisibleActions={3}
       />
-      <div className="w-full flex flex-wrap items-center justify-center">
+      <div className="w-full flex flex-wrap gap-xs items-center justify-center">
         {data.map((el, i) => (
           <HvCheckBox
             key={el.id}
-            className="w-160px p-xs m-xs bg-atmo2"
-            label={el.value}
+            classes={{ container: "items-center w-120px h-40px" }}
+            label={`Value ${el.id + 1}`}
             checked={el.checked}
-            onChange={(e, checked) => handleChange(e, i, checked)}
+            onChange={(e, checked) => (evt, i, checked) => {
+              const newData = [...data];
+              newData[i].checked = checked;
+              setData(newData);
+            }}
           />
         ))}
       </div>
-    </div>
+    </>
   );
 }
 ```
@@ -115,7 +106,7 @@ const addEntry = (i: number) => ({
 export default function Demo() {
   const [data, setData] = useState(() => [...Array(18).keys()].map(addEntry));
   const [page, setPage] = useState(0);
-  const [pageSize, setPageSize] = useState(pageSizeOptions[1]);
+  const [pageSize, setPageSize] = useState(pageSizeOptions[2]);
 
   const handleSelectAllPages = (checked = true) => {
     setData(data.map((el) => ({ ...el, checked })));
@@ -141,19 +132,13 @@ export default function Demo() {
     setData(newData);
   };
 
-  const handleChange: SampleComponentProps["onChange"] = (_, i, checked) => {
-    const newData = [...data];
-    newData[i + pageSize * page].checked = checked;
-    setData(newData);
-  };
-
   const handleAction: HvBulkActionsProps["onAction"] = (event, action) => {
     const selected = data.filter((el) => el.checked);
 
     switch (action.id) {
       case "add": {
         const newEls = selected.map((el) =>
-          addEntry(`${el.id}-copy-${uniqueId()}`),
+          addEntry(`${el.id}-copy-${Math.random().toString(36).slice(2, 5)}`),
         );
         setData([...data, ...newEls]);
         break;
@@ -188,14 +173,18 @@ export default function Demo() {
         maxVisibleActions={2}
         showSelectAllPages
       />
-      <div className="w-full flex flex-wrap items-center justify-center">
+      <div className="w-full flex flex-wrap gap-xs items-center justify-center">
         {data.slice(pageSize * page, pageSize * (page + 1)).map((el, i) => (
           <HvCheckBox
             key={el.id}
-            className="w-160px p-xs m-xs bg-atmo2"
+            classes={{ container: "items-center w-120px h-40px" }}
             label={el.value}
             checked={el.checked}
-            onChange={(e, checked) => handleChange(e, i, checked)}
+            onChange={(evt, checked) => {
+              const newData = [...data];
+              newData[i + pageSize * page].checked = checked;
+              setData(newData);
+            }}
           />
         ))}
       </div>

--- a/apps/docs/src/pages/components/bulk-actions.mdx
+++ b/apps/docs/src/pages/components/bulk-actions.mdx
@@ -38,7 +38,9 @@ export const getStaticProps = async ({ params }) => {
     maxVisibleActions: { defaultValue: 2 },
     semantic: { defaultValue: false },
   }}
-  decorator={(component) => <div className="w-full">{component}</div>}
+  componentProps={{
+    className: "w-full",
+  }}
 />
 
 ### With content

--- a/apps/docs/src/pages/components/button.mdx
+++ b/apps/docs/src/pages/components/button.mdx
@@ -41,7 +41,7 @@ export const getStaticProps = async ({ params }) => {
 ### Sizes
 
 ```tsx live
-<>
+<div className="flex gap-xs items-center">
   <HvButton size="sm">Small</HvButton>
   <HvButton size="md">Medium</HvButton>
   <HvButton size="lg">Large</HvButton>
@@ -51,7 +51,7 @@ export const getStaticProps = async ({ params }) => {
   <HvButton icon size="lg" aria-label="Play">
     <Play />
   </HvButton>
-</>
+</div>
 ```
 
 ### Icon
@@ -60,10 +60,10 @@ Use the `startIcon` or `endIcon` props to insert an icon on the button.
 You can also use the `icon` prop and pass icon directly to `children` of the `HvButton` component.
 
 When using icon-only buttons (`icon` prop), it's preferable to use the `HvIconButton` component instead,
-as it wraps the button in an `HvTooltip` component and requires a `title` label.
+as it wraps the button in an `HvTooltip` component and enforces an accessible `title` label.
 
 ```tsx live
-<>
+<div className="flex gap-xs items-center">
   <HvButton startIcon={<Play />} variant="primary">
     Play
   </HvButton>
@@ -76,7 +76,7 @@ as it wraps the button in an `HvTooltip` component and requires a `title` label.
   <HvIconButton title="Play">
     <Play size="XS" />
   </HvIconButton>
-</>
+</div>
 ```
 
 ### Custom root component
@@ -86,14 +86,14 @@ You can use the `component` prop to change the root component of the button to b
 ```tsx live
 export default function Demo() {
   return (
-    <>
+    <div className="flex gap-xs">
       <HvButton variant="subtle" component="a" href="#" startIcon={<Link />}>
         Link
       </HvButton>
       <HvButton variant="subtle" component={MyLink} to="#" startIcon={<Link />}>
         Custom link
       </HvButton>
-    </>
+    </div>
   );
 }
 

--- a/apps/docs/src/pages/components/card.mdx
+++ b/apps/docs/src/pages/components/card.mdx
@@ -112,7 +112,7 @@ export default function Demo() {
   const [checked, setChecked] = useState(null);
 
   return (
-    <div className="flex flex-row gap-2 w-full">
+    <div className="flex flex-row gap-sm w-full">
       {storages.map((p, idx) => (
         <StorageCard
           selected={checked === idx}
@@ -151,7 +151,7 @@ function StorageCard({
         <HvCardHeader
           title={
             <div className="flex justify-between items-center">
-              <div className="flex gap-1 items-center">
+              <div className="flex gap-xs items-center">
                 {icon}
                 <HvTypography variant="title4">{title}</HvTypography>
               </div>

--- a/apps/docs/src/pages/components/carousel.mdx
+++ b/apps/docs/src/pages/components/carousel.mdx
@@ -28,12 +28,13 @@ export const getStaticProps = async ({ params }) => {
     showFullscreen: { defaultValue: true },
     controlsPosition: { defaultValue: "top" },
   }}
+  decorator={(children) => <div className="overflow">{children}</div>}
 >
   {[...Array(7).keys()].map((i) => (
     <HvCarouselSlide
-      key={`https://lumada-design.github.io/assets/landscape${i + 1}.jpg`}
+      key={i}
       src={`https://lumada-design.github.io/assets/landscape${i + 1}.jpg`}
-      alt={`image-${i}`}
+      alt={`landscape ${i + 1}`}
     />
   ))}
 </Playground>

--- a/apps/docs/src/pages/components/carousel.mdx
+++ b/apps/docs/src/pages/components/carousel.mdx
@@ -47,17 +47,15 @@ The `thumbnailsPosition` prop allows you to set the position of the thumbnails, 
 ```tsx live
 export default function Demo() {
   return (
-    <HvCarousel renderThumbnail={renderThumbnail}>
+    <HvCarousel
+      renderThumbnail={(i) => <img src={images[i]} alt={`thumbnail ${i}`} />}
+    >
       {images.map((src, i) => (
-        <HvCarouselSlide key={src} src={src} alt={`image-${i}`} />
+        <HvCarouselSlide key={src} src={src} alt={`image ${i}`} />
       ))}
     </HvCarousel>
   );
 }
-
-const renderThumbnail = (i: number) => (
-  <img src={images[i]} alt={`thumbnail-${i}`} />
-);
 
 const images = [...Array(7).keys()].map(
   (i) => `https://lumada-design.github.io/assets/landscape${i + 1}.jpg`,
@@ -118,9 +116,9 @@ You can control the `HvCarousel`'s configuration via the `carouselOptions` prop.
 >
   {[...Array(7).keys()].map((i) => (
     <HvCarouselSlide
-      key={`https://lumada-design.github.io/assets/landscape${i + 1}.jpg`}
+      key={i}
       src={`https://lumada-design.github.io/assets/landscape${i + 1}.jpg`}
-      alt={`image-${i}`}
+      alt={`image ${i}`}
     />
   ))}
 </HvCarousel>
@@ -137,14 +135,11 @@ A Carousel supports any kind of content, not just images.
     .map((src, i) => (
       <HvCarouselSlide key={src} size="50%">
         <div style={{ position: "relative" }}>
-          <div className="absolute w-70% m-md p-xs bg-base_dark color-base_light bg-opacity-40">
-            <HvTypography
-              variant="title3"
-              style={{ color: theme.colors.base_light }}
-            >
+          <div className="absolute w-70% m-md p-xs bg-base_dark text-base_light bg-opacity-40">
+            <HvTypography className="text-inherit" variant="title3">
               Travel destination {i + 1}
             </HvTypography>
-            <HvTypography style={{ color: theme.colors.base_light }}>
+            <HvTypography className="text-inherit">
               Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
               eiusmod tempor incididunt ut labore et dolore magna aliqua.
             </HvTypography>

--- a/apps/docs/src/pages/components/code-editor.mdx
+++ b/apps/docs/src/pages/components/code-editor.mdx
@@ -27,13 +27,7 @@ To use the Code Editor component you'll have to install the `@hitachivantara/uik
 npm install @hitachivantara/uikit-react-code-editor
 ```
 
-Then it's ready to use:
-
-```tsx live
-<HvCodeEditor />
-```
-
-You can specify a language throught the `language` prop to get proper syntax highlighting and define a default value:
+You can specify a language through the `language` prop to get proper syntax highlighting and define a default value:
 
 ```tsx live
 <HvCodeEditor
@@ -91,7 +85,7 @@ export default function Demo() {
 }
 
 const Header = ({ title, onOpen }: { title: string; onOpen: () => void }) => (
-  <HvPanel className="flex items-center">
+  <HvPanel className="flex items-center border border-b-none">
     <HvTypography component="div" variant="label">
       {title}
     </HvTypography>
@@ -147,7 +141,7 @@ You can also create your own language plugins. The following example shows how t
 import { useRef, useState } from "react";
 
 const Header = ({ onFormat }: { onFormat: HvButtonProps["onClick"] }) => (
-  <div className="flex justify-between items-center p-xs bg-atmo1 border-atmo4 border-b-none">
+  <HvPanel className="flex justify-between items-center border border-b-none">
     <HvTypography variant="label">Custom Language Plugin</HvTypography>
     <Code />
     <div style={{ flex: 1 }} />
@@ -155,7 +149,7 @@ const Header = ({ onFormat }: { onFormat: HvButtonProps["onClick"] }) => (
     <HvButton variant="primaryGhost" onClick={onFormat}>
       Format
     </HvButton>
-  </div>
+  </HvPanel>
 );
 
 const completionProvider = (monaco: Monaco) => {

--- a/apps/docs/src/pages/components/color-picker.mdx
+++ b/apps/docs/src/pages/components/color-picker.mdx
@@ -45,6 +45,7 @@ You can configure the following Color Picker regions:
   defaultValue="#F6941E"
   showCustomColors
   showSavedColors
+  className="w-fit"
   defaultSavedColorsValue={["#95A", "#E95", "#8BA", "#759"]}
   recommendedColors={["#F00", "#0F0", "#00F", "#FF0", "#0FF", "#F0F"]}
   recommendedColorsPosition="top"

--- a/apps/docs/src/pages/components/dashboard.mdx
+++ b/apps/docs/src/pages/components/dashboard.mdx
@@ -34,18 +34,12 @@ for information on the properties that can be used in the layout items. Each ite
     { i: "4", x: 10, y: 0, w: 2, h: 1, static: true },
   ]}
 >
-  {["1", "2", "3", "4"]
-    .map((id) => ({
-      id,
-      type: "txt",
-      label: `Item ${id}`,
-    }))
-    .map((item) => (
-      <HvSection
-        key={item.id}
-        title={<HvTypography variant="title3">{item.label}</HvTypography>}
-      />
-    ))}
+  {["1", "2", "3", "4"].map((i) => (
+    <HvSection
+      key={i}
+      title={<HvTypography variant="title3">Item {i}</HvTypography>}
+    />
+  ))}
 </HvDashboard>
 ```
 
@@ -103,19 +97,18 @@ export default function Demo() {
             }
 
             return (
-              <div key={item.id} className="flex">
-                <HvSection
-                  classes={{ content: "h-full" }}
-                  title={
-                    <HvTypography
-                      variant="title3"
-                      className="capitalize"
-                    >{`${item.type} chart`}</HvTypography>
-                  }
-                >
-                  <Component {...props} />
-                </HvSection>
-              </div>
+              <HvSection
+                key={item.id}
+                className="flex"
+                classes={{ content: "h-full" }}
+                title={
+                  <HvTypography variant="title3" className="capitalize">
+                    {`${item.type} chart`}
+                  </HvTypography>
+                }
+              >
+                <Component {...props} />
+              </HvSection>
             );
           })}
         </HvDashboard>

--- a/apps/docs/src/pages/components/date-picker.mdx
+++ b/apps/docs/src/pages/components/date-picker.mdx
@@ -38,6 +38,7 @@ Use the `showActions` property to display Apply/Cancel buttons at the bottom.
   value={new Date("1970-02-03")}
   placeholder="Select date"
   label="Date"
+  className="w-fit"
 />
 ```
 
@@ -50,6 +51,7 @@ Use the `labels` object to customize the internal labels of the date picker.
   showActions
   label="This is the title for the date picker"
   placeholder="Custom placeholder"
+  className="w-fit"
   labels={{
     applyLabel: "Custom apply",
     cancelLabel: "Custom cancel",
@@ -76,9 +78,9 @@ export default function Demo() {
   const toggleOpen = () => setOpen((o) => !o);
 
   return (
-    <>
+    <div className="flex gap-sm">
       <HvDatePicker
-        style={{ flex: 1 }}
+        className="flex-1"
         expanded={open}
         aria-label="Date"
         placeholder="Select date"
@@ -92,7 +94,7 @@ export default function Demo() {
       <HvButton variant="secondarySubtle" onClick={toggleOpen}>
         {open ? "Close" : "Open"}
       </HvButton>
-    </>
+    </div>
   );
 }
 ```
@@ -138,7 +140,7 @@ export default function Demo() {
   const [date, setDate] = useState(new Date("2020-09-05"));
 
   const options = (
-    <HvListContainer role="menu" style={{ minWidth: 100 }} interactive>
+    <HvListContainer interactive role="menu" className="min-w-100px">
       <HvListItem role="menuitem" disabled>
         Today
       </HvListItem>

--- a/apps/docs/src/pages/components/dialog.mdx
+++ b/apps/docs/src/pages/components/dialog.mdx
@@ -27,30 +27,46 @@ import { useState } from "react";
 
 export default function Demo() {
   const [open, setOpen] = useState(false);
-  const [maxWidth, setMaxWidth] = useState("md");
+  const [maxWidth, setMaxWidth] = useState("sm");
   const [fullWidth, setFullWidth] = useState(true);
+  const [fullHeight, setFullHeight] = useState(false);
 
   return (
     <>
       <HvButton onClick={() => setOpen(true)}>Open dialog</HvButton>
       <HvDialog
+        open={open}
         maxWidth={maxWidth}
         fullWidth={fullWidth}
-        open={open}
+        fullHeight={fullHeight}
         onClose={() => setOpen(false)}
-        style={{ overflow: "visible" }}
       >
         <HvDialogTitle variant="warning">Set Maximum Width</HvDialogTitle>
-        <HvDialogContent
-          indentContent
-          className="flex items-end gap-2 w-full justify-center"
-        >
-          <SizeSelector
-            maxWidth={maxWidth}
-            fullWidth={fullWidth}
-            setMaxWidth={setMaxWidth}
-            setFullWidth={setFullWidth}
-          />
+        <HvDialogContent indentContent className="flex items-start">
+          <div className="flex gap-sm items-end">
+            <HvSelect
+              label="Maximum width"
+              value={maxWidth}
+              onChange={(evt, val) => setMaxWidth(val)}
+              enablePortal
+            >
+              {["xs", "sm", "md", "lg", "xl"].map((size) => (
+                <HvOption key={size} value={size}>
+                  {size}
+                </HvOption>
+              ))}
+            </HvSelect>
+            <HvCheckBox
+              checked={fullWidth}
+              label="fullWidth"
+              onChange={(_, checked) => setFullWidth(checked)}
+            />
+            <HvCheckBox
+              checked={fullHeight}
+              label="fullHeight"
+              onChange={(_, checked) => setFullHeight(checked)}
+            />
+          </div>
         </HvDialogContent>
         <HvDialogActions>
           <HvButton variant="secondaryGhost" onClick={() => setOpen(false)}>
@@ -61,28 +77,6 @@ export default function Demo() {
     </>
   );
 }
-
-const SizeSelector = ({ maxWidth, setMaxWidth, fullWidth, setFullWidth }) => (
-  <>
-    <HvSelect
-      label="Maximum width"
-      value={maxWidth}
-      onChange={(evt, val) => setMaxWidth(val)}
-      enablePortal
-    >
-      {["xs", "sm", "md", "lg", "xl"].map((size) => (
-        <HvOption key={size} value={size}>
-          {size}
-        </HvOption>
-      ))}
-    </HvSelect>
-    <HvCheckBox
-      checked={fullWidth}
-      label="Fullwidth"
-      onChange={(_, checked) => setFullWidth(checked)}
-    />
-  </>
-);
 ```
 
 ### Semantic
@@ -94,62 +88,56 @@ The `HvDialog` component can receive a `variant` prop to set the status of the d
 import { useState } from "react";
 
 export default function Demo() {
-  const [open, setOpen] = useState(false);
-  const [variant, setVariant] = useState(undefined);
-
-  const handleOpen = (variant: string) => {
-    setVariant(variant)
-    setOpen(true);
-  };
-
   return (
-    <>
-      <SemanticDialog open={open} variant={variant} onClose={() => setOpen(false)} />
-      <HvButton variant="warning" onClick={() => handleOpen("warning")}>
-        Warning
-      </HvButton>
-      <HvButton variant="positive" onClick={() => handleOpen("success")}>
-        Success
-      </HvButton>
-      <HvButton variant="negative" onClick={() => handleOpen("error")}>
-        Error
-      </HvButton>
-      <HvButton variant="secondarySubtle" onClick={() => handleOpen("info")}>
-        Info
-      </HvButton>
-    </>
+    <div className="flex gap-xs">
+      <SemanticDialog variant="success" />
+      <SemanticDialog variant="warning" />
+      <SemanticDialog variant="error" />
+      <SemanticDialog variant="info" />
+    </div>
   );
 }
 
-const SemanticDialog = ({ open, variant, onClose}: HvDialogProps) => (
-  <HvDialog open={open} variant={variant}  onClose={onClose}>
-    <HvDialogTitle variant={variant}>Switch model view?</HvDialogTitle>
-    <HvDialogContent indentContent>
-      Switching to model view will clear all the fields in your
-      visualization. You will need to re-select your fields.
-    </HvDialogContent>
-    <HvDialogActions>
-      <HvButton variant={buttonVariantMap[variant]} onClick={onClose}>
-        Apply
-      </HvButton>
+const SemanticDialog = ({ variant }: HvDialogProps) => {
+  const [open, setOpen] = useState(false);
+  const handleClose = () => setOpen(false);
+
+  return (
+    <>
+      <HvDialog open={open} variant={variant} onClose={handleClose}>
+        <HvDialogTitle variant={variant}>Switch model view?</HvDialogTitle>
+        <HvDialogContent indentContent>
+          Switching to model view will clear all the fields in your
+          visualization. You will need to re-select your fields.
+        </HvDialogContent>
+        <HvDialogActions>
+          <HvButton variant={buttonVariantMap[variant]} onClick={handleClose}>
+            Apply
+          </HvButton>
+          <HvButton autoFocus variant="secondaryGhost" onClick={handleClose}>
+            Cancel
+          </HvButton>
+        </HvDialogActions>
+      </HvDialog>
       <HvButton
-        autoFocus
-        variant="secondaryGhost"
-        onClick={onClose}
+        className="capitalize"
+        variant={buttonVariantMap[variant]}
+        onClick={() => setOpen(true)}
       >
-        Cancel
+        {variant}
       </HvButton>
-    </HvDialogActions>
-  </Dialog>
-)
+    </>
+  );
+};
 
 const buttonVariantMap: Record<
   NonNullable<HvDialogProps["variant"]>,
   HvButtonVariant
 > = {
-  error: "negative",
   success: "positive",
   warning: "warning",
+  error: "negative",
+  info: "subtle",
 };
 ```
 
@@ -307,7 +295,7 @@ export default function Demo() {
   const [postData, setPostData] = useState({});
 
   return (
-    <div className="flex flex-col gap-2">
+    <div className="flex flex-col items-start gap-sm">
       <HvButton onClick={() => setOpen(true)}>Create a post</HvButton>
       <HvTypography variant="title4">Form data:</HvTypography>
       <pre>{JSON.stringify(postData, null, 2)}</pre>

--- a/apps/docs/src/pages/components/dot-pagination.mdx
+++ b/apps/docs/src/pages/components/dot-pagination.mdx
@@ -34,22 +34,11 @@ The `page` prop is used to control the current page, and the `onPageChange` prop
 import { useState } from "react";
 
 export default function Demo() {
-  const [page, setPage] = useState<number>(0);
-
-  const pages = [
-    "This is page 1",
-    "And this is page 2",
-    "This is page 3",
-    "This is page 4",
-    "And finally, this is page 5",
-  ];
+  const [page, setPage] = useState(0);
 
   return (
-    <div className="w-100% flex justify-center flex-col items-center">
-      <div className="text-center">
-        <HvTypography>{pages[page]}</HvTypography>
-      </div>
-      <br />
+    <div className="w-full grid place-items-center gap-sm">
+      <HvTypography>{pages[page]}</HvTypography>
       <HvDotPagination
         page={page}
         pages={pages.length}
@@ -70,6 +59,14 @@ export default function Demo() {
     </div>
   );
 }
+
+const pages = [
+  "This is page 1",
+  "And this is page 2",
+  "This is page 3",
+  "This is page 4",
+  "And finally, this is page 5",
+];
 ```
 
 ### Custom dots
@@ -80,22 +77,14 @@ You can use custom icons for the selected and unselected dots in the `HvDotPagin
 import { useState } from "react";
 
 export default function Demo() {
-  const [page, setPage] = useState<number>(0);
-  const pages = [
-    "This is page 1",
-    "And this is page 2",
-    "Now you can see page 3",
-    "Look, it's page 4",
-    "And finally, this is page 5",
-  ];
+  const [page, setPage] = useState(0);
 
   return (
-    <div className="w-100% flex flex-col items-center justify-center">
+    <div className="w-full grid place-items-center gap-sm">
       <HvTypography>{pages[page]}</HvTypography>
-      <br />
       <HvDotPagination
-        unselectedIcon={<RadioButtonUnselected iconSize="XS" />}
-        selectedIcon={<CurrentStep iconSize="XS" />}
+        unselectedIcon={<RadioButtonUnselected size="XS" />}
+        selectedIcon={<CurrentStep size="XS" />}
         page={page}
         pages={pages.length}
         onPageChange={(_, value) => setPage(value)}
@@ -115,6 +104,14 @@ export default function Demo() {
     </div>
   );
 }
+
+const pages = [
+  "This is page 1",
+  "And this is page 2",
+  "Now you can see page 3",
+  "Look, it's page 4",
+  "And finally, this is page 5",
+];
 ```
 
 ### Related components

--- a/apps/docs/src/pages/components/drawer.mdx
+++ b/apps/docs/src/pages/components/drawer.mdx
@@ -69,13 +69,11 @@ export default function Demo() {
   };
 
   return (
-    <>
-      <div className="flex gap-sm">
-        <HvButton onClick={() => handleAnchorChange("left")}>Left</HvButton>
-        <HvButton onClick={() => handleAnchorChange("top")}>Top</HvButton>
-        <HvButton onClick={() => handleAnchorChange("bottom")}>Bottom</HvButton>
-        <HvButton onClick={() => handleAnchorChange("right")}>Right</HvButton>
-      </div>
+    <div className="flex gap-sm">
+      <HvButton onClick={() => handleAnchorChange("left")}>Left</HvButton>
+      <HvButton onClick={() => handleAnchorChange("top")}>Top</HvButton>
+      <HvButton onClick={() => handleAnchorChange("bottom")}>Bottom</HvButton>
+      <HvButton onClick={() => handleAnchorChange("right")}>Right</HvButton>
       <HvDrawer
         anchor={anchor}
         onClose={() => setOpen(false)}
@@ -91,7 +89,7 @@ export default function Demo() {
           <HvTypography tabIndex={0}>Your drawer content</HvTypography>
         </HvDialogContent>
       </HvDrawer>
-    </>
+    </div>
   );
 }
 ```
@@ -106,15 +104,11 @@ import { useRef, useState } from "react";
 
 export default function Demo() {
   const [open, setOpen] = useState(false);
-  const containerRef = useRef(null);
 
   return (
-    <div
-      className="w-full h-[300px] flex relative justify-end"
-      ref={containerRef}
-    >
+    <div className="w-full h-300px flex relative justify-end">
       <div
-        className="flex flex-col gap-xs  bg-atmo2"
+        className="flex flex-col gap-xs"
         style={{ width: open ? "70%" : "100%" }}
       >
         <HvHeader
@@ -143,7 +137,6 @@ export default function Demo() {
         </div>
       </div>
       <HvDrawer
-        ref={containerRef.current}
         variant="persistent"
         anchor="left"
         onClose={() => setOpen(false)}

--- a/apps/docs/src/pages/components/dropdown-menu.mdx
+++ b/apps/docs/src/pages/components/dropdown-menu.mdx
@@ -73,7 +73,7 @@ export default function Demo() {
   const [open, setOpen] = useState(false);
 
   return (
-    <div style={{ display: "flex", gap: 5 }}>
+    <div className="flex gap-xs">
       <HvButton variant="secondaryGhost" onClick={() => setOpen(!open)}>
         {`Click to ${!open ? "Open" : "Close"}`}
       </HvButton>

--- a/apps/docs/src/pages/components/empty-state.mdx
+++ b/apps/docs/src/pages/components/empty-state.mdx
@@ -44,7 +44,7 @@ You can specify any content as the `message` or `action`. This can be a button, 
   title="No visualization data available"
   icon={<BarChart />}
   action={
-    <div className="flex flex-col gap-1 items-center">
+    <div className="flex flex-col gap-xs items-center">
       <HvButton variant="secondarySubtle">Upload data</HvButton>
       <HvTypography link component="a" href="#">
         Back to homepage

--- a/apps/docs/src/pages/components/footer.mdx
+++ b/apps/docs/src/pages/components/footer.mdx
@@ -22,10 +22,12 @@ export const getStaticProps = async ({ params }) => {
       defaultValue: "© Hitachi Vantara LLC 2025. All Rights Reserved.",
     },
     links: {
-      defaultValue: "Privay Policy",
+      defaultValue: "Privacy Policy",
     },
   }}
-  decorator={(component) => <div className="w-full">{component}</div>}
+  componentProps={{
+    className: "w-full",
+  }}
 />
 
 ### Custom labels

--- a/apps/docs/src/pages/components/global-actions.mdx
+++ b/apps/docs/src/pages/components/global-actions.mdx
@@ -60,38 +60,36 @@ The `section` variant of Global Actions should be used to group related blocks o
 The content of the Global Actions can be customized. This is useful when you want to add different elements other than the title and actions.
 
 ```tsx live
-<div className="w-full">
-  <HvGlobalActions
-    backButton={
-      <HvIconButton title="Go back">
-        <Backwards />
-      </HvIconButton>
-    }
-    title={
-      <>
-        <Home title="Home" />
-        <HvBreadCrumb
-          listRoute={[
-            { label: "Label 1", path: "#route1" },
-            { label: "Label 2", path: "#route2" },
-            { label: "Label 3", path: "#route3" },
-            { label: "Label 4", path: "#route4" },
-            { label: "Label 5", path: "#route5" },
-          ]}
-          maxVisible={2}
-        />
-      </>
-    }
-  >
-    <HvButton variant="secondaryGhost">Primary</HvButton>
-    <HvDropDownMenu
-      placement="left"
-      dataList={[
-        { label: "Action 2" },
-        { label: "Action 3" },
-        { label: "Action 4" },
-      ]}
-    />
-  </HvGlobalActions>
-</div>
+<HvGlobalActions
+  backButton={
+    <HvIconButton title="Go back">
+      <Backwards />
+    </HvIconButton>
+  }
+  title={
+    <>
+      <Home title="Home" />
+      <HvBreadCrumb
+        listRoute={[
+          { label: "Label 1", path: "#route1" },
+          { label: "Label 2", path: "#route2" },
+          { label: "Label 3", path: "#route3" },
+          { label: "Label 4", path: "#route4" },
+          { label: "Label 5", path: "#route5" },
+        ]}
+        maxVisible={2}
+      />
+    </>
+  }
+>
+  <HvButton variant="secondaryGhost">Action</HvButton>
+  <HvDropDownMenu
+    placement="left"
+    dataList={[
+      { label: "Action 2" },
+      { label: "Action 3" },
+      { label: "Action 4" },
+    ]}
+  />
+</HvGlobalActions>
 ```

--- a/apps/docs/src/pages/components/grid.mdx
+++ b/apps/docs/src/pages/components/grid.mdx
@@ -39,7 +39,6 @@ export default function Demo() {
         <HvGrid item xs={12} lg={6}>
           <HvPanel className="content-center h-100px">xs=12 lg=6</HvPanel>
         </HvGrid>
-
         <HvGrid item xs={12} md={6} lg={4}>
           <HvPanel className="content-center h-100px">xs=12 md=6 lg=4</HvPanel>
         </HvGrid>
@@ -49,10 +48,9 @@ export default function Demo() {
         <HvGrid item xs={12} md={6} lg={4}>
           <HvPanel className="content-center h-100px">xs=12 md=6 lg=4</HvPanel>
         </HvGrid>
-
-        <HvGrid item xs={12} sm={6} md={4} lg={3} xl={2}>
+        <HvGrid item xs={12} sm={6} lg={3} xl={2}>
           <HvPanel className="content-center h-100px">
-            xs=12 sm=6 md=4 lg=3 xl=2
+            xs=12 sm=6 lg=3 xl=2
           </HvPanel>
         </HvGrid>
         <HvGrid item xs={12} sm={6} md={4} lg={3} xl={2}>

--- a/apps/docs/src/pages/components/input.mdx
+++ b/apps/docs/src/pages/components/input.mdx
@@ -109,7 +109,7 @@ export default function Demo() {
   const dateTimeRef = useRef<HTMLInputElement>(null);
 
   return (
-    <>
+    <div className="flex gap-sm">
       <HvInput
         label="Number"
         className="min-w-80px"
@@ -137,7 +137,7 @@ export default function Demo() {
         inputProps={{ type: "time", step: 1 }}
         endAdornment={<Time onClick={() => timeRef.current?.showPicker()} />}
       />
-    </>
+    </div>
   );
 }
 ```
@@ -198,7 +198,7 @@ If you need to apply a custom layout, e.g. for providing a prefix or suffix, you
 
 ### Autocomplete
 
-Inputs can have a autocomplete suggestons using the `suggestionListCallback`.
+Inputs can have a autocomplete suggestions using the `suggestionListCallback`.
 
 ```tsx live
 import { useState } from "react";

--- a/apps/docs/src/pages/components/loading-container.mdx
+++ b/apps/docs/src/pages/components/loading-container.mdx
@@ -1,5 +1,6 @@
 import {
   HvLoadingContainer,
+  HvPanel,
   loadingContainerClasses,
 } from "@hitachivantara/uikit-react-core";
 
@@ -34,7 +35,5 @@ export const getStaticProps = async ({ params }) => {
     style: { width: "100%" },
   }}
 >
-  <div className="flex items-center justify-center bg-gray h-200px">
-    My content
-  </div>
+  <HvPanel className="grid place-items-center h-200px">My content</HvPanel>
 </Playground>

--- a/apps/docs/src/pages/components/loading.mdx
+++ b/apps/docs/src/pages/components/loading.mdx
@@ -60,7 +60,7 @@ function LoadingButton({ onClick, children, ...others }: HvButtonProps) {
 
   return (
     <HvButton
-      style={{ width: 120 }}
+      className="w-140px"
       disabled={isLoading}
       onClick={async (event) => {
         setIsLoading(true);
@@ -69,11 +69,7 @@ function LoadingButton({ onClick, children, ...others }: HvButtonProps) {
       }}
       {...others}
     >
-      {!isLoading ? (
-        children
-      ) : (
-        <HvLoading small hidden={!isLoading} color="inherit" />
-      )}
+      {isLoading ? <HvLoading small color="inherit" /> : children}
     </HvButton>
   );
 }

--- a/apps/docs/src/pages/components/multi-button.mdx
+++ b/apps/docs/src/pages/components/multi-button.mdx
@@ -57,8 +57,8 @@ You can use the buttons underneath to display the multibutton content in differe
 For example, you can use icons, display labels only or set some items as disabled.
 
 ```tsx live
-<div className="flex flex-col gap-2">
-  <HvMultiButton style={{ width: "fit-content" }}>
+<div className="flex flex-col gap-sm">
+  <HvMultiButton className="w-fit">
     <HvButton icon aria-label="Map">
       <Map />
     </HvButton>
@@ -69,12 +69,12 @@ For example, you can use icons, display labels only or set some items as disable
       <Bus />
     </HvButton>
   </HvMultiButton>
-  <HvMultiButton style={{ width: "320px" }}>
+  <HvMultiButton className="w-320px">
     <HvButton>Map</HvButton>
     <HvButton>Location</HvButton>
     <HvButton>Transport</HvButton>
   </HvMultiButton>
-  <HvMultiButton style={{ width: "320px" }}>
+  <HvMultiButton className="w-320px">
     <HvButton startIcon={<Map />}>Map</HvButton>
     <HvButton disabled>Location</HvButton>
     <HvButton endIcon={<Bus />}>Transport</HvButton>
@@ -91,7 +91,7 @@ export default function MultiButtonControlled() {
   const [selection, setSelection] = useState([]);
 
   return (
-    <>
+    <div className="flex gap-sm">
       <HvButton
         variant="primarySubtle"
         onClick={() => setSelection([1, 2, 3, 4, 5])}
@@ -99,7 +99,7 @@ export default function MultiButtonControlled() {
         Select weekdays
       </HvButton>
 
-      <HvMultiButton style={{ width: "224px" }}>
+      <HvMultiButton className="w-fit">
         {buttons.map((button, i) => (
           <HvButton
             key={`${buttons[i]}`}
@@ -117,7 +117,7 @@ export default function MultiButtonControlled() {
           </HvButton>
         ))}
       </HvMultiButton>
-    </>
+    </div>
   );
 }
 
@@ -137,36 +137,32 @@ const buttons = [
 You can create a split button by using the `HvMultiButton` in conjunction with the `HvButton` and the `HvDropDownMenu` components.
 
 ```tsx live
-import { useMemo, useState } from "react";
+import { useState } from "react";
 
 export default function Demo() {
-  const options = useMemo(
-    () => [
-      { label: "Merge commit" },
-      { label: "Squash and merge" },
-      { label: "Rebase and merge" },
-    ],
-    [],
-  );
   const [selectedOption, setSelectedOption] = useState(options[0]);
 
   return (
-    <HvSimpleGrid cols={3} spacing="sm">
-      <HvMultiButton split>
-        <HvButton>{selectedOption.label}</HvButton>
-        <HvDropDownMenu
-          dataList={options}
-          icon={<DropDownXS />}
-          onClick={(e, item) =>
-            setSelectedOption(
-              options.filter((option) => option.label === item.label)[0],
-            )
-          }
-        />
-      </HvMultiButton>
-    </HvSimpleGrid>
+    <HvMultiButton split>
+      <HvButton>{selectedOption.label}</HvButton>
+      <HvDropDownMenu
+        dataList={options}
+        icon={<DropDownXS />}
+        onClick={(e, item) =>
+          setSelectedOption(
+            options.filter((option) => option.label === item.label)[0],
+          )
+        }
+      />
+    </HvMultiButton>
   );
 }
+
+const options = [
+  { label: "Merge commit" },
+  { label: "Squash and merge" },
+  { label: "Rebase and merge" },
+];
 ```
 
 ### Related components

--- a/apps/docs/src/pages/components/overflow-tooltip.mdx
+++ b/apps/docs/src/pages/components/overflow-tooltip.mdx
@@ -38,5 +38,5 @@ export const getStaticProps = async ({ params }) => {
         "This is a very long text that should be cut because it so long that it doesn't fit",
     },
   }}
-  decorator={(component) => <div className="max-w-160px">{component}</div>}
+  decorator={(children) => <div className="max-w-160px">{children}</div>}
 />

--- a/apps/docs/src/pages/components/pagination.mdx
+++ b/apps/docs/src/pages/components/pagination.mdx
@@ -56,13 +56,12 @@ export default function Demo() {
   const numPages = Math.ceil(data.length / pageSize);
 
   return (
-    <div className="w-full">
+    <>
       <div className="flex flex-wrap gap-sm rounded">
         {data.slice(pageSize * page, pageSize * (page + 1)).map((i) => (
-          <HvPanel
-            className="w-[100px] text-center"
-            key={i}
-          >{`Item ${i + 1}`}</HvPanel>
+          <HvPanel key={i} className="w-[100px] text-center">
+            {`Item ${i + 1}`}
+          </HvPanel>
         ))}
       </div>
       <HvPagination
@@ -76,7 +75,7 @@ export default function Demo() {
         onPageSizeChange={setPageSize}
         labels={{ pageSizeEntryName: "items" }}
       />
-    </div>
+    </>
   );
 }
 ```

--- a/apps/docs/src/pages/components/panel.mdx
+++ b/apps/docs/src/pages/components/panel.mdx
@@ -14,9 +14,7 @@ export const getStaticProps = async ({ params }) => {
 ### Usage
 
 ```tsx live
-<div className="w-full">
-  <HvPanel className="h-100px">Panel Content</HvPanel>
-</div>
+<HvPanel className="h-100px">Panel Content</HvPanel>
 ```
 
 ### With scroll

--- a/apps/docs/src/pages/components/radio-group.mdx
+++ b/apps/docs/src/pages/components/radio-group.mdx
@@ -19,61 +19,21 @@ export const getStaticProps = async ({ params }) => {
   Component={HvRadioGroup}
   componentName="HvRadioGroup"
   controls={{
-    label: {
-      type: "text",
-      defaultValue: "Visualization type",
-    },
-    description: {
-      type: "text",
-      defaultValue: "Select how you want to visualize your dataset",
-    },
-    orientation: {
-      defaultValue: "vertical",
-    },
-    required: {
-      defaultValue: true,
-    },
-    disabled: {
-      defaultValue: false,
-    },
+    label: { defaultValue: "Type" },
+    description: { defaultValue: "Visualization type" },
+    orientation: { defaultValue: "vertical" },
+    required: { defaultValue: true },
+    disabled: { defaultValue: false },
+    readOnly: { defaultValue: false },
+  }}
+  componentProps={{
+    defaultChecked: false,
   }}
 >
   <HvRadio label="Bar Chart" value="1" />
   <HvRadio label="Line Chart" value="2" />
   <HvRadio label="Pie Chart" value="3" />
 </Playground>
-
-### States
-
-```tsx live
-<div className="flex gap-xs items-start">
-  <HvRadioGroup required label="Required">
-    <HvRadio label="Radio 1" value="1" />
-    <HvRadio label="Radio 2" value="2" checked />
-    <HvRadio label="Radio 3" value="3" />
-  </HvRadioGroup>
-  <HvRadioGroup disabled label="Disabled">
-    <HvRadio label="Radio 1" value="1" />
-    <HvRadio label="Radio 2" value="2" checked />
-    <HvRadio label="Radio 3" value="3" />
-  </HvRadioGroup>
-  <HvRadioGroup readOnly label="Readonly">
-    <HvRadio label="Radio 1" value="1" />
-    <HvRadio label="Radio 2" value="2" checked />
-    <HvRadio label="Radio 3" value="3" />
-  </HvRadioGroup>
-  <HvRadioGroup status="invalid" statusMessage="Oh no!" label="Invalid">
-    <HvRadio label="Radio 1" value="1" />
-    <HvRadio label="Radio 2" value="2" checked />
-    <HvRadio label="Radio 3" value="3" />
-  </HvRadioGroup>
-  <HvRadioGroup label="Mixed">
-    <HvRadio label="Radio 1" value="1" />
-    <HvRadio label="Radio 2" value="2" disabled />
-    <HvRadio label="Radio 3" value="3" semantic checked />
-  </HvRadioGroup>
-</div>
-```
 
 ### Controlled
 
@@ -83,29 +43,19 @@ Controlled radio button group. Choosing the first option will result in an inval
 import { useState } from "react";
 
 export default function Demo() {
-  const [value, setValue] = useState<string>("2");
+  const [value, setValue] = useState("2");
   const [status, setStatus] = useState<HvFormStatus>("standBy");
-
-  const handleOnChange = (
-    _: React.ChangeEvent<HTMLInputElement>,
-    newValue: string,
-  ) => {
-    setValue(newValue);
-
-    if (newValue === "none") {
-      setStatus("invalid");
-    } else {
-      setStatus("valid");
-    }
-  };
 
   return (
     <HvRadioGroup
       label="Choose the best radio button"
       value={value}
-      onChange={handleOnChange}
       status={status}
       statusMessage={'Don\'t select "None"!'}
+      onChange={(evt, newValue) => {
+        setValue(newValue);
+        setStatus(newValue === "none" ? "invalid" : "valid");
+      }}
     >
       <HvRadio label="None" value="none" />
       <HvRadio label="Radio 1" value="1" />

--- a/apps/docs/src/pages/components/radio.mdx
+++ b/apps/docs/src/pages/components/radio.mdx
@@ -15,23 +15,14 @@ export const getStaticProps = async ({ params }) => {
   Component={HvRadio}
   componentName="HvRadio"
   controls={{
-    checked: {
-      defaultValue: false,
-    },
-    required: {
-      defaultValue: true,
-    },
-    disabled: {
-      defaultValue: false,
-    },
-    semantic: {
-      defaultValue: false,
-    },
+    required: { defaultValue: true },
+    disabled: { defaultValue: false },
+    semantic: { defaultValue: false },
   }}
   componentProps={{
     label: "I have read and agree to the terms and conditions",
     statusMessage: "Please accept the terms and conditions",
-    checked: false,
+    defaultChecked: false,
     indeterminate: false,
   }}
 />
@@ -47,14 +38,14 @@ export default function Demo() {
   const [isChecked, setIsChecked] = useState(false);
 
   return (
-    <>
+    <div className="flex gap-xs">
       <HvRadio checked={isChecked} label="Radio 1" />
       <HvRadio
         checked={isChecked}
         onChange={(_, checked) => setIsChecked(checked)}
         label="Radio 2"
       />
-    </>
+    </div>
   );
 }
 ```

--- a/apps/docs/src/pages/components/scroll-to-horizontal.mdx
+++ b/apps/docs/src/pages/components/scroll-to-horizontal.mdx
@@ -51,7 +51,7 @@ export const getStaticProps = async ({ params }) => {
 ### With content
 
 ```tsx live
-<div className="flex flex-col">
+<>
   <HvScrollToHorizontal
     scrollElementId="pageContentId-2"
     options={[
@@ -88,7 +88,7 @@ export const getStaticProps = async ({ params }) => {
       </HvPanel>
     ))}
   </HvContainer>
-</div>
+</>
 ```
 
 - [`HvScrollToVertical`](/components/scroll-to-vertical)

--- a/apps/docs/src/pages/components/scroll-to-vertical.mdx
+++ b/apps/docs/src/pages/components/scroll-to-vertical.mdx
@@ -51,9 +51,9 @@ export const getStaticProps = async ({ params }) => {
 ### With content
 
 ```tsx live
-<>
+<div className="flex gap-xs">
   <HvScrollToVertical
-    scrollElementId="pageContentId-2"
+    scrollElementId="content2"
     options={[
       { label: "Server", value: "mainId2-1" },
       { label: "Optimization", value: "mainId2-2" },
@@ -62,16 +62,7 @@ export const getStaticProps = async ({ params }) => {
     ]}
     tooltipPosition="right"
   />
-  <HvContainer
-    id="pageContentId-2"
-    style={{
-      display: "flex",
-      flexDirection: "column",
-      gap: 20,
-      height: 400,
-      overflow: "auto",
-    }}
-  >
+  <HvContainer id="content2" className="grid gap-sm h-400px overflow-auto">
     {[
       { label: "Server", value: "mainId2-1" },
       { label: "Optimization", value: "mainId2-2" },
@@ -88,7 +79,7 @@ export const getStaticProps = async ({ params }) => {
       </HvPanel>
     ))}
   </HvContainer>
-</>
+</div>
 ```
 
 - [`HvScrollToHorizontal`](/components/scroll-to-horizontal)

--- a/apps/docs/src/pages/components/section.mdx
+++ b/apps/docs/src/pages/components/section.mdx
@@ -64,7 +64,7 @@ export default function Demo() {
   const [expanded, setExpanded] = useState(false);
 
   return (
-    <div className="grid gap-2 w-full">
+    <div className="grid gap-sm w-full">
       <HvButton className="w-1/4" onClick={() => setExpanded((p) => !p)}>
         Expand
       </HvButton>

--- a/apps/docs/src/pages/components/select.mdx
+++ b/apps/docs/src/pages/components/select.mdx
@@ -46,8 +46,8 @@ export const getStaticProps = async ({ params }) => {
 </Playground>
 
 <Callout type="info">
-  If you need features like search or multi-select you should use the
-  [`HvDropdown`](/components/dropdown) component.
+  If you need a search filter or multi-select checkboxes, consider using
+  [`HvDropdown`](/components/dropdown) instead.
 </Callout>
 
 ### Options
@@ -56,7 +56,7 @@ As an alternative to the `HvOption` `children`, `HvSelect` supports passing an `
 
 Keep in mind that the `children` is more flexible, as it allows using `HvOptionGroup` and distinct `label` and rendering (`children`) values.
 
-```jsx live
+```tsx live
 <HvSelect
   label="Country"
   description="Please select a country"

--- a/apps/docs/src/pages/components/simple-grid.mdx
+++ b/apps/docs/src/pages/components/simple-grid.mdx
@@ -1,7 +1,6 @@
 import { Callout } from "nextra/components";
 import {
-  HvCard,
-  HvCardContent,
+  HvPanel,
   HvSimpleGrid,
   simpleGridClasses,
 } from "@hitachivantara/uikit-react-core";
@@ -36,12 +35,8 @@ export const getStaticProps = async ({ params }) => {
     },
   }}
 >
-  {Array.from({ length: 6 }, (_, i) => (
-    <HvCard bgcolor="atmo2">
-      <HvCardContent className="flex items-center justify-center">
-        Item {i + 1}
-      </HvCardContent>
-    </HvCard>
+  {[...Array(6).keys()].map((i) => (
+    <HvPanel>Item {i + 1}</HvPanel>
   ))}
 </Playground>
 
@@ -61,11 +56,7 @@ Use the `breakpoints` prop to define the number of columns and spacing for diffe
     ]}
   >
     {[...Array(6).keys()].map((i) => (
-      <HvCard bgcolor="atmo2">
-        <HvCardContent className="flex items-center justify-center">
-          Item {i + 1}
-        </HvCardContent>
-      </HvCard>
+      <HvPanel>Item {i + 1}</HvPanel>
     ))}
   </HvSimpleGrid>
 </div>

--- a/apps/docs/src/pages/components/simple-grid.mdx
+++ b/apps/docs/src/pages/components/simple-grid.mdx
@@ -35,7 +35,6 @@ export const getStaticProps = async ({ params }) => {
       defaultValue: "sm",
     },
   }}
-  decorator={(component) => <div className="w-full">{component}</div>}
 >
   {Array.from({ length: 6 }, (_, i) => (
     <HvCard bgcolor="atmo2">

--- a/apps/docs/src/pages/components/skeleton.mdx
+++ b/apps/docs/src/pages/components/skeleton.mdx
@@ -31,7 +31,7 @@ export const getStaticProps = async ({ params }) => {
       defaultValue: false,
     },
   }}
-  decorator={(comp) => <div className="w-190px">{comp}</div>}
+  decorator={(children) => <div className="w-190px">{children}</div>}
   children={<div>My skeleton example content</div>}
 />
 

--- a/apps/docs/src/pages/components/skeleton.mdx
+++ b/apps/docs/src/pages/components/skeleton.mdx
@@ -40,7 +40,7 @@ export const getStaticProps = async ({ params }) => {
 If you pass no `width` or `height` props, the skeleton will adapt to the content size.
 
 ```tsx live
-<div className="flex flex-col gap-1">
+<div className="flex flex-col gap-xs">
   <HvSkeleton variant="circle">
     <HvAvatar alt="Beatrice" src="https://i.imgur.com/bE7vg3N.png" size="md" />
   </HvSkeleton>

--- a/apps/docs/src/pages/components/slider.mdx
+++ b/apps/docs/src/pages/components/slider.mdx
@@ -44,9 +44,8 @@ export default function Demo() {
   const [values, setValues] = useState([40, 80]);
 
   return (
-    <div className="w-full">
+    <>
       <HvSlider
-        className="w-full"
         label="Failure Rate"
         values={values}
         onChange={setValues}
@@ -68,7 +67,7 @@ export default function Demo() {
           Increment
         </HvButton>
       </div>
-    </div>
+    </>
   );
 }
 ```
@@ -84,7 +83,6 @@ export default function Demo() {
       label="Severity"
       hideInput
       defaultValues={[3]}
-      className="w-full"
       // step customization
       minPointValue={1}
       maxPointValue={5}

--- a/apps/docs/src/pages/components/snackbar-provider.mdx
+++ b/apps/docs/src/pages/components/snackbar-provider.mdx
@@ -35,49 +35,29 @@ After adding the provider at the root of your app, you can call the `useHvSnackb
 export default function Demo() {
   return (
     <HvSnackbarProvider autoHideDuration={3000}>
-      <SnackbarButtons />
+      <div className="flex gap-sm">
+        <SnackbarButton variant="success" />
+        <SnackbarButton variant="warning" />
+        <SnackbarButton variant="error" />
+        <SnackbarButton variant="default" />
+      </div>
     </HvSnackbarProvider>
   );
 }
 
-const SnackbarButtons = () => {
+const SnackbarButton = ({ variant }: { variant: HvSnackbarVariant }) => {
   const { enqueueSnackbar, closeSnackbar } = useHvSnackbar();
 
   return (
-    <div className="flex gap-sm">
-      <HvButton
-        variant="secondarySubtle"
-        onClick={() => {
-          enqueueSnackbar("This is a success snackbar", { variant: "success" });
-        }}
-      >
-        Success
-      </HvButton>
-      <HvButton
-        variant="secondarySubtle"
-        onClick={() => {
-          enqueueSnackbar("This is a warning snackbar", { variant: "warning" });
-        }}
-      >
-        Warning
-      </HvButton>
-      <HvButton
-        variant="secondarySubtle"
-        onClick={() => {
-          enqueueSnackbar("This is an error snackbar", { variant: "error" });
-        }}
-      >
-        Error
-      </HvButton>
-      <HvButton
-        variant="secondarySubtle"
-        onClick={() => {
-          enqueueSnackbar("This is a default snackbar", { variant: "default" });
-        }}
-      >
-        Default
-      </HvButton>
-    </div>
+    <HvButton
+      variant="subtle"
+      className="capitalize"
+      onClick={() => {
+        enqueueSnackbar(`This is a ${variant} snackbar.`, { variant });
+      }}
+    >
+      {variant}
+    </HvButton>
   );
 };
 ```
@@ -91,12 +71,12 @@ Check the [`HvSnackbar`](/components/snackbar) documentation for more informatio
 export default function Demo() {
   return (
     <HvSnackbarProvider autoHideDuration={3000}>
-      <SnackbarButtons />
+      <SnackbarButton />
     </HvSnackbarProvider>
   );
 }
 
-const SnackbarButtons = () => {
+const SnackbarButton = () => {
   const { enqueueSnackbar, closeSnackbar } = useHvSnackbar();
 
   return (
@@ -133,25 +113,25 @@ be dismissed automically after a some time.
 export default function Demo() {
   return (
     <HvSnackbarProvider autoHideDuration={3000}>
-      <SnackbarButtons />
+      <SnackbarButton />
     </HvSnackbarProvider>
   );
 }
 
-const SnackbarButtons = () => {
+const SnackbarButton = () => {
   const { enqueueSnackbar, closeSnackbar } = useHvSnackbar();
 
   return (
     <HvButton
-      variant="secondarySubtle"
+      variant="subtle"
       onClick={() => {
-        const snackbarLabel = (
+        enqueueSnackbar(
           <HvOverflowTooltip
             paragraphOverflow
             data={`This is a very ${"very ".repeat(26)}long snackbar.`}
-          />
+          />,
+          { variant: "default" },
         );
-        enqueueSnackbar(snackbarLabel, { variant: "default" });
       }}
     >
       Overflow

--- a/apps/docs/src/pages/components/snackbar.mdx
+++ b/apps/docs/src/pages/components/snackbar.mdx
@@ -17,18 +17,12 @@ export const getStaticProps = async ({ params }) => {
   Component={HvSnackbar}
   componentName="HvSnackbar"
   controls={{
-    label: {
-      defaultValue: "This is an informational message.",
-    },
-    variant: {
-      defaultValue: "default",
-    },
-    showIcon: {
-      defaultValue: true,
-    },
+    label: { defaultValue: "This is a success message." },
+    variant: { defaultValue: "success" },
+    showIcon: { defaultValue: true },
+    open: { defaultValue: true },
   }}
   componentProps={{
-    open: true,
     style: { position: "relative", top: 0 },
   }}
 />
@@ -70,7 +64,7 @@ Use the `action` prop to add an action to the snackbar. The `onAction` prop is a
 Although not desirable, sometimes you may need to display a long message in the snackbar. You can combine the snackbar with the [`HvOverflowTooltip`](/components/overflow-tooltip) component to display the full message.
 
 ```tsx live
-<div className="flex flex-col gap-2">
+<div className="flex flex-col gap-sm">
   <HvSnackbar
     open
     label={
@@ -122,21 +116,6 @@ export default function Demo() {
     }, 100);
   };
 
-  const handleTransition = (val) => {
-    setOpen(false);
-    setTransitionDirection(val);
-  };
-
-  const handleClose = (_, reason) => {
-    if (reason === "timeout") {
-      setOpen(false);
-    }
-  };
-
-  const handleDurationChange = (_, val) => {
-    setAutoHideDuration(val);
-  };
-
   return (
     <div className="flex justify-center w-full">
       <HvSnackbar
@@ -147,14 +126,21 @@ export default function Demo() {
         anchorOrigin={anchorOrigin}
         transitionDirection={transitionDirection}
         autoHideDuration={autoHideDuration}
-        onClose={handleClose}
+        onClose={(evt, reason) => {
+          if (reason === "timeout") {
+            setOpen(false);
+          }
+        }}
       />
-      <div className="flex flex-col gap-4">
+      <div className="flex flex-col gap-md">
         <div className="w-full flex justify-between">
           <HvSelect
             label="Transition direction"
             value={transitionDirection}
-            onChange={(_, val) => handleTransition(val)}
+            onChange={(_, val) => {
+              setOpen(false);
+              setTransitionDirection(val);
+            }}
             style={{ width: "120px" }}
           >
             {["up", "down", "left", "right"].map((direction) => (
@@ -167,10 +153,10 @@ export default function Demo() {
             type="number"
             label="Autohide duration"
             value={autoHideDuration}
-            onChange={handleDurationChange}
+            onChange={(_, val) => setAutoHideDuration(val)}
           />
         </div>
-        <div className="flex gap-4 w-full justify-between">
+        <div className="flex gap-md w-full justify-between">
           <HvButton
             variant="primarySubtle"
             onClick={() => handleOpen({ vertical: "top", horizontal: "left" })}
@@ -193,7 +179,7 @@ export default function Demo() {
           </HvButton>
         </div>
 
-        <div className="flex gap-4 w-full">
+        <div className="flex gap-md w-full">
           <HvButton
             variant="primarySubtle"
             onClick={() =>

--- a/apps/docs/src/pages/components/stack.mdx
+++ b/apps/docs/src/pages/components/stack.mdx
@@ -2,7 +2,6 @@ import {
   HvPanel,
   HvStack,
   stackClasses,
-  theme,
 } from "@hitachivantara/uikit-react-core";
 
 import Playground from "@docs/components/code/Playground";
@@ -20,24 +19,14 @@ export const getStaticProps = async ({ params }) => {
   Component={HvStack}
   componentName="HvStack"
   controls={{
-    direction: {
-      defaultValue: "row",
-    },
-    spacing: {
-      defaultValue: "sm",
-    },
-    divider: {
-      defaultValue: false,
-    },
+    direction: { defaultValue: "row" },
+    spacing: { defaultValue: "sm" },
+    divider: { defaultValue: false },
   }}
 >
-
-    {[...Array(4).keys()].map((index) => (
-      <HvPanel className="bg-atmo2">
-        {index + 1}
-      </HvPanel>
-    ))}
-
+  {[...Array(4).keys()].map((index) => (
+    <HvPanel key={index}>{index + 1}</HvPanel>
+  ))}
 </Playground>
 
 ### Custom direction
@@ -48,7 +37,7 @@ below shows a stack in a column format for breakpoints `xs` and `sm`, and in a r
 ```tsx live
 <HvStack direction={{ xs: "column", md: "row" }} spacing="xs" divider={false}>
   {[...Array(4).keys()].map((index) => (
-    <HvPanel className="bg-atmo2">{index + 1}</HvPanel>
+    <HvPanel key={index}>{index + 1}</HvPanel>
   ))}
 </HvStack>
 ```
@@ -60,7 +49,7 @@ The `divider` property can be a boolean (rendering the default divider), or a `R
 ```tsx live
 <HvStack direction="row" className="flex items-center" divider={<DropRight />}>
   {[...Array(4).keys()].map((index) => (
-    <HvPanel className="rounded-full size-48px grid place-content-center bg-atmo2">
+    <HvPanel className="rounded-full size-48px grid place-content-center">
       {index + 1}
     </HvPanel>
   ))}

--- a/apps/docs/src/pages/components/tabs.mdx
+++ b/apps/docs/src/pages/components/tabs.mdx
@@ -48,10 +48,6 @@ import { useState } from "react";
 export default function Demo() {
   const [value, setValue] = useState(0);
 
-  const handleChange: HvTabsProps["onChange"] = (evt, newValue) => {
-    setValue(newValue);
-  };
-
   return (
     <div className="grid gap-xs w-full">
       <HvTabs variant="fullWidth" value={value}>

--- a/apps/docs/src/pages/components/tag.mdx
+++ b/apps/docs/src/pages/components/tag.mdx
@@ -15,20 +15,10 @@ export const getStaticProps = async ({ params }) => {
   Component={HvTag}
   componentName="HvTag"
   controls={{
-    label: {
-      type: "text",
-      defaultValue: "Tag label",
-    },
-    color: {
-      type: "color",
-      defaultValue: "neutral_20",
-    },
-    disabled: {
-      defaultValue: false,
-    },
-    selectable: {
-      defaultValue: false,
-    },
+    label: { defaultValue: "Tag label" },
+    color: { type: "color", defaultValue: "neutral_20" },
+    disabled: { defaultValue: false },
+    selectable: { defaultValue: false },
   }}
 />
 
@@ -37,12 +27,12 @@ export const getStaticProps = async ({ params }) => {
 You can change the default color of the tag by passing a color name from the UI Kit color palette, a CSS color name or a hex color code.
 
 ```tsx live
-<>
+<div className="flex gap-xs">
   <HvTag label="Tag Label" color="positive" />
   <HvTag label="Tag Label" color="cat2" />
   <HvTag label="Tag Label" color="aquamarine" />
   <HvTag label="Tag Label" color="#c73aa8" />
-</>
+</div>
 ```
 
 ### Long text

--- a/apps/docs/src/pages/components/time-picker.mdx
+++ b/apps/docs/src/pages/components/time-picker.mdx
@@ -37,6 +37,7 @@ following the time [`input` format](https://developer.mozilla.org/en-US/docs/Web
 
 ```tsx live
 <form
+  className="flex gap-xs items-end"
   onSubmit={(event) => {
     event.preventDefault();
     const formData = new FormData(event.currentTarget);
@@ -68,7 +69,7 @@ export default function Demo() {
     : "—";
 
   return (
-    <div className="grid gap-sm">
+    <div className="grid gap-sm justify-start">
       <HvTypography variant="title4">Date: {prettyValue}</HvTypography>
       <HvTimePicker
         label="Time Picker"

--- a/apps/docs/src/pages/components/toggle-button.mdx
+++ b/apps/docs/src/pages/components/toggle-button.mdx
@@ -16,14 +16,10 @@ export const getStaticProps = async ({ params }) => {
   Component={HvToggleButton}
   componentName="HvToggleButton"
   controls={{
-    selected: {
-      defaultValue: false,
-    },
-    disabled: {
-      defaultValue: false,
-    },
+    disabled: { defaultValue: false },
   }}
   componentProps={{
+    defaultSelected: false,
     notSelectedIcon: <Favorite />,
     selectedIcon: <FavoriteSelected />,
   }}

--- a/apps/docs/src/pages/components/tooltip.mdx
+++ b/apps/docs/src/pages/components/tooltip.mdx
@@ -45,7 +45,7 @@ export const getStaticProps = async ({ params }) => {
 To "hide" a Tooltip, remove its `title`; `disableFocusListener` and `disableHoverListener` disable focus or hover, respectively.
 
 ```tsx live
-<div className="w-full flex justify-around pt-10">
+<div className="w-full flex justify-around pt-xl">
   <HvTooltip placement="right" title="">
     <HvButton variant="secondaryGhost">No tooltip</HvButton>
   </HvTooltip>
@@ -64,7 +64,7 @@ A Tooltip can be attached to any side (see `placement`) of any element or compon
  If the component doesn't do so, a workaround is to wrap it in a `div`.
 
 ```tsx live
-<div className="w-full flex justify-around pt-10">
+<div className="w-full flex justify-around pt-xl">
   <HvTooltip
     placement="right"
     title="Tooltips can showcase truncated text. The text should be concise and not
@@ -102,7 +102,7 @@ A Tooltip will grow to the size of its content. Keep in mind that the Tooltip `t
  and is not keyboard-navigable, therefore it shouldn't be too complex or contain interactable elements.
 
 ```tsx live
-<div className="w-full flex justify-around pt-10">
+<div className="w-full flex justify-around pt-xl">
   <HvTooltip
     title={
       <span className="max-w-250px">

--- a/apps/docs/src/pages/components/tree-view.mdx
+++ b/apps/docs/src/pages/components/tree-view.mdx
@@ -26,9 +26,7 @@ export const getStaticProps = async ({ params }) => {
     multiSelect: { defaultValue: false },
     disableSelection: { defaultValue: false },
   }}
-  decorator={(component) => (
-    <HvPanel style={{ width: 300 }}>{component}</HvPanel>
-  )}
+  decorator={(children) => <HvPanel className="w-300px">{children}</HvPanel>}
 >
   <HvTreeItem nodeId="1" label="Applications">
     <HvTreeItem nodeId="10" label="Calendar.app" />

--- a/packages/core/src/Tag/Tag.tsx
+++ b/packages/core/src/Tag/Tag.tsx
@@ -63,9 +63,7 @@ export interface HvTagProps
  * A Tag is one word that describes a specific aspect of an asset. A single asset can have
  * multiple tags.
  * Use tags to highlight an item's status for quick recognition and navigation
- * Use color to indicate meanings that users can learn and recognize across products
- *
- * It leverages the [MUI Chip](https://mui.com/material-ui/react-chip/) component
+ * Use color to indicate meanings that users can learn and recognize across products.
  */
 export const HvTag = forwardRef<
   // no-indent


### PR DESCRIPTION
- review `Live` and `Playground` layouts.
  - isolate `LivePreview`'s styles so they don't "hyjack" samples
- review samples's layout due to `LivePreview` samples
  - some other consistency fixes were made: fix typos & layouts, review usage of deprecated props, leverage container component (`HvSection`/`HvPanel`), sample/code alignment, etc.