### PR TITLE
chore: update default color on `Tag` main story

### DIFF
--- a/packages/core/src/Tag/stories/Tag.stories.tsx
+++ b/packages/core/src/Tag/stories/Tag.stories.tsx
@@ -26,7 +26,7 @@ export const Main: StoryObj<HvTagProps> = {
   args: {
     label: "Tag Label",
     type: "semantic",
-    color: "infoDimmed",
+    color: "positive",
     disabled: false,
   },
   argTypes: {


### PR DESCRIPTION
Change from this:
![image](https://github.com/user-attachments/assets/f008d43b-0ee3-4a6d-b71a-860667654577)

to this:
![image](https://github.com/user-attachments/assets/6635f58f-4381-40fc-bad5-26653e30fe1a)
