### PR TITLE
fix(TagsInput): focus management & input size issues

### DIFF
--- a/packages/core/src/BaseInput/BaseInput.tsx
+++ b/packages/core/src/BaseInput/BaseInput.tsx
@@ -35,8 +35,12 @@ export interface HvBaseInputProps
   readOnly?: boolean;
   /** If true, the input element will be required. */
   required?: boolean;
-  /** The function that will be executed onChange, allows modification of the input,
-   * it receives the value. If a new value should be presented it must returned it. */
+  /**
+   * Callback fired when the value is changed.
+   *
+   * You can pull out the new value by accessing `event.target.value` (string),
+   * or using the second callback argument.
+   */
   onChange?: (
     event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
     value: string,

--- a/packages/core/src/Input/Input.tsx
+++ b/packages/core/src/Input/Input.tsx
@@ -30,6 +30,7 @@ import {
   HvInputValidity,
   validateInput,
 } from "../BaseInput/validations";
+import type { HvButtonBaseProps } from "../ButtonBase";
 import {
   HvAdornment,
   HvFormElement,
@@ -86,11 +87,11 @@ export interface HvInputProps<
     HvBaseInputProps,
     "onChange" | "onBlur" | "onFocus" | "onKeyDown"
   > {
-  /** The form element name. */
+  /** @inheritdoc */
   name?: string;
-  /** The value of the form element. */
+  /** @inheritdoc */
   value?: React.InputHTMLAttributes<InputElement>["value"];
-  /** When uncontrolled, defines the initial input value. */
+  /** @inheritdoc */
   defaultValue?: React.InputHTMLAttributes<InputElement>["value"];
   /**
    * The label of the form element.
@@ -101,11 +102,11 @@ export interface HvInputProps<
   label?: React.ReactNode;
   /** Provide additional descriptive text for the form element. */
   description?: React.ReactNode;
-  /** Indicates that the form element is disabled. */
+  /** @inheritdoc */
   disabled?: boolean;
-  /** Indicates that the form element is not editable. */
+  /** @inheritdoc */
   readOnly?: boolean;
-  /** Indicates that user input is required on the form element. */
+  /** @inheritdoc */
   required?: boolean;
   /**
    * The status of the form element.
@@ -118,16 +119,13 @@ export interface HvInputProps<
   status?: HvFormStatus;
   /** The error message to show when `status` is "invalid". */
   statusMessage?: string;
+  /** @inheritdoc */
+  onChange?: (event: React.ChangeEvent<InputElement>, value: string) => void;
   /**
    * Callback called when the user submits the value by pressing Enter/Return.
    *
-   * Also called when the search button is clicked (when type is "search").
+   * Also called when the search button is clicked (when `type="search"`).
    */
-  /**
-   * The function that will be executed onChange, allows modification of the input,
-   * it receives the value. If a new value should be presented it must returned it.
-   */
-  onChange?: (event: React.ChangeEvent<InputElement>, value: string) => void;
   onEnter?: (event: React.KeyboardEvent<InputElement>, value: string) => void;
   /**
    * The function that will be executed onBlur, allows checking the validation state,
@@ -652,6 +650,7 @@ export const HvInput = fixedForwardRef(function HvInput<
           aria-controls={setId(elementId, "input")}
           icon={revealPassword ? <PreviewOff /> : <Preview />}
           tabIndex={0}
+          {...({ selected: revealPassword } satisfies HvButtonBaseProps)}
         />
       </HvTooltip>
     );

--- a/packages/core/src/Tag/Tag.tsx
+++ b/packages/core/src/Tag/Tag.tsx
@@ -180,7 +180,7 @@ export const HvTag = forwardRef<
       >
         {label}
       </HvTypography>
-      {onDelete && deleteIcon}
+      {onDelete && !disabled && deleteIcon}
     </HvButtonBase>
   );
 });

--- a/packages/core/src/TagsInput/TagsInput.styles.tsx
+++ b/packages/core/src/TagsInput/TagsInput.styles.tsx
@@ -4,12 +4,6 @@ import { theme } from "@hitachivantara/uikit-styles";
 import { outlineStyles } from "../utils/focusUtils";
 
 export const { staticClasses, useClasses } = createClasses("HvTagsInput", {
-  input: {
-    width: "100%",
-    margin: 0,
-    padding: 0,
-    ...theme.typography.caption1,
-  },
   /** @deprecated unused */
   listItemGutters: {},
   /** @deprecated use `chipRoot` */
@@ -50,9 +44,10 @@ export const { staticClasses, useClasses } = createClasses("HvTagsInput", {
     display: "flex",
     alignItems: "center",
     alignContent: "flex-start",
-    gap: theme.space.xs,
+    gap: theme.spacing("xxs", "xs"),
     cursor: "text",
     width: "100%",
+    minHeight: 32,
     padding: theme.spacing("xxs", "xs"),
     overflow: "auto",
     position: "relative",
@@ -74,7 +69,6 @@ export const { staticClasses, useClasses } = createClasses("HvTagsInput", {
     },
 
     "&$singleLine": {
-      height: 32, // TODO: review fixed height
       flexWrap: "nowrap",
     },
 
@@ -86,29 +80,23 @@ export const { staticClasses, useClasses } = createClasses("HvTagsInput", {
       borderColor: theme.colors.negative_120,
     },
   },
-  /** @deprecated use `tagInputRoot` instead */
+  /** @deprecated use `classes.input` instead */
   tagInputContainerRoot: {},
-  tagInputRoot: {
+  /** @deprecated use `classes.input` instead */
+  tagInputRoot: {},
+  input: {
     display: "flex",
     flex: "1 0 auto",
-    height: 24,
-    lineHeight: "24px",
-
+    height: "auto",
     width: 0,
     minWidth: 60,
     border: "none",
-    marginLeft: 0,
-    marginRight: 0,
+    margin: 0,
     padding: 0,
-
-    "&": {
-      backgroundColor: "transparent",
-    },
-
-    "&&:focus-within": {
-      outline: "none",
-      boxShadow: "none",
-    },
+    ...theme.typography.caption1,
+    backgroundColor: "transparent",
+    outline: "none",
+    boxShadow: "none",
   },
   /** @deprecated unused.  use `:focus` or `:focus-visible` instead */
   tagSelected: {},
@@ -121,10 +109,6 @@ export const { staticClasses, useClasses } = createClasses("HvTagsInput", {
   singleLine: {},
   error: { float: "left" },
   inputExtension: {},
-  suggestionsContainer: {
-    width: "100%",
-    position: "relative",
-    top: 59,
-  },
+  suggestionsContainer: {},
   suggestionList: {},
 });

--- a/packages/core/src/TagsInput/TagsInput.styles.tsx
+++ b/packages/core/src/TagsInput/TagsInput.styles.tsx
@@ -1,50 +1,37 @@
 import { createClasses } from "@hitachivantara/uikit-react-utils";
 import { theme } from "@hitachivantara/uikit-styles";
 
-import { baseInputClasses } from "../BaseInput";
-import { suggestionsClasses } from "../FormElement/Suggestions";
+import { outlineStyles } from "../utils/focusUtils";
 
 export const { staticClasses, useClasses } = createClasses("HvTagsInput", {
   input: {
     width: "100%",
+    margin: 0,
+    padding: 0,
     ...theme.typography.caption1,
   },
-  listItemGutters: { padding: "0 5px" },
-  listItemRoot: {
-    marginBottom: 2,
-    height: 24,
-    lineHeight: "24px",
-
-    "&:not(:last-child)": {
-      marginBottom: 2,
-    },
-
-    "&$singleLine": {
-      display: "table-cell",
-      paddingTop: "2px",
-    },
-  },
+  /** @deprecated unused */
+  listItemGutters: {},
+  /** @deprecated use `chipRoot` */
+  listItemRoot: {},
   root: { display: "inline-block", width: "100%" },
+  // TODO: consider renaming this
   chipRoot: {
     maxWidth: "none",
   },
   disabled: {
     "& $tagsList": {
       backgroundColor: theme.colors.atmo2,
-      border: `1px solid ${theme.colors.atmo4}`,
-
-      "&:focus-within, &:hover": {
-        border: `1px solid ${theme.colors.atmo4}`,
+      "&,:hover": {
+        borderColor: theme.colors.atmo4,
       },
     },
   },
   readOnly: {
     "& $tagsList": {
       backgroundColor: theme.colors.atmo2,
-      border: `1px solid ${theme.colors.secondary_60}`,
-
-      "&:hover": {
-        border: `1px solid ${theme.colors.secondary_60}`,
+      "&,:hover": {
+        borderColor: theme.colors.secondary_60,
       },
     },
   },
@@ -61,13 +48,12 @@ export const { staticClasses, useClasses } = createClasses("HvTagsInput", {
   },
   tagsList: {
     display: "flex",
+    alignItems: "center",
     alignContent: "flex-start",
-    float: "left",
-    clear: "both",
+    gap: theme.space.xs,
+    cursor: "text",
     width: "100%",
-    maxWidth: "100%",
-    height: "32px",
-    padding: 5,
+    padding: theme.spacing("xxs", "xs"),
     overflow: "auto",
     position: "relative",
 
@@ -75,95 +61,62 @@ export const { staticClasses, useClasses } = createClasses("HvTagsInput", {
     flexWrap: "wrap",
 
     backgroundColor: theme.colors.atmo1,
-    border: `1px solid ${theme.colors.secondary_80}`,
+    borderWidth: 1,
+    borderColor: theme.colors.secondary_80,
     borderRadius: theme.radii.base,
 
     "&:hover": {
-      cursor: "text",
-      border: `1px solid ${theme.colors.primary}`,
+      borderColor: theme.colors.primary,
     },
 
-    [`& .${baseInputClasses.inputRoot}`]: {
-      border: "none",
-    },
-
-    "&:focus, &:focus-within, &:focus-visible": {
-      outlineColor: "#52A8EC",
-      outlineStyle: "solid",
-      outlineWidth: "0px",
-      outlineOffset: "-1px",
-      boxShadow: "0 0 0 1px #52A8EC, 0 0 0 4px rgba(29,155,209,.3)",
+    "&:focus-within, &:focus-visible": {
+      ...outlineStyles,
     },
 
     "&$singleLine": {
-      overflowX: "hidden",
-      overflowY: "hidden",
-      height: 32,
-      display: "table-row",
-      paddingTop: 0,
+      height: 32, // TODO: review fixed height
+      flexWrap: "nowrap",
     },
 
     "&$error": {
-      border: `1px solid ${theme.colors.negative_120}`,
+      borderColor: theme.colors.negative_120,
     },
 
     "&$invalid": {
-      border: `1px solid ${theme.colors.negative_120}`,
+      borderColor: theme.colors.negative_120,
     },
   },
-  tagInputContainerRoot: {
+  /** @deprecated use `tagInputRoot` instead */
+  tagInputContainerRoot: {},
+  tagInputRoot: {
     display: "flex",
-    flexGrow: 1,
+    flex: "1 0 auto",
     height: 24,
     lineHeight: "24px",
 
-    "&$singleLine": {
-      display: "table-cell",
-      minWidth: 60,
-      width: "100%",
-      paddingTop: "3px",
-      verticalAlign: "middle",
+    width: 0,
+    minWidth: 60,
+    border: "none",
+    marginLeft: 0,
+    marginRight: 0,
+    padding: 0,
+
+    "&": {
+      backgroundColor: "transparent",
     },
-  },
-  tagInputRoot: {
-    [`& .${baseInputClasses.root}`]: {
-      width: "100%",
-      border: "none",
-    },
-    [`&& .${baseInputClasses.inputRoot}`]: {
-      marginLeft: 0,
-      marginRight: 0,
-      flex: "1 1 auto",
-      height: 24,
-      lineHeight: "24px",
-      padding: 0,
-      border: "none",
-    },
-    [`& .${baseInputClasses.inputRootFocused}`]: {
+
+    "&&:focus-within": {
       outline: "none",
       boxShadow: "none",
     },
-    [`& .${baseInputClasses.root} .${baseInputClasses.inputRootReadOnly}`]: {
-      backgroundColor: "transparent",
-      border: "none",
-      "&:hover": {
-        border: "none",
-      },
-    },
-    [`&& .${baseInputClasses.input}`]: {
-      marginLeft: 0,
-    },
   },
-  tagSelected: {
-    outlineColor: "#52A8EC",
-    outlineStyle: "solid",
-    outlineWidth: "0px",
-    outlineOffset: "-1px",
-    boxShadow: "0 0 0 1px #52A8EC, 0 0 0 4px rgba(29,155,209,.3)",
-  },
+  /** @deprecated unused.  use `:focus` or `:focus-visible` instead */
+  tagSelected: {},
   /** @deprecated unused. use `::after` instead */
   tagInputBorderContainer: {},
+  /** @deprecated unused. use `:focus` or `:focus-visible` instead */
   tagInputRootFocused: {},
+  /** @deprecated unused */
   tagInputRootEmpty: {},
   singleLine: {},
   error: { float: "left" },
@@ -172,9 +125,6 @@ export const { staticClasses, useClasses } = createClasses("HvTagsInput", {
     width: "100%",
     position: "relative",
     top: 59,
-    [`& .${suggestionsClasses.root} .${suggestionsClasses.list} &`]: {
-      width: "100%",
-    },
   },
   suggestionList: {},
 });

--- a/packages/core/src/hooks/useFocus.ts
+++ b/packages/core/src/hooks/useFocus.ts
@@ -1,0 +1,43 @@
+import { useMemo } from "react";
+
+import { getDocument } from "../utils/document";
+
+/** server-side safe `document.activeElement` wrapper */
+const getActiveEl = () => getDocument()?.activeElement || null;
+
+function makeFocusUtils(containerRef: React.RefObject<HTMLElement>) {
+  function focus(el?: Element | null, checkFocus = true) {
+    if (!checkFocus || containerRef.current?.contains(getActiveEl())) {
+      (el as HTMLElement)?.focus();
+    }
+  }
+
+  return {
+    focusPrevious() {
+      focus(getActiveEl()?.previousElementSibling);
+    },
+    focusNext() {
+      focus(getActiveEl()?.nextElementSibling);
+    },
+    focusFirst() {
+      focus(getActiveEl()?.parentElement?.firstElementChild);
+    },
+    focusLast() {
+      focus(getActiveEl()?.parentElement?.lastElementChild);
+    },
+    focusChild(index: number) {
+      focus(containerRef.current?.children[index], false);
+    },
+    focusSibling(index: number) {
+      focus(getActiveEl()?.parentElement?.children[index]);
+    },
+  };
+}
+
+export function useFocus({
+  containerRef,
+}: {
+  containerRef: React.RefObject<HTMLElement>;
+}) {
+  return useMemo(() => makeFocusUtils(containerRef), [containerRef]);
+}

--- a/packages/core/src/utils/focusUtils.ts
+++ b/packages/core/src/utils/focusUtils.ts
@@ -1,7 +1,3 @@
 export const outlineStyles = {
-  outlineColor: "#52A8EC",
-  outlineStyle: "solid",
-  outlineWidth: "0px",
-  outlineOffset: "-1px",
   boxShadow: "0 0 0 1px #52A8EC, 0 0 0 4px rgba(29,155,209,.3)",
 };

--- a/packages/styles/src/themes/ds3.ts
+++ b/packages/styles/src/themes/ds3.ts
@@ -1187,21 +1187,21 @@ const ds3 = makeTheme((theme) => ({
         readOnly: {
           "& .HvTagsInput-tagsList": {
             backgroundColor: theme.colors.atmo1,
-            border: `1px solid transparent`,
+            borderColor: "transparent",
             "&:hover": {
-              border: `1px solid transparent`,
+              borderColor: "transparent",
             },
           },
         },
         tagInputRoot: {
-          "& .HvBaseInput-root::after": {
+          "&::after": {
             display: "none",
           },
         },
         tagsList: {
-          border: `1px solid ${theme.colors.atmo4}`,
+          borderColor: theme.colors.atmo4,
           "&:hover": {
-            border: `1px solid ${theme.colors.secondary}`,
+            borderColor: theme.colors.secondary,
           },
         },
       },


### PR DESCRIPTION
- overhauls `HvTagsInput` by simplifying DOM structure (removed `HvListContainer`/`HvListItem`/`HvInput`) and leveraging flex features (fixes #4553)
- fix label<->input id mapping
- review focus & internal state management
  - make input uncontrolled & use native focus `previousElementSibling`
  - remove internal state & `useEffects`

