### PR TITLE
feat(Tag): update P+ styles

### DIFF
--- a/apps/docs/src/pages/components/tag.mdx
+++ b/apps/docs/src/pages/components/tag.mdx
@@ -17,22 +17,53 @@ export const getStaticProps = async ({ params }) => {
   componentName="HvTag"
   controls={{
     label: { defaultValue: "Tag label" },
-    color: { type: "color", defaultValue: "neutral_20" },
+    color: { defaultValue: "positive" },
     disabled: { defaultValue: false },
     selectable: { defaultValue: false },
   }}
 />
 
-### Different colors
+### Colors
 
-You can change the default color of the tag by passing a color name from the UI Kit color palette, a CSS color name or a hex color code.
+The color of the tag can be changed using the `color` prop. It accepts any UI Kit or CSS color.
 
 ```tsx live
 <div className="flex gap-xs">
-  <HvTag label="Tag Label" color="positive" />
-  <HvTag label="Tag Label" color="cat2" />
-  <HvTag label="Tag Label" color="aquamarine" />
-  <HvTag label="Tag Label" color="#c73aa8" />
+  <HvTag selectable label="Tag" />
+  <HvTag selectable label="Semantic tag" color="positive" />
+  <HvTag selectable label="Semantic tag" color="warning" />
+  <HvTag selectable label="Semantic tag" color="negative" />
+  <HvTag selectable label="Custom tag" color="pink" />
+  <HvTag selectable label="Custom tag" color="#c73aa8" />
+</div>
+```
+
+### Sizes
+
+The size of the tag can be changed using the `size` prop.
+
+```tsx live
+<div className="flex gap-xs">
+  <HvTag selectable label="Tag label" size="xs" />
+  <HvTag selectable label="Tag label" size="sm" />
+  <HvTag selectable label="Tag label" size="md" />
+</div>
+```
+
+### Icons
+
+An icon can be added using `icon` prop.
+A built-in checkbox icon can be shown by using the `showSelectIcon` prop.
+
+```tsx live
+<div className="flex gap-xs">
+  <HvTag
+    selectable
+    icon={<Abacus size="xs" className="size-12px" />}
+    label="Tag with icon"
+    size="sm"
+  />
+  <HvTag selectable showSelectIcon label="Tag with checkbox" size="sm" />
 </div>
 ```
 
@@ -63,9 +94,9 @@ Tags can have click actions.
 />
 ```
 
-### Controlled selectable state
+### Controlled selection
 
-To use the selectable tags in a controlled way, set the `selected` prop to `true` of `false`.
+The tag selection state can be controlled using the `selected` prop.
 
 ```tsx live
 import { useState } from "react";
@@ -73,11 +104,11 @@ import { useState } from "react";
 const tags = ["Asset 1", "Asset 2", "Asset 3", "Asset 4"];
 
 export default function Demo() {
-  const [selectedTags, setSelectedTags] = useState(["Asset 1", "Asset 3"]);
+  const [selectedTags, setSelectedTags] = useState(tags.slice(0, 2));
 
   return (
     <div className="grid gap-sm">
-      <div className="flex gap-sm">
+      <div className="flex gap-xs">
         {tags.map((tag, i) => (
           <HvTag
             key={`${tag}-${i}`}
@@ -94,7 +125,6 @@ export default function Demo() {
           />
         ))}
       </div>
-      <br />
       <div className="flex items-center gap-xs">
         <HvTypography variant="label">Selected tags:</HvTypography>
         <div>{selectedTags.join(", ")}</div>

--- a/packages/core/src/Table/stories/TableRenderers/utils.tsx
+++ b/packages/core/src/Table/stories/TableRenderers/utils.tsx
@@ -59,8 +59,7 @@ const newRendererEntry = (i: number): NewRendererEntry => {
     eventType: generateLongString(i === 3 ? undefined : "Anomaly detection", i),
     status: {
       status_name: getOption(["Closed", "Open"], i),
-      status_color: getOption(["negativeDimmed", "positiveDimmed"], i),
-      status_text_color: "black",
+      status_color: getOption(["negative_20", "positive_20"], i),
     },
     riskScore: (i % 100) + 1,
     isDisabled: i % 3 === 0,

--- a/packages/core/src/Tag/Tag.styles.tsx
+++ b/packages/core/src/Tag/Tag.styles.tsx
@@ -8,26 +8,53 @@ export const { staticClasses, useClasses } = createClasses("HvTag", {
     justifyContent: "center",
     cursor: "default",
     color: theme.colors.textDark,
-    backgroundColor: "var(--bgColor)",
-    height: 16,
+    borderColor: theme.colors.border,
     borderRadius: 0,
     maxWidth: 180,
     whiteSpace: "nowrap",
+    transition: "background-color 0.3s ease",
 
-    ":hover, :focus": {
-      backgroundColor: "var(--bgColor)",
+    "&,:hover,:focus-visible": {
+      backgroundColor: "var(--tagColor)",
     },
   },
+  hasIcon: {
+    paddingLeft: 2,
+  },
+  /** @deprecated */
+  outlined: {
+    outlineStyle: "solid",
+  },
+  /** @deprecated */
   categorical: {
     borderRadius: 8,
     "& $label": {
       color: theme.colors.text,
     },
+    "& $icon": {
+      display: "none",
+    },
+  },
+  xs: {
+    height: 16,
+  },
+  sm: {
+    height: 24,
+    "& $label": {
+      ...theme.typography.caption1,
+      color: "inherit",
+    },
+  },
+  md: {
+    height: 32,
+    "& $label": {
+      ...theme.typography.body,
+      color: "inherit",
+    },
   },
 
   disabled: {
-    backgroundColor: theme.colors.bgDisabled,
-    ":hover, :focus": {
+    "&,:hover,:focus-visible": {
       backgroundColor: theme.colors.bgDisabled,
     },
     "& $label": {
@@ -49,10 +76,10 @@ export const { staticClasses, useClasses } = createClasses("HvTag", {
   clickable: {
     cursor: "pointer",
   },
+  // TODO: remove in favour of `hasIcon` once it's no longer needed
   icon: {
     width: 12,
     height: 12,
-    marginLeft: 2,
   },
 
   /** @deprecated use `root` instead */

--- a/packages/core/src/Tag/stories/Tag.stories.tsx
+++ b/packages/core/src/Tag/stories/Tag.stories.tsx
@@ -6,6 +6,7 @@ import {
   HvTagProps,
   theme,
 } from "@hitachivantara/uikit-react-core";
+import { Abacus } from "@hitachivantara/uikit-react-icons";
 
 import { Selectable as SelectableStory } from "./Selectable";
 import SelectableRaw from "./Selectable?raw";
@@ -140,6 +141,46 @@ export const Test: StoryObj = {
         color="negative"
         classes={{ root: css({ color: theme.colors.negativeDimmed }) }}
       />
+      <HvTag label="default" />
+      <HvTag selectable label="selectable" />
+      <HvTag selectable size="sm" label="positive" color="positive" />
+      <HvTag selectable size="sm" label="warning" color="warning" />
+      <HvTag selectable size="sm" label="negative" color="negative" />
+      <HvTag selectable size="sm" label="info" color="info" />
+      <HvTag selectable size="sm" label="info" color="info" disabled />
+      <HvTag selectable showSelectIcon size="sm" label="Select" />
+      <HvTag selectable showSelectIcon size="sm" label="Select" disabled />
+      <HvTag
+        selectable
+        size="sm"
+        label="Tag"
+        showSelectIcon={false}
+        icon={<Abacus size="xs" className="size-12px" />}
+        onDelete={() => {}}
+      />
+      <HvTag
+        disabled
+        selectable
+        size="sm"
+        label="Tag"
+        showSelectIcon={false}
+        icon={<Abacus size="xs" className="size-12px" />}
+        onDelete={() => {}}
+      />
+      <HvTag selectable size="md" label="orange" color="orange" />
+      <HvTag selectable size="md" label="lime" color="lime" />
+      <HvTag selectable size="md" label="yellow" color="yellow" />
+      <HvTag selectable size="md" label="green" color="green" />
+      <HvTag selectable size="md" label="teal" color="teal" />
+      <HvTag selectable size="md" label="cyan" color="cyan" />
+      <HvTag selectable size="md" label="blue" color="blue" />
+      <HvTag selectable size="md" label="indigo" color="indigo" />
+      <HvTag selectable size="md" label="violet" color="violet" />
+      <HvTag selectable size="md" label="purple" color="purple" />
+      <HvTag selectable size="md" label="fuchsia" color="fuchsia" />
+      <HvTag selectable size="md" label="pink" color="pink" />
+      <HvTag selectable size="md" label="rose" color="rose" />
+      <HvTag selectable size="md" label="rebeccapurple" color="rebeccapurple" />
     </div>
   ),
 };

--- a/packages/styles/src/theme.ts
+++ b/packages/styles/src/theme.ts
@@ -183,6 +183,7 @@ export const theme = {
   palette,
   spacing,
   alpha,
+  mix,
 };
 
 export type HvTheme = typeof theme;

--- a/packages/styles/src/themes/ds3.ts
+++ b/packages/styles/src/themes/ds3.ts
@@ -1179,6 +1179,16 @@ const ds3 = makeTheme((theme) => ({
         },
       },
     },
+    HvTag: {
+      classes: {
+        root: {
+          "--tagColor": theme.colors.neutral_20,
+        },
+        categorical: {
+          "--tagColor": theme.alpha("cat1", 0.2),
+        },
+      },
+    },
     HvTagsInput: {
       classes: {
         disabled: {

--- a/packages/styles/src/themes/ds5.ts
+++ b/packages/styles/src/themes/ds5.ts
@@ -244,6 +244,16 @@ const ds5 = makeTheme((theme) => ({
         },
       },
     },
+    HvTag: {
+      classes: {
+        root: {
+          "--tagColor": theme.colors.neutral_20,
+        },
+        categorical: {
+          "--tagColor": theme.alpha("cat1", 0.2),
+        },
+      },
+    },
   } satisfies Record<string, Record<string, any> | { classes?: CSSProperties }>,
   header: {
     height: "64px",

--- a/packages/styles/src/themes/pentahoPlus.ts
+++ b/packages/styles/src/themes/pentahoPlus.ts
@@ -34,6 +34,8 @@ const buttonColors = {
   },
 };
 
+const semaColors = ["positive", "warning", "negative", "info"] as const;
+
 const notificationMap = {
   success: "positive",
   warning: "warning",
@@ -625,23 +627,72 @@ const pentahoPlus = makeTheme((theme) => ({
       },
     },
     HvTag: {
+      showSelectIcon: false,
       classes: {
         root: {
-          borderRadius: theme.radii.full,
-          padding: theme.spacing("2px", 0),
+          outline: `1px solid ${theme.colors.border}`,
+          borderRadius: theme.radii.round,
+          ":where(:not([data-color],.HvTag-disabled))": {
+            color: theme.colors.text,
+            "--tagColor": theme.colors.bgContainer,
+          },
+
+          ":where([data-color]:not(.HvTag-disabled))": {
+            ":where(:not([data-color$=_20],[data-color^=cat]))": {
+              color: "var(--tagColor)",
+              backgroundColor: theme.mix("var(--tagColor)", "8%", "white"),
+              outlineColor: theme.mix("var(--tagColor)", "30%", "white"),
+              "&&.HvTag-clickable:has(:hover,:focus-visible)": {
+                backgroundColor: theme.mix("var(--tagColor)", "20%", "white"),
+              },
+            },
+
+            ...Object.fromEntries(
+              semaColors.map((color) => [
+                [`&[data-color=${color}]`],
+                {
+                  color: theme.colors[`${color}Strong`],
+                  backgroundColor: theme.colors[`${color}Dimmed`],
+                  outlineColor: theme.colors[`${color}Border`],
+                  "&.HvTag-clickable:has(:hover,:focus-visible)": {
+                    backgroundColor: theme.colors[`${color}Subtle`],
+                  },
+                },
+              ]),
+            ),
+          },
         },
+        hasIcon: {
+          paddingLeft: theme.space.xs,
+        },
+        xs: { borderRadius: 4 },
+        sm: { borderRadius: 6 },
+        md: { borderRadius: 8 },
         label: {
           paddingLeft: 8,
           paddingRight: 8,
         },
-        icon: {
-          marginLeft: theme.space.xs,
-        },
         deleteIcon: {
           borderRadius: "inherit",
-          paddingRight: 4,
+          marginRight: 4,
         },
-        selected: {},
+        clickable: {
+          ":hover": {
+            backgroundColor: theme.colors.bgHover,
+          },
+        },
+        selected: {
+          "&&": {
+            outlineColor: "currentcolor",
+          },
+        },
+        disabled: {
+          color: theme.colors.textDisabled,
+          outlineColor: "transparent",
+          "&,:hover": {
+            backgroundColor: theme.colors.bgDisabled,
+          },
+        },
       },
     },
     HvIconContainer: {


### PR DESCRIPTION
- update `HvTag` to the new Pentaho+ styles
  - current P+ semantic tags need to be updated (eg. `positive_20` -> `positive`)
- support any custom color in Pentaho+ theme (similar to `HvButton`)
- recover `variant` prop from `Chip` (deprecated)
- add `size` prop
- add `showSelectIcon` to allow disabling checkbox icon (hidden in P+ theme)