### PR TITLE
docs: customize color picker to better represent `HvColorAny`

### DIFF
--- a/apps/docs/src/components/code/Controls.tsx
+++ b/apps/docs/src/components/code/Controls.tsx
@@ -186,6 +186,20 @@ export const Controls = ({ prop, state, control, onChange }: ControlsProps) => {
       }
       onChange={(value) => onChange(prop, value)}
       className="w-full"
+      recommendedColors={[
+        "positive",
+        "negative",
+        "warning",
+        "info",
+        "accent",
+        "catastrophic",
+        "primary",
+        "secondary",
+        "cat1",
+        "cat2",
+        "gold",
+        "coral",
+      ]}
     />
   );
 

--- a/apps/docs/src/pages/components/button.mdx
+++ b/apps/docs/src/pages/components/button.mdx
@@ -29,7 +29,7 @@ export const getStaticProps = async ({ params }) => {
     },
     radius: {
       type: "slider",
-      defaultValue: "base",
+      defaultValue: "full",
     },
     disabled: {
       defaultValue: false,

--- a/apps/docs/src/pages/components/tag.mdx
+++ b/apps/docs/src/pages/components/tag.mdx
@@ -17,7 +17,7 @@ export const getStaticProps = async ({ params }) => {
   componentName="HvTag"
   controls={{
     label: { defaultValue: "Tag label" },
-    color: { defaultValue: "positive" },
+    color: { defaultValue: "positive", type: "color" },
     disabled: { defaultValue: false },
     selectable: { defaultValue: false },
   }}


### PR DESCRIPTION
This is just a simple customization of the color picker used on the docs to allow a better experience on props of type `HvColorAny`. It will allow entering colors from the UI Kit theme (`positive`, `primary`, etc.), CSS color names (`gold`, `coral`, etc.) or HEX/RGB values.

Also updated the default button radius on the docs to be `full`