### PR TITLE
fix(Input): support native uncontrolled behaviours & text adornment

### DIFF
--- a/packages/core/src/BaseInput/validations.ts
+++ b/packages/core/src/BaseInput/validations.ts
@@ -118,7 +118,6 @@ export const computeValidationMessage = (
  */
 export const validateInput = (
   input: HTMLInputElement | HTMLTextAreaElement | null,
-  value: string,
   required: boolean | undefined,
   minCharQuantity: any,
   maxCharQuantity: any,
@@ -139,6 +138,8 @@ export const validateInput = (
     typeMismatch: input?.validity?.typeMismatch,
     valueMissing: input?.validity?.valueMissing,
   };
+
+  const value = input?.value;
 
   if (!value) {
     if (required) {

--- a/packages/core/src/FormElement/Adornment/Adornment.styles.tsx
+++ b/packages/core/src/FormElement/Adornment/Adornment.styles.tsx
@@ -1,28 +1,21 @@
 import { createClasses } from "@hitachivantara/uikit-react-utils";
 import { theme } from "@hitachivantara/uikit-styles";
 
-import { outlineStyles } from "../../utils/focusUtils";
-
 export const { staticClasses, useClasses } = createClasses("HvAdornment", {
-  root: {},
-  icon: { width: 32, height: 32 },
-  adornment: {
-    backgroundColor: "transparent",
-    border: "none",
-    padding: 0,
-    margin: 0,
+  root: {
+    width: 32,
+    height: 30,
   },
-  adornmentIcon: { cursor: "default", pointerEvents: "none" },
+  /** @deprecated use `classes.root` */
+  icon: {},
+  /** @deprecated use `classes.root` */
+  adornment: {},
+  /** @deprecated use `classes.root` */
+  adornmentIcon: {},
   hideIcon: { display: "none" },
-  adornmentButton: {
-    cursor: "pointer",
-    "&:focus": {
-      ...outlineStyles,
-    },
-  },
+  /** @deprecated use `classes.root` */
+  adornmentButton: {},
   disabled: {
-    "&$adornmentButton": { cursor: "not-allowed" },
-    "&$adornmentIcon": { cursor: "not-allowed" },
     "& svg *.color0": { fill: theme.colors.secondary_60 },
   },
 });

--- a/packages/core/src/FormElement/Adornment/Adornment.test.tsx
+++ b/packages/core/src/FormElement/Adornment/Adornment.test.tsx
@@ -1,19 +1,29 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
-import { CloseXS } from "@hitachivantara/uikit-react-icons";
 
 import { HvAdornment } from ".";
 
 describe("Adornment", () => {
-  it("should render the passed icon", () => {
-    render(<HvAdornment icon={<CloseXS title="close icon" />} />);
-    expect(screen.getByRole("img", { name: "close icon" })).toBeInTheDocument();
+  it("renders the passed icon", () => {
+    render(<HvAdornment icon={<div data-testid="mock-icon" />} />);
+    expect(screen.getByTestId("mock-icon")).toBeInTheDocument();
   });
 
-  it("should render a button if a 'onClick' is passed", async () => {
+  it("renders a clickable a11y-hidden button", async () => {
     const mockFn = vi.fn();
-    render(<HvAdornment icon={<CloseXS />} onClick={mockFn} />);
+    render(<HvAdornment icon={<div />} onClick={mockFn} />);
+    expect(screen.queryByRole("button")).toBeNull();
+    const button = document.querySelector("button");
+    expect(button).toBeInTheDocument();
+
+    await userEvent.click(button!);
+    expect(mockFn).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders a button when 'onClick' & 'tabIndex' is passed", async () => {
+    const mockFn = vi.fn();
+    render(<HvAdornment icon={<div />} onClick={mockFn} tabIndex={0} />);
 
     const button = screen.getByRole("button");
     expect(button).toBeInTheDocument();

--- a/packages/core/src/Input/Input.styles.tsx
+++ b/packages/core/src/Input/Input.styles.tsx
@@ -12,6 +12,7 @@ export const { staticClasses, useClasses } = createClasses("HvInput", {
     display: "flex",
     flexDirection: "row",
     height: "30px",
+    alignItems: "center",
     justifyContent: "center",
     marginRight: 1,
   },

--- a/packages/core/src/Input/Input.test.tsx
+++ b/packages/core/src/Input/Input.test.tsx
@@ -5,6 +5,7 @@ import { vi } from "vitest";
 import { Map } from "@hitachivantara/uikit-react-icons";
 
 import { HvInput, HvInputProps } from ".";
+import { HvAdornment } from "../FormElement";
 
 const Suggestions = ({ ...others }: Partial<HvInputProps>) => {
   const [value, setValue] = useState("");
@@ -57,6 +58,25 @@ describe("Input", () => {
     expect(screen.getByText("kg")).toBeVisible();
   });
 
+  it("can press custom endAdornment with keyboard", async () => {
+    const clickMock = vi.fn();
+    render(
+      <HvInput
+        endAdornment={
+          <HvAdornment onClick={clickMock} tabIndex={0} icon={<div />} />
+        }
+      />,
+    );
+
+    const user = userEvent.setup();
+    await user.tab();
+    expect(screen.getByRole("textbox")).toHaveFocus();
+    await user.tab();
+    expect(screen.getByRole("button")).toHaveFocus();
+    await user.keyboard("{enter}");
+    expect(clickMock).toHaveBeenCalledTimes(1);
+  });
+
   it("renders the startAdornment", () => {
     render(<HvInput startAdornment={<Map data-testid="icon" />} />);
 
@@ -75,7 +95,7 @@ describe("Input", () => {
     );
 
     expect(screen.getByRole("searchbox")).toBeDisabled();
-    const adornment = screen.getByLabelText("Search"); // role can't be used since the parent has aria-hidden
+    const adornment = document.querySelector("button"); // role can't be used since it has aria-hidden
     expect(adornment).toHaveAttribute("aria-disabled", "true");
   });
 

--- a/packages/core/src/Input/Input.test.tsx
+++ b/packages/core/src/Input/Input.test.tsx
@@ -46,8 +46,19 @@ describe("Input", () => {
     expect(input).toBeDisabled();
   });
 
-  it("renders the custom icon", () => {
+  it("renders the endAdornment", () => {
     render(<HvInput endAdornment={<Map data-testid="icon" />} />);
+
+    expect(screen.getByTestId("icon")).toBeVisible();
+  });
+
+  it("renders a text endAdornment", () => {
+    render(<HvInput endAdornment="kg" />);
+    expect(screen.getByText("kg")).toBeVisible();
+  });
+
+  it("renders the startAdornment", () => {
+    render(<HvInput startAdornment={<Map data-testid="icon" />} />);
 
     expect(screen.getByTestId("icon")).toBeVisible();
   });
@@ -82,6 +93,44 @@ describe("Input", () => {
     expect(screen.getByLabelText("My input")).toBeDisabled(); // can't find by role searchbox since password inputs don't have a role...
     const adornment = screen.getByLabelText("Reveal password"); // roles can't be used since the parent has aria-hidden
     expect(adornment).toHaveAttribute("aria-disabled", "true");
+  });
+
+  it("captures the value in a form submission", async () => {
+    const defaultValue = "John Doe";
+    let capturedValue = "";
+    render(
+      <form
+        onSubmit={(evt) => {
+          evt.preventDefault();
+          const formData = new FormData(evt.currentTarget);
+          capturedValue = formData.get("username") as string;
+        }}
+      >
+        <HvInput name="username" defaultValue={defaultValue} />
+        <button type="submit">Submit</button>
+      </form>,
+    );
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("button", { name: "Submit" }));
+    expect(capturedValue).toBe(defaultValue);
+  });
+
+  it("resets the value when reset button is pressed", async () => {
+    const initialValue = "John Doe";
+    render(
+      <form onSubmit={(evt) => evt.preventDefault()}>
+        <HvInput name="username" defaultValue={initialValue} />
+        <button type="reset">Reset</button>
+      </form>,
+    );
+
+    const user = userEvent.setup();
+    await user.type(screen.getByRole("textbox"), "suffix");
+    expect(screen.getByRole("textbox")).toHaveValue(`${initialValue}suffix`);
+
+    await user.click(screen.getByRole("button", { name: "Reset" }));
+    expect(screen.getByRole("textbox")).toHaveValue(initialValue);
   });
 
   it("does not trigger the suggestions on focus by default", async () => {

--- a/packages/core/src/Input/SearchBox.stories.tsx
+++ b/packages/core/src/Input/SearchBox.stories.tsx
@@ -17,29 +17,34 @@ import { Fail } from "@hitachivantara/uikit-react-icons";
 
 import countryNamesArray, { continents, countries } from "./stories/countries";
 
-/**
- * A search box is a text input box with the dedicated function of accepting user input to be searched for in a database.
- * Search boxes are commonly accompanied by a search button/icon to submit the query.
- * However, the search button should be omitted in the filter as you type mode, where the trigger is automatic and related to the text string.
- */
-const SearchBox = () => null;
+const description = `
+ A search box is a text input box with the dedicated function of accepting user input to be searched for in a database.
+ Search boxes are commonly accompanied by a search button/icon to submit the query.
+ However, the search button should be omitted in the filter as you type mode, where the trigger is automatic and related to the text string.`;
 
 const meta: Meta<typeof HvInput> = {
   title: "Components/Input/Search Box",
-  component: SearchBox,
+  component: HvInput,
+  parameters: {
+    // @ts-expect-error outdated types
+    docs: { description: { component: description } },
+  },
   decorators: [(Story) => <div style={{ height: "300px" }}>{Story()}</div>],
 };
 
 export default meta;
 
-export const Main: StoryObj = {
-  render: () => {
+export const Main: StoryObj<HvInputProps> = {
+  args: {
+    placeholder: "Search",
+  },
+  render: (args) => {
     return (
       <HvInput
         type="search"
         aria-label="Select country"
-        placeholder="Search"
         onEnter={(_, value) => console.log(value)}
+        {...args}
       />
     );
   },

--- a/packages/core/src/TextArea/TextArea.tsx
+++ b/packages/core/src/TextArea/TextArea.tsx
@@ -251,7 +251,6 @@ export const HvTextArea = forwardRef<
   const performValidation = useCallback(() => {
     const inputValidity = validateInput(
       inputRef.current,
-      String(value),
       required,
       minCharQuantity,
       maxCharQuantity,
@@ -278,7 +277,6 @@ export const HvTextArea = forwardRef<
     setValidationMessage,
     setValidationState,
     validation,
-    value,
   ]);
 
   /**


### PR DESCRIPTION
- remove `useControlled` logic from `HvInput` (`HvInputBase` already has it)
  - this allows for native uncontrolled behaviour (like form reset) to work
- fix `endAdornment` not allowing non `ReactElement` values
- add support for focusable `HvAdornment`
- fix showPassword toggle not being focusable

fixes HVUIKIT-7060