### PR TITLE
chore(deps): allow react@19 to be used

### DIFF
--- a/.config/test.setup.tsx
+++ b/.config/test.setup.tsx
@@ -5,7 +5,7 @@ import { HvProvider } from "@hitachivantara/uikit-react-core";
 
 import "@testing-library/jest-dom";
 
-const customRender = (ui: React.ReactElement, options = {}) =>
+const customRender = (ui: React.ReactElement<any>, options = {}) =>
   render(ui, {
     // wrap provider(s) here if needed
     wrapper: ({ children }) => <HvProvider>{children}</HvProvider>,

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 <div align="center">
 
 ![License](https://img.shields.io/badge/license-Apache%202-blue.svg)
-![React](https://img.shields.io/badge/react-17|18-blue.svg)
+![React](https://img.shields.io/badge/react-17+-blue.svg)
 ![Node](https://img.shields.io/badge/node-16+-brightgreen.svg)
 [![Nightly](https://github.com/lumada-design/hv-uikit-react/actions/workflows/nightly.yml/badge.svg)](https://github.com/lumada-design/hv-uikit-react/actions/workflows/nightly.yml)
 

--- a/apps/app/src/generator/CodeEditor/CodeEditor.tsx
+++ b/apps/app/src/generator/CodeEditor/CodeEditor.tsx
@@ -30,7 +30,7 @@ const CodeEditor = ({
 }: {
   themeName: string;
   setCopied: Dispatch<SetStateAction<boolean>>;
-}): JSX.Element => {
+}) => {
   const { selectedTheme, selectedMode, changeTheme } = useTheme();
 
   const { customTheme, updateCustomTheme, themeChanges } =

--- a/apps/app/src/generator/Colors/Colors.tsx
+++ b/apps/app/src/generator/Colors/Colors.tsx
@@ -13,7 +13,7 @@ import { useGeneratorContext } from "~/generator/GeneratorContext";
 import { styles } from "./Colors.styles";
 import { getColorGroupName, getColors, groupsToShow } from "./utils";
 
-const Colors = (): JSX.Element => {
+const Colors = () => {
   const { colors, selectedMode } = useTheme();
   const { customTheme, updateCustomTheme } = useGeneratorContext();
 

--- a/apps/docs/src/components/code/Controls.tsx
+++ b/apps/docs/src/components/code/Controls.tsx
@@ -204,7 +204,7 @@ export const Controls = ({ prop, state, control, onChange }: ControlsProps) => {
   );
 
   // Map of renderers for specific control types
-  const rendererMap: Record<string, () => JSX.Element | null> = {
+  const rendererMap: Record<string, () => React.ReactNode> = {
     slider: () =>
       propMeta?.type?.name === "enum" ? renderSliderControl() : null,
     radio: () =>

--- a/docs/guides/theming/ThemeStructure.tsx
+++ b/docs/guides/theming/ThemeStructure.tsx
@@ -1,4 +1,4 @@
-import { ReactElement, ReactNode, useState } from "react";
+import { useState } from "react";
 import { css } from "@emotion/css";
 import { clsx } from "clsx";
 import { HvCodeEditor } from "@hitachivantara/uikit-react-code-editor";
@@ -99,7 +99,7 @@ const ThemeValue = ({
   level,
   label,
 }: {
-  children: ReactNode;
+  children: React.ReactNode;
   level: number;
   label: string;
 }) => (
@@ -126,7 +126,7 @@ export const ThemeStructure = () => {
     value: object | string | number,
     label: string,
     level: number,
-  ): ReactElement => {
+  ) => {
     return (
       <HvAccordion
         key={`${label}-${level}`}
@@ -155,7 +155,7 @@ export const ThemeStructure = () => {
     value: object | string | number | undefined,
     label: string,
     level: number,
-  ): ReactElement => {
+  ): React.ReactNode => {
     if (value && typeof value === "object" && !Array.isArray(value)) {
       // Level
       return (

--- a/examples/uikit-app-shell/package.json
+++ b/examples/uikit-app-shell/package.json
@@ -14,7 +14,7 @@
     "@hitachivantara/app-shell-navigation": "latest",
     "@hitachivantara/uikit-react-core": "latest",
     "@hitachivantara/uikit-react-icons": "latest",
-    "@mui/material": "^5.12.2",
+    "@mui/material": "^5.16.14",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.14.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -33835,9 +33835,9 @@
       "peerDependencies": {
         "@emotion/react": "^11.11.1",
         "@emotion/styled": "^11.11.0",
-        "@mui/material": "^5.12.2",
-        "react": "^17.0.0 || ^18.0.0",
-        "react-dom": "^17.0.0 || ^18.0.0"
+        "@mui/material": "^5.16.14",
+        "react": ">=17.0.0",
+        "react-dom": ">=17.0.0"
       }
     },
     "packages/config": {
@@ -33895,9 +33895,9 @@
       "peerDependencies": {
         "@emotion/react": "^11.11.1",
         "@emotion/styled": "^11.11.0",
-        "@mui/material": "^5.12.2",
-        "react": "^17.0.0 || ^18.0.0",
-        "react-dom": "^17.0.0 || ^18.0.0"
+        "@mui/material": "^5.16.14",
+        "react": ">=17.0.0",
+        "react-dom": ">=17.0.0"
       }
     },
     "packages/icons": {
@@ -33922,8 +33922,8 @@
       "peerDependencies": {
         "@emotion/react": "^11.11.1",
         "@emotion/styled": "^11.11.0",
-        "react": "^17.0.0 || ^18.0.0",
-        "react-dom": "^17.0.0 || ^18.0.0"
+        "react": ">=17.0.0",
+        "react-dom": ">=17.0.0"
       }
     },
     "packages/lab": {
@@ -33956,10 +33956,9 @@
       },
       "peerDependencies": {
         "@emotion/react": "^11.11.1",
-        "@emotion/styled": "^11.11.0",
-        "@mui/material": "^5.12.2",
-        "react": "^17.0.0 || ^18.0.0",
-        "react-dom": "^17.0.0 || ^18.0.0"
+        "@mui/material": "^5.16.14",
+        "react": ">=17.0.0",
+        "react-dom": ">=17.0.0"
       }
     },
     "packages/pentaho": {
@@ -33985,9 +33984,9 @@
       "peerDependencies": {
         "@emotion/react": "^11.11.1",
         "@emotion/styled": "^11.11.0",
-        "@mui/material": "^5.12.2",
-        "react": "^17.0.0 || ^18.0.0",
-        "react-dom": "^17.0.0 || ^18.0.0"
+        "@mui/material": "^5.16.14",
+        "react": ">=17.0.0",
+        "react-dom": ">=17.0.0"
       }
     },
     "packages/shared": {
@@ -34004,8 +34003,8 @@
         "vite": "^5.1.0"
       },
       "peerDependencies": {
-        "react": "^17.0.0 || ^18.0.0",
-        "react-dom": "^17.0.0 || ^18.0.0"
+        "react": ">=17.0.0",
+        "react-dom": ">=17.0.0"
       }
     },
     "packages/styles": {
@@ -34054,8 +34053,8 @@
         "vite": "^5.1.0"
       },
       "peerDependencies": {
-        "react": "^17.0.0 || ^18.0.0",
-        "react-dom": "^17.0.0 || ^18.0.0"
+        "react": ">=17.0.0",
+        "react-dom": ">=17.0.0"
       }
     },
     "packages/viz": {
@@ -34075,12 +34074,12 @@
       "peerDependencies": {
         "@emotion/react": "^11.11.1",
         "@emotion/styled": "^11.11.0",
-        "@mui/material": "^5.12.2",
+        "@mui/material": "^5.16.14",
         "arquero": "^5.2.0",
         "echarts": "^5.4.2",
         "echarts-for-react": "^3.0.2",
-        "react": "^17.0.0 || ^18.0.0",
-        "react-dom": "^17.0.0 || ^18.0.0"
+        "react": ">=17.0.0",
+        "react-dom": ">=17.0.0"
       }
     }
   }

--- a/packages/code-editor/package.json
+++ b/packages/code-editor/package.json
@@ -34,9 +34,9 @@
   "peerDependencies": {
     "@emotion/react": "^11.11.1",
     "@emotion/styled": "^11.11.0",
-    "@mui/material": "^5.12.2",
-    "react": "^17.0.0 || ^18.0.0",
-    "react-dom": "^17.0.0 || ^18.0.0"
+    "@mui/material": "^5.16.14",
+    "react": ">=17.0.0",
+    "react-dom": ">=17.0.0"
   },
   "dependencies": {
     "@hitachivantara/uikit-react-utils": "^0.2.29",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -34,9 +34,9 @@
   "peerDependencies": {
     "@emotion/react": "^11.11.1",
     "@emotion/styled": "^11.11.0",
-    "@mui/material": "^5.12.2",
-    "react": "^17.0.0 || ^18.0.0",
-    "react-dom": "^17.0.0 || ^18.0.0"
+    "@mui/material": "^5.16.14",
+    "react": ">=17.0.0",
+    "react-dom": ">=17.0.0"
   },
   "dependencies": {
     "@emotion/cache": "^11.11.0",

--- a/packages/core/src/AppSwitcher/Action/Action.tsx
+++ b/packages/core/src/AppSwitcher/Action/Action.tsx
@@ -24,7 +24,7 @@ export interface HvAppSwitcherActionApplication {
   /** URL with the icon location to be used to represent the application. iconUrl will only be used if no iconElement is provided. */
   iconUrl?: string;
   /** Element to be added as the icon representing the application. The iconElement will be the primary option to be displayed. */
-  iconElement?: React.ReactElement;
+  iconElement?: React.ReactElement<any>;
   /** Small description of the application. */
   description?: string;
   /**  URL where the application is accessible. */

--- a/packages/core/src/BreadCrumb/PathElement/PathElement.tsx
+++ b/packages/core/src/BreadCrumb/PathElement/PathElement.tsx
@@ -10,7 +10,7 @@ export type HvPathElementClasses = ExtractNames<typeof useClasses>;
 export interface HvPathElementProps {
   last?: boolean;
   classes?: HvPathElementClasses;
-  children: React.ReactElement;
+  children: React.ReactElement<any>;
 }
 
 export const HvPathElement = ({

--- a/packages/core/src/DotPagination/DotPagination.tsx
+++ b/packages/core/src/DotPagination/DotPagination.tsx
@@ -32,13 +32,13 @@ export interface HvDotPaginationProps
    *
    * The default icon is `OtherStep`.
    */
-  unselectedIcon?: React.ReactElement;
+  unselectedIcon?: React.ReactElement<any>;
   /**
    * Icon to override the default one used for the selected state.
    *
    * The default icon is `CurrentStep`.
    */
-  selectedIcon?: React.ReactElement;
+  selectedIcon?: React.ReactElement<any>;
   /**
    *  The number of pages the component has.
    */
@@ -65,8 +65,8 @@ export interface HvDotPaginationProps
 }
 
 const getSelectorIcons = (
-  radioIcon?: React.ReactElement,
-  radioCheckedIcon?: React.ReactElement,
+  radioIcon?: React.ReactElement<any>,
+  radioCheckedIcon?: React.ReactElement<any>,
   classes?: HvDotPaginationClasses,
 ) => {
   return {

--- a/packages/core/src/DropDownMenu/DropDownMenu.tsx
+++ b/packages/core/src/DropDownMenu/DropDownMenu.tsx
@@ -31,7 +31,7 @@ const DEFAULT_LABELS = {
 export interface HvDropDownMenuProps
   extends HvBaseProps<HTMLDivElement, "onClick" | "onToggle"> {
   /** Icon. */
-  icon?: React.ReactElement;
+  icon?: React.ReactElement<any>;
   /**
    * A list containing the elements to be rendered.
    *

--- a/packages/core/src/Dropdown/Dropdown.tsx
+++ b/packages/core/src/Dropdown/Dropdown.tsx
@@ -284,7 +284,7 @@ export const HvDropdown = fixedForwardRef(function HvDropdown<
     );
   }
 
-  const dropdownHeaderRef = useRef<HTMLDivElement>();
+  const dropdownHeaderRef = useRef<HTMLDivElement | undefined>(undefined);
 
   const {
     ref: refProp,

--- a/packages/core/src/FileUploader/Preview/Preview.tsx
+++ b/packages/core/src/FileUploader/Preview/Preview.tsx
@@ -17,7 +17,7 @@ export interface HvFileUploaderPreviewProps
   /**
    * Content that represents the preview of an uploaded file.
    */
-  children: React.ReactElement;
+  children: React.ReactNode;
   /**
    * Callback executed when the preview is unmounted.
    *

--- a/packages/core/src/Focus/Focus.tsx
+++ b/packages/core/src/Focus/Focus.tsx
@@ -13,7 +13,7 @@ export type HvFocusClasses = ExtractNames<typeof useClasses>;
 export type HvFocusStrategies = "listbox" | "menu" | "card" | "grid";
 
 export interface HvFocusProps extends HvBaseProps<HTMLElement, "children"> {
-  children: React.ReactElement;
+  children: React.ReactElement<any>;
   /** Extra configuration for the child element. */
   configuration?: {
     tabIndex?: number;
@@ -25,7 +25,7 @@ export interface HvFocusProps extends HvBaseProps<HTMLElement, "children"> {
   /** Whether the focus is disabled. */
   disabled?: boolean;
   /** The reference to the root element to hold all Focus' context. */
-  rootRef?: React.RefObject<HTMLElement>;
+  rootRef?: React.RefObject<HTMLElement | null>;
   /** Show focus when click element. v */
   focusOnClick?: boolean;
   /** Show focus when click element. v */

--- a/packages/core/src/InlineEditor/InlineEditor.tsx
+++ b/packages/core/src/InlineEditor/InlineEditor.tsx
@@ -96,7 +96,7 @@ export const HvInlineEditor = fixedForwardRef(function HvInlineEditor<
   const [value, setValue] = useControlled(valueProp, defaultValue);
   const [editMode, setEditMode] = useState(false);
   const [cachedValue, setCachedValue] = useState(value);
-  const inputRef = useRef<HTMLInputElement>();
+  const inputRef = useRef<HTMLInputElement | undefined>(undefined);
   const { activeTheme } = useTheme();
   const [isOverflowing, setIsOverflowing] = useState(false);
 

--- a/packages/core/src/MultiButton/MultiButton.tsx
+++ b/packages/core/src/MultiButton/MultiButton.tsx
@@ -1,10 +1,4 @@
-import {
-  Children,
-  cloneElement,
-  isValidElement,
-  ReactElement,
-  useMemo,
-} from "react";
+import { Children, cloneElement, isValidElement, useMemo } from "react";
 import {
   useDefaultProps,
   type ExtractNames,
@@ -52,7 +46,7 @@ export const HvMultiButton = (props: HvMultiButtonProps) => {
 
   // Filter children: remove invalid and undefined/null
   const buttons = useMemo(() => {
-    const btns: ReactElement[] = [];
+    const btns: React.ReactElement[] = [];
     Children.forEach(children, (child) => {
       if (child && isValidElement(child)) {
         btns.push(child);

--- a/packages/core/src/Table/renderers/DateColumnCell.tsx
+++ b/packages/core/src/Table/renderers/DateColumnCell.tsx
@@ -13,7 +13,7 @@ export interface HvDateColumnCellProp {
 export const HvDateColumnCell = ({
   date,
   dateFormat,
-}: HvDateColumnCellProp): JSX.Element => {
+}: HvDateColumnCellProp) => {
   const formattedDate = useMemo(() => {
     if (date)
       return dayjs(date).format(

--- a/packages/core/src/Table/renderers/ProgressColumnCell.tsx
+++ b/packages/core/src/Table/renderers/ProgressColumnCell.tsx
@@ -39,7 +39,7 @@ export const HvProgressColumnCell = ({
   total,
   color = "primary",
   "aria-labelledby": ariaLabelledBy,
-}: HvProgressColumnCellProp): JSX.Element => {
+}: HvProgressColumnCellProp) => {
   const { classes } = useClasses();
 
   const percentage = normalizeProgressBar(partial, total);

--- a/packages/core/src/Table/renderers/SwitchColumnCell.tsx
+++ b/packages/core/src/Table/renderers/SwitchColumnCell.tsx
@@ -36,7 +36,7 @@ export const HvSwitchColumnCell = ({
   falseLabel,
   trueLabel,
   switchProps,
-}: HvSwitchColumnCellProp): JSX.Element => {
+}: HvSwitchColumnCellProp) => {
   const { classes } = useClasses();
 
   return (

--- a/packages/core/src/Tabs/Tab/Tab.tsx
+++ b/packages/core/src/Tabs/Tab/Tab.tsx
@@ -16,7 +16,7 @@ export interface HvTabProps extends Omit<MuiTabProps, "children"> {
   /** If `true`, the tab will be disabled. */
   disabled?: boolean;
   /** The icon element. */
-  icon?: React.ReactElement | string;
+  icon?: React.ReactElement<any> | string;
   /** The label element. */
   label?: React.ReactNode;
   /** The position of the icon relative to the label. */

--- a/packages/core/src/Tag/Tag.tsx
+++ b/packages/core/src/Tag/Tag.tsx
@@ -46,7 +46,7 @@ export interface HvTagProps
   /** The color variant of the tag */
   color?: HvColorAny;
   /** Icon used to customize the delete icon */
-  deleteIcon?: React.ReactElement;
+  deleteIcon?: React.ReactElement<any>;
   /**
    * The callback fired when the delete icon is pressed.
    * This function has to be provided to the component, in order to render the delete icon

--- a/packages/core/src/TagsInput/TagsInput.tsx
+++ b/packages/core/src/TagsInput/TagsInput.tsx
@@ -166,7 +166,7 @@ export const HvTagsInput = forwardRef<HTMLElement, HvTagsInputProps>(
     const inputRef = useRef<HTMLInputElement>(null);
     const containerRef = useRef<HTMLDivElement>(null);
     const skipReset = useRef(false);
-    const blurTimeout = useRef<any>();
+    const blurTimeout = useRef<any>(null);
     const focusUtils = useFocus({ containerRef });
 
     const forkedContainerRef = useForkRef(ref, containerRef);

--- a/packages/core/src/Tooltip/Tooltip.tsx
+++ b/packages/core/src/Tooltip/Tooltip.tsx
@@ -53,7 +53,7 @@ export interface HvTooltipProps extends Omit<MuiTooltipProps, "classes"> {
   /**
    * Node to apply the tooltip.
    */
-  children: React.ReactElement;
+  children: React.ReactElement<any>;
   /**
    * Id attribute value of an HTML Element to have the tooltip appended to it.
    */

--- a/packages/core/src/TreeView/internals/hooks/useInstanceEventHandler.ts
+++ b/packages/core/src/TreeView/internals/hooks/useInstanceEventHandler.ts
@@ -48,7 +48,7 @@ export function createUseInstanceEventHandler(
     const subscription = React.useRef<(() => void) | null>(null);
     const handlerRef = React.useRef<
       TreeViewEventListener<TreeViewUsedEvents<Signature>[E]> | undefined
-    >();
+    >(undefined);
     handlerRef.current = handler;
     const cleanupTokenRef = React.useRef<UnregisterToken | null>(null);
 

--- a/packages/core/src/TreeView/internals/types/plugin.ts
+++ b/packages/core/src/TreeView/internals/types/plugin.ts
@@ -15,7 +15,7 @@ export interface TreeViewPluginOptions<
   state: TreeViewUsedState<TSignature>;
   models: TreeViewUsedModels<TSignature>;
   setState: React.Dispatch<React.SetStateAction<TreeViewUsedState<TSignature>>>;
-  rootRef: React.RefObject<HTMLUListElement>;
+  rootRef: React.RefObject<HTMLUListElement | null>;
 }
 
 type TreeViewModelsInitializer<TSignature extends TreeViewAnyPluginSignature> =

--- a/packages/core/src/hooks/useClickOutside.ts
+++ b/packages/core/src/hooks/useClickOutside.ts
@@ -3,7 +3,7 @@ import { useEffect } from "react";
 export type HvClickOutsideEvent = MouseEvent | KeyboardEvent | TouchEvent;
 
 export const useClickOutside = <T extends HTMLElement = HTMLElement>(
-  ref: React.RefObject<T>,
+  ref: React.RefObject<T | null>,
   handler: (event: HvClickOutsideEvent) => void,
 ) => {
   useEffect(() => {

--- a/packages/core/src/types/generic.ts
+++ b/packages/core/src/types/generic.ts
@@ -57,8 +57,8 @@ export type Arrayable<T> = T | T[];
 /** React.forwardRef with fixed type declarations */
 export function fixedForwardRef<T, P = {}>(
   // TODO: change `React.ReactElement | null` to `React.ReactNode` in v6 (requires ts@5+)
-  render: (props: P, ref: React.Ref<T>) => React.ReactElement | null,
-): (props: P & React.RefAttributes<T>) => React.ReactElement | null {
+  render: (props: P, ref: React.Ref<T>) => React.ReactElement<any> | null,
+): (props: P & React.RefAttributes<T>) => React.ReactElement<any> | null {
   // https://github.com/DefinitelyTyped/DefinitelyTyped/pull/70361#issuecomment-2327456092
   return forwardRef(render as any) as any;
 }

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -37,8 +37,8 @@
   "peerDependencies": {
     "@emotion/react": "^11.11.1",
     "@emotion/styled": "^11.11.0",
-    "react": "^17.0.0 || ^18.0.0",
-    "react-dom": "^17.0.0 || ^18.0.0"
+    "react": ">=17.0.0",
+    "react-dom": ">=17.0.0"
   },
   "dependencies": {
     "@hitachivantara/uikit-styles": "^5.44.1"

--- a/packages/lab/package.json
+++ b/packages/lab/package.json
@@ -34,9 +34,9 @@
   "peerDependencies": {
     "@emotion/react": "^11.11.1",
     "@emotion/styled": "^11.11.0",
-    "@mui/material": "^5.12.2",
-    "react": "^17.0.0 || ^18.0.0",
-    "react-dom": "^17.0.0 || ^18.0.0"
+    "@mui/material": "^5.16.14",
+    "react": ">=17.0.0",
+    "react-dom": ">=17.0.0"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.1.0",

--- a/packages/lab/src/Wizard/WizardContent/WizardContent.tsx
+++ b/packages/lab/src/Wizard/WizardContent/WizardContent.tsx
@@ -51,7 +51,7 @@ export const HvWizardContent = ({
 
   const arrayChildren = Children.toArray(children) as ChildElement[];
 
-  const summaryRef = useRef<HTMLElement>();
+  const summaryRef = useRef<HTMLElement | undefined>(undefined);
   const resizedRef = useRef({ height: 0, width: 0 });
   const [containerRef, sizes] = useElementSize();
 

--- a/packages/pentaho/package.json
+++ b/packages/pentaho/package.json
@@ -33,9 +33,9 @@
   "peerDependencies": {
     "@emotion/react": "^11.11.1",
     "@emotion/styled": "^11.11.0",
-    "@mui/material": "^5.12.2",
-    "react": "^17.0.0 || ^18.0.0",
-    "react-dom": "^17.0.0 || ^18.0.0"
+    "@mui/material": "^5.16.14",
+    "react": ">=17.0.0",
+    "react-dom": ">=17.0.0"
   },
   "dependencies": {
     "@emotion/css": "^11.11.0",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -30,8 +30,8 @@
     "prepublishOnly": "npm run build && npx clean-publish"
   },
   "peerDependencies": {
-    "react": "^17.0.0 || ^18.0.0",
-    "react-dom": "^17.0.0 || ^18.0.0"
+    "react": ">=17.0.0",
+    "react-dom": ">=17.0.0"
   },
   "dependencies": {
     "@emotion/cache": "^11.11.0",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -30,8 +30,8 @@
     "prepublishOnly": "npm run build && npx clean-publish"
   },
   "peerDependencies": {
-    "react": "^17.0.0 || ^18.0.0",
-    "react-dom": "^17.0.0 || ^18.0.0"
+    "react": ">=17.0.0",
+    "react-dom": ">=17.0.0"
   },
   "dependencies": {
     "@emotion/serialize": "^1.1.2",

--- a/packages/viz/package.json
+++ b/packages/viz/package.json
@@ -34,12 +34,12 @@
   "peerDependencies": {
     "@emotion/react": "^11.11.1",
     "@emotion/styled": "^11.11.0",
-    "@mui/material": "^5.12.2",
+    "@mui/material": "^5.16.14",
     "arquero": "^5.2.0",
     "echarts": "^5.4.2",
     "echarts-for-react": "^3.0.2",
-    "react": "^17.0.0 || ^18.0.0",
-    "react-dom": "^17.0.0 || ^18.0.0"
+    "react": ">=17.0.0",
+    "react-dom": ">=17.0.0"
   },
   "dependencies": {
     "@hitachivantara/uikit-react-utils": "^0.2.29",


### PR DESCRIPTION
- bump MUI dependency to one that supports `react@19`
- `react@19` migration (basically just types): [useRef without arguments](https://react.dev/blog/2024/04/25/react-19-upgrade-guide#useref-requires-argument), [JSX.Element](https://react.dev/blog/2024/04/25/react-19-upgrade-guide#the-jsx-namespace-in-typescript) & [ReactElement<unknown>](https://react.dev/blog/2024/04/25/react-19-upgrade-guide#changes-to-the-reactelement-typescript-type) usage
- relax react restrictions to >= 17 so that react@19 doesn't error out:
```
npm ERR! Could not resolve dependency:
npm ERR! peer react@"^17.0.0 || ^18.0.0" from @hitachivantara/uikit-react-icons@5.14.2
npm ERR! node_modules/@hitachivantara/uikit-react-icons
npm ERR!   @hitachivantara/uikit-react-icons@"latest" from the root project
```

UI Kit + React@19 example: https://stackblitz.com/edit/github-ndrq4ctx?file=src%2FApp.tsx
