### PR TITLE
docs: add `LineChart` documentation

### DIFF
--- a/apps/docs/src/components/Examples.tsx
+++ b/apps/docs/src/components/Examples.tsx
@@ -1,6 +1,7 @@
 import { clsx } from "clsx";
 import Link from "next/link";
 import { HvTypography } from "@hitachivantara/uikit-react-core";
+import { BarChart, Table } from "@hitachivantara/uikit-react-icons";
 
 import charts from "../pages/examples/charts.mdx?raw";
 import tables from "../pages/examples/tables.mdx?raw";
@@ -13,6 +14,17 @@ const countCodeBlocks = (fileContent: string): number => {
     /<CodeBlock[\s\S]*?>[\s\S]*?<\/CodeBlock>|<CodeBlock[\s\S]*?\/>/g;
   const matches = fileContent.match(codeBlockRegex);
   return matches ? matches.length : 0;
+};
+
+const getSectionIcon = (title: string) => {
+  switch (title) {
+    case "Tables":
+      return <Table size="md" />;
+    case "Charts":
+      return <BarChart size="md" />;
+    default:
+      return null;
+  }
 };
 
 /**
@@ -40,13 +52,21 @@ export const Examples = () => {
       <div className="px-1 py-3">
         <HvTypography variant="title2">Examples</HvTypography>
         <HvTypography variant="body">
-          Heroes, feature sections, newsletter sign-up forms — everything you
-          need to build beautiful pages.
+          Explore practical examples demonstrating how to use our components in
+          different scenarios and real-world scenarios. You can find an extended
+          list of UI Kit examples on our{" "}
+          <HvTypography
+            className="color-primary hover:underline"
+            component="a"
+            href="https://stackblitz.com/orgs/github/lumada-design/collections"
+          >
+            StackBlitz collection
+          </HvTypography>
         </HvTypography>
       </div>
 
       {/* Section Grid */}
