### PR TITLE
fix(BaseInput): simplify structure

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -196,7 +196,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
       "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
@@ -246,7 +245,6 @@
       "version": "7.26.2",
       "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.26.2.tgz",
       "integrity": "sha512-Z0WgzSEa+aUcdiJuCIqgujCshpMWgUpgOxXotrYPSA53hA3qopNaqcJpyr0hVb1FeWdnqFA35/fUtXgBK8srQg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -256,7 +254,6 @@
       "version": "7.26.0",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.26.0.tgz",
       "integrity": "sha512-i1SLeK+DzNnQ3LL/CswPCa/E5u4lh1k6IAEphON8F+cXt0t9euTshDru0q7/IqMa1PMPz5RnHuHscF8/ZJsStg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
@@ -287,14 +284,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@babel/core/node_modules/semver": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -333,7 +328,6 @@
       "version": "7.25.9",
       "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.25.9.tgz",
       "integrity": "sha512-j9Db8Suy6yV/VHa4qzrj9yZfZxhLWQdVnRlXxmKLYlhWUVB1sB2G5sxuWYXk/whHD9iW76PmNzxZ4UCnTQTVEQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/compat-data": "^7.25.9",
@@ -350,7 +344,6 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -419,7 +412,6 @@
       "version": "7.26.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.26.0.tgz",
       "integrity": "sha512-xO+xu6B5K2czEnQye6BHA7DolFFmS3LB7stHZFaOLb1pAwO1HWLS8fXA+eh0A2yIvltPVmx3eNNDBJA2SLHXFw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-module-imports": "^7.25.9",
@@ -524,7 +516,6 @@
       "version": "7.25.9",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.25.9.tgz",
       "integrity": "sha512-e/zv1co8pp55dNdEcCynfj9X7nyUKUXoUEwfXqaZt0omVOmDe9oOTdKStH4GmAw6zxMFs50ZayuMfHDKlO7Tfw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -534,7 +525,6 @@
       "version": "7.26.0",
       "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.26.0.tgz",
       "integrity": "sha512-tbhNuIxNcVb21pInl3ZSjksLCvgdZy9KwJ8brv993QtIVKJBBkYXz4q4ZbAv31GdnC+R90np23L5FbEBlthAEw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/template": "^7.25.9",
@@ -2419,7 +2409,6 @@
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/@ianvs/prettier-plugin-sort-imports/-/prettier-plugin-sort-imports-4.3.1.tgz",
       "integrity": "sha512-ZHwbyjkANZOjaBm3ZosADD2OUYGFzQGxfy67HmGZU94mHqe7g1LCMA7YYKB1Cq+UTPCBqlAYapY0KXAjKEw8Sg==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/core": "^7.24.0",
@@ -5728,7 +5717,7 @@
       "version": "1.48.2",
       "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.48.2.tgz",
       "integrity": "sha512-54w1xCWfXuax7dz4W2M9uw0gDyh+ti/0K/MxcCUxChFh37kkdxPdfZDw5QBbuPUJHr1CiHJ1hXgSs+GgeQc5Zw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright": "1.48.2"
@@ -11323,7 +11312,6 @@
       "version": "4.24.2",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.2.tgz",
       "integrity": "sha512-ZIc+Q62revdMcqC6aChtW4jz3My3klmCO1fEmINZY/8J3EpBg5/A/D0AKmBveUh6pgoeycoMkVMko84tuYS+Gg==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -14491,7 +14479,6 @@
       "version": "5.5.1",
       "resolved": "https://registry.npmjs.org/echarts/-/echarts-5.5.1.tgz",
       "integrity": "sha512-Fce8upazaAXUVUVsjgV6mBnGuqgO+JNDlcgF79Dksy4+wgGpQB2lmYoO4TSweFg/mZITdpGHomw/cNBJZj1icA==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "2.3.0",
@@ -14502,7 +14489,6 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/echarts-for-react/-/echarts-for-react-3.0.2.tgz",
       "integrity": "sha512-DRwIiTzx8JfwPOVgGttDytBqdp5VzCSyMRIxubgU/g2n9y3VLUmF2FK7Icmg/sNVkv4+rktmrLN9w22U2yy3fA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -14517,7 +14503,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
       "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
