### PR TITLE
style(input): remove autofill override

### DIFF
--- a/packages/core/src/BaseInput/BaseInput.styles.tsx
+++ b/packages/core/src/BaseInput/BaseInput.styles.tsx
@@ -6,11 +6,6 @@ import { outlineStyles } from "../utils/focusUtils";
 export const { staticClasses, useClasses } = createClasses("HvBaseInput", {
   root: {
     // #region `input` style reset
-    "input:-webkit-autofill": {
-      WebkitBoxShadow: `0 0 0px 1000px ${theme.colors.textDimmed} inset`,
-      WebkitTextFillColor: theme.colors.text,
-    },
-
     // Clears number input up/down arrows in Chrome and Firefox
     "input[type=number]": {
       MozAppearance: "textfield",


### PR DESCRIPTION
Removes our `:-webkit-autofill` color overrides:
![image](https://github.com/user-attachments/assets/0da9d074-4e3f-421a-b078-c5bc38d2d0d7) ![image](https://github.com/user-attachments/assets/81723c56-3882-468a-b050-699e7ca8d0ac)
