### PR TITLE
test: remove icons dependency

### DIFF
--- a/packages/core/src/ActionsGeneric/ActionsGeneric.test.tsx
+++ b/packages/core/src/ActionsGeneric/ActionsGeneric.test.tsx
@@ -1,26 +1,14 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
-import {
-  Add,
-  Delete,
-  Preview,
-  Upload,
-} from "@hitachivantara/uikit-react-icons";
 
 import { HvActionsGeneric, HvActionsGenericProps } from "./ActionsGeneric";
 
 const actions: HvActionsGenericProps["actions"] = [
-  { id: "post", label: "Add", icon: <Add />, disabled: true },
-  { id: "get", label: "Preview", icon: <Preview />, iconOnly: true },
-  {
-    id: "put",
-    label: "Upload",
-    icon: <Upload />,
-    disabled: true,
-    iconOnly: false,
-  },
-  { id: "delete", label: "Delete", icon: <Delete /> },
+  { id: "post", label: "Add", icon: <div />, disabled: true },
+  { id: "get", label: "Preview", icon: <div />, iconOnly: true },
+  { id: "put", label: "Upload", disabled: true, iconOnly: false },
+  { id: "delete", label: "Delete" },
 ];
 
 describe("ActionsGeneric", () => {

--- a/packages/core/src/Avatar/Avatar.test.tsx
+++ b/packages/core/src/Avatar/Avatar.test.tsx
@@ -1,6 +1,5 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
-import { LogIn } from "@hitachivantara/uikit-react-icons";
 
 import { HvAvatar } from "./Avatar";
 
@@ -14,10 +13,10 @@ describe("Avatar", () => {
   it("renders the icon", () => {
     render(
       <HvAvatar>
-        <LogIn title="login" />
+        <div data-testid="login" />
       </HvAvatar>,
     );
 
-    expect(screen.getByRole("img", { name: "login" })).toBeInTheDocument();
+    expect(screen.getByTestId("login")).toBeInTheDocument();
   });
 });

--- a/packages/core/src/AvatarGroup/AvatarGroup.test.tsx
+++ b/packages/core/src/AvatarGroup/AvatarGroup.test.tsx
@@ -1,5 +1,4 @@
 import { render, screen } from "@testing-library/react";
-import { LogIn } from "@hitachivantara/uikit-react-icons";
 
 import { HvAvatar } from "../Avatar/Avatar";
 import { HvAvatarGroup } from "./AvatarGroup";
@@ -13,13 +12,13 @@ describe("HvAvatarGroup", () => {
     render(
       <HvAvatarGroup>
         <HvAvatar>
-          <LogIn title="login" />
+          <div role="img" />
         </HvAvatar>
         <HvAvatar>
-          <LogIn title="login" />
+          <div role="img" />
         </HvAvatar>
         <HvAvatar>
-          <LogIn title="login" />
+          <div role="img" />
         </HvAvatar>
       </HvAvatarGroup>,
     );
@@ -32,33 +31,27 @@ describe("HvAvatarGroup", () => {
     render(
       <HvAvatarGroup maxVisible={1}>
         <HvAvatar>
-          <LogIn title="login" />
+          <div data-testid="img" />
         </HvAvatar>
         <HvAvatar>
-          <LogIn title="login" />
+          <div data-testid="img" />
         </HvAvatar>
         <HvAvatar>
-          <LogIn title="login" />
+          <div data-testid="img" />
         </HvAvatar>
       </HvAvatarGroup>,
     );
 
-    const renderedAvatars = screen.getAllByRole("img");
+    const renderedAvatars = screen.getAllByTestId("img");
     expect(renderedAvatars).toHaveLength(1);
   });
 
   it("renders overflow avatar when number of avatars exceeds maxVisible", () => {
     render(
       <HvAvatarGroup maxVisible={2}>
-        <HvAvatar>
-          <LogIn title="login" />
-        </HvAvatar>
-        <HvAvatar>
-          <LogIn title="login" />
-        </HvAvatar>
-        <HvAvatar>
-          <LogIn title="login" />
-        </HvAvatar>
+        <HvAvatar />
+        <HvAvatar />
+        <HvAvatar />
       </HvAvatarGroup>,
     );
 

--- a/packages/core/src/Badge/Badge.test.tsx
+++ b/packages/core/src/Badge/Badge.test.tsx
@@ -1,6 +1,5 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
-import { Alert } from "@hitachivantara/uikit-react-icons";
 
 import { HvBadge } from "./Badge";
 
@@ -37,9 +36,9 @@ describe("Badge", () => {
   });
 
   it("should render correctly with svg", () => {
-    render(<HvBadge label={100} showCount icon={<Alert title="Alert" />} />);
+    render(<HvBadge label={100} showCount icon={<div data-testid="icon" />} />);
     expect(screen.queryByText("99+")).toBeInTheDocument();
-    expect(screen.getByRole("img", { name: "Alert" })).toBeInTheDocument();
+    expect(screen.getByTestId("icon")).toBeInTheDocument();
   });
 
   it("should render correctly with custom label", () => {

--- a/packages/core/src/BulkActions/BulkActions.test.tsx
+++ b/packages/core/src/BulkActions/BulkActions.test.tsx
@@ -2,7 +2,6 @@ import { useState } from "react";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
-import { Add, Delete, Lock, Preview } from "@hitachivantara/uikit-react-icons";
 
 import { HvBulkActions, HvBulkActionsProps } from "./BulkActions";
 
@@ -20,10 +19,10 @@ const Sample = (props: Partial<HvBulkActionsProps>) => {
       onSelectAll={handleSelectAll}
       maxVisibleActions={2}
       actions={[
-        { id: "add", label: "Add", icon: <Add /> },
-        { id: "delete", label: "Delete", icon: <Delete /> },
-        { id: "lock", label: "Lock", icon: <Lock /> },
-        { id: "put", label: "Preview", icon: <Preview /> },
+        { id: "add", label: "Add", icon: <div /> },
+        { id: "delete", label: "Delete", icon: <div /> },
+        { id: "lock", label: "Lock", icon: <div /> },
+        { id: "put", label: "Preview", icon: <div /> },
       ]}
       {...props}
     />

--- a/packages/core/src/Button/Button.test.tsx
+++ b/packages/core/src/Button/Button.test.tsx
@@ -1,7 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
-import { Alert } from "@hitachivantara/uikit-react-icons";
 
 import { HvLoading } from "../Loading";
 import { HvButton } from "./Button";
@@ -36,8 +35,8 @@ describe("Button", () => {
   it("renders the custom content", () => {
     render(
       <HvButton
-        startIcon={<Alert data-testid="startId" />}
-        endIcon={<Alert data-testid="endId" />}
+        startIcon={<div data-testid="startId" />}
+        endIcon={<div data-testid="endId" />}
       >
         <HvLoading data-testid="loadingId" />
         content

--- a/packages/core/src/IconButton/IconButton.test.tsx
+++ b/packages/core/src/IconButton/IconButton.test.tsx
@@ -1,7 +1,6 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { vi } from "vitest";
-import { Download } from "@hitachivantara/uikit-react-icons";
 
 import { HvIconButton, HvIconButtonProps } from "./IconButton";
 
@@ -10,7 +9,7 @@ const title = "My tooltip button";
 const renderIconButton = (props?: Partial<HvIconButtonProps>) =>
   render(
     <HvIconButton title={title} {...props}>
-      <Download data-testid="downloadIconId" />
+      <div data-testid="downloadIconId" />
     </HvIconButton>,
   );
 

--- a/packages/core/src/Input/Input.test.tsx
+++ b/packages/core/src/Input/Input.test.tsx
@@ -2,7 +2,6 @@ import { useState } from "react";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { vi } from "vitest";
-import { Map } from "@hitachivantara/uikit-react-icons";
 
 import { HvInput, HvInputProps } from ".";
 import { HvAdornment } from "../FormElement";
@@ -48,7 +47,7 @@ describe("Input", () => {
   });
 
   it("renders the endAdornment", () => {
-    render(<HvInput endAdornment={<Map data-testid="icon" />} />);
+    render(<HvInput endAdornment={<div data-testid="icon" />} />);
 
     expect(screen.getByTestId("icon")).toBeVisible();
   });
@@ -78,7 +77,7 @@ describe("Input", () => {
   });
 
   it("renders the startAdornment", () => {
-    render(<HvInput startAdornment={<Map data-testid="icon" />} />);
+    render(<HvInput startAdornment={<div data-testid="icon" />} />);
 
     expect(screen.getByTestId("icon")).toBeVisible();
   });

--- a/packages/core/src/Kpi/Kpi.test.tsx
+++ b/packages/core/src/Kpi/Kpi.test.tsx
@@ -1,8 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
-import { TopXS } from "@hitachivantara/uikit-react-icons";
 
-import { HvKpi } from ".";
+import { HvKpi } from "./Kpi";
 
 describe("Kpi", () => {
   it("should render all components", () => {
@@ -17,8 +16,8 @@ describe("Kpi", () => {
           comparisonIndicatorInfo: "Comparison indicator info",
         }}
         visualComparison="Visual comparison"
-        trendIndicator={<TopXS role="img" title="Trend indicator" />}
-        visualIndicator={<TopXS role="img" title="Visual indicator" />}
+        trendIndicator={<div data-testid="trendIndicator" />}
+        visualIndicator={<div data-testid="visualIndicator" />}
       />,
     );
 
@@ -27,11 +26,7 @@ describe("Kpi", () => {
     expect(screen.getByText("Unit")).toBeInTheDocument();
     expect(screen.getByText("Comparison indicator info")).toBeInTheDocument();
     expect(screen.getByText("Visual comparison")).toBeInTheDocument();
-    expect(
-      screen.getByRole("img", { name: "Trend indicator" }),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole("img", { name: "Visual indicator" }),
-    ).toBeInTheDocument();
+    expect(screen.getByTestId("trendIndicator")).toBeInTheDocument();
+    expect(screen.getByTestId("visualIndicator")).toBeInTheDocument();
   });
 });

--- a/packages/core/src/MultiButton/MultiButton.test.tsx
+++ b/packages/core/src/MultiButton/MultiButton.test.tsx
@@ -1,6 +1,5 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
-import { LocationPin, Map } from "@hitachivantara/uikit-react-icons";
 
 import { HvButton } from "../Button";
 import { HvMultiButton } from "./MultiButton";
@@ -9,10 +8,10 @@ describe("MultiButton", () => {
   it("should render the buttons", () => {
     render(
       <HvMultiButton>
-        <HvButton key="1" startIcon={<Map />}>
+        <HvButton key="1" startIcon={<div />}>
           Button1
         </HvButton>
-        <HvButton key="2" startIcon={<LocationPin />}>
+        <HvButton key="2" startIcon={<div />}>
           Button2
         </HvButton>
       </HvMultiButton>,

--- a/packages/core/src/Snackbar/Snackbar.test.tsx
+++ b/packages/core/src/Snackbar/Snackbar.test.tsx
@@ -1,7 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
-import { Alert } from "@hitachivantara/uikit-react-icons";
 
 import { HvSnackbar, HvSnackbarProps } from "./Snackbar";
 
@@ -40,7 +39,7 @@ describe("Snackbar", () => {
   });
 
   it("renders the custom icon icon", () => {
-    setup({ customIcon: <Alert data-testid="iconId" /> });
+    setup({ customIcon: <div data-testid="iconId" /> });
     const icon = screen.getByTestId("iconId");
     expect(icon).toBeInTheDocument();
   });

--- a/packages/core/src/ToggleButton/ToggleButton.test.tsx
+++ b/packages/core/src/ToggleButton/ToggleButton.test.tsx
@@ -1,7 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
-import { Lock, Unlock } from "@hitachivantara/uikit-react-icons";
 
 import { HvToggleButton } from "./ToggleButton";
 
@@ -10,8 +9,8 @@ describe("ToggleButton", () => {
     render(
       <HvToggleButton
         aria-label="Lock"
-        notSelectedIcon={<Unlock data-testid="logo-unlock" />}
-        selectedIcon={<Lock data-testid="logo-lock" />}
+        notSelectedIcon={<div data-testid="logo-unlock" />}
+        selectedIcon={<div data-testid="logo-lock" />}
       />,
     );
     expect(screen.queryByTestId("logo-unlock")).toBeInTheDocument();
@@ -24,8 +23,8 @@ describe("ToggleButton", () => {
     render(
       <HvToggleButton
         aria-label="Lock"
-        notSelectedIcon={<Unlock data-testid="logo-unlock" />}
-        selectedIcon={<Lock data-testid="logo-lock" />}
+        notSelectedIcon={<div data-testid="logo-unlock" />}
+        selectedIcon={<div data-testid="logo-lock" />}
         onClick={onClickMock}
       />,
     );

--- a/packages/core/src/VerticalNavigation/Actions/Actions.test.tsx
+++ b/packages/core/src/VerticalNavigation/Actions/Actions.test.tsx
@@ -1,14 +1,13 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
-import { Play, Stop } from "@hitachivantara/uikit-react-icons";
 
 import { HvVerticalNavigationAction, HvVerticalNavigationActions } from ".";
 
 const Sample = () => (
   <HvVerticalNavigationActions>
-    <HvVerticalNavigationAction label="Action 1" icon={<Play />} />
+    <HvVerticalNavigationAction label="Action 1" icon={<div />} />
     <HvVerticalNavigationAction label="Action 2" />
-    <HvVerticalNavigationAction label="Action 3" icon={<Stop />} />
+    <HvVerticalNavigationAction label="Action 3" icon={<div />} />
   </HvVerticalNavigationActions>
 );
 

--- a/packages/core/src/VerticalNavigation/Header/Header.test.tsx
+++ b/packages/core/src/VerticalNavigation/Header/Header.test.tsx
@@ -1,6 +1,5 @@
 import { render } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
-import { Play, Stop } from "@hitachivantara/uikit-react-icons";
 
 import { HvVerticalNavigationHeader } from ".";
 
@@ -8,8 +7,8 @@ const Sample = () => {
   return (
     <HvVerticalNavigationHeader
       title="Menu"
-      openIcon={<Play />}
-      closeIcon={<Stop />}
+      openIcon={<div />}
+      closeIcon={<div />}
       collapseButtonProps={{
         "aria-label": "collapseButton",
         "aria-expanded": true,

--- a/packages/core/src/VerticalNavigation/TreeView/TreeView.test.tsx
+++ b/packages/core/src/VerticalNavigation/TreeView/TreeView.test.tsx
@@ -1,6 +1,5 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
-import { Play, Stop } from "@hitachivantara/uikit-react-icons";
 
 import {
   HvVerticalNavigationTreeView,
@@ -10,7 +9,7 @@ import {
 
 const Sample = (props: HvVerticalNavigationTreeViewProps) => (
   <HvVerticalNavigationTreeView {...props}>
-    <HvVerticalNavigationTreeViewItem icon={<Play />} nodeId="1" label="System">
+    <HvVerticalNavigationTreeViewItem icon={<div />} nodeId="1" label="System">
       <HvVerticalNavigationTreeViewItem nodeId="2" label="SCPodF">
         <HvVerticalNavigationTreeViewItem nodeId="3" label="Compute" disabled />
         <HvVerticalNavigationTreeViewItem nodeId="4" label="Storage" />
@@ -24,7 +23,7 @@ const Sample = (props: HvVerticalNavigationTreeViewProps) => (
     </HvVerticalNavigationTreeViewItem>
 
     <HvVerticalNavigationTreeViewItem
-      icon={<Stop />}
+      icon={<div />}
       nodeId="7"
       label="Administration"
     >

--- a/packages/core/src/VerticalNavigation/VerticalNavigation.test.tsx
+++ b/packages/core/src/VerticalNavigation/VerticalNavigation.test.tsx
@@ -2,7 +2,6 @@ import { useMemo, useState } from "react";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it } from "vitest";
-import { LogOut, User } from "@hitachivantara/uikit-react-icons";
 
 import {
   HvVerticalNavigation,
@@ -105,8 +104,8 @@ const Sample = ({
           data={navigationData}
         />
         <HvVerticalNavigationActions>
-          <HvVerticalNavigationAction label="Profile" icon={<User />} />
-          <HvVerticalNavigationAction label="Logout" icon={<LogOut />} />
+          <HvVerticalNavigationAction label="Profile" icon={<div />} />
+          <HvVerticalNavigationAction label="Logout" icon={<div />} />
         </HvVerticalNavigationActions>
       </HvVerticalNavigation>
     </div>

--- a/packages/lab/src/Flow/Flow.test.tsx
+++ b/packages/lab/src/Flow/Flow.test.tsx
@@ -2,7 +2,6 @@ import { useState } from "react";
 import { render, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { HvButton } from "@hitachivantara/uikit-react-core";
-import { Favorite, Heart } from "@hitachivantara/uikit-react-icons";
 import { theme } from "@hitachivantara/uikit-styles";
 
 import {
@@ -22,7 +21,7 @@ const nodeGroups: HvFlowNodeGroups = {
     label: "Assets",
     color: "cat3_80",
     description: "This is my description 1.",
-    icon: <Heart />,
+    icon: <div />,
     items: [
       { nodeType: "boomArm", label: "Boom Arm" },
       { nodeType: "spaceMountain", label: "Space Mountain" },
@@ -32,7 +31,7 @@ const nodeGroups: HvFlowNodeGroups = {
     label: "Digital Twin",
     color: "cat2_80",
     description: "This is my description 2.",
-    icon: <Favorite />,
+    icon: <div />,
     items: [{ nodeType: "toyStory", label: "Toy Story" }],
   },
 };

--- a/packages/pentaho/src/Canvas/BottomPanel/BottomPanel.test.tsx
+++ b/packages/pentaho/src/Canvas/BottomPanel/BottomPanel.test.tsx
@@ -1,7 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, it, vi } from "vitest";
-import { Close } from "@hitachivantara/uikit-react-icons";
 
 import { HvCanvasBottomPanel, HvCanvasBottomPanelProps } from "./BottomPanel";
 
@@ -21,7 +20,7 @@ const renderSimplePanel = (props?: Partial<HvCanvasBottomPanelProps>) =>
     <HvCanvasBottomPanel
       open
       tabs={panelTabs}
-      overflowActions={[{ id: "action", label: "Action", icon: <Close /> }]}
+      overflowActions={[{ id: "action", label: "Action", icon: <div /> }]}
       {...props}
     >
       Content


### PR DESCRIPTION
using UI Kit icons is unnecessary to testing the components
this should also (theoretically) improve test performance and reliability