### PR TITLE
ci: disable storybook PR deployment

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -28,3 +28,4 @@ jobs:
     secrets: inherit
     with:
       publish-folder: pr-${{ github.event.number }}
+      publish-storybook: false


### PR DESCRIPTION
- Chromatic already has its own Storybook PR deployment
- this is also our slowest workflow step