### PR TITLE
docs: add `ScatterPlot` documentation

### DIFF
--- a/apps/docs/src/pages/charts/_meta.ts
+++ b/apps/docs/src/pages/charts/_meta.ts
@@ -3,4 +3,5 @@ export default {
     type: "separator",
     title: "Charts",
   },
+  "get-started": "Get Started",
 };

--- a/apps/docs/src/pages/charts/bar-chart.mdx
+++ b/apps/docs/src/pages/charts/bar-chart.mdx
@@ -1,10 +1,3 @@
-import { Callout } from "nextra/components";
-import {
-  HvBarChart,
-  HvPanel,
-  HvVizProvider,
-} from "@hitachivantara/uikit-react-viz";
-
 import { getComponentData } from "../../utils/component";
 
 import { Playground } from "../../components/code/Playground";
@@ -16,11 +9,6 @@ export const getStaticProps = async ({ params }) => {
 };
 
 <Header />
-
-<Callout type="info">
-  Please check the [Visualizations Guide](/documentation/visualizations) for
-  details on how to build your visualizations.
-</Callout>
 
 ### Usage
 

--- a/apps/docs/src/pages/charts/get-started.mdx
+++ b/apps/docs/src/pages/charts/get-started.mdx
@@ -13,6 +13,11 @@ To use the visualizations components, you need to install the `@hitachivantara/u
 npm install @hitachivantara/uikit-react-viz
 ```
 
+## Apache ECharts
+
+UI Kit's charts are based on the [Apache ECharts](https://echarts.apache.org/en/index.html) library.
+If you need any feature that's not covered by the UI Kit charts documentation, please refer to the [Apache ECharts documentation](https://echarts.apache.org/en/option.html#title).
+
 ## Provider
 
 Before using any of the UI Kit visualizations, it's necessary to add the `HvVizProvider` component to your application.

--- a/apps/docs/src/pages/charts/scatter-plot.mdx
+++ b/apps/docs/src/pages/charts/scatter-plot.mdx
@@ -1,6 +1,3 @@
-import { Callout } from "nextra/components";
-import { HvScatterPlot } from "@hitachivantara/uikit-react-viz";
-
 import { getComponentData } from "../../utils/component";
 
 import { Playground } from "../../components/code/Playground";
@@ -12,11 +9,6 @@ export const getStaticProps = async ({ params }) => {
 };
 
 <Header />
-
-<Callout type="info">
-  Please check the [Visualizations Guide](/documentation/visualizations) for
-  details on how to build your visualizations.
-</Callout>
 
 ### Usage
 

