### PR TITLE
fix(Selection): align Checkbox/Radio styles

### DIFF
--- a/packages/core/src/BaseCheckBox/BaseCheckBox.styles.ts
+++ b/packages/core/src/BaseCheckBox/BaseCheckBox.styles.ts
@@ -9,19 +9,15 @@ export const { staticClasses, useClasses } = createClasses("HvBaseCheckBox", {
     width: 32,
     minWidth: 32,
     height: 32,
-    borderRadius: theme.radii.base,
+    borderRadius: theme.radii.round,
     cursor: "pointer",
-    "&:hover": {
+    ":hover": {
       backgroundColor: theme.colors.bgHover,
-      borderRadius: theme.radii.round,
     },
   },
   disabled: {
     cursor: "not-allowed",
     pointerEvents: "initial",
-    "&:hover": {
-      backgroundColor: "transparent",
-    },
   },
   focusVisible: {
     "& svg": {

--- a/packages/core/src/BaseCheckBox/CheckBoxIcon.tsx
+++ b/packages/core/src/BaseCheckBox/CheckBoxIcon.tsx
@@ -22,6 +22,7 @@ const { useClasses } = createClasses("HvCheckBoxIcon", {
   },
   indeterminate: {
     color: theme.colors.textSubtle,
+    backgroundColor: theme.colors.bgContainer,
   },
   semantic: {
     "&[data-variant=indeterminate]": {

--- a/packages/core/src/CheckBox/CheckBox.styles.tsx
+++ b/packages/core/src/CheckBox/CheckBox.styles.tsx
@@ -8,62 +8,33 @@ export const { staticClasses, useClasses } = createClasses("HvCheckBox", {
   container: {
     cursor: "pointer",
     display: "flex",
-    height: "32px",
+    alignItems: "center",
     transition: "background-color 150ms cubic-bezier(0.4, 0, 0.2, 1) 0ms",
+    borderRadius: theme.radii.base,
 
-    "&:hover": {
+    "&:hover:not($disabled)": {
       backgroundColor: theme.colors.bgHover,
-      borderRadius: theme.radii.base,
+    },
+    ":where(:has($label)) $checkbox": {
+      borderRadius: "inherit",
     },
   },
+  invalidContainer: {},
   disabled: {
     cursor: "not-allowed",
     "& $label": { color: theme.colors.textDisabled, cursor: "not-allowed" },
-    "&:hover": {
-      backgroundColor: "transparent",
-    },
   },
   focusVisible: {
+    backgroundColor: theme.colors.bgPageSecondary,
     ...outlineStyles,
-
-    "& div": {
-      backgroundColor: theme.colors.bgPageSecondary,
-    },
-
-    [`& $checkbox div > svg`]: {
-      outline: "none",
-      boxShadow: "none",
-    },
   },
-  invalidContainer: {
-    borderBottom: `1px solid ${theme.form.errorColor}`,
-
-    "&:hover": {
-      borderBottomLeftRadius: "0px",
-      borderBottomRightRadius: "0px",
-    },
-  },
-  checkbox: { height: "32px" },
-  invalidCheckbox: {
-    "::after": {
-      content: '""',
-      position: "absolute",
-      bottom: 0,
-      left: 0,
-      width: "100%",
-      height: 1,
-      backgroundColor: theme.form.errorColor,
-    },
-  },
+  checkbox: {},
+  invalidCheckbox: {},
   label: {
-    overflow: "hidden",
-    textOverflow: "ellipsis",
     verticalAlign: "middle",
     paddingRight: theme.space.xs,
-    whiteSpace: "nowrap",
     ...theme.typography.body,
     cursor: "pointer",
-    height: "32px",
     lineHeight: "32px",
     width: "100%",
   },

--- a/packages/core/src/CheckBox/CheckBox.tsx
+++ b/packages/core/src/CheckBox/CheckBox.tsx
@@ -232,6 +232,7 @@ export const HvCheckBox = forwardRef<HTMLButtonElement, HvCheckBoxProps>(
           >
             {checkbox}
             <HvLabel
+              noWrap
               id={setId(elementId, "label")}
               htmlFor={setId(elementId, "input")}
               label={label}
@@ -247,7 +248,6 @@ export const HvCheckBox = forwardRef<HTMLButtonElement, HvCheckBoxProps>(
             id={setId(elementId, "error")}
             disableAdornment={!hasLabel}
             hideText={!hasLabel}
-            disableBorder
           >
             {validationMessage}
           </HvWarningText>

--- a/packages/core/src/Dropdown/List/List.styles.tsx
+++ b/packages/core/src/Dropdown/List/List.styles.tsx
@@ -19,7 +19,5 @@ export const { staticClasses, useClasses } = createClasses("HvDropdownList", {
   searchContainer: { marginBottom: theme.space.xs },
   listBorderDown: {},
   listContainer: { padding: theme.space.sm },
-  selectAllContainer: {},
-  selection: {},
   selectAll: {},
 });

--- a/packages/core/src/Dropdown/List/List.tsx
+++ b/packages/core/src/Dropdown/List/List.tsx
@@ -12,7 +12,7 @@ import { HvButton } from "../../Button";
 import { HvCheckBox } from "../../CheckBox";
 import { HvInput } from "../../Input";
 import { HvList, HvListProps, HvListValue } from "../../List";
-import { HvTypography } from "../../Typography";
+import { CounterLabel } from "../../utils/CounterLabel";
 import { setId } from "../../utils/setId";
 import type { HvDropdownLabels } from "../Dropdown";
 import { getSelected } from "../utils";
@@ -249,46 +249,22 @@ export const HvDropdownList = (props: HvDropdownListProps) => {
     updateSelectAll(newList);
   };
 
-  /**
-   * Create selecteAll component.
-   *
-   * @returns {*}
-   */
   const renderSelectAll = () => {
-    const selectAll = labels?.selectAll;
-    const multiSelectionConjunction = labels?.multiSelectionConjunction;
-    const nbrSelected = getSelected(list).length;
-
-    const defaultLabel = (
-      <HvTypography component="span">
-        {nbrSelected > 0 ? (
-          <>
-            <b>{nbrSelected}</b>
-            {` ${multiSelectionConjunction} ${list.length}`}
-          </>
-        ) : (
-          <>
-            <b>{selectAll}</b>
-            {` (${list.length})`}
-          </>
-        )}
-      </HvTypography>
-    );
-
     return (
-      <div className={classes.selectAllContainer}>
-        <HvCheckBox
-          id={setId(id, "select-all")}
-          label={defaultLabel}
-          onChange={() => handleSelectAll()}
-          classes={{
-            container: classes.selection,
-          }}
-          className={classes.selectAll}
-          indeterminate={anySelected && !allSelected}
-          checked={allSelected}
-        />
-      </div>
+      <HvCheckBox
+        id={setId(id, "select-all")}
+        label={
+          <CounterLabel
+            selected={getSelected(list).length}
+            total={list.length}
+            conjunctionLabel={labels?.multiSelectionConjunction}
+          />
+        }
+        onChange={handleSelectAll}
+        className={classes.selectAll}
+        indeterminate={anySelected && !allSelected}
+        checked={allSelected}
+      />
     );
   };
 

--- a/packages/core/src/Dropdown/utils.tsx
+++ b/packages/core/src/Dropdown/utils.tsx
@@ -2,14 +2,11 @@ import { HvListValue } from "../List";
 import type { HvDropdownLabels } from "./Dropdown";
 
 /** Filter selected elements. */
-const getSelected = (list: HvListValue[] = []) =>
+export const getSelected = (list: HvListValue[] = []) =>
   list.filter((elem) => elem.selected);
 
-/** Checks if any element of the list is selected. */
-const hasSelected = (list: HvListValue[]) => getSelected(list).length > 0;
-
 /** Gets the selection label according to selection. */
-const getSelectionLabel = (
+export const getSelectionLabel = (
   labels: HvDropdownLabels | undefined,
   placeholder: string,
   multiSelect: boolean,
@@ -28,5 +25,3 @@ const getSelectionLabel = (
   }
   return { selected: selected.length > 0 ? selected[0].label : placeholder };
 };
-
-export { getSelectionLabel, getSelected, hasSelected };

--- a/packages/core/src/Radio/Radio.stories.tsx
+++ b/packages/core/src/Radio/Radio.stories.tsx
@@ -232,53 +232,24 @@ export const Test: StoryObj<HvRadioProps> = {
   },
   render: () => (
     <>
-      <HvRadio disabled name="disabled" label="Disabled" value="1" />
-      <HvRadio
-        disabled
-        name="disabled"
-        defaultChecked
-        label="Disabled"
-        value="1"
-      />
-      <HvRadio readOnly name="readonly" label="Readonly" value="1" />
-      <HvRadio
-        readOnly
-        name="readonly"
-        defaultChecked
-        label="Readonly"
-        value="1"
-      />
-      <HvRadio required name="required" label="Required" value="1" />
-      <HvRadio
-        required
-        name="required"
-        defaultChecked
-        label="Required"
-        value="1"
-      />
+      <HvRadio disabled label="Disabled" />
+      <HvRadio disabled defaultChecked label="Disabled" />
+      <HvRadio readOnly label="Readonly" />
+      <HvRadio readOnly defaultChecked label="Readonly" />
+      <HvRadio required label="Required" />
+      <HvRadio required defaultChecked label="Required" />
+      <HvRadio status="invalid" statusMessage="Oh no!" label="Invalid" />
       <HvRadio
         status="invalid"
         statusMessage="Oh no!"
-        name="invalid"
-        label="Invalid"
-        value="1"
-      />
-      <HvRadio
-        status="invalid"
-        statusMessage="Oh no!"
-        name="invalid"
         defaultChecked
         label="Invalid"
-        value="1"
       />
-      <HvRadio semantic name="semantic" label="Semantic" value="1" />
-      <HvRadio
-        semantic
-        name="semantic"
-        defaultChecked
-        label="Semantic"
-        value="1"
-      />
+      <HvRadio semantic label="Semantic" />
+      <HvRadio semantic defaultChecked label="Semantic" />
+      <HvRadio aria-label="radio" />
+      <HvRadio defaultChecked aria-label="radio" />
+      <HvRadio defaultChecked disabled aria-label="radio" />
     </>
   ),
 };

--- a/packages/core/src/Radio/Radio.styles.tsx
+++ b/packages/core/src/Radio/Radio.styles.tsx
@@ -12,15 +12,21 @@ export const { staticClasses, useClasses } = createClasses("HvRadio", {
     transition: "background-color 150ms cubic-bezier(0.4, 0, 0.2, 1) 0ms",
     borderRadius: theme.radii.base,
 
-    ":hover:not($disabled)": {
+    "&:hover:not($disabled)": {
       backgroundColor: theme.colors.bgHover,
+    },
+    ":where(:has($label)) $radio": {
+      borderRadius: "inherit",
     },
   },
   invalidContainer: {},
   disabled: {
     cursor: "not-allowed",
-
     "& $label": { color: theme.colors.textDisabled, cursor: "not-allowed" },
+  },
+  focusVisible: {
+    backgroundColor: theme.colors.bgPageSecondary,
+    ...outlineStyles,
   },
   radio: {},
   invalidRadio: {},
@@ -31,10 +37,6 @@ export const { staticClasses, useClasses } = createClasses("HvRadio", {
     cursor: "pointer",
     lineHeight: "32px",
     width: "100%",
-  },
-  focusVisible: {
-    backgroundColor: theme.colors.bgPageSecondary,
-    ...outlineStyles,
   },
   checked: {},
   semantic: {},

--- a/packages/core/src/stories/Components.test.stories.tsx
+++ b/packages/core/src/stories/Components.test.stories.tsx
@@ -111,29 +111,31 @@ export const TestInputs: StoryObj = {
         <div className="grid gap-xs w-120px">
           {renderStory(CheckBoxGroupVariantsStory, context)}
         </div>
-        <div className="grid gap-xs w-120px">
+        <div className="flex flex-col gap-xs w-120px">
           {renderStory(RadioGroupVariantsStory, context)}
         </div>
-        <div className="grid w-160px">
+        <div className="flex flex-col w-160px">
           {renderStory(CheckBoxTestStory, context)}
         </div>
         <div className="grid gap-sm w-120px">
           <div className="flex w-full flex-wrap">
             {renderStory(RadioTestStory, context)}
           </div>
-          {renderStory(SwitchVariantsStory, context)}
+          <div className="flex w-full flex-wrap">
+            {renderStory(SwitchVariantsStory, context)}
+          </div>
         </div>
         <div className="flex flex-col gap-xs flex-1">
           {renderStory(SliderRangeVariantsStory, context)}
           <div className="flex gap-xs">
             {renderStory(SelectionListVariantsStory, context)}
           </div>
+          {renderStory(RadioGroupHorizontalStory, context)}
         </div>
       </div>
       <div className="flex gap-sm w-full flex-wrap [&>*]:w-220px">
         {renderStory(TagsInputVariantsStory, context)}
       </div>
-      <div>{renderStory(RadioGroupHorizontalStory, context)}</div>
       <div>{renderStory(InlineEditorTestStory, context)}</div>
     </div>
   ),

--- a/packages/styles/src/themes/pentahoPlus.ts
+++ b/packages/styles/src/themes/pentahoPlus.ts
@@ -454,9 +454,7 @@ const pentahoPlus = makeTheme((theme) => ({
     HvBaseCheckBox: {
       classes: {
         root: {
-          "&,:hover": {
-            borderRadius: "4px",
-          },
+          borderRadius: "4px",
         },
       },
     },


### PR DESCRIPTION
- remove dead code (`& div > svg`)
- hoist `borderRadius`
- leverage `HvWarningText`'s error border in `HvCheckbox`
- add more Radio tests & make input tests more compact

fixes: 
![image](https://github.com/user-attachments/assets/b669f258-010b-4793-8a34-9db74c558c1c)  ![image](https://github.com/user-attachments/assets/c8b7ed40-2944-4fdb-b344-68fca6e22599) ![image](https://github.com/user-attachments/assets/d05a6f3d-c394-4ace-8e1e-ad6011c38d29)