-      <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-6">
+      <div className="grid grid-cols-1 sm:grid-cols-3 md:grid-cols-3 gap-6">
         {sections.map((section) => (
           <Link
             key={section.title}
@@ -66,7 +86,7 @@ export const Examples = () => {
                 variant="body"
                 className="text-[var(--uikit-colors-secondary_80)]"
               >
-                Image Placeholder
+                {getSectionIcon(section.title)}
               </HvTypography>
             </div>
             {/* Section Title */}

--- a/apps/docs/src/components/Examples.tsx
+++ b/apps/docs/src/components/Examples.tsx
@@ -2,6 +2,7 @@ import { clsx } from "clsx";
 import Link from "next/link";
 import { HvTypography } from "@hitachivantara/uikit-react-core";
 
+import charts from "../pages/examples/charts.mdx?raw";
 import tables from "../pages/examples/tables.mdx?raw";
 
 /**
@@ -26,11 +27,11 @@ export const Examples = () => {
       total: countCodeBlocks(tables),
       path: "/examples/tables",
     },
-    { title: "Feature Sections", total: 0, path: "/examples" },
-    { title: "CTA Sections", total: 0, path: "/examples" },
-    { title: "Bento Grids", total: 0, path: "/examples" },
-    { title: "Pricing Sections", total: 0, path: "/examples" },
-    { title: "Header Sections", total: 0, path: "/examples" },
+    {
+      title: "Charts",
+      total: countCodeBlocks(charts),
+      path: "/examples/charts",
+    },
   ];
 
   return (

--- a/apps/docs/src/examples/charts/LineChartStreaming.tsx
+++ b/apps/docs/src/examples/charts/LineChartStreaming.tsx
@@ -1,0 +1,65 @@
+import { useEffect, useRef, useState } from "react";
+import { Random } from "@hitachivantara/uikit-react-core";
+import { HvLineChart } from "@hitachivantara/uikit-react-viz";
+
+export default function Demo() {
+  const r = new Random();
+  const rand = (diff: number) => r.next() * diff - diff / 2;
+
+  const generateDates = (initialDate: Date, num = 200) =>
+    Array.from(Array(num).keys()).map((i) =>
+      new Date(new Date(initialDate).setDate(initialDate.getDate() + i))
+        .toISOString()
+        .slice(0, 10),
+    );
+
+  const generateValues = (num = 10, start = 200, inc = 8) => {
+    const values = [start];
+    for (let i = 0; i <= num; i += 1) {
+      values.push(values[i] + rand(inc));
+    }
+    return values;
+  };
+
+  const date = useRef(new Date(2020, 1, 1));
+  const values = useRef(generateValues(200));
+
+  const generateData = () => {
+    return {
+      Date: generateDates(date.current),
+      "Sales Target": values.current,
+    };
+  };
+
+  const [data, setData] = useState(generateData());
+
+  const addDaysToCurrentDate = (num: number) => {
+    const currentDay = new Date(date.current);
+    date.current = new Date(currentDay.setDate(currentDay.getDate() + num));
+  };
+
+  useEffect(() => {
+    const interval = setTimeout(() => {
+      addDaysToCurrentDate(1);
+
+      const intervalValues = values.current.slice();
+      intervalValues.splice(0, 1);
+      values.current = intervalValues.concat(
+        generateValues(1, intervalValues[intervalValues.length]),
+      );
+
+      setData(generateData());
+    }, 1000);
+
+    return () => clearTimeout(interval);
+  });
+
+  return (
+    <HvLineChart
+      height={400}
+      data={data}
+      groupBy="Date"
+      measures={{ field: "Sales Target", hideSymbol: true }}
+    />
+  );
+}

--- a/apps/docs/src/pages/charts/bar-chart.mdx
+++ b/apps/docs/src/pages/charts/bar-chart.mdx
@@ -485,13 +485,3 @@ If necessary, you can customize the chart's option and take advantage of the add
   }}
 />
 ```
-
-### Related components
-
-- [Line Chart](/documentation/components/line-chart)
-- [Donut Chart](/documentation/components/donut-chart)
-- [Scatter Plot](/documentation/components/scatter-plot)
-- [Box Plot](/documentation/components/box-plot)
-- [Confusion Matrix](/documentation/components/confusion-matrix)
-- [Tree Map](/documentation/components/tree-map)
-- [Heat Map](/documentation/components/heat-map)

--- a/apps/docs/src/pages/charts/line-chart.mdx
+++ b/apps/docs/src/pages/charts/line-chart.mdx
@@ -1,0 +1,384 @@
+import { Callout } from "nextra/components";
+import {
+  HvLineChart,
+  HvPanel,
+  HvVizProvider,
+} from "@hitachivantara/uikit-react-viz";
+
+import { getComponentData } from "../../utils/component";
+
+import { Playground } from "../../components/code/Playground";
+import { Header } from "../../components/Header";
+
+export const getStaticProps = async ({ params }) => {
+  const meta = await getComponentData("LineChart", "viz", {}, [], true);
+  return { props: { ssg: { meta } } };
+};
+
+<Header />
+
+<Callout type="info">
+  Please check the [Visualizations Guide](/documentation/visualizations) for
+  details on how to build your visualizations.
+</Callout>
+
+### Usage
+
+This example demonstrates a simple line chart with a single data series. Each dot represents a data point,
+and a tooltip appears on hover to display additional information. Setting the `horizontalRangeSlider.show` prop to `true`
+will display a range slider at the bottom of the chart to allow users to zoom in on a specific range of data.
+
+```tsx live
+<HvLineChart
+  height={300}
+  data={{
+    Month: [
+      "Jan",
+      "Feb",
+      "Mar",
+      "Apr",
+      "May",
+      "Jun",
+      "Jul",
+      "Aug",
+      "Sep",
+      "Oct",
+      "Nov",
+      "Dec",
+    ],
+    Temperature: [
+      9.2, 10.2, 12.3, 13.6, 16.3, 19.7, 21.9, 22.1, 20.1, 16.6, 12.5, 10.1,
+    ],
+  }}
+  groupBy="Month"
+  measures="Temperature"
+  horizontalRangeSlider={{ show: true }}
+/>
+```
+
+### Area
+
+If you to color the area below the line on the chart just set the `area` prop to `true`.
+
+```tsx live
+<HvLineChart
+  height={300}
+  data={{
+    Month: [
+      "Jan",
+      "Feb",
+      "Mar",
+      "Apr",
+      "May",
+      "Jun",
+      "Jul",
+      "Aug",
+      "Sep",
+      "Oct",
+      "Nov",
+      "Dec",
+    ],
+    Temperature: [
+      9.2, 10.2, 12.3, 13.6, 16.3, 19.7, 21.9, 22.1, 20.1, 16.6, 12.5, 10.1,
+    ],
+  }}
+  groupBy="Month"
+  measures="Temperature"
+  area
+/>
+```
+
+### Mixed line and area
+
+The `area` prop can also be set to `true` for a specific measure so that you can combine area and line views on the same chart.
+
+```tsx live
+<HvLineChart
+  height={300}
+  data={{
+    Quarter: ["Q1", "Q2", "Q3", "Q4"],
+    "Sales Target": [4500, 3700, 4300, 5500],
+    Sales: [5000, 3300, 3760, 6230],
+  }}
+  groupBy="Quarter"
+  measures={["Sales Target", { field: "Sales", area: true }]}
+/>
+```
+
+### Stacked area chart
+
+The following example illustrates how to use the `stacked` prop to stack the lines on top of each other.
+
+```tsx live
+<HvLineChart
+  height={400}
+  data={{
+    Group: ["Group 1", "Group 2", "Group 3"],
+    "Sales Target": [2300, 1000, 8500],
+    "Sales Per Rep": [6000, 1000, 1000],
+    "Monthly Sales": [3700, 7500, 1100],
+    Target: [2100, 8500, 3000],
+    Cash: [500, 8000, 9500],
+  }}
+  groupBy="Group"
+  measures={[
+    "Sales Target",
+    "Sales Per Rep",
+    "Monthly Sales",
+    "Target",
+    "Cash",
+  ]}
+  area
+  stack="total"
+/>
+```
+
+### Mixed line and stacked area
+
+You can also mix a stacked area chart with a line chart by setting the `stack` and `area` props accordingly for the measures you want to stack.
+
+```tsx live
+<HvLineChart
+  height={300}
+  data={{
+    Quarter: ["Q1", "Q2", "Q3", "Q4"],
+    "Sales Dep 1": [2300, 9000, 8500, 1000],
+    "Sales Dep 2": [6000, 2000, 1000, 2000],
+    "Sales Target": [10000, 10000, 10000, 10000],
+  }}
+  groupBy="Quarter"
+  measures={[
+    { field: "Sales Dep 1", stack: "total", area: true },
+    { field: "Sales Dep 2", stack: "total", area: true },
+    { field: "Sales Target" },
+  ]}
+/>
+```
+
+### Multiple lines
+
+You can display multiple lines on the same chart by providing an array of measures to the `measures` prop.
+
+```tsx live
+<HvLineChart
+  height={300}
+  data={new Map<string, (string | number)[]>()
+    .set("Month", [
+      "Jan",
+      "Feb",
+      "Mar",
+      "Apr",
+      "May",
+      "Jun",
+      "Jul",
+      "Aug",
+      "Sep",
+      "Oct",
+      "Nov",
+      "Dec",
+    ])
+    .set(
+      "Minimum",
+      [5.3, 6.0, 7.7, 8.9, 11.4, 14.2, 15.9, 16.1, 14.7, 12.2, 8.6, 6.5],
+    )
+    .set(
+      "Maximum",
+      [13.1, 14.4, 16.9, 18.2, 21.3, 25.1, 27.8, 28.1, 25.6, 21.1, 16.3, 13.7],
+    )}
+  groupBy="Month"
+  measures={["Minimum", "Maximum"]}
+/>
+```
+
+### Multiple lines with splitBy
+
+The following example illustrates how to use `splitBy` to split the data by a specific criteria.
+In this case the data is split by `Country` and `Medal` creating several lines for each combination.
+Use the live editor to remove or change the split by criteria and see the differences.
+
+```tsx live
+<HvLineChart
+  height={400}
+  data={{
+    Country: [
+      "Portugal",
+      "Portugal",
+      "Spain",
+      "Spain",
+      "USA",
+      "USA",
+      "Canada",
+      "Canada",
+      "Portugal",
+      "Portugal",
+      "Spain",
+      "Spain",
+      "USA",
+      "USA",
+      "Canada",
+      "Canada",
+      "Portugal",
+      "Portugal",
+      "Spain",
+      "Spain",
+      "USA",
+      "USA",
+      "Canada",
+      "Canada",
+    ],
+    Year: [
+      2018, 2018, 2018, 2018, 2018, 2018, 2018, 2018, 2019, 2019, 2019, 2019,
+      2019, 2019, 2019, 2019, 2020, 2020, 2020, 2020, 2020, 2020, 2020, 2020,
+    ],
+    Medal: [
+      "gold",
+      "silver",
+      "gold",
+      "silver",
+      "gold",
+      "silver",
+      "gold",
+      "silver",
+      "gold",
+      "silver",
+      "gold",
+      "silver",
+      "gold",
+      "silver",
+      "gold",
+      "silver",
+      "gold",
+      "silver",
+      "gold",
+      "silver",
+      "gold",
+      "silver",
+      "gold",
+      "silver",
+    ],
+    Total: [
+      3, 2, 1, 0, 4, 11, 8, 3, 2, 9, 0, 5, 3, 6, 2, 1, 7, 5, 6, 9, 2, 5, 6, 7,
+    ],
+  }}
+  groupBy="Year"
+  measures="Total"
+  splitBy={["Country", "Medal"]}
+  seriesNameFormatter={(s) => `${s?.split("_").join(" ")}`}
+/>
+```
+
+### Multiple Y axes
+
+```tsx live
+<HvLineChart
+  height={400}
+  data={{
+    Month: [
+      "Jan",
+      "Feb",
+      "Mar",
+      "Apr",
+      "May",
+      "Jun",
+      "Jul",
+      "Aug",
+      "Sep",
+      "Oct",
+      "Nov",
+      "Dec",
+    ],
+    Temperature: [
+      7.0, 6.2, 4.3, 12.5, 5.3, 12.2, 20.3, 23.4, 25.0, 17.5, 13.0, 11.2,
+    ],
+    Precipitation: [
+      12.6, 15.9, 19.0, 26.0, 28.2, 70.7, 145.6, 132.2, 78.7, 22.8, 4.0, 2.9,
+    ],
+  }}
+  yAxis={[
+    {
+      id: "temp",
+      labelFormatter: (value?: string | number) => `${value} ºC`,
+      name: "Temperature",
+    },
+    {
+      id: "prec",
+      labelFormatter: (value?: string | number) => `${value} mm`,
+      name: "Precipitation",
+    },
+  ]}
+  groupBy="Month"
+  measures={[
+    {
+      field: "Temperature",
+      yAxis: "temp",
+      valueFormatter: (value?: string | number) => `${value} ºC`,
+    },
+    {
+      field: "Precipitation",
+      yAxis: "prec",
+      valueFormatter: (value?: string | number) => `${value} mm`,
+    },
+  ]}
+/>
+```
+
+### Custom ECharts options
+
+If necessary, you can customize the chart's option and take advantage of the additional properties offered by ECharts.
+In this example we change the type of line to a smooth curved line and add a markLine to show the average value.
+We also change the color of the line and the dots based on the value of the data point.
+
+```tsx live
+<HvLineChart
+  height={400}
+  data={{
+    Month: [
+      "Jan",
+      "Feb",
+      "Mar",
+      "Apr",
+      "May",
+      "Jun",
+      "Jul",
+      "Aug",
+      "Sep",
+      "Oct",
+      "Nov",
+      "Dec",
+    ],
+    "Sales Target": [
+      5929, 2393, 1590, 7817, 4749, 1702, 2381, 2909, 6732, 3098, 2119, 2146,
+    ],
+  }}
+  groupBy="Month"
+  measures="Sales Target"
+  onOptionChange={(option) => {
+    if (Array.isArray(option.yAxis) && option.yAxis.length === 1) {
+      option.yAxis = [{ ...option.yAxis[0], splitNumber: 8 }];
+    }
+    option.series[0].markLine = {
+      data: [{ yAxis: 3000, name: "Average" }],
+      symbol: "none",
+      itemStyle: {
+        color: "#666",
+      },
+      label: {
+        color: "#666",
+      },
+    };
+    option.series[0].smooth = true;
+    option.series[0].lineStyle = {
+      color: "#999",
+    };
+    option.series[0].itemStyle = {
+      color(params: any) {
+        return params.data[1] > 3000 ? "#090" : "#900";
+      },
+    };
+
+    option.series[0].symbolSize = 8;
+
+    return option;
+  }}
+/>
+```

--- a/apps/docs/src/pages/examples/_meta.ts
+++ b/apps/docs/src/pages/examples/_meta.ts
@@ -11,4 +11,10 @@ export default {
       layout: "full",
     },
   },
+  charts: {
+    type: "page",
+    theme: {
+      layout: "full",
+    },
+  },
 };

--- a/apps/docs/src/pages/examples/charts.mdx
+++ b/apps/docs/src/pages/examples/charts.mdx
@@ -1,0 +1,11 @@
+import { CodeBlock } from "../../components/code/CodeBlock";
+
+import lineChartStreamingCode from "../../examples/charts/LineChartStreaming?raw";
+
+# Charts examples
+
+## Line chart with streaming
+
+A line chart with regular interval updates.
+
+<CodeBlock code={{ main: lineChartStreamingCode }} />


### PR DESCRIPTION
- adds documentation for the `LineChart` component
- adds new `charts` examples section with one example
- also added the `UI Kit Charts` collection to the [UI Kit StackBlitz collections](https://stackblitz.com/orgs/github/lumada-design/collections) with a sample of a chart that loads Arrow data