### PR TITLE
style: cleanup styles for custom icons

### DIFF
--- a/packages/core/src/Avatar/Avatar.tsx
+++ b/packages/core/src/Avatar/Avatar.tsx
@@ -10,8 +10,15 @@ import { getColor, HvColorAny, HvSize } from "@hitachivantara/uikit-styles";
 import { useAvatarGroupContext } from "../AvatarGroup/AvatarGroupContext";
 import { useImageLoaded } from "../hooks/useImageLoaded";
 import { HvBaseProps } from "../types/generic";
-import { decreaseSize } from "../utils/sizes";
 import { staticClasses, useClasses } from "./Avatar.styles";
+
+const decreaseSizeMap = {
+  xl: "lg",
+  lg: "md",
+  md: "sm",
+  sm: "xs",
+  xs: "xs",
+} satisfies Record<HvSize, HvSize>;
 
 export { staticClasses as avatarClasses };
 
@@ -117,7 +124,7 @@ export const HvAvatar = forwardRef<
     children = (
       <User
         color={color}
-        iconSize={decreaseSize(size)}
+        size={decreaseSizeMap[size]}
         className={classes.fallback}
       />
     );

--- a/packages/core/src/BaseCheckBox/BaseCheckBox.tsx
+++ b/packages/core/src/BaseCheckBox/BaseCheckBox.tsx
@@ -86,12 +86,10 @@ export interface HvBaseCheckBoxProps
   classes?: HvBaseCheckBoxClasses;
 }
 
