### PR TITLE
feat(Typography): inherit text color

### DIFF
--- a/packages/core/src/AppSwitcher/Action/Action.styles.tsx
+++ b/packages/core/src/AppSwitcher/Action/Action.styles.tsx
@@ -30,7 +30,6 @@ export const { staticClasses, useClasses } = createClasses(
       cursor: "pointer",
 
       textDecoration: "inherit",
-      color: "inherit",
       backgroundColor: "inherit",
 
       "$disabled &": {

--- a/packages/core/src/BaseDropdown/BaseDropdown.styles.tsx
+++ b/packages/core/src/BaseDropdown/BaseDropdown.styles.tsx
@@ -81,7 +81,6 @@ export const { useClasses, staticClasses } = createClasses("HvBaseDropdown", {
     boxSizing: "border-box",
     paddingLeft: theme.space.xs,
     paddingRight: theme.sizes.sm,
-    color: "inherit",
   },
   selectionDisabled: {},
   placeholder: {

--- a/packages/core/src/Loading/Loading.styles.tsx
+++ b/packages/core/src/Loading/Loading.styles.tsx
@@ -43,7 +43,9 @@ export const { staticClasses, useClasses } = createClasses("HvLoading", {
     ":nth-of-type(2)": { animationDelay: "0.22s" },
     ":nth-of-type(3)": { animationDelay: "0.44s" },
   },
-  label: {},
+  label: {
+    ...theme.typography.caption1,
+  },
   overlay: {},
   blur: {},
   hidden: { display: "none" },

--- a/packages/core/src/Loading/Loading.tsx
+++ b/packages/core/src/Loading/Loading.tsx
@@ -7,7 +7,6 @@ import {
 import { getColor, HvColorAny } from "@hitachivantara/uikit-styles";
 
 import { HvBaseProps } from "../types/generic";
-import { HvTypography } from "../Typography";
 import { range } from "../utils/helpers";
 import { staticClasses, useClasses } from "./Loading.styles";
 
@@ -82,11 +81,7 @@ export const HvLoading = forwardRef<
           />
         ))}
       </div>
-      {label && (
-        <HvTypography variant="caption1" className={classes.label}>
-          {label}
-        </HvTypography>
-      )}
+      {label && <div className={classes.label}>{label}</div>}
     </div>
   );
 });

--- a/packages/core/src/Typography/Typography.styles.ts
+++ b/packages/core/src/Typography/Typography.styles.ts
@@ -4,6 +4,7 @@ import { theme } from "@hitachivantara/uikit-styles";
 export const { useClasses, staticClasses } = createClasses("HvTypography", {
   root: {
     fontFamily: theme.fontFamily.body,
+    color: "inherit",
   },
   disabled: {
     color: theme.colors.secondary_60,

--- a/packages/core/src/VerticalNavigation/TreeView/TreeViewItem.styles.tsx
+++ b/packages/core/src/VerticalNavigation/TreeView/TreeViewItem.styles.tsx
@@ -43,7 +43,6 @@ export const { staticClasses, useClasses } = createClasses(
       width: "100%",
       display: "flex",
       justifyContent: "flex-start",
-      color: "inherit",
       alignItems: "center",
       height: "32px",
       borderLeft: `4px solid transparent`,

--- a/packages/styles/src/types.ts
+++ b/packages/styles/src/types.ts
@@ -1,4 +1,4 @@
-import * as CSS from "csstype";
+import type { StandardProperties } from "csstype";
 
 import * as tokens from "./tokens";
 import { colors } from "./tokens/colors";
@@ -13,7 +13,7 @@ const flattenTokens = {
   },
 };
 
-interface CSSProperties extends CSS.Properties<string | number> {}
+interface CSSProperties extends StandardProperties<string | number> {}
 
 export type HvThemeTokens = typeof flattenTokens;
 


### PR DESCRIPTION
adds `"inherit"` to `HvTypography`

opened because https://github.com/lumada-design/hv-uikit-react/pull/4575 found a few coloring issues in icons, so doing the same for the Typography
UPDATE: issues were found in disabled/readOnly states