### PR TITLE
fix(input): internal padding when autofilling

### DIFF
--- a/packages/core/src/BaseInput/BaseInput.styles.tsx
+++ b/packages/core/src/BaseInput/BaseInput.styles.tsx
@@ -105,7 +105,7 @@ export const { staticClasses, useClasses } = createClasses("HvBaseInput", {
     height: "100%",
     marginLeft: theme.space.xs,
     marginRight: theme.space.xs,
-    padding: theme.spacing("5px", 0),
+    padding: 0,
     backgroundColor: "transparent",
     overflow: "hidden",
     textOverflow: "ellipsis",


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/b3487fd9-9095-4584-905a-ee4422527b60) ![image](https://github.com/user-attachments/assets/9acc3376-8c98-4cd2-be35-4c362036174c)


Safari visual tests already cover this padding scenario