-const getSelectorIcons = () => {
-  return {
-    checkbox: <Box />,
-    checkboxPartial: <Partial />,
-    checkboxChecked: <Check />,
-  };
+const icons = {
+  checkbox: <Box />,
+  checkboxPartial: <Partial />,
+  checkboxChecked: <Check />,
 };
 
 /**
@@ -127,8 +125,6 @@ export const HvBaseCheckBox = forwardRef<
   const { classes, cx } = useClasses(classesProp);
 
   const [focusVisible, setFocusVisible] = useState<boolean>(false);
-
-  const icons = getSelectorIcons();
 
   const onChangeCallback = useCallback(
     (event: React.ChangeEvent<HTMLInputElement>) => {

--- a/packages/core/src/BaseRadio/BaseRadio.tsx
+++ b/packages/core/src/BaseRadio/BaseRadio.tsx
@@ -85,11 +85,9 @@ export interface HvBaseRadioProps
   onBlur?: (event: React.FocusEvent<any>) => void;
 }
 
-export const getSelectorIcons = () => {
-  return {
-    radio: <Unselected />,
-    radioChecked: <Selected />,
-  };
+const icons = {
+  radio: <Unselected />,
+  radioChecked: <Selected />,
 };
 
 /**
@@ -140,8 +138,6 @@ export const HvBaseRadio = forwardRef<HTMLButtonElement, HvBaseRadioProps>(
       },
       [onBlur],
     );
-
-    const icons = getSelectorIcons();
 
     const onLocalChange = useCallback(
       (evt: React.ChangeEvent<HTMLInputElement>) => {

--- a/packages/core/src/Button/Button.styles.ts
+++ b/packages/core/src/Button/Button.styles.ts
@@ -28,22 +28,25 @@ export const { staticClasses, useClasses } = createClasses("HvButton", {
     ...theme.typography.label,
     color: "var(--color, currentcolor)",
     backgroundColor: "transparent",
-    height: "var(--HvButton-height)",
+    height: "var(--HvButton-height, fit-content)",
     border: "1px solid transparent",
     borderRadius: `var(--radius, ${theme.radii.base})`,
     padding: theme.spacing(0, "sm"),
+
+    "& $startIcon, & $endIcon": {
+      flexShrink: 0,
+      lineHeight: 0,
+      marginTop: -1,
+      marginBottom: -1,
+    },
   },
   /** applied to the _left_ icon container */
   startIcon: {
     marginLeft: theme.spacing(-1),
-    marginTop: -1,
-    marginBottom: -1,
   },
   /** applied to the _right_ icon container */
   endIcon: {
     marginRight: theme.spacing(-1),
-    marginTop: -1,
-    marginBottom: -1,
   },
   focusVisible: {},
   /** applied to the root element when disabled */
@@ -61,10 +64,7 @@ export const { staticClasses, useClasses } = createClasses("HvButton", {
   icon: {
     margin: 0,
     padding: 0,
-    height: "fit-content",
-    "& > *": {
-      margin: -1,
-    },
+    width: "var(--HvButton-height, fit-content)",
   },
   /** applied to the root element when using the `contained` variant */
   contained: {

--- a/packages/core/src/ColorPicker/SavedColors/SavedColors.tsx
+++ b/packages/core/src/ColorPicker/SavedColors/SavedColors.tsx
@@ -7,7 +7,7 @@ import {
   type ExtractNames,
 } from "@hitachivantara/uikit-react-utils";
 
-import { HvButton } from "../../Button";
+import { HvIconButton } from "../../IconButton";
 import { staticClasses, useClasses } from "./SavedColors.styles";
 
 export { staticClasses as colorPickerSavedColorsClasses };
@@ -45,15 +45,14 @@ export const SavedColors = (props: SavedColorsProps) => {
 
   return (
     <div className={classes.root}>
-      <HvButton
+      <HvIconButton
         className={classes.addButton}
         variant="secondarySubtle"
-        icon
         onClick={onAddColor}
-        aria-label={addButtonAriaLabel}
+        title={addButtonAriaLabel}
       >
         <Add aria-hidden />
-      </HvButton>
+      </HvIconButton>
       {colors.map((color, index) => (
         <div
           key={`saved-color-${color}-${index}`}
@@ -69,14 +68,14 @@ export const SavedColors = (props: SavedColorsProps) => {
             />
           </div>
           <div className={classes.removeButtonRoot}>
-            <HvButton
+            <HvIconButton
               className={classes.removeButton}
               variant="secondarySubtle"
               onClick={() => onRemoveColor(color, index)}
-              aria-label={deleteButtonAriaLabel}
+              title={deleteButtonAriaLabel}
             >
               <CloseXS aria-hidden iconSize="XS" />
-            </HvButton>
+            </HvIconButton>
           </div>
         </div>
       ))}

--- a/packages/core/src/DotPagination/DotPagination.styles.tsx
+++ b/packages/core/src/DotPagination/DotPagination.styles.tsx
@@ -9,23 +9,27 @@ export const { useClasses, staticClasses } = createClasses("HvDotPagination", {
 
   horizontal: {
     width: "auto",
+    gap: theme.space.xs,
   },
-
+  /** @deprecated use `classes.radio` instead */
   radioRoot: {},
 
   radio: {
     height: 16,
     width: 16,
-    minWidth: 16,
+    minWidth: 24,
+    minHeight: 24,
     color: "inherit",
 
     "&:hover": {
-      backgroundColor: theme.colors.infoDimmed,
       borderRadius: theme.radii.full,
     },
   },
 
   icon: {
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
     minWidth: 0,
     width: 16,
     height: 16,
@@ -35,6 +39,13 @@ export const { useClasses, staticClasses } = createClasses("HvDotPagination", {
       border: "none",
       width: "unset",
       height: "unset",
+    },
+    "& > div": {
+      color: theme.colors.text,
+      backgroundColor: "currentcolor",
+      width: "1em",
+      height: "1em",
+      borderRadius: "50%",
     },
   },
 });

--- a/packages/core/src/DotPagination/DotPagination.tsx
+++ b/packages/core/src/DotPagination/DotPagination.tsx
@@ -1,14 +1,25 @@
 import { cloneElement } from "react";
-import { CurrentStep, OtherStep } from "@hitachivantara/uikit-react-icons";
 import {
   useDefaultProps,
   type ExtractNames,
 } from "@hitachivantara/uikit-react-utils";
 
-import { HvRadio } from "../Radio";
+import { HvBaseRadio } from "../BaseRadio";
 import { HvRadioGroup, HvRadioGroupProps } from "../RadioGroup";
 import { range } from "../utils/helpers";
 import { staticClasses, useClasses } from "./DotPagination.styles";
+
+const currentStep = (
+  <div style={{ fontSize: 8 }}>
+    <div />
+  </div>
+);
+
+const otherStep = (
+  <div style={{ fontSize: 4 }}>
+    <div />
+  </div>
+);
 
 export { staticClasses as dotPaginationClasses };
 
@@ -59,15 +70,12 @@ const getSelectorIcons = (
   classes?: HvDotPaginationClasses,
 ) => {
   return {
-    radio: cloneElement(radioIcon || <OtherStep width={8} height={8} />, {
+    radio: cloneElement(radioIcon || otherStep, {
       className: classes?.icon,
     }),
-    radioChecked: cloneElement(
-      radioCheckedIcon || <CurrentStep width={8} height={8} />,
-      {
-        className: classes?.icon,
-      },
-    ),
+    radioChecked: cloneElement(radioCheckedIcon || currentStep, {
+      className: classes?.icon,
+    }),
   };
 };
 
@@ -102,18 +110,15 @@ export const HvDotPagination = (props: HvDotPaginationProps) => {
       {...others}
     >
       {range(pages).map((i) => (
-        <HvRadio
-          classes={{
-            radio: classes.radio,
-            root: classes.radioRoot,
-          }}
+        <HvBaseRadio
+          className={cx(classes.radioRoot, classes.radio)}
           key={i}
           value={i}
           checked={page === i}
           onChange={(event) => onPageChange?.(event, i)}
           icon={icons.radio}
           checkedIcon={icons.radioChecked}
-          aria-label={getItemAriaLabel?.(i)}
+          inputProps={{ "aria-label": getItemAriaLabel?.(i) }}
         />
       ))}
     </HvRadioGroup>

--- a/packages/core/src/FileUploader/File/File.styles.tsx
+++ b/packages/core/src/FileUploader/File/File.styles.tsx
@@ -2,7 +2,16 @@ import { createClasses } from "@hitachivantara/uikit-react-utils";
 import { theme } from "@hitachivantara/uikit-styles";
 
 export const { staticClasses, useClasses } = createClasses("HvFile", {
-  root: {},
+  root: {
+    position: "relative",
+    display: "flex",
+    gap: theme.space.xs,
+    alignItems: "center",
+    backgroundColor: theme.colors.bgContainer,
+    padding: theme.space.xs,
+    border: `1px solid ${theme.colors.border}`,
+    borderRadius: `0px 0px ${theme.radii.round} ${theme.radii.round}`,
+  },
   progressbar: {
     position: "absolute",
     top: "-1px",
@@ -12,23 +21,18 @@ export const { staticClasses, useClasses } = createClasses("HvFile", {
   },
   progressbarBack: {},
   nameText: {
-    overflow: "hidden",
-    textOverflow: "ellipsis",
-    whiteSpace: "nowrap",
+    display: "flex",
+    alignItems: "center",
+    flex: 1,
   },
   progressTextContainer: {
     display: "flex",
     flexGrow: 1,
     alignItems: "center",
   },
-  removeButton: {
-    width: 32,
-    height: 32,
-    margin: `0px ${theme.space.xs}`,
-  },
+  removeButton: {},
   previewContainer: {
     display: "flex",
-    margin: `0px ${theme.space.xs}`,
     width: "48px",
     height: "48px",
     justifyContent: "center",
@@ -51,9 +55,7 @@ export const { staticClasses, useClasses } = createClasses("HvFile", {
     },
   },
   icon: {
-    width: 32,
-    height: 32,
-    margin: `0px ${theme.space.xs}`,
+    margin: theme.space.xs,
   },
   fail: {},
 });

--- a/packages/core/src/FileUploader/File/File.tsx
+++ b/packages/core/src/FileUploader/File/File.tsx
@@ -157,11 +157,13 @@ export const HvFile = (props: HvFileProps) => {
 
       {statusIcon}
 
-      <HvTypography className={classes.nameText} variant="label">
-        {data.name}
-      </HvTypography>
+      <div className={classes.nameText}>
+        <HvTypography noWrap variant="label">
+          {data.name}
+        </HvTypography>
 
-      <span className={classes.progressTextContainer}>{progressText}</span>
+        <span className={classes.progressTextContainer}>{progressText}</span>
+      </div>
 
       {data.preview && (
         <div className={classes.previewContainer}>{data.preview}</div>

--- a/packages/core/src/FileUploader/FileList/FileList.styles.tsx
+++ b/packages/core/src/FileUploader/FileList/FileList.styles.tsx
@@ -2,7 +2,7 @@ import { createClasses } from "@hitachivantara/uikit-react-utils";
 import { theme } from "@hitachivantara/uikit-styles";
 
 export const { staticClasses, useClasses } = createClasses("HvFileList", {
-  list: {
+  root: {
     display: "flex",
     flexDirection: "column",
     gap: theme.space.xs,
@@ -11,13 +11,5 @@ export const { staticClasses, useClasses } = createClasses("HvFileList", {
     marginTop: theme.space.sm,
     listStyle: "none",
   },
-  listItem: {
-    position: "relative",
-    display: "flex",
-    alignItems: "center",
-    background: theme.colors.bgContainer,
-    padding: `${theme.space.xs} 0px`,
-    border: `1px solid ${theme.colors.border}`,
-    borderRadius: `0px 0px ${theme.radii.round} ${theme.radii.round}`,
-  },
+  listItem: {},
 });

--- a/packages/core/src/FileUploader/FileList/FileList.tsx
+++ b/packages/core/src/FileUploader/FileList/FileList.tsx
@@ -48,7 +48,7 @@ export const HvFileList = (props: HvFileListProps) => {
   if (!hasFiles) return null;
 
   return (
-    <ul id={setId(id, "list")} className={classes.list}>
+    <ul id={setId(id, "list")} className={classes.root}>
       {list.map((data) => (
         <HvFile
           key={data.id}

--- a/packages/core/src/InlineEditor/InlineEditor.styles.tsx
+++ b/packages/core/src/InlineEditor/InlineEditor.styles.tsx
@@ -16,7 +16,7 @@ export const { staticClasses, useClasses } = createClasses("HvInlineEditor", {
     color: theme.colors.textDisabled,
   },
   button: {
-    padding: theme.spacing("6px", "8px", "5px", "8px"),
+    padding: theme.spacing(0, "xs"),
     minHeight: "32px",
 
     boxSizing: "border-box",

--- a/packages/core/src/MultiButton/MultiButton.styles.tsx
+++ b/packages/core/src/MultiButton/MultiButton.styles.tsx
@@ -18,10 +18,9 @@ export const { staticClasses, useClasses } = createClasses("HvMultiButton", {
 
     "& $button": {
       minWidth: 32,
-      width: "100%",
       maxWidth: 200,
       padding: 0,
-      flex: "1 1 auto",
+      flex: "1 1 0%",
       borderColor: "inherit",
       borderRadius: 0,
       fontWeight: theme.typography.body.fontWeight,
@@ -106,11 +105,12 @@ export const { staticClasses, useClasses } = createClasses("HvMultiButton", {
   selected: {},
   vertical: {
     flexDirection: "column",
+    alignItems: "stretch",
     height: "auto",
     borderColor: `transparent ${theme.colors.border}`,
     "& $button": {
       minWidth: 32,
-      width: "100%",
+      flex: "1 1 32px",
       "&$firstButton": {
         borderTopColor: theme.colors.border,
         borderTopLeftRadius: "inherit",
@@ -127,7 +127,6 @@ export const { staticClasses, useClasses } = createClasses("HvMultiButton", {
       },
       "&$selected": {
         height: 32,
-        width: "calc(100% + 2px)",
         borderColor: theme.colors.text,
       },
     },

--- a/packages/core/src/QueryBuilder/QueryBuilder.styles.tsx
+++ b/packages/core/src/QueryBuilder/QueryBuilder.styles.tsx
@@ -83,10 +83,8 @@ export const { useClasses, staticClasses } = createClasses("HvQueryBuilder", {
   /** Styles applied to the action button container. */
   actionButtonContainer: {
     marginLeft: "auto",
-
-    "&>*": {
-      marginLeft: theme.space.sm,
-    },
+    display: "flex",
+    gap: theme.space.sm,
   },
   /** Styles applied to the top action button container. */
   topActionButtonContainer: {

--- a/packages/core/src/Slider/SliderInput/SliderInput.styles.tsx
+++ b/packages/core/src/Slider/SliderInput/SliderInput.styles.tsx
@@ -1,7 +1,13 @@
 import { createClasses } from "@hitachivantara/uikit-react-utils";
+import { theme } from "@hitachivantara/uikit-styles";
 
 export const { staticClasses, useClasses } = createClasses("HvSliderInput", {
-  inputRoot: { display: "flex" },
+  root: {
+    display: "flex",
+    alignItems: "center",
+    color: theme.colors.textSubtle,
+    gap: theme.space.xs,
+    fontSize: 16,
+  },
   input: { maxWidth: "50px" },
-  inputContainer: { display: "flex" },
 });

--- a/packages/core/src/Slider/SliderInput/SliderInput.tsx
+++ b/packages/core/src/Slider/SliderInput/SliderInput.tsx
@@ -1,5 +1,4 @@
-import { useEffect, useState } from "react";
-import { Remove } from "@hitachivantara/uikit-react-icons";
+import { Fragment, useEffect, useState } from "react";
 import { type ExtractNames } from "@hitachivantara/uikit-react-utils";
 
 import { HvFormStatus } from "../../FormElement";
@@ -84,12 +83,10 @@ export const HvSliderInput = ({
   }, [markDigits, valuesProp]);
 
   return (
-    <div className={cx(classes.inputRoot, className)} {...others}>
+    <div className={cx(classes.root, className)} {...others}>
       {inputValues.map((value, index) => (
-        <div key={setId(id, index)} className={classes.inputContainer}>
-          {index !== 0 && (
-            <Remove color={disabled ? "textDisabled" : undefined} />
-          )}
+        <Fragment key={setId(id, index)}>
+          {index !== 0 && <span>—</span>}
           <HvInput
             id={setId(id, index)}
             aria-label={`${label}-${index}`}
@@ -109,7 +106,7 @@ export const HvSliderInput = ({
             disableClear
             {...inputProps[index]}
           />
-        </div>
+        </Fragment>
       ))}
     </div>
   );

--- a/packages/core/src/VerticalNavigation/TreeView/TreeViewItem.styles.tsx
+++ b/packages/core/src/VerticalNavigation/TreeView/TreeViewItem.styles.tsx
@@ -138,6 +138,7 @@ export const { staticClasses, useClasses } = createClasses(
     },
     icon: {
       display: "flex",
+      alignItems: "center",
       "> div:first-of-type": {
         marginLeft: "var(--icon-margin-left)",
       },

--- a/packages/lab/src/StepNavigation/DefaultNavigation/Step/Step.styles.tsx
+++ b/packages/lab/src/StepNavigation/DefaultNavigation/Step/Step.styles.tsx
@@ -1,19 +1,10 @@
 import { createClasses } from "@hitachivantara/uikit-react-core";
 
 export const { staticClasses, useClasses } = createClasses("HvStep", {
-  root: {},
-  ghost: {
-    "&:hover": {
-      backgroundColor: "transparent",
-    },
-    "&$ghostDisabled": {
-      cursor: "default",
-    },
-    "&$ghostDisabled&:hover": {
-      cursor: "default",
-    },
+  root: {
+    width: "fit-content",
+    height: "fit-content",
   },
-  ghostDisabled: {},
   notCurrent: { margin: "-8px" },
   xs: {},
   sm: {},

--- a/packages/lab/src/StepNavigation/DefaultNavigation/Step/Step.tsx
+++ b/packages/lab/src/StepNavigation/DefaultNavigation/Step/Step.tsx
@@ -98,43 +98,33 @@ export const HvStep = ({
   const IconComponent = iconStateObject[state];
 
   return (
-    <div
-      className={cx(
-        classes.root,
-        {
-          [classes.notCurrent]: state !== "Current",
-        },
-        className,
-      )}
+    <HvButton
+      className={cx(classes.root, className, {
+        [classes.notCurrent]: state !== "Current",
+      })}
+      aria-label={title}
+      icon
+      disabled={disabled ?? ["Current", "Disabled"].includes(state)}
+      onClick={onClick}
     >
-      <HvButton
-        className={cx(classes.ghost, {
-          [classes.ghostDisabled]: state === "Current",
-        })}
-        aria-label={`${title}`}
-        icon
-        disabled={disabled ?? ["Current", "Disabled"].includes(state)}
-        onClick={onClick}
+      <HvAvatar
+        className={cx(classes.avatar, classes[size])}
+        backgroundColor={backgroundColor}
+        status={status}
+        size={size}
       >
-        <HvAvatar
-          className={cx(classes.avatar, classes[size])}
-          backgroundColor={backgroundColor}
-          status={status}
-          size={size}
-        >
-          {IconComponent ? (
-            <IconComponent
-              color={color}
-              semantic={semantic}
-              width={svgSize}
-              height={svgSize}
-              iconSize={iconSize}
-            />
-          ) : (
-            number
-          )}
-        </HvAvatar>
-      </HvButton>
-    </div>
+        {IconComponent ? (
+          <IconComponent
+            color={color}
+            semantic={semantic}
+            width={svgSize}
+            height={svgSize}
+            iconSize={iconSize}
+          />
+        ) : (
+          number
+        )}
+      </HvAvatar>
+    </HvButton>
   );
 };

--- a/packages/styles/src/themes/ds3.ts
+++ b/packages/styles/src/themes/ds3.ts
@@ -719,6 +719,10 @@ const ds3 = makeTheme((theme) => ({
     },
     HvFile: {
       classes: {
+        root: {
+          border: "none",
+          borderRadius: "0px",
+        },
         progressbarContainer: {
           height: "2px",
         },
@@ -729,14 +733,6 @@ const ds3 = makeTheme((theme) => ({
             width: "100%",
             height: "100%",
           },
-        },
-      },
-    },
-    HvFileList: {
-      classes: {
-        listItem: {
-          border: "none",
-          borderRadius: "0px",
         },
       },
     },

--- a/packages/styles/src/themes/pentahoPlus.ts
+++ b/packages/styles/src/themes/pentahoPlus.ts
@@ -530,14 +530,6 @@ const pentahoPlus = makeTheme((theme) => ({
         },
       },
     },
-    HvDotPagination: {
-      classes: {
-        radio: {
-          width: 16,
-          minWidth: 16,
-        },
-      },
-    },
     HvBaseSwitch: {
       classes: {
         root: {


### PR DESCRIPTION
- minor icon usage & spacing fixes found in #4487
- improve support for external icons, but ensuring `<HvButton icon>`
  - follows defined (`var(--HvButton-height)`) `height`
- replace `HvSlider` dash  dot icons with inline `-`
- replace & `HvDotPagination` with styled div
  - improve touch-target size (should be [24x24](https://www.levelaccess.com/blog/designer-tips-improving-button-accessibility/) or more)