--- a/apps/docs/src/pages/charts/scatter-plot.mdx
+++ b/apps/docs/src/pages/charts/scatter-plot.mdx
@@ -1,0 +1,184 @@
+import { Callout } from "nextra/components";
+import { HvScatterPlot } from "@hitachivantara/uikit-react-viz";
+
+import { getComponentData } from "../../utils/component";
+
+import { Playground } from "../../components/code/Playground";
+import { Header } from "../../components/Header";
+
+export const getStaticProps = async ({ params }) => {
+  const meta = await getComponentData("ScatterPlot", "viz", {}, [], true);
+  return { props: { ssg: { meta } } };
+};
+
+<Header />
+
+<Callout type="info">
+  Please check the [Visualizations Guide](/documentation/visualizations) for
+  details on how to build your visualizations.
+</Callout>
+
+### Usage
+
+This example demonstrates a simple scatter plot with a single data series. Each bar represents a data point, and a tooltip appears on hover to display additional information. Setting the `horizontalRangeSlider.show` prop to true will display a range slider at the bottom of the chart to allow users to zoom in on a specific range of data.
+
+```tsx live
+<HvScatterPlot
+  height={400}
+  horizontalRangeSlider={{
+    show: true,
+  }}
+  data={{
+    y: Array.from(Array(500).keys()).map((i) => i * 0.001 + Math.random()),
+    x: Array.from(Array(500).keys()).map((i) => i * 0.001 + Math.random()),
+  }}
+  groupBy="x"
+  measures="y"
+/>
+```
+
+### Multiple plots with splitBy
+
+Use the `splitBy` to create multiple plots in the same chart. In this example we have two countries with 10 data points each.
+The `splitBy` prop is used to create two separate plots, one for each country.
+
+```tsx live
+<HvScatterPlot
+  height={400}
+  data={{
+    Country: [
+      ...Array.from(Array(10)).map(() => "Portugal"),
+      ...Array.from(Array(10)).map(() => "Spain"),
+    ],
+    Time: [
+      ...Array.from(Array(10).keys()).map((i) =>
+        new Date(
+          new Date(new Date(0, 0, 0, 9, 0, 0)).setHours(
+            new Date(0, 0, 0, 9, 0, 0).getHours() + i,
+          ),
+        ).getTime(),
+      ),
+      ...Array.from(Array(10).keys()).map((i) =>
+        new Date(
+          new Date(new Date(0, 0, 0, 9, 0, 0)).setHours(
+            new Date(0, 0, 0, 9, 0, 0).getHours() + i,
+          ),
+        ).getTime(),
+      ),
+    ],
+    Sales: [
+      ...Array.from(Array(10)).map(() =>
+        Math.floor(Math.random() * (5000 - 500 + 1) + 500),
+      ),
+      ...Array.from(Array(10)).map(() =>
+        Math.floor(Math.random() * (5000 - 500 + 1) + 500),
+      ),
+    ],
+  }}
+  groupBy="Time"
+  measures="Sales"
+  splitBy="Country"
+  yAxis={{
+    name: "Number of Sales",
+  }}
+  xAxis={{ type: "time" }}
+  tooltip={{
+    titleFormatter: (x?: string | number) =>
+      x ? `${new Date(x).toLocaleTimeString()}` : "",
+  }}
+/>
+```
+
+### Multiple Y axes
+
+You can create a scatter plot with multiple Y axes by defining the `yAxis` prop as an array of objects.
+Each object should have a unique `id` and a `name` to identify the axis.
+The `measures` prop should be an array of objects, each with a `yAxis` field that matches the `id` of the corresponding axis.
+
+```tsx live
+<HvScatterPlot
+  height={400}
+  data={{
+    Humidity: [42, 46, 48, 50, 40, 35, 30, 22, 21, 12, 10, 15, 18, 22, 22],
+    Temperature: [20, 22, 24, 26, 28, 30, 32, 34, 36, 38, 40, 38, 35, 30, 28],
+    Time: Array.from(Array(15).keys()).map((i) =>
+      new Date(
+        new Date(new Date(0, 0, 0, 6, 0, 0)).setHours(
+          new Date(0, 0, 0, 6, 0, 0).getHours() + i,
+        ),
+      ).getTime(),
+    ),
+  }}
+  groupBy="Time"
+  measures={[
+    {
+      yAxis: "temp",
+      field: "Temperature",
+      valueFormatter: (x?: string | number) => `${x}ºC`,
+    },
+    {
+      yAxis: "humidity",
+      field: "Humidity",
+      valueFormatter: (x?: string | number) => `${x}%`,
+    },
+  ]}
+  yAxis={[
+    {
+      id: "temp",
+      name: "Temperature",
+      labelFormatter: (x?: string | number) => `${x}ºC`,
+    },
+    {
+      id: "humidity",
+      name: "Humidity",
+      labelFormatter: (x?: string | number) => `${x}%`,
+      minValue: 10,
+    },
+  ]}
+  xAxis={{
+    type: "time",
+  }}
+  tooltip={{
+    titleFormatter: (x?: string | number) =>
+      x ? `${new Date(x).toLocaleTimeString()}` : "",
+  }}
+/>
+```
+
+### Custom ECharts options
+
+If necessary, you can customize the chart's option and take advantage of the additional properties offered by ECharts.
+Here we are adding a mark line to the chart.
+
+```tsx live
+<HvScatterPlot
+  height={400}
+  data={{
+    y: [50, 65, 70, 73, 80, 88, 100, 120, 150, 186, 224, 286, 340, 380, 400],
+    x: Array.from(
+      Array(
+        [50, 65, 70, 73, 80, 88, 100, 120, 150, 186, 224, 286, 340, 380, 400]
+          .length,
+      ).keys(),
+    ).map((i) => i + 1),
+  }}
+  groupBy="x"
+  measures="y"
+  onOptionChange={(option) => {
+    option.series[0].markLine = {
+      lineStyle: { type: "solid" },
+      data: [
+        [
+          { coord: [0, 0], symbol: "none" },
+          { coord: [15, 300], symbol: "none" },
+        ],
+      ],
+      label: {
+        formatter: "y = 20x",
+        position: "insideMiddleTop",
+      },
+    };
+    return option;
+  }}
+/>
+```

--- a/apps/docs/src/pages/documentation/_meta.ts
+++ b/apps/docs/src/pages/documentation/_meta.ts
@@ -21,6 +21,5 @@ export default {
   styling: "Styling",
   layout: "Layout",
   forms: "Forms",
-  visualizations: "Visualizations",
   accessibility: "Accessibility",
 };


### PR DESCRIPTION
⚠️ This PR also moves the visualizations guide to a "Get Started" section on the `charts` section. I believe this is more useful as it keeps all information on visualizations in one place. [Mantine also does the same thing](https://mantine.dev/charts/getting-started/). 