### PR TITLE
refactor(Button): use outline instead of border

### DIFF
--- a/packages/core/src/Button/Button.stories.tsx
+++ b/packages/core/src/Button/Button.stories.tsx
@@ -1,4 +1,3 @@
-import { css } from "@emotion/css";
 import { StoryObj } from "@storybook/react";
 import { HvButton, HvButtonProps } from "@hitachivantara/uikit-react-core";
 import {
@@ -158,17 +157,7 @@ export const FocusableWhenDisabled: StoryObj<HvButtonProps> = {
 export const Icons: StoryObj<HvButtonProps> = {
   decorators: [
     (Story) => (
-      <div
-        className={css({
-          display: "flex",
-          flexFlow: "column",
-          gap: 10,
-          "& > div": {
-            display: "flex",
-            gap: 20,
-          },
-        })}
-      >
+      <div className="grid gap-10px [&>div]:flex [&>div]:gap-20px">
         {Story()}
       </div>
     ),
@@ -176,18 +165,18 @@ export const Icons: StoryObj<HvButtonProps> = {
   render: () => (
     <>
       <div>
-        <HvButton icon aria-label="Play" variant="primaryGhost">
-          <Play iconSize="M" />
+        <HvButton icon aria-label="Play" variant="primarySubtle">
+          <Play size="M" />
         </HvButton>
         <HvButton icon aria-label="Pause">
-          <Pause iconSize="M" />
+          <Pause size="M" />
         </HvButton>
         <HvButton icon disabled aria-label="Stop">
-          <Stop iconSize="M" />
+          <Stop size="M" />
         </HvButton>
       </div>
       <div>
-        <HvButton startIcon={<Play />} variant="primaryGhost">
+        <HvButton startIcon={<Play />} variant="primarySubtle">
           Play
         </HvButton>
         <HvButton startIcon={<Pause />} variant="secondaryGhost">
@@ -198,7 +187,7 @@ export const Icons: StoryObj<HvButtonProps> = {
         </HvButton>
       </div>
       <div>
-        <HvButton endIcon={<Play />} variant="primaryGhost">
+        <HvButton endIcon={<Play />} variant="primarySubtle">
           Play
         </HvButton>
         <HvButton endIcon={<Pause />} variant="secondaryGhost">

--- a/packages/core/src/Button/Button.styles.ts
+++ b/packages/core/src/Button/Button.styles.ts
@@ -29,32 +29,28 @@ export const { staticClasses, useClasses } = createClasses("HvButton", {
     color: "var(--color, currentcolor)",
     backgroundColor: "transparent",
     height: "var(--HvButton-height)",
-    border: "1px solid transparent",
+    border: "none",
+    outline: "1px solid transparent",
+    outlineOffset: -1,
     borderRadius: `var(--radius, ${theme.radii.base})`,
     padding: theme.spacing(0, "sm"),
   },
   /** applied to the _left_ icon container */
   startIcon: {
     marginLeft: theme.spacing(-1),
-    marginTop: -1,
-    marginBottom: -1,
   },
   /** applied to the _right_ icon container */
   endIcon: {
     marginRight: theme.spacing(-1),
-    marginTop: -1,
-    marginBottom: -1,
   },
   focusVisible: {},
   /** applied to the root element when disabled */
   disabled: {
     cursor: "not-allowed",
     color: theme.colors.textDisabled,
-    backgroundColor: "transparent",
-    borderColor: "transparent",
-    ":hover, :focus-visible": {
+    "&,:hover,:focus-visible": {
       backgroundColor: "transparent",
-      borderColor: "transparent",
+      outlineColor: "transparent",
     },
   },
   /** applied to the root element when is icon-only */
@@ -62,9 +58,6 @@ export const { staticClasses, useClasses } = createClasses("HvButton", {
     margin: 0,
     padding: 0,
     height: "fit-content",
-    "& > *": {
-      margin: -1,
-    },
   },
   /** applied to the root element when using the `contained` variant */
   contained: {
@@ -81,7 +74,7 @@ export const { staticClasses, useClasses } = createClasses("HvButton", {
   },
   /** applied to the root element when using the `subtle` variant */
   subtle: {
-    borderColor: "currentcolor",
+    outlineColor: "currentcolor",
   },
   /** applied to the root element when using the `ghost` variant */
   ghost: {},
@@ -89,7 +82,7 @@ export const { staticClasses, useClasses } = createClasses("HvButton", {
   semantic: {
     color: theme.colors.textDark,
     backgroundColor: "transparent",
-    borderColor: "transparent",
+    outlineColor: "transparent",
     "&:hover, &:focus-visible": {
       backgroundColor: theme.alpha("textLight", 0.3),
     },

--- a/packages/core/src/DropdownButton/DropdownButton.styles.tsx
+++ b/packages/core/src/DropdownButton/DropdownButton.styles.tsx
@@ -5,11 +5,9 @@ import { buttonClasses } from "../Button";
 
 // TODO: review override
 const disabledStyle = {
-  backgroundColor: theme.colors.bgDisabled,
-  borderColor: theme.colors.bgDisabled,
-  [`&.${buttonClasses.subtle},&.${buttonClasses.ghost}`]: {
+  [`&,&.${buttonClasses.subtle},&.${buttonClasses.ghost}`]: {
     backgroundColor: theme.colors.bgDisabled,
-    borderColor: theme.colors.bgDisabled,
+    outlineColor: theme.colors.bgDisabled,
     "&:hover": { backgroundColor: theme.colors.bgDisabled },
   },
 };

--- a/packages/pentaho/src/Canvas/BottomPanel/BottomPanel.styles.tsx
+++ b/packages/pentaho/src/Canvas/BottomPanel/BottomPanel.styles.tsx
@@ -67,11 +67,9 @@ export const { staticClasses, useClasses } = createClasses(
       pointerEvents: "none",
       [`&& .${buttonClasses.disabled}`]: {
         pointerEvents: "none",
-        backgroundColor: "transparent",
-        borderColor: "transparent",
-        ":hover": {
+        "&,:hover": {
           backgroundColor: "transparent",
-          borderColor: "transparent",
+          outlineColor: "transparent",
         },
       },
     },

--- a/packages/styles/src/themes/ds3.ts
+++ b/packages/styles/src/themes/ds3.ts
@@ -447,11 +447,11 @@ const ds3 = makeTheme((theme) => ({
         },
         secondarySubtle: {
           backgroundColor: theme.colors.atmo1,
-          borderColor: theme.colors.atmo4,
+          outlineColor: theme.colors.atmo4,
         },
         secondary: {
           backgroundColor: theme.colors.atmo1,
-          borderColor: theme.colors.atmo4,
+          outlineColor: theme.colors.atmo4,
         },
         ghost: {},
         disabled: {
@@ -459,7 +459,7 @@ const ds3 = makeTheme((theme) => ({
             backgroundColor: theme.colors.atmo3,
           },
           "&.HvButton-subtle": {
-            borderColor: theme.colors.atmo4,
+            outlineColor: theme.colors.atmo4,
           },
         },
       },

--- a/packages/styles/src/themes/ds5.ts
+++ b/packages/styles/src/themes/ds5.ts
@@ -197,26 +197,26 @@ const ds5 = makeTheme((theme) => ({
           ":where([data-color=primary]:not(.HvButton-disabled))": {
             ":hover, &:focus-visible": {
               backgroundColor: theme.colors.primary_80,
-              borderColor: theme.colors.primary_80,
+              outlineColor: theme.colors.primary_80,
             },
           },
           ":where([data-color=positive]:not(.HvButton-disabled))": {
             ":hover, &:focus-visible": {
               backgroundColor: theme.colors.positive_80,
-              borderColor: theme.colors.positive_80,
+              outlineColor: theme.colors.positive_80,
             },
           },
           ":where([data-color=warning]:not(.HvButton-disabled))": {
             backgroundColor: theme.colors.warning_120,
             ":hover, &:focus-visible": {
               backgroundColor: theme.colors.warning_140,
-              borderColor: theme.colors.warning_140,
+              outlineColor: theme.colors.warning_140,
             },
           },
           ":where([data-color=negative]:not(.HvButton-disabled))": {
             ":hover, &:focus-visible": {
               backgroundColor: theme.colors.negative_80,
-              borderColor: theme.colors.negative_80,
+              outlineColor: theme.colors.negative_80,
             },
           },
         },

--- a/packages/styles/src/themes/pentahoPlus.ts
+++ b/packages/styles/src/themes/pentahoPlus.ts
@@ -599,7 +599,7 @@ const pentahoPlus = makeTheme((theme) => ({
       classes: {
         root: {
           "&& .HvButton-secondarySubtle": {
-            borderColor: inputColors.border,
+            outlineColor: inputColors.border,
             backgroundColor: inputColors.bg,
           },
           "&& .HvDropdownButton-openUp": {
@@ -676,7 +676,7 @@ const pentahoPlus = makeTheme((theme) => ({
         button: {
           borderRadius: 2,
           "&:focus": {
-            borderColor: theme.colors.secondary,
+            outlineColor: theme.colors.secondary,
           },
         },
         inputRoot: {
@@ -719,25 +719,25 @@ const pentahoPlus = makeTheme((theme) => ({
           },
         },
         subtle: {
-          borderColor: "color-mix(in srgb, currentcolor, transparent 60%)",
+          outlineColor: "color-mix(in srgb, currentcolor, transparent 60%)",
           ":where(:not(.HvButton-disabled))": {
             "&[data-color=primary]": {
-              borderColor: buttonColors.primary.subtleBorder,
+              outlineColor: buttonColors.primary.subtleBorder,
               backgroundColor: buttonColors.primary.subtleBg,
             },
             "&[data-color=secondary]": {
-              borderColor: buttonColors.secondary.subtleBorder,
+              outlineColor: buttonColors.secondary.subtleBorder,
               backgroundColor: buttonColors.secondary.subtleBg,
             },
             ":hover": {
               backgroundColor: theme.colors.primaryDimmed,
             },
             ":active": {
-              borderColor: "transparent",
+              outlineColor: "transparent",
               backgroundColor: theme.colors.primarySubtle,
             },
             "&[data-color=positive]": {
-              borderColor: theme.colors.positiveBorder,
+              outlineColor: theme.colors.positiveBorder,
               backgroundColor: theme.colors.positiveDimmed,
               ":hover": { backgroundColor: theme.colors.positiveSubtle },
               ":active": {
@@ -745,13 +745,13 @@ const pentahoPlus = makeTheme((theme) => ({
               },
             },
             "&[data-color=warning]": {
-              borderColor: theme.colors.warningBorder,
+              outlineColor: theme.colors.warningBorder,
               backgroundColor: theme.colors.warningDimmed,
               ":hover": { backgroundColor: theme.colors.warningSubtle },
               ":active": { backgroundColor: theme.colors.warningBorder },
             },
             "&[data-color=negative]": {
-              borderColor: theme.colors.negativeBorder,
+              outlineColor: theme.colors.negativeBorder,
               backgroundColor: theme.colors.negativeDimmed,
               ":hover": { backgroundColor: theme.colors.negativeSubtle },
               ":active": {
@@ -782,7 +782,7 @@ const pentahoPlus = makeTheme((theme) => ({
         disabled: {
           color: theme.colors.textDisabled,
           ":not(.HvButton-ghost)": {
-            borderColor: "transparent",
+            outlineColor: "transparent",
             backgroundColor: theme.colors.bgDisabled,
             "&:hover, &:active": {
               backgroundColor: theme.colors.bgDisabled,
@@ -848,17 +848,17 @@ const pentahoPlus = makeTheme((theme) => ({
         },
         disabled: {
           backgroundColor: theme.colors.bgDisabled,
-          borderColor: theme.colors.bgDisabled,
+          outlineColor: theme.colors.bgDisabled,
           "&.HvButton-subtle": {
             backgroundColor: theme.colors.bgDisabled,
-            borderColor: theme.colors.bgDisabled,
+            outlineColor: theme.colors.bgDisabled,
             "&:hover": {
               backgroundColor: theme.colors.bgDisabled,
             },
           },
           "&.HvButton-ghost": {
             backgroundColor: theme.colors.bgDisabled,
-            borderColor: theme.colors.bgDisabled,
+            outlineColor: theme.colors.bgDisabled,
             "&:hover": {
               backgroundColor: theme.colors.bgDisabled,
             },
@@ -1098,8 +1098,7 @@ const pentahoPlus = makeTheme((theme) => ({
           backgroundColor: inputColors.bg,
         },
         headerOpen: {
-          borderColor: inputColors.border,
-          "&:hover": {
+          "&,:hover": {
             borderColor: inputColors.border,
           },
         },
@@ -1112,7 +1111,7 @@ const pentahoPlus = makeTheme((theme) => ({
       classes: {
         iconSelected: {
           "&[data-color=secondary]": {
-            borderColor: inputColors.border,
+            outlineColor: inputColors.border,
           },
         },
       },


### PR DESCRIPTION
allows removing negative margins so the button doesn't grow more than it should