-      "dev": true,
       "license": "0BSD"
     },
     "node_modules/ejs": {
@@ -14540,7 +14525,6 @@
       "version": "1.5.50",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.50.tgz",
       "integrity": "sha512-eMVObiUQ2LdgeO1F/ySTXsvqvxb6ZH2zPGaMYsWzRDdOddUa77tdmI0ltg+L16UpbWdhPmuF3wIQYyQq65WfZw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/embla-carousel": {
@@ -14603,7 +14587,6 @@
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
       "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -14614,7 +14597,6 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -14993,7 +14975,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -16085,7 +16066,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-equals": {
@@ -16721,7 +16701,6 @@
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
       "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -22145,7 +22124,6 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
       "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
@@ -24819,7 +24797,6 @@
       "version": "2.0.18",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.18.tgz",
       "integrity": "sha512-d9VeXT4SJ7ZeOqGX6R5EM022wpL+eWPooLI+5UpWn2jCT1aosUQEhQP214x33Wkwx3JQMvIm+tIoVOdodFS40g==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/nopt": {
@@ -26559,7 +26536,7 @@
       "version": "1.48.2",
       "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.48.2.tgz",
       "integrity": "sha512-NjYvYgp4BPmiwfe31j4gHLa3J7bD2WiBz8Lk2RoSsmX38SVIARZ18VYjxLjAcDsAhA+F4iSEXTSGgjua0rrlgQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright-core": "1.48.2"
@@ -26578,7 +26555,7 @@
       "version": "1.48.2",
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.48.2.tgz",
       "integrity": "sha512-sjjw+qrLFlriJo64du+EK0kJgZzoQPsabGF4lBvsid+3CNIZIYLgnMj9V6JY5VhM2Peh20DJWIVpVljLLnlawA==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
@@ -26698,7 +26675,6 @@
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.3.tgz",
       "integrity": "sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "prettier": "bin/prettier.cjs"
@@ -29017,7 +28993,6 @@
       "version": "7.5.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
       "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -29033,7 +29008,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "yallist": "^4.0.0"
@@ -29046,7 +29020,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/sentence-case": {
@@ -29315,7 +29288,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/size-sensor/-/size-sensor-1.0.2.tgz",
       "integrity": "sha512-2NCmWxY7A9pYKGXNBfteo4hy14gWu47rg5692peVMst6lQLPKrVjhY+UTEsPI5ceFRJSl3gVgMYaUi/hKuaiKw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/slash": {
@@ -31424,7 +31396,6 @@
       "version": "5.4.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.2.tgz",
       "integrity": "sha512-+2/g0Fds1ERlP6JsakQQDXjZdZMM+rqpamFZJEKh4kwTIn3iDkgKtby0CeNd5ATNZ4Ry1ax15TMx0W2V+miizQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -31840,7 +31811,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.1.tgz",
       "integrity": "sha512-R8UzCaa9Az+38REPiJ1tXlImTJXlVfgHZsglwBD/k6nj76ctsH1E3q4doGrukiLQd3sGQYu56r5+lo5r94l29A==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -33543,7 +33513,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/yaml": {
@@ -33659,7 +33628,6 @@
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/zrender/-/zrender-5.6.0.tgz",
       "integrity": "sha512-uzgraf4njmmHAbEUxMJ8Oxg+P3fT04O+9p7gY+wJRVxo8Ge+KmYv0WJev945EH4wFuc4OY2NLXz46FZrWS9xJg==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "tslib": "2.3.0"
@@ -33669,7 +33637,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
       "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
-      "dev": true,
       "license": "0BSD"
     },
     "node_modules/zustand": {

--- a/packages/core/src/BaseInput/BaseInput.styles.tsx
+++ b/packages/core/src/BaseInput/BaseInput.styles.tsx
@@ -5,221 +5,129 @@ import { outlineStyles } from "../utils/focusUtils";
 
 export const { staticClasses, useClasses } = createClasses("HvBaseInput", {
   root: {
-    display: "inline-block",
+    // #region `input` style reset
+    "input:-webkit-autofill": {
+      WebkitBoxShadow: `0 0 0px 1000px ${theme.colors.atmo1} inset`,
+      WebkitTextFillColor: theme.colors.secondary,
+    },
+
+    // Clears number input up/down arrows in Chrome and Firefox
+    "input[type=number]": {
+      MozAppearance: "textfield",
+      "&::-webkit-outer-spin-button,&::-webkit-inner-spin-button": {
+        WebkitAppearance: "none",
+        margin: 0,
+      },
+    },
+
+    // Clears time input clock in Chrome
+    "input::-webkit-calendar-picker-indicator": {
+      display: "none",
+    },
+
+    // Clears search input clear button in Chrome
+    "input[type=search]::-webkit-search-decoration,input[type=search]::-webkit-search-cancel-button,input[type=search]::-webkit-search-results-button,input[type=search]::-webkit-search-results-decoration":
+      {
+        display: "none",
+      },
+    // #endregion
+
+    display: "inline-flex",
     width: "100%",
     position: "relative",
-
-    "&:hover $inputBorderContainer": {
-      backgroundColor: theme.colors.primary,
-    },
-
-    "&:focus-within $inputBorderContainer": {
-      backgroundColor: theme.colors.primary,
-    },
-  },
-  disabled: {
-    "& $inputRoot": {
-      backgroundColor: theme.colors.atmo2,
-      borderColor: theme.colors.secondary_60,
-    },
-
-    "& $inputBorderContainer": {
-      backgroundColor: theme.colors.atmo4,
-    },
-
-    "&:hover $inputBorderContainer": {
-      backgroundColor: theme.colors.atmo4,
-    },
-
-    "&& $input": {
-      color: theme.colors.secondary_60,
-      WebkitTextFillColor: theme.colors.secondary_60,
-    },
-
-    "& $inputRootMultiline": {
-      "& $input": {
-        backgroundColor: theme.colors.atmo2,
-        border: `1px solid ${theme.colors.secondary_60}`,
-      },
-    },
-
-    "&:hover $inputRootMultiline": {
-      "& $input": {
-        backgroundColor: theme.colors.atmo2,
-        border: `1px solid ${theme.colors.secondary_60}`,
-      },
-    },
-  },
-  invalid: {
-    "&:not(.disabled)": {
-      "& $inputBorderContainer": {
-        backgroundColor: theme.colors.negative_120,
-      },
-
-      "&:hover $inputBorderContainer": {
-        backgroundColor: theme.colors.negative_120,
-      },
-
-      "& $inputRootMultiline": {
-        "& $input": {
-          border: `1px solid ${theme.colors.negative_120}`,
-        },
-      },
-
-      "&:hover $inputRootMultiline": {
-        "& $input": {
-          border: `1px solid ${theme.colors.negative_120}`,
-        },
-      },
-
-      "&:focus-within $inputRootMultiline": {
-        "& $input": {
-          border: `1px solid ${theme.colors.negative_120}`,
-        },
-      },
-    },
-  },
-  resizable: { width: "auto" },
-  readOnly: {
-    "& $inputBorderContainer": {
-      backgroundColor: "transparent",
-    },
-
-    "&:hover $inputBorderContainer": {
-      backgroundColor: "transparent",
-    },
-
-    "&:focus-within $inputBorderContainer": {
-      backgroundColor: "transparent",
-    },
-
-    "& $inputRootMultiline": {
-      "& $input": {
-        border: `1px solid ${theme.colors.secondary_60}`,
-        backgroundColor: theme.colors.atmo2,
-      },
-    },
-
-    "&:hover $inputRootMultiline": {
-      "& $input": {
-        border: `1px solid ${theme.colors.secondary_60}`,
-        backgroundColor: theme.colors.atmo2,
-      },
-    },
-
-    "&:focus-within $inputRootMultiline": {
-      "& $input": {
-        border: `1px solid ${theme.colors.secondary_60}`,
-        backgroundColor: theme.colors.atmo2,
-      },
-    },
-  },
-  inputBorderContainer: {
-    position: "absolute",
-    width: "calc(100% - 4px)",
-    height: "0px",
-    top: "31px",
-    left: "2px",
-    backgroundColor: theme.colors.atmo4,
-  },
-  inputRootInvalid: { borderColor: theme.colors.negative_120 },
-  inputRootReadOnly: {
-    borderColor: theme.colors.secondary_60,
-    backgroundColor: theme.colors.atmo2,
-  },
-  inputRoot: {
     margin: 0,
-    width: "100%",
     borderRadius: theme.radii.base,
     height: "32px",
-    border: `1px solid ${theme.colors.secondary}`,
+    borderWidth: 1,
+    borderColor: theme.colors.secondary,
     boxSizing: "border-box",
     backgroundColor: theme.colors.atmo1,
     fontFamily: theme.fontFamily.body,
 
-    "&:hover:not($inputRootDisabled):not($inputRootInvalid):not($inputRootReadOnly)":
-      {
-        borderColor: theme.colors.primary,
-      },
-
-    "&:hover:not($inputRootDisabled)::before": {
-      borderBottom: "none",
+    ":hover:not($disabled,$invalid,$readOnly)": {
+      borderColor: theme.colors.primary,
     },
-
-    "&::before": {
-      borderBottom: "none",
-    },
-
-    "&::after": {
-      borderBottom: "none",
+    ":focus-within:not($disabled)": {
+      ...outlineStyles,
     },
   },
-  inputRootFocused: {
-    backgroundColor: theme.colors.atmo1,
-    ...outlineStyles,
+  disabled: {
+    backgroundColor: theme.colors.atmo2,
+    borderColor: theme.colors.secondary_60,
 
-    "&:hover": {
-      backgroundColor: theme.colors.atmo1,
-    },
-
-    "&$inputRootReadOnly": {
-      backgroundColor: theme.colors.atmo2,
-    },
-  },
-  inputRootDisabled: {
     cursor: "not-allowed",
 
     "&&::before": {
       borderBottomStyle: "none",
     },
   },
-  inputRootMultiline: {
+  invalid: {
+    borderColor: theme.colors.negative_120,
+  },
+  multiline: {
     padding: 0,
-    backgroundColor: "transparent",
     overflow: "auto",
-    border: "none",
     height: "auto",
 
     "& $input": {
-      border: `1px solid ${theme.colors.secondary}`,
       borderRadius: theme.radii.base,
-      backgroundColor: theme.colors.atmo1,
       height: "auto",
       minHeight: "21px",
       padding: "5px 10px",
       overflow: "auto",
-      marginLeft: "0px",
-      marginRight: "0px",
-
-      "&:hover": {
-        border: `1px solid ${theme.colors.primary}`,
-      },
+      margin: 0,
     },
   },
+  resizable: { width: "auto" },
+  readOnly: {
+    borderColor: theme.colors.secondary_60,
+    backgroundColor: theme.colors.atmo2,
+  },
+  focused: {},
+  /** @deprecated unused. use `::after` instead */
+  inputBorderContainer: {},
+  /** @deprecated use `classes.invalid` instead */
+  inputRootInvalid: { borderColor: theme.colors.negative_120 },
+  /** @deprecated use `classes.readOnly` instead */
+  inputRootReadOnly: {
+    borderColor: theme.colors.secondary_60,
+    backgroundColor: theme.colors.atmo2,
+  },
+  /** @deprecated use `classes.root` instead */
+  inputRoot: {},
+  /** @deprecated unused */
+  inputRootFocused: {},
+  /** @deprecated use `classes.disabled` instead */
+  inputRootDisabled: {},
+  /** @deprecated use `classes.multiline` instead */
+  inputRootMultiline: {},
   input: {
-    height: "19px",
+    height: "100%",
     marginLeft: theme.space.xs,
     marginRight: theme.space.xs,
-    padding: "6px 0 5px",
+    padding: theme.spacing("5px", 0),
+    backgroundColor: "transparent",
     overflow: "hidden",
     textOverflow: "ellipsis",
     outline: "none",
     width: "initial",
     flexGrow: 1,
-    ...(theme.typography.body as React.CSSProperties),
+    ...theme.typography.body,
 
     "&::placeholder": {
       opacity: 1,
       color: theme.colors.secondary_80,
     },
-
-    "&::-ms-clear": {
-      display: "none",
-    },
   },
-  inputDisabled: {},
+  inputDisabled: {
+    color: theme.colors.secondary_60,
+    WebkitTextFillColor: theme.colors.secondary_60,
+  },
   inputReadOnly: {
     color: theme.colors.secondary_80,
   },
-  inputResizable: { resize: "both", width: "100%" },
+  inputResizable: {
+    resize: "both",
+    width: "100%",
+  },
 });

--- a/packages/core/src/BaseInput/BaseInput.tsx
+++ b/packages/core/src/BaseInput/BaseInput.tsx
@@ -1,12 +1,10 @@
 import { forwardRef, useContext } from "react";
-import { css as emotionCss, Global } from "@emotion/react";
-import MuiInputBase, { InputBaseProps } from "@mui/material/InputBase";
+import MuiInputBase, { type InputBaseProps } from "@mui/material/InputBase";
 import { useForkRef } from "@mui/material/utils";
 import {
   useDefaultProps,
   type ExtractNames,
 } from "@hitachivantara/uikit-react-utils";
-import { theme } from "@hitachivantara/uikit-styles";
 
 import {
   buildAriaPropsFromContext,
@@ -19,34 +17,6 @@ import { staticClasses, useClasses } from "./BaseInput.styles";
 export { staticClasses as baseInputClasses };
 
 export type HvBaseInputClasses = ExtractNames<typeof useClasses>;
-
-// Global styles for the base input.
-const baseInputStyles = emotionCss({
-  "input:-webkit-autofill": {
-    WebkitBoxShadow: `0 0 0px 1000px ${theme.colors.atmo1} inset`,
-    WebkitTextFillColor: theme.colors.secondary,
-  },
-
-  // Clears number input up/down arrows in Chrome and Firefox
-  "input::-webkit-outer-spin-button,input::-webkit-inner-spin-button": {
-    WebkitAppearance: "none",
-    margin: 0,
-  },
-  "input[type=number]": {
-    MozAppearance: "textfield",
-  },
-
-  // Clears time input clock in Chrome
-  "input::-webkit-calendar-picker-indicator": {
-    display: "none",
-  },
-
-  // Clears search input clear button in Chrome
-  "input::-webkit-search-decoration,input::-webkit-search-cancel-button,input::-webkit-search-results-button,input::-webkit-search-results-decoration":
-    {
-      display: "none",
-    },
-});
 
 export interface HvBaseInputProps
   extends Omit<
@@ -110,7 +80,7 @@ export const HvBaseInput = forwardRef<
     placeholder,
     multiline,
     resizable,
-    invalid,
+    invalid: invalidProp,
     inputRef,
     inputProps = {},
     ...others
@@ -127,7 +97,7 @@ export const HvBaseInput = forwardRef<
 
   const forkedRef = useForkRef(ref, inputRef);
 
-  const localInvalid = invalid || formElementProps.status === "invalid";
+  const invalid = invalidProp || formElementProps.status === "invalid";
 
   const formElementDescriptorsContext = useContext(
     HvFormElementDescriptorsContext,
@@ -135,61 +105,48 @@ export const HvBaseInput = forwardRef<
   const ariaProps = buildAriaPropsFromContext(
     inputProps,
     formElementDescriptorsContext,
-    localInvalid,
+    invalid,
     id,
   );
 
   return (
-    <>
-      <Global styles={baseInputStyles} />
-      <div
-        className={cx(classes.root, className, {
-          [classes.disabled]: formElementProps.disabled,
-          [classes.invalid]: localInvalid,
-          [classes.resizable]: multiline && resizable,
-          [classes.readOnly]: formElementProps.readOnly,
-        })}
-      >
-        <MuiInputBase
-          id={id}
-          name={formElementProps.name}
-          value={value}
-          defaultValue={defaultValue}
-          type={type}
-          placeholder={placeholder}
-          readOnly={!!formElementProps.readOnly}
-          disabled={formElementProps.disabled}
-          onChange={(event) => onChange?.(event, event.target.value)}
-          className={cx({
-            [classes.inputRootInvalid]: localInvalid,
-            [classes.inputRootReadOnly]: formElementProps.readOnly,
-          })}
-          classes={{
-            root: classes.inputRoot,
-            focused: classes.inputRootFocused,
-            disabled: classes.inputRootDisabled,
-            multiline: classes.inputRootMultiline,
-            input: cx(classes.input, {
-              [classes.inputResizable]: !formElementProps.disabled && resizable,
-              [classes.inputDisabled]: formElementProps.disabled,
-              [classes.inputReadOnly]: formElementProps.readOnly,
-            }),
-          }}
-          inputProps={{
-            // Avoid the required attribute at the root node
-            required: formElementProps.required,
-            ...inputProps,
-            ...ariaProps,
-          }}
-          inputRef={forkedRef}
-          multiline={multiline}
-          rows={10}
-          {...others}
-        />
-        {!multiline && (
-          <div role="presentation" className={classes.inputBorderContainer} />
-        )}
-      </div>
-    </>
+    <MuiInputBase
+      id={id}
+      name={formElementProps.name}
+      value={value}
+      defaultValue={defaultValue}
+      placeholder={placeholder}
+      readOnly={!!formElementProps.readOnly}
+      disabled={formElementProps.disabled}
+      onChange={(event) => onChange?.(event, event.target.value)}
+      className={cx(classes.root, classes.inputRoot, className, {
+        [classes.inputRootMultiline]: multiline,
+        [classes.multiline]: multiline,
+        [classes.inputRootInvalid]: invalid,
+        [classes.invalid]: invalid,
+        [classes.inputRootReadOnly]: formElementProps.readOnly,
+        [classes.readOnly]: formElementProps.readOnly,
+        [classes.inputRootDisabled]: formElementProps.disabled,
+        [classes.disabled]: formElementProps.disabled,
+      })}
+      classes={{
+        focused: cx(classes.focused, classes.inputRootFocused),
+        input: cx(classes.input, {
+          [classes.inputResizable]: !formElementProps.disabled && resizable,
+          [classes.inputDisabled]: formElementProps.disabled,
+          [classes.inputReadOnly]: formElementProps.readOnly,
+        }),
+      }}
+      inputProps={{
+        // Avoid the required attribute at the root node
+        required: formElementProps.required,
+        ...inputProps,
+        ...ariaProps,
+      }}
+      inputRef={forkedRef}
+      multiline={multiline}
+      {...(multiline ? { rows: 10 } : { type })}
+      {...others}
+    />
   );
 });

--- a/packages/core/src/Calendar/CalendarHeader/CalendarHeader.styles.tsx
+++ b/packages/core/src/Calendar/CalendarHeader/CalendarHeader.styles.tsx
@@ -13,8 +13,4 @@ export const { staticClasses, useClasses } = createClasses("HvCalendarHeader", {
   headerDayOfWeek: {
     color: theme.colors.secondary_80,
   },
-  headerDate: {},
-  input: {},
-  inputBorderContainer: {},
-  invalidMessageStyling: {},
 });

--- a/packages/core/src/Calendar/CalendarHeader/CalendarHeader.tsx
+++ b/packages/core/src/Calendar/CalendarHeader/CalendarHeader.tsx
@@ -159,12 +159,6 @@ export const HvCalendarHeader = (props: HvCalendarHeaderProps) => {
       <HvInput
         type="text"
         id={setId(id, "header-input")}
-        className={classes.headerDate}
-        classes={{
-          input: classes.input,
-          inputBorderContainer: classes.inputBorderContainer,
-          error: classes.invalidMessageStyling,
-        }}
         placeholder={localeFormat}
         value={inputValue}
         aria-labelledby={label?.[0]?.id}

--- a/packages/core/src/InlineEditor/InlineEditor.styles.tsx
+++ b/packages/core/src/InlineEditor/InlineEditor.styles.tsx
@@ -1,22 +1,15 @@
 import { createClasses } from "@hitachivantara/uikit-react-utils";
 import { theme } from "@hitachivantara/uikit-styles";
 
-import { baseInputClasses } from "../BaseInput";
-import { inputClasses } from "../Input";
-
 export const { staticClasses, useClasses } = createClasses("HvInlineEditor", {
-  root: {
-    [`& .${baseInputClasses.inputRoot}.${inputClasses.inputRoot}`]: {
-      height: "100%",
-      minHeight: "32px",
-    },
-  },
-  inputBorderContainer: {
-    top: "unset",
-    bottom: 0,
-  },
+  root: {},
+  /** @deprecated unused. use `classes.root::after` instead */
+  inputBorderContainer: {},
   input: {},
-  inputRoot: {},
+  inputRoot: {
+    height: "100%",
+    minHeight: "32px",
+  },
   text: {},
   largeText: {},
   textEmpty: {

--- a/packages/core/src/InlineEditor/InlineEditor.tsx
+++ b/packages/core/src/InlineEditor/InlineEditor.tsx
@@ -153,7 +153,6 @@ export const HvInlineEditor = fixedForwardRef(function HvInlineEditor<
           classes={{
             root: classes.inputRoot,
             input: classes.input,
-            inputBorderContainer: classes.inputBorderContainer,
           }}
           inputProps={{
             style: {

--- a/packages/core/src/Input/Input.styles.tsx
+++ b/packages/core/src/Input/Input.styles.tsx
@@ -34,18 +34,9 @@ export const { staticClasses, useClasses } = createClasses("HvInput", {
     backgroundColor: theme.colors.atmo1,
     boxShadow: `0px 8px 0px ${theme.colors.atmo1}, 0px 0px 9px 0px rgba(65,65,65,.12)`,
   },
-  input: {
-    "&::-ms-clear": {
-      display: "none",
-    },
-  },
+  input: {},
   inputRoot: {
-    ":hover": {
-      "& $iconClear": {
-        display: "block",
-      },
-    },
-    ":focus-within $iconClear": {
+    ":is(:hover,:focus-within) $iconClear": {
       display: "block",
     },
   },
@@ -54,14 +45,9 @@ export const { staticClasses, useClasses } = createClasses("HvInput", {
       display: "block",
     },
   },
-  inputRootDisabled: {
-    cursor: "not-allowed",
-  },
+  inputRootDisabled: {},
   inputRootMultiline: { padding: 0 },
-  inputBorderContainer: {
-    "$hasSuggestions &": {
-      display: "none",
-    },
-  },
+  /** @deprecated unused. use `::after` instead */
+  inputBorderContainer: {},
   error: {},
 });

--- a/packages/core/src/Input/Input.test.tsx
+++ b/packages/core/src/Input/Input.test.tsx
@@ -47,9 +47,9 @@ describe("Input", () => {
   });
 
   it("renders the custom icon", () => {
-    render(<HvInput endAdornment={<Map role="presentation" />} />);
+    render(<HvInput endAdornment={<Map data-testid="icon" />} />);
 
-    expect(screen.getByRole("presentation")).toBeVisible();
+    expect(screen.getByTestId("icon")).toBeVisible();
   });
 
   it("renders the adornment as disabled for the search when the input is disabled", () => {

--- a/packages/core/src/Input/Input.tsx
+++ b/packages/core/src/Input/Input.tsx
@@ -129,6 +129,7 @@ export interface HvInputProps<
    * it receives the value. If a new value should be presented it must returned it.
    */
   onChange?: (event: React.ChangeEvent<InputElement>, value: string) => void;
+  // onEnter?: (event: React.KeyboardEvent<InputElement>, value: string) => void;
   onEnter?: (
     event: React.KeyboardEvent<InputElement> | React.MouseEvent,
     value: string,
@@ -825,11 +826,10 @@ export const HvInput = fixedForwardRef(function HvInput<
         type={realType}
         classes={{
           input: classes.input,
-          inputRoot: classes.inputRoot,
-          inputRootFocused: classes.inputRootFocused,
-          inputRootDisabled: classes.inputRootDisabled,
-          inputRootMultiline: classes.inputRootMultiline,
-          inputBorderContainer: classes.inputBorderContainer,
+          root: classes.inputRoot,
+          focused: classes.inputRootFocused,
+          disabled: classes.inputRootDisabled,
+          multiline: classes.inputRootMultiline,
         }}
         invalid={isStateInvalid}
         inputProps={{

--- a/packages/core/src/Select/Select.styles.ts
+++ b/packages/core/src/Select/Select.styles.ts
@@ -11,7 +11,7 @@ export const { staticClasses, useClasses } = createClasses("HvSelect", {
   disabled: {},
   readOnly: {},
   invalid: {
-    border: `1px solid ${theme.colors.negative_120}`,
+    borderColor: theme.colors.negative_120,
   },
   labelContainer: {
     display: "flex",

--- a/packages/core/src/TagsInput/TagsInput.styles.tsx
+++ b/packages/core/src/TagsInput/TagsInput.styles.tsx
@@ -129,9 +129,6 @@ export const { staticClasses, useClasses } = createClasses("HvTagsInput", {
     [`& .${baseInputClasses.root}`]: {
       width: "100%",
       border: "none",
-      "&:hover $tagInputBorderContainer": {
-        background: "none",
-      },
     },
     [`&& .${baseInputClasses.inputRoot}`]: {
       marginLeft: 0,
@@ -141,10 +138,6 @@ export const { staticClasses, useClasses } = createClasses("HvTagsInput", {
       lineHeight: "24px",
       padding: 0,
       border: "none",
-    },
-    [`& .${baseInputClasses.inputBorderContainer}`]: {
-      border: "none",
-      background: "none",
     },
     [`& .${baseInputClasses.inputRootFocused}`]: {
       outline: "none",
@@ -168,6 +161,7 @@ export const { staticClasses, useClasses } = createClasses("HvTagsInput", {
     outlineOffset: "-1px",
     boxShadow: "0 0 0 1px #52A8EC, 0 0 0 4px rgba(29,155,209,.3)",
   },
+  /** @deprecated unused. use `::after` instead */
   tagInputBorderContainer: {},
   tagInputRootFocused: {},
   tagInputRootEmpty: {},

--- a/packages/core/src/TextArea/TextArea.styles.tsx
+++ b/packages/core/src/TextArea/TextArea.styles.tsx
@@ -7,7 +7,7 @@ export const { staticClasses, useClasses } = createClasses("HvTextArea", {
   invalid: {},
   baseInput: { clear: "both", float: "left" },
   input: {},
-  inputResizable: { width: "100%", resize: "both" },
+  inputResizable: {},
   labelContainer: { float: "left", display: "flex", alignItems: "flex-start" },
   label: {},
   description: { display: "block", float: "left" },

--- a/packages/core/src/TimePicker/Unit/Unit.styles.ts
+++ b/packages/core/src/TimePicker/Unit/Unit.styles.ts
@@ -53,7 +53,4 @@ export const { staticClasses, useClasses } = createClasses("HvTimePickerUnit", {
     minWidth: 40,
     maxWidth: 40,
   },
-  inputBorderContainer: {
-    top: 40,
-  },
 });

--- a/packages/core/src/TimePicker/Unit/Unit.tsx
+++ b/packages/core/src/TimePicker/Unit/Unit.tsx
@@ -53,7 +53,6 @@ export const Unit = ({
           classes={{
             input: classes.input,
             root: classes.inputContainer,
-            inputBorderContainer: classes.inputBorderContainer,
             inputRoot: classes.inputRoot,
           }}
           onKeyDown={(event) => {

--- a/packages/styles/src/CssBaseline.ts
+++ b/packages/styles/src/CssBaseline.ts
@@ -1,10 +1,6 @@
 import { theme } from "./theme";
 
 const baseline = {
-  /* Clears input's clear and reveal buttons from IE */
-  "input[type=search]::-ms-clear": { display: "none", width: 0, height: 0 },
-  "input[type=search]::-ms-reveal": { display: "none", width: 0, height: 0 },
-
   /* Clears input's clear button from Chrome */
   'input[type="search"]::-webkit-search-decoration': { display: "none" },
   'input[type="search"]::-webkit-search-cancel-button': { display: "none" },

--- a/packages/styles/src/themes/ds3.ts
+++ b/packages/styles/src/themes/ds3.ts
@@ -302,86 +302,59 @@ const ds3 = makeTheme((theme) => ({
     HvBaseInput: {
       classes: {
         root: {
-          "&:hover .HvBaseInput-inputBorderContainer": {
-            backgroundColor: theme.colors.secondary,
-          },
+          border: "none",
 
-          "&:focus-within .HvBaseInput-inputBorderContainer": {
-            backgroundColor: theme.colors.secondary,
+          ":not(.HvBaseInput-disabled):not(.HvBaseInput-invalid):not(.HvBaseInput-readOnly)":
+            {
+              ":hover,:focus-within": {
+                borderColor: theme.colors.secondary,
+                "::after": {
+                  borderBottomColor: theme.colors.secondary,
+                },
+              },
+            },
+
+          "::after": {
+            content: '" "',
+            position: "absolute",
+            inset: "auto 0 0",
+            margin: "0 2px",
+            borderBottom: `1px solid ${theme.colors.atmo4}`,
+          },
+        },
+        invalid: {
+          "::after": {
+            borderBottomColor: theme.colors.negative_120,
           },
         },
         disabled: {
-          "& .HvBaseInput-inputRoot": {
-            backgroundColor: theme.colors.atmo3,
-            borderColor: "transparent",
-          },
+          backgroundColor: theme.colors.atmo3,
 
           "&& .HvBaseInput-input": {
             color: theme.colors.secondary_60,
             WebkitTextFillColor: theme.colors.secondary_60,
           },
-
-          "& .HvBaseInput-inputRootMultiline": {
-            "& .HvBaseInput-input": {
-              backgroundColor: theme.colors.atmo3,
-              border: `1px solid ${theme.colors.atmo4}`,
-            },
+        },
+        multiline: {
+          border: `1px solid ${theme.colors.atmo4}`,
+          "&::after": {
+            display: "none",
           },
-
-          "&:hover .HvBaseInput-inputRootMultiline": {
-            "& .HvBaseInput-input": {
-              backgroundColor: theme.colors.atmo3,
-              border: `1px solid ${theme.colors.atmo4}`,
-            },
+          "&.HvBaseInput-disabled": {
+            borderColor: theme.colors.atmo4,
           },
         },
         readOnly: {
-          "& .HvBaseInput-inputRootMultiline": {
-            "& .HvBaseInput-input": {
-              border: `1px solid transparent`,
-              backgroundColor: theme.colors.atmo1,
-            },
-          },
-
-          "&:hover .HvBaseInput-inputRootMultiline": {
-            "& .HvBaseInput-input": {
-              border: `1px solid transparent`,
-              backgroundColor: theme.colors.atmo1,
-            },
-          },
-
-          "&:focus-within .HvBaseInput-inputRootMultiline": {
-            "& .HvBaseInput-input": {
-              border: `1px solid transparent`,
-              backgroundColor: theme.colors.atmo1,
-            },
-          },
-        },
-        inputBorderContainer: {
-          height: "1px",
-        },
-        inputRootReadOnly: {
           borderColor: "transparent",
           backgroundColor: theme.colors.atmo1,
-        },
-        inputRoot: {
-          border: "none",
-          "&:hover:not(.HvBaseInput-inputRootDisabled):not(.HvBaseInput-inputRootInvalid):not(.HvBaseInput-inputRootReadOnly)":
-            {
-              borderColor: theme.colors.secondary,
-            },
-        },
-        inputRootFocused: {
-          "&.HvBaseInput-inputRootReadOnly": {
-            backgroundColor: theme.colors.atmo1,
+
+          "::after": {
+            borderColor: "transparent",
           },
         },
-        inputRootMultiline: {
-          "& .HvBaseInput-input": {
-            border: `1px solid ${theme.colors.atmo4}`,
-            "&:hover": {
-              border: `1px solid ${theme.colors.secondary}`,
-            },
+        focused: {
+          "&.HvBaseInput-readOnly": {
+            backgroundColor: theme.colors.atmo1,
           },
         },
         input: {
@@ -492,27 +465,21 @@ const ds3 = makeTheme((theme) => ({
     HvCalendarHeader: {
       classes: {
         root: {
-          marginTop: theme.spacing("xs"),
-          paddingBottom: "32px",
-
-          "&.HvCalendarHeader-invalid": {
-            paddingBottom: 0,
+          marginTop: theme.space.xs,
+          paddingBottom: 32,
+          "& input": {
+            height: "27px",
+            fontSize: "18px",
+            letterSpacing: "0.02em",
+            lineHeight: "28px",
+            fontWeight: theme.fontWeights.semibold,
           },
         },
-        headerDate: {
-          "& .HvBaseInput-inputBorderContainer": {
-            top: 33,
-          },
+        invalid: {
+          paddingBottom: 0,
         },
         headerDayOfWeek: {
           color: theme.colors.secondary,
-        },
-        input: {
-          height: "27px",
-          fontSize: "18px",
-          letterSpacing: "0.02em",
-          lineHeight: "28px",
-          fontWeight: theme.fontWeights.semibold,
         },
       },
     },
@@ -1224,6 +1191,11 @@ const ds3 = makeTheme((theme) => ({
             "&:hover": {
               border: `1px solid transparent`,
             },
+          },
+        },
+        tagInputRoot: {
+          "& .HvBaseInput-root::after": {
+            display: "none",
           },
         },
         tagsList: {

--- a/packages/styles/src/themes/pentahoPlus.ts
+++ b/packages/styles/src/themes/pentahoPlus.ts
@@ -53,8 +53,6 @@ const inputColors = {
   borderActive: ld(slate[700], slate[300]),
 };
 
-const inputBorder = `1px solid ${inputColors.border}`;
-
 const pentahoPlus = makeTheme((theme) => ({
   name: "pentahoPlus",
   colors: {
@@ -557,7 +555,7 @@ const pentahoPlus = makeTheme((theme) => ({
       classes: {
         root: {
           "&& .HvButton-secondarySubtle": {
-            border: inputBorder,
+            borderColor: inputColors.border,
             backgroundColor: inputColors.bg,
           },
           "&& .HvDropdownButton-openUp": {
@@ -571,14 +569,14 @@ const pentahoPlus = makeTheme((theme) => ({
           borderRadius: theme.radii.base,
         },
         panel: {
-          border: inputBorder,
+          borderColor: inputColors.border,
         },
       },
     },
     HvSuggestions: {
       classes: {
         list: {
-          border: inputBorder,
+          borderColor: inputColors.border,
         },
       },
     },
@@ -604,17 +602,14 @@ const pentahoPlus = makeTheme((theme) => ({
     },
     HvInlineEditor: {
       classes: {
-        root: {
-          "& .HvButton-root": {
-            borderRadius: "2px",
-
-            "&:focus": {
-              borderColor: theme.colors.secondary,
-            },
+        button: {
+          borderRadius: 2,
+          "&:focus": {
+            borderColor: theme.colors.secondary,
           },
-          "& .HvBaseInput-inputRoot": {
-            borderRadius: "2px",
-          },
+        },
+        inputRoot: {
+          borderRadius: 2,
         },
       },
     },
@@ -1015,32 +1010,26 @@ const pentahoPlus = makeTheme((theme) => ({
     },
     HvBaseInput: {
       classes: {
-        inputRoot: {
-          border: inputBorder,
+        root: {
+          borderColor: inputColors.border,
           backgroundColor: inputColors.bg,
-        },
-        inputRootMultiline: {
-          "&& textarea": {
-            border: inputBorder,
-            backgroundColor: inputColors.bg,
-          },
         },
       },
     },
     HvBaseDropdown: {
       classes: {
         header: {
-          border: inputBorder,
+          borderColor: inputColors.border,
           backgroundColor: inputColors.bg,
         },
         headerOpen: {
-          border: inputBorder,
+          borderColor: inputColors.border,
           "&:hover": {
-            border: inputBorder,
+            borderColor: inputColors.border,
           },
         },
         panel: {
-          border: inputBorder,
+          borderColor: inputColors.border,
         },
       },
     },
@@ -1048,7 +1037,7 @@ const pentahoPlus = makeTheme((theme) => ({
       classes: {
         iconSelected: {
           "&[data-color=secondary]": {
-            border: inputBorder,
+            borderColor: inputColors.border,
           },
         },
       },


### PR DESCRIPTION
- remove `Global` styles in favour of `classes.root` usage
- merge the 2 redundant `HvBaseInput` "containers"
  - now there's only a container and the `input` (coming from MUI)
- remove the bloated `ds3` `inputBorderContainer` logic, in favour of `::after` overrides