### PR TITLE
chore: cleanup unused/deprecated properties

### DIFF
--- a/apps/docs/src/pages/components/card.mdx
+++ b/apps/docs/src/pages/components/card.mdx
@@ -21,7 +21,7 @@ export const getStaticProps = async ({ params }) => {
   className="w-380px"
   bgcolor="atmo1"
   statusColor="positive"
-  icon={<Leaf iconSize="S" color="positive" />}
+  icon={<Leaf size="S" color="positive" />}
 >
   <HvCardHeader
     title={<HvTypography variant="title4">Schedule New Job</HvTypography>}

--- a/apps/docs/src/pages/components/header.mdx
+++ b/apps/docs/src/pages/components/header.mdx
@@ -28,7 +28,7 @@ can also use your own components.
   <HvHeaderBrand name="Pentaho+" />
   <HvHeaderActions>
     <HvIconButton title="Open Notifications panel">
-      <HvBadge count={1} icon={<Alert />} />
+      <HvBadge label={1} icon={<Alert />} />
     </HvIconButton>
     <HvIconButton title="Open User panel">
       <User />
@@ -72,7 +72,7 @@ export default function Demo() {
 
       <HvHeaderActions>
         <HvIconButton title="Open Notifications panel">
-          <HvBadge count={1} icon={<Alert />} />
+          <HvBadge label={1} icon={<Alert />} />
         </HvIconButton>
         {isLgUp && (
           <HvIconButton title="Open User panel">

--- a/apps/docs/src/pages/components/vertical-navigation.mdx
+++ b/apps/docs/src/pages/components/vertical-navigation.mdx
@@ -400,10 +400,8 @@ export default function Demo() {
           <Favorite />
         ) : (
           <div className="flex items-center">
-            <Favorite style={{ "--color-0": "inherit" }} />
-            <HvTypography variant="label" style={{ color: "inherit" }}>
-              Custom App
-            </HvTypography>
+            <Favorite />
+            <HvTypography variant="label">Custom App</HvTypography>
           </div>
         )}
         <CollapsibleButton
@@ -417,10 +415,7 @@ export default function Demo() {
       <HvVerticalNavigationActions>
         <div className="relative">
           {!collapsed && (
-            <Backwards
-              color="currentcolor"
-              className="absolute pointer-events-none top-0px right-0px"
-            />
+            <Backwards className="absolute pointer-events-none top-0 right-0" />
           )}
           <HvVerticalNavigationAction
             label={collapsed ? "Expand menu" : "Collapse menu"}

--- a/docs/guides/styling/UtilityClasses.stories.tsx
+++ b/docs/guides/styling/UtilityClasses.stories.tsx
@@ -102,7 +102,7 @@ export const Test: StoryObj = {
       <HvTypography variant="title4">Text & icons</HvTypography>
       <section>
         <div className="flex items-center text-warning">
-          <Abacus color="currentColor" />
+          <Abacus />
           <span>Text goes here</span>
         </div>
       </section>

--- a/packages/core/src/Accordion/Accordion.tsx
+++ b/packages/core/src/Accordion/Accordion.tsx
@@ -98,7 +98,7 @@ export const HvAccordion = forwardRef<
         onClick={handleClick}
         variant={labelVariant}
       >
-        <DropUpXS color="inherit" rotate={!isOpen} />
+        <DropUpXS rotate={!isOpen} />
         {label}
       </HvTypography>
     );

--- a/packages/core/src/Avatar/Avatar.stories.tsx
+++ b/packages/core/src/Avatar/Avatar.stories.tsx
@@ -103,16 +103,16 @@ export const IconAvatars: StoryObj<HvAvatarProps> = {
     return (
       <>
         <HvAvatar>
-          <LogIn color="textDimmed" iconSize="XS" />
+          <LogIn color="textDimmed" size="XS" />
         </HvAvatar>
         <HvAvatar backgroundColor="positive">
-          <Archives color="textDimmed" iconSize="XS" />
+          <Archives color="textDimmed" size="XS" />
         </HvAvatar>
         <HvAvatar backgroundColor="info">
-          <Search color="textDimmed" iconSize="XS" />
+          <Search color="textDimmed" size="XS" />
         </HvAvatar>
         <HvAvatar backgroundColor="warning">
-          <Bookmark color="textDimmed" iconSize="XS" />
+          <Bookmark color="textDimmed" size="XS" />
         </HvAvatar>
       </>
     );
@@ -146,7 +146,7 @@ export const Variants: StoryObj<HvAvatarProps> = {
     docs: {
       description: {
         story:
-          "You can configure the `size` and `variant` of an avatar. When using an icon, set its `iconSize` to the size immediately below the avatar size.",
+          "You can configure the `size` and `variant` of an avatar. When using an icon, set its `size` to the size immediately below the avatar size.",
       },
     },
   },
@@ -159,7 +159,7 @@ export const Variants: StoryObj<HvAvatarProps> = {
           NA
         </HvAvatar>
         <HvAvatar size="lg" backgroundColor="warning">
-          <Bookmark iconSize="M" color={["textLight", "textDark"]} />
+          <Bookmark size="M" color={["textLight", "textDark"]} />
         </HvAvatar>
         <HvAvatar
           size="xl"
@@ -223,7 +223,6 @@ export const Actions: StoryObj<HvAvatarProps> = {
       <>
         <HvButton
           icon
-          overrideIconColors={false}
           component="a"
           href="#profile-url"
           aria-label="External link"
@@ -232,24 +231,15 @@ export const Actions: StoryObj<HvAvatarProps> = {
             <LinkIcon color="textDimmed" />
           </HvAvatar>
         </HvButton>
-        <HvButton
-          icon
-          overrideIconColors={false}
-          aria-label="Open the user profile"
-        >
+        <HvButton icon aria-label="Open the user profile">
           <HvAvatar size="md" />
         </HvButton>
-        <HvButton icon overrideIconColors={false} aria-label="Business Manager">
+        <HvButton icon aria-label="Business Manager">
           <HvAvatar backgroundColor="sema19" size="md" badge="negative">
             BM
           </HvAvatar>
         </HvButton>
-        <HvButton
-          icon
-          overrideIconColors={false}
-          aria-label="Business Manager"
-          radius="none"
-        >
+        <HvButton icon aria-label="Business Manager" radius="none">
           <HvAvatar
             backgroundColor="sema19"
             size="md"
@@ -259,11 +249,7 @@ export const Actions: StoryObj<HvAvatarProps> = {
             BM
           </HvAvatar>
         </HvButton>
-        <HvButton
-          icon
-          overrideIconColors={false}
-          aria-label="Clara Soul profile"
-        >
+        <HvButton icon aria-label="Clara Soul profile">
           <HvAvatar
             alt="Clara Soul"
             src="https://i.imgur.com/6sYhSb6.png"
@@ -271,12 +257,7 @@ export const Actions: StoryObj<HvAvatarProps> = {
             status="positive"
           />
         </HvButton>
-        <HvButton
-          icon
-          overrideIconColors={false}
-          aria-label="Clara Soul profile"
-          radius="none"
-        >
+        <HvButton icon aria-label="Clara Soul profile" radius="none">
           <HvAvatar
             alt="Clara Soul"
             src="https://i.imgur.com/6sYhSb6.png"
@@ -309,7 +290,7 @@ export const Test: StoryObj = {
         NA
       </HvAvatar>
       <HvAvatar size="lg" backgroundColor="warning">
-        <Bookmark iconSize="M" color={["textLight", "textDark"]} />
+        <Bookmark size="M" color={["textLight", "textDark"]} />
       </HvAvatar>
       <HvAvatar size="xs" variant="square" status="positive">
         AB

--- a/packages/core/src/Button/Button.stories.tsx
+++ b/packages/core/src/Button/Button.stories.tsx
@@ -22,7 +22,6 @@ export const Main: StoryObj<HvButtonProps> = {
     disabled: false,
     size: undefined,
     radius: undefined,
-    overrideIconColors: false,
     selected: false,
     onClick: () => console.log("clicked"),
   },

--- a/packages/core/src/DatePicker/DatePicker.tsx
+++ b/packages/core/src/DatePicker/DatePicker.tsx
@@ -489,7 +489,7 @@ export const HvDatePicker = forwardRef<HTMLDivElement, HvDatePickerProps>(
           onClickOutside={handleCalendarClose}
           onContainerCreation={focusOnContainer}
           placeholder={dateString || placeholder || ""}
-          adornment={<Calendar className={classes.icon} color="currentcolor" />}
+          adornment={<Calendar className={classes.icon} />}
           popperProps={{
             modifiers: [
               { name: "preventOverflow", enabled: escapeWithReference },

--- a/packages/core/src/Header/Header.stories.tsx
+++ b/packages/core/src/Header/Header.stories.tsx
@@ -143,7 +143,7 @@ export const Main: StoryObj<HvHeaderProps> = {
               onClick={() => console.log("alerts")}
               aria-label="Open Notifications panel"
             >
-              <HvBadge count={1} icon={<Alert />} />
+              <HvBadge label={1} icon={<Alert />} />
             </HvButton>
             {isLgUp && (
               <HvButton onClick={() => {}} aria-label="Open User panel" icon>
@@ -332,7 +332,7 @@ export const Test: StoryObj = {
         <HvHeaderNavigation data={navigationDataMain} />
         <HvHeaderActions>
           <HvButton icon aria-label="Open Notifications panel">
-            <HvBadge count={1} icon={<Alert />} />
+            <HvBadge label={1} icon={<Alert />} />
           </HvButton>
           <HvButton onClick={() => {}} aria-label="Open User panel" icon>
             <User />

--- a/packages/core/src/InlineEditor/InlineEditor.tsx
+++ b/packages/core/src/InlineEditor/InlineEditor.tsx
@@ -169,7 +169,6 @@ export const HvInlineEditor = fixedForwardRef(function HvInlineEditor<
       ) : (
         <HvButton
           variant="secondaryGhost"
-          overrideIconColors={false}
           endIcon={
             <Edit
               color="textDisabled"

--- a/packages/core/src/Table/TableHeader/TableHeader.tsx
+++ b/packages/core/src/Table/TableHeader/TableHeader.tsx
@@ -166,7 +166,6 @@ export const HvTableHeader = forwardRef<HTMLElement, HvTableHeaderProps>(
             <HvButton
               className={classes.sortButton}
               icon
-              overrideIconColors={false}
               aria-label="Sort"
               {...sortButtonProps}
             >

--- a/packages/core/src/TreeView/stories/VerticalNavigation.tsx
+++ b/packages/core/src/TreeView/stories/VerticalNavigation.tsx
@@ -45,13 +45,10 @@ const NavigationItem = forwardRef<HTMLLIElement, CustomTreeItemProps>(
       <HvTreeItem
         ref={ref}
         nodeId={nodeId}
-        style={mergeStyles(
-          {},
-          {
-            "--level": level,
-            pointerEvents: disabled ? "none" : undefined,
-          },
-        )}
+        style={mergeStyles(undefined, {
+          "--level": level,
+          pointerEvents: disabled ? "none" : undefined,
+        })}
         classes={{
           group: classes.group,
           content: classes.content,

--- a/packages/core/src/VerticalNavigation/NavigationSlider/NavigationSlider.tsx
+++ b/packages/core/src/VerticalNavigation/NavigationSlider/NavigationSlider.tsx
@@ -99,7 +99,7 @@ export const HvVerticalNavigationSlider = (
                 className={classes.forwardButton}
                 aria-label={forwardButtonAriaLabel}
               >
-                <DropRightXS color="currentcolor" />
+                <DropRightXS />
               </HvButton>
             ) : undefined
           }

--- a/packages/core/src/VerticalNavigation/TreeView/TreeViewItem.tsx
+++ b/packages/core/src/VerticalNavigation/TreeView/TreeViewItem.tsx
@@ -524,9 +524,7 @@ export const HvVerticalNavigationTreeViewItem = forwardRef(
               </div>
             )}
 
-            {isOpen && expandable && (
-              <DropDownXS color="currentcolor" rotate={expanded} />
-            )}
+            {isOpen && expandable && <DropDownXS rotate={expanded} />}
           </HvTypography>
         </HvTooltip>
       );

--- a/packages/core/src/VerticalNavigation/stories/Custom.tsx
+++ b/packages/core/src/VerticalNavigation/stories/Custom.tsx
@@ -96,9 +96,7 @@ export const Custom = () => {
       <HvVerticalNavigationTree data={data} />
       <HvVerticalNavigationActions>
         <div className={classes.collapseBtn}>
-          {!collapsed && (
-            <Backwards color="currentcolor" className={classes.collapseIcon} />
-          )}
+          {!collapsed && <Backwards className={classes.collapseIcon} />}
           <HvVerticalNavigationAction
             label={collapsed ? "Expand menu" : "Collapse menu"}
             icon={collapsed ? <Forwards /> : undefined}

--- a/packages/core/src/utils/Callout.tsx
+++ b/packages/core/src/utils/Callout.tsx
@@ -146,7 +146,7 @@ export const HvCallout = forwardRef<
   } = useDefaultProps("HvCallout", props);
   const { classes, cx } = useClasses(classesProp, false);
   const { activeTheme } = useTheme();
-  const icon = customIcon || (showIcon && iconVariant(variant, "inherit"));
+  const icon = customIcon || (showIcon && iconVariant(variant));
 
   // TODO: consider making this flex-flow only, so it adapts according to the
   // content length, available space, number of actions, etc.

--- a/packages/lab/src/Flow/Node/BaseNode.tsx
+++ b/packages/lab/src/Flow/Node/BaseNode.tsx
@@ -140,12 +140,9 @@ export const HvFlowBaseNode = ({
 
   return (
     <div
-      style={mergeStyles(
-        {},
-        {
-          "--node-color": color,
-        },
-      )}
+      style={mergeStyles(undefined, {
+        "--node-color": color,
+      })}
       className={cx(
         "nowheel", // Disables the default canvas pan behaviour when scrolling inside the node
         classes.root,
@@ -167,12 +164,9 @@ export const HvFlowBaseNode = ({
       </NodeToolbar>
       <div className={classes.headerContainer}>
         <div
-          style={mergeStyles(
-            {},
-            {
-              "--icon-color": iconColor,
-            },
-          )}
+          style={mergeStyles(undefined, {
+            "--icon-color": iconColor,
+          })}
           className={classes.titleContainer}
         >
           {icon}

--- a/packages/lab/src/Flow/Node/Node.tsx
+++ b/packages/lab/src/Flow/Node/Node.tsx
@@ -130,7 +130,6 @@ export const HvFlowNode = ({
           {hasParams && (
             <HvButton
               icon
-              overrideIconColors={false}
               onClick={() => setShowParams((p) => !p)}
               aria-label={
                 showParams ? labels?.collapseLabel : labels?.expandLabel

--- a/packages/lab/src/Flow/stories/BaseHook/Node.tsx
+++ b/packages/lab/src/Flow/stories/BaseHook/Node.tsx
@@ -89,12 +89,9 @@ export const Node = ({ id, groupId = "teapot", input, output }: NodeProps) => {
 
   return (
     <div
-      style={mergeStyles(
-        {},
-        {
-          "--color": color,
-        },
-      )}
+      style={mergeStyles(undefined, {
+        "--color": color,
+      })}
       className={cx("nowheel", classes.root)}
       onMouseEnter={toggleShowActions}
       onMouseLeave={toggleShowActions}

--- a/packages/lab/src/StepNavigation/DefaultNavigation/Step/Step.tsx
+++ b/packages/lab/src/StepNavigation/DefaultNavigation/Step/Step.tsx
@@ -113,7 +113,6 @@ export const HvStep = ({
         })}
         aria-label={`${title}`}
         icon
-        overrideIconColors={false}
         disabled={disabled ?? ["Current", "Disabled"].includes(state)}
         onClick={onClick}
       >

--- a/packages/lab/src/StepNavigation/SimpleNavigation/Dot/Dot.tsx
+++ b/packages/lab/src/StepNavigation/SimpleNavigation/Dot/Dot.tsx
@@ -56,7 +56,6 @@ export const HvDot = ({
       )}
       aria-label={`${title}`}
       icon
-      overrideIconColors={false}
       disabled={disabled ?? ["Current", "Disabled"].includes(state)}
       onClick={onClick}
     >


### PR DESCRIPTION
such as
- `HvBadge` `color` -> `label`
- icons `iconSize` -> `size`
- remove `overrideIconColors`
- other unnecessary `inherit`/`currentColor` overrides