### PR TITLE
style(LabelContainer): add internal component & align styles

### DIFF
--- a/packages/core/src/BaseInput/validations.ts
+++ b/packages/core/src/BaseInput/validations.ts
@@ -14,22 +14,19 @@ const isEmail = (email: string) => {
   return regexp.test(email);
 };
 
-export const validationTypes = Object.freeze({
-  none: "none",
-  number: "number",
-  email: "email",
-});
+type HvValidationType = "none" | "number" | "email";
 
 /** Returns the input's validation type based in the type of the input. */
-export const computeValidationType = (type: React.HTMLInputTypeAttribute) => {
+export const computeValidationType = (
+  type: React.HTMLInputTypeAttribute,
+): HvValidationType => {
   switch (type) {
     case "number":
-      return validationTypes.number;
+      return "number";
     case "email":
-      return validationTypes.email;
-
+      return "email";
     default:
-      return validationTypes.none;
+      return "none";
   }
 };
 
@@ -38,14 +35,14 @@ export const computeValidationType = (type: React.HTMLInputTypeAttribute) => {
  */
 export const hasBuiltInValidations = (
   required: boolean | undefined,
-  validationType: React.HTMLInputTypeAttribute,
+  validationType: HvValidationType,
   minCharQuantity: number | null | undefined,
   maxCharQuantity: number | null | undefined,
   validation?: (value: string) => boolean,
   inputProps?: InputBaseComponentProps,
 ) =>
   required ||
-  validationType !== validationTypes.none ||
+  validationType !== "none" ||
   minCharQuantity != null ||
   maxCharQuantity != null ||
   validation != null ||
@@ -119,7 +116,7 @@ export const validateInput = (
   required: boolean | undefined,
   minCharQuantity: any,
   maxCharQuantity: any,
-  validationType: string,
+  validationType: HvValidationType,
   validation?: (value: string) => boolean,
 ): HvInputValidity => {
   // bootstrap validity object using browser's built-in validation
@@ -161,14 +158,14 @@ export const validateInput = (
     // the validationType is used instead of type
     // for the same reason stated above
     switch (validationType) {
-      case validationTypes.number:
+      case "number":
         if (!isNumeric(value)) {
           inputValidity.typeMismatch = true;
           inputValidity.valid = false;
         }
         break;
 
-      case validationTypes.email:
+      case "email":
         if (!isEmail(value)) {
           inputValidity.typeMismatch = true;
           inputValidity.valid = false;

--- a/packages/core/src/BaseInput/validations.ts
+++ b/packages/core/src/BaseInput/validations.ts
@@ -1,6 +1,6 @@
 import { InputBaseComponentProps } from "@mui/material/InputBase";
 
-import { validationStates } from "../FormElement";
+import { HvFormStatus } from "../FormElement";
 
 /** Checks if the value is a number. */
 const isNumeric = (num: string) =>
@@ -63,17 +63,15 @@ export const hasBuiltInValidations = (
 export const computeValidationState = (
   inputValidity: HvInputValidity,
   isEmptyValue: boolean,
-) => {
+): HvFormStatus => {
   // to keep 2.x behaviour,
   // consider that if the value is empty (and not required) we're returning to the standBy state.
   // might not make sense, as it makes impossible to say if the user explicitly cleared the input.
   if (inputValidity.valid && isEmptyValue) {
-    return validationStates.standBy;
+    return "standBy";
   }
 
-  return inputValidity.valid
-    ? validationStates.valid
-    : validationStates.invalid;
+  return inputValidity.valid ? "valid" : "invalid";
 };
 
 /**

--- a/packages/core/src/Calendar/CalendarHeader/CalendarHeader.tsx
+++ b/packages/core/src/Calendar/CalendarHeader/CalendarHeader.tsx
@@ -67,11 +67,8 @@ export const HvCalendarHeader = (props: HvCalendarHeaderProps) => {
     inputValue.length === 0 || (inputValue && isDate(new Date(inputValue))),
   );
 
-  const validateInput = (incomingValid: any) =>
-    incomingValid === undefined || isDate(new Date(incomingValid));
-
   useEffect(() => {
-    const valid = validateInput(localValue);
+    const valid = !localValue || isDate(new Date(localValue));
     setIsValidValue(valid);
     if (valid) {
       if (!localValue) {

--- a/packages/core/src/CheckBoxGroup/CheckBoxGroup.tsx
+++ b/packages/core/src/CheckBoxGroup/CheckBoxGroup.tsx
@@ -19,6 +19,7 @@ import {
   HvLabel,
   HvWarningText,
 } from "../FormElement";
+import { HvLabelContainer } from "../FormElement/LabelContainer";
 import { useControlled } from "../hooks/useControlled";
 import { useUniqueId } from "../hooks/useUniqueId";
 import { HvBaseProps } from "../types/generic";
@@ -347,20 +348,20 @@ export const HvCheckBoxGroup = forwardRef<HTMLDivElement, HvCheckBoxGroupProps>(
         readOnly={readOnly}
         className={cx(classes.root, className)}
       >
-        {label && (
-          <HvLabel
-            showGutter
-            id={setId(elementId, "label")}
-            label={label}
-            className={classes.label}
-          />
-        )}
-
-        {description && (
-          <HvInfoMessage id={setId(elementId, "description")}>
-            {description}
-          </HvInfoMessage>
-        )}
+        <HvLabelContainer>
+          {label && (
+            <HvLabel
+              id={setId(elementId, "label")}
+              label={label}
+              className={classes.label}
+            />
+          )}
+          {description && (
+            <HvInfoMessage disableGutter id={setId(elementId, "description")}>
+              {description}
+            </HvInfoMessage>
+          )}
+        </HvLabelContainer>
 
         <div
           ref={ref}

--- a/packages/core/src/ColorPicker/ColorPicker.styles.tsx
+++ b/packages/core/src/ColorPicker/ColorPicker.styles.tsx
@@ -2,10 +2,7 @@ import { createClasses } from "@hitachivantara/uikit-react-utils";
 
 export const { staticClasses, useClasses } = createClasses("HvColorPicker", {
   root: {},
-  labelContainer: {
-    display: "flex",
-    alignItems: "flex-start",
-  },
+  labelContainer: {},
   label: {},
   description: {},
   headerColorValue: {

--- a/packages/core/src/ColorPicker/ColorPicker.tsx
+++ b/packages/core/src/ColorPicker/ColorPicker.tsx
@@ -9,6 +9,7 @@ import { HvColorAny } from "@hitachivantara/uikit-styles";
 import { HvBaseDropdown } from "../BaseDropdown";
 import { HvDropdownProps } from "../Dropdown";
 import { HvFormElement, HvInfoMessage, HvLabel } from "../FormElement";
+import { HvLabelContainer } from "../FormElement/LabelContainer";
 import { useControlled } from "../hooks/useControlled";
 import { useLabels } from "../hooks/useLabels";
 import { useUniqueId } from "../hooks/useUniqueId";
@@ -227,25 +228,24 @@ export const HvColorPicker = forwardRef<HTMLDivElement, HvColorPickerProps>(
         className={cx(classes.root, className)}
       >
         {(hasLabel || hasDescription) && (
-          <div className={classes.labelContainer}>
+          <HvLabelContainer className={classes.labelContainer}>
             {hasLabel && (
               <HvLabel
-                showGutter
                 id={setId(elementId, "label")}
                 label={label}
                 className={classes.label}
               />
             )}
-
             {hasDescription && (
               <HvInfoMessage
+                disableGutter
                 id={setId(elementId, "description")}
                 className={classes.description}
               >
                 {description}
               </HvInfoMessage>
             )}
-          </div>
+          </HvLabelContainer>
         )}
         <HvBaseDropdown
           ref={ref}

--- a/packages/core/src/DatePicker/DatePicker.styles.tsx
+++ b/packages/core/src/DatePicker/DatePicker.styles.tsx
@@ -10,11 +10,7 @@ export const { staticClasses, useClasses } = createClasses("HvDatePicker", {
   },
   leftContainer: {},
   rightContainer: {},
-
-  labelContainer: {
-    display: "flex",
-    alignItems: "flex-start",
-  },
+  labelContainer: {},
   label: {},
   description: {},
   error: {},

--- a/packages/core/src/DatePicker/DatePicker.tsx
+++ b/packages/core/src/DatePicker/DatePicker.tsx
@@ -19,6 +19,7 @@ import {
   HvWarningText,
   isInvalid,
 } from "../FormElement";
+import { HvLabelContainer } from "../FormElement/LabelContainer";
 import { useControlled } from "../hooks/useControlled";
 import { useLabels } from "../hooks/useLabels";
 import { useUniqueId } from "../hooks/useUniqueId";
@@ -446,25 +447,24 @@ export const HvDatePicker = forwardRef<HTMLDivElement, HvDatePickerProps>(
         {...others}
       >
         {(hasLabel || hasDescription) && (
-          <div className={classes.labelContainer}>
+          <HvLabelContainer className={classes.labelContainer}>
             {hasLabel && (
               <HvLabel
-                showGutter
                 id={setId(elementId, "label")}
                 label={label}
                 className={classes.label}
               />
             )}
-
             {hasDescription && (
               <HvInfoMessage
+                disableGutter
                 id={setId(elementId, "description")}
                 className={classes.description}
               >
                 {description}
               </HvInfoMessage>
             )}
-          </div>
+          </HvLabelContainer>
         )}
         <HvBaseDropdown
           ref={dropdownForkedRef}

--- a/packages/core/src/Dropdown/Dropdown.styles.tsx
+++ b/packages/core/src/Dropdown/Dropdown.styles.tsx
@@ -7,7 +7,7 @@ export const { staticClasses, useClasses } = createClasses("HvDropdown", {
     position: "relative",
     display: "inline-block",
   },
-  labelContainer: { display: "flex", alignItems: "flex-start" },
+  labelContainer: {},
   label: {},
   description: {},
   error: {},

--- a/packages/core/src/Dropdown/Dropdown.tsx
+++ b/packages/core/src/Dropdown/Dropdown.tsx
@@ -15,6 +15,7 @@ import {
   HvWarningText,
   isInvalid,
 } from "../FormElement";
+import { HvLabelContainer } from "../FormElement/LabelContainer";
 import { useControlled } from "../hooks/useControlled";
 import { useLabels } from "../hooks/useLabels";
 import { useUniqueId } from "../hooks/useUniqueId";
@@ -458,25 +459,24 @@ export const HvDropdown = fixedForwardRef(function HvDropdown<
       {...others}
     >
       {(hasLabel || hasDescription) && (
-        <div className={classes.labelContainer}>
+        <HvLabelContainer className={classes.labelContainer}>
           {hasLabel && (
             <HvLabel
-              showGutter
               id={setId(elementId, "label")}
               label={label}
               className={classes.label}
             />
           )}
-
           {hasDescription && (
             <HvInfoMessage
+              disableGutter
               id={setId(elementId, "description")}
               className={classes.description}
             >
               {description}
             </HvInfoMessage>
           )}
-        </div>
+        </HvLabelContainer>
       )}
       <HvBaseDropdown
         ref={dropdownForkedRef}

--- a/packages/core/src/FileUploader/DropZone/DropZone.styles.tsx
+++ b/packages/core/src/FileUploader/DropZone/DropZone.styles.tsx
@@ -23,11 +23,6 @@ export const { staticClasses, useClasses } = createClasses("HvDropZone", {
     },
   },
   dropZoneLabelsGroup: {
-    display: "flex",
-    justifyContent: "start",
-
-    "& label:nth-of-type(1)": {},
-
     "& p:nth-of-type(2)": {
       marginLeft: "auto",
     },

--- a/packages/core/src/FileUploader/DropZone/DropZone.tsx
+++ b/packages/core/src/FileUploader/DropZone/DropZone.tsx
@@ -10,6 +10,7 @@ import {
   HvInfoMessage,
   HvLabel,
 } from "../../FormElement";
+import { HvLabelContainer } from "../../FormElement/LabelContainer";
 import { useLabels } from "../../hooks/useLabels";
 import { useUniqueId } from "../../hooks/useUniqueId";
 import { HvIcon } from "../../icons";
@@ -170,22 +171,21 @@ export const HvDropZone = (props: HvDropZoneProps) => {
   return (
     <>
       {!hideLabels && (
-        <div id={id} className={classes.dropZoneLabelsGroup}>
+        <HvLabelContainer id={id} className={classes.dropZoneLabelsGroup}>
           <HvLabel
-            showGutter
             id={setId(id, "input-file-label")}
             htmlFor={setId(id, "input-file")}
             label={label ?? labels?.dropzone}
             className={classes.dropZoneLabel}
           />
-          <HvInfoMessage id={setId(id, "description")}>
+          <HvInfoMessage disableGutter id={setId(id, "description")}>
             {Number.isInteger(maxFileSize) &&
               `${labels?.sizeWarning} ${convertUnits(maxFileSize)}`}
             {labels?.acceptedFiles
               ? labels.acceptedFiles
               : accept && `\u00A0(${accept?.replaceAll(",", ", ")})`}
           </HvInfoMessage>
-        </div>
+        </HvLabelContainer>
       )}
       <div
         id={setId(id, "input-file-container")}

--- a/packages/core/src/FilterGroup/FilterGroup.styles.tsx
+++ b/packages/core/src/FilterGroup/FilterGroup.styles.tsx
@@ -3,7 +3,7 @@ import { createClasses } from "@hitachivantara/uikit-react-utils";
 export const { staticClasses, useClasses } = createClasses("HvFilterGroup", {
   root: {},
   label: {},
-  labelContainer: { display: "flex", alignItems: "flex-start" },
+  labelContainer: {},
   description: {},
   error: {},
 });

--- a/packages/core/src/FilterGroup/FilterGroup.tsx
+++ b/packages/core/src/FilterGroup/FilterGroup.tsx
@@ -12,6 +12,7 @@ import {
   HvLabel,
   HvWarningText,
 } from "../FormElement";
+import { HvLabelContainer } from "../FormElement/LabelContainer";
 import { useControlled } from "../hooks/useControlled";
 import { useLabels } from "../hooks/useLabels";
 import { useUniqueId } from "../hooks/useUniqueId";
@@ -178,10 +179,9 @@ export const HvFilterGroup = forwardRef<HTMLDivElement, HvFilterGroupProps>(
         {...others}
       >
         {(hasLabel || hasDescription) && (
-          <div className={classes.labelContainer}>
+          <HvLabelContainer className={classes.labelContainer}>
             {hasLabel && (
               <HvLabel
-                showGutter
                 id={setId(elementId, "label")}
                 htmlFor={setId(elementId, "input")}
                 label={label}
@@ -191,13 +191,14 @@ export const HvFilterGroup = forwardRef<HTMLDivElement, HvFilterGroupProps>(
 
             {hasDescription && (
               <HvInfoMessage
+                disableGutter
                 id={setId(elementId, "description")}
                 className={classes.description}
               >
                 {description}
               </HvInfoMessage>
             )}
-          </div>
+          </HvLabelContainer>
         )}
         <HvFilterGroupProvider
           defaultValue={defaultValue}

--- a/packages/core/src/FormElement/LabelContainer.tsx
+++ b/packages/core/src/FormElement/LabelContainer.tsx
@@ -1,0 +1,36 @@
+import {
+  createClasses,
+  ExtractNames,
+  useDefaultProps,
+} from "@hitachivantara/uikit-react-utils";
+import { theme } from "@hitachivantara/uikit-styles";
+
+const { useClasses } = createClasses("HvLabelContainer", {
+  root: {
+    display: "flex",
+    alignItems: "center",
+    gap: theme.space.xs,
+    height: 24,
+    marginBottom: theme.space.xxs,
+  },
+});
+
+export interface HvLabelContainerProps
+  extends React.HTMLAttributes<HTMLDivElement> {
+  classes?: ExtractNames<typeof useClasses>;
+}
+
+/**
+ * A container for the label and description combo of form elements.
+ * @internal @private
+ */
+export const HvLabelContainer = (props: HvLabelContainerProps) => {
+  const {
+    className,
+    classes: classesProp,
+    ...others
+  } = useDefaultProps("HvLabelContainer", props);
+  const { classes, cx } = useClasses(classesProp, false);
+
+  return <div className={cx(classes.root, className)} {...others} />;
+};

--- a/packages/core/src/FormElement/utils.ts
+++ b/packages/core/src/FormElement/utils.ts
@@ -132,13 +132,5 @@ export const buildAriaPropsFromContext = (
   return arias;
 };
 
-export const validationStates = Object.freeze({
-  standBy: "standBy",
-  valid: "valid",
-  invalid: "invalid",
-});
-
-export const isValid = (state: HvFormStatus) =>
-  state === validationStates.valid;
-export const isInvalid = (state: HvFormStatus) =>
-  state === validationStates.invalid;
+export const isValid = (state: HvFormStatus) => state === "valid";
+export const isInvalid = (state: HvFormStatus) => state === "invalid";

--- a/packages/core/src/Input/Input.styles.tsx
+++ b/packages/core/src/Input/Input.styles.tsx
@@ -5,11 +5,7 @@ import { suggestionsClasses } from "../FormElement/Suggestions";
 
 export const { staticClasses, useClasses } = createClasses("HvInput", {
   root: { display: "block" },
-  labelContainer: {
-    display: "flex",
-    alignItems: "flex-start",
-    paddingBottom: 2,
-  },
+  labelContainer: {},
   label: {},
   description: {},
   adornmentsBox: {

--- a/packages/core/src/Input/Input.tsx
+++ b/packages/core/src/Input/Input.tsx
@@ -26,7 +26,6 @@ import {
   HvWarningText,
   isInvalid,
   isValid,
-  validationStates,
 } from "../FormElement";
 import {
   HvSuggestion,
@@ -286,9 +285,9 @@ export const HvInput = fixedForwardRef(function HvInput<
   const isEmptyValue = !inputRef.current?.value;
 
   // Validation related state
-  const [validationState, setValidationState] = useControlled(
+  const [validationState, setValidationState] = useControlled<HvFormStatus>(
     status,
-    validationStates.standBy,
+    "standBy",
   );
 
   const [validationMessage, setValidationMessage] = useControlled(
@@ -478,7 +477,7 @@ export const HvInput = fixedForwardRef(function HvInput<
     setFocused(true);
 
     // reset validation status to standBy (only when status is uncontrolled)
-    setValidationState(validationStates.standBy);
+    setValidationState("standBy");
 
     onFocus?.(event as any, event.target.value);
   };
@@ -534,7 +533,7 @@ export const HvInput = fixedForwardRef(function HvInput<
     (!onEnter ||
       type !== "search" ||
       disableSearchButton ||
-      validationState !== validationStates.standBy);
+      validationState !== "standBy");
 
   const showSearchIcon = type === "search" && !disableSearchButton;
 
@@ -547,7 +546,7 @@ export const HvInput = fixedForwardRef(function HvInput<
   const handleClear = useCallback(
     (event: React.MouseEvent<HTMLButtonElement>) => {
       // reset validation status to standBy (only when status is uncontrolled)
-      setValidationState(validationStates.standBy);
+      setValidationState("standBy");
 
       changeInputValue(inputRef.current, "");
 
@@ -593,8 +592,7 @@ export const HvInput = fixedForwardRef(function HvInput<
     // If the search icon is not actionable, only show it when the input is empty or active
     const reallyShowIt =
       showSearchIcon &&
-      (isEmptyValue ||
-        (onEnter && validationState === validationStates.standBy));
+      (isEmptyValue || (onEnter && validationState === "standBy"));
 
     if (!reallyShowIt) return null;
 

--- a/packages/core/src/Input/Input.tsx
+++ b/packages/core/src/Input/Input.tsx
@@ -27,6 +27,7 @@ import {
   isInvalid,
   isValid,
 } from "../FormElement";
+import { HvLabelContainer } from "../FormElement/LabelContainer";
 import {
   HvSuggestion,
   HvSuggestions,
@@ -715,10 +716,9 @@ export const HvInput = fixedForwardRef(function HvInput<
       onBlur={onContainerBlurHandler}
     >
       {(hasLabel || hasDescription) && (
-        <div className={classes.labelContainer}>
+        <HvLabelContainer className={classes.labelContainer}>
           {hasLabel && (
             <HvLabel
-              showGutter
               id={setId(elementId, "label")}
               className={classes.label}
               htmlFor={setId(elementId, "input")}
@@ -728,13 +728,14 @@ export const HvInput = fixedForwardRef(function HvInput<
 
           {hasDescription && (
             <HvInfoMessage
+              disableGutter
               id={setId(elementId, "description")}
               className={classes.description}
             >
               {description}
             </HvInfoMessage>
           )}
-        </div>
+        </HvLabelContainer>
       )}
       <HvBaseInput
         id={

--- a/packages/core/src/QueryBuilder/Rule/Rule.styles.tsx
+++ b/packages/core/src/QueryBuilder/Rule/Rule.styles.tsx
@@ -26,7 +26,7 @@ export const { useClasses, staticClasses } = createClasses(
         zIndex: 2,
 
         width: "17px",
-        height: "39px",
+        height: "44px",
 
         borderBottom: `1px solid ${theme.colors.border}`,
         borderLeft: `1px solid ${theme.colors.border}`,

--- a/packages/core/src/RadioGroup/RadioGroup.tsx
+++ b/packages/core/src/RadioGroup/RadioGroup.tsx
@@ -17,6 +17,7 @@ import {
   HvLabel,
   HvWarningText,
 } from "../FormElement";
+import { HvLabelContainer } from "../FormElement/LabelContainer";
 import { useControlled } from "../hooks/useControlled";
 import { useUniqueId } from "../hooks/useUniqueId";
 import { HvBaseProps } from "../types/generic";
@@ -246,20 +247,21 @@ export const HvRadioGroup = forwardRef<HTMLDivElement, HvRadioGroupProps>(
         readOnly={readOnly}
         className={cx(classes.root, className)}
       >
-        {label && (
-          <HvLabel
-            showGutter
-            id={setId(elementId, "label")}
-            label={label}
-            className={classes.label}
-          />
-        )}
+        <HvLabelContainer>
+          {label && (
+            <HvLabel
+              id={setId(elementId, "label")}
+              label={label}
+              className={classes.label}
+            />
+          )}
 
-        {description && (
-          <HvInfoMessage id={setId(elementId, "description")}>
-            {description}
-          </HvInfoMessage>
-        )}
+          {description && (
+            <HvInfoMessage disableGutter id={setId(elementId, "description")}>
+              {description}
+            </HvInfoMessage>
+          )}
+        </HvLabelContainer>
 
         <div
           ref={ref}

--- a/packages/core/src/Select/Select.styles.ts
+++ b/packages/core/src/Select/Select.styles.ts
@@ -13,10 +13,7 @@ export const { staticClasses, useClasses } = createClasses("HvSelect", {
   invalid: {
     borderColor: theme.form.errorColor,
   },
-  labelContainer: {
-    display: "flex",
-    alignItems: "flex-start",
-  },
+  labelContainer: {},
   label: {},
   description: {},
   select: {},

--- a/packages/core/src/Select/Select.tsx
+++ b/packages/core/src/Select/Select.tsx
@@ -25,6 +25,7 @@ import {
   HvLabel,
   HvWarningText,
 } from "../FormElement";
+import { HvLabelContainer } from "../FormElement/LabelContainer";
 import { useUniqueId } from "../hooks/useUniqueId";
 import { HvListContainer } from "../ListContainer";
 import { fixedForwardRef } from "../types/generic";
@@ -239,10 +240,9 @@ export const HvSelect = fixedForwardRef(function HvSelect<
       {...others}
     >
       {(label || description) && (
-        <div className={classes.labelContainer}>
+        <HvLabelContainer className={classes.labelContainer}>
           {label && (
             <HvLabel
-              showGutter
               id={labelId}
               htmlFor={id}
               label={label}
@@ -250,11 +250,15 @@ export const HvSelect = fixedForwardRef(function HvSelect<
             />
           )}
           {description && (
-            <HvInfoMessage id={descriptionId} className={classes.description}>
+            <HvInfoMessage
+              disableGutter
+              id={descriptionId}
+              className={classes.description}
+            >
               {description}
             </HvInfoMessage>
           )}
-        </div>
+        </HvLabelContainer>
       )}
       <HvDropdownButton
         id={id}

--- a/packages/core/src/Slider/Slider.tsx
+++ b/packages/core/src/Slider/Slider.tsx
@@ -18,7 +18,6 @@ import {
   HvFormStatus,
   HvLabel,
   HvWarningText,
-  validationStates,
 } from "../FormElement";
 import { useControlled } from "../hooks/useControlled";
 import { useUniqueId } from "../hooks/useUniqueId";
@@ -357,19 +356,19 @@ export const HvSlider = forwardRef<
     const mappedValues =
       generateKnobsPositionAndValues(knobsPositions).knobsValues;
 
-    const newValidationState = mappedValues.map((knobValue) => {
+    const newValidationState = mappedValues.map<HvFormStatus>((knobValue) => {
       if (required && (knobValue == null || Number.isNaN(knobValue))) {
         invalid = true;
         requiredMsg = true;
-        return validationStates.invalid;
+        return "invalid";
       }
 
       if (knobValue < minPointValue || knobValue > maxPointValue) {
         invalid = true;
-        return validationStates.invalid;
+        return "invalid";
       }
 
-      return validationStates.valid;
+      return "valid";
     });
 
     setValidationState([...newValidationState]);

--- a/packages/core/src/Slider/Slider.tsx
+++ b/packages/core/src/Slider/Slider.tsx
@@ -19,6 +19,7 @@ import {
   HvLabel,
   HvWarningText,
 } from "../FormElement";
+import { HvLabelContainer } from "../FormElement/LabelContainer";
 import { useControlled } from "../hooks/useControlled";
 import { useUniqueId } from "../hooks/useUniqueId";
 import { HvInputProps } from "../Input";
@@ -605,7 +606,7 @@ export const HvSlider = forwardRef<
       {...others}
     >
       {(hasLabel || !hideInput) && (
-        <div
+        <HvLabelContainer
           className={cx(classes.labelContainer, {
             [classes.labelIncluded]: hasLabel,
             [classes.onlyInput]: !hasLabel,
@@ -633,7 +634,7 @@ export const HvSlider = forwardRef<
               inputProps={inputProps}
             />
           )}
-        </div>
+        </HvLabelContainer>
       )}
 
       <div className={cx(classes.sliderBase, classes.sliderContainer)}>

--- a/packages/core/src/Slider/utils.ts
+++ b/packages/core/src/Slider/utils.ts
@@ -1,6 +1,6 @@
 import { theme } from "@hitachivantara/uikit-styles";
 
-import { HvFormStatus, validationStates } from "../FormElement";
+import type { HvFormStatus } from "../FormElement";
 import { sliderStyles as styles } from "./Slider.styles";
 import { HvKnobProperty, HvMarkProperty } from "./types";
 
@@ -404,13 +404,13 @@ export const convertStatusToArray = (
   status?: HvFormStatus | HvFormStatus[],
 ): {
   arrayStatus?: HvFormStatus[];
-  arrayDefaultStatus: (keyof typeof validationStates)[];
+  arrayDefaultStatus: HvFormStatus[];
 } => {
   const result: {
     arrayStatus?: HvFormStatus[];
-    arrayDefaultStatus: (keyof typeof validationStates)[];
+    arrayDefaultStatus: HvFormStatus[];
   } = {
-    arrayDefaultStatus: Array.from({ length }, () => validationStates.standBy),
+    arrayDefaultStatus: Array.from({ length }, () => "standBy"),
   };
 
   if (status == null) {
@@ -427,18 +427,16 @@ export const convertStatusToArray = (
 
 export const statusArrayToFormStatus = (
   arrayStatus: HvFormStatus[],
-): keyof typeof validationStates => {
-  const invalid = arrayStatus.some(
-    (status) => status === validationStates.invalid,
-  );
+): HvFormStatus => {
+  const invalid = arrayStatus.some((status) => status === "invalid");
 
-  if (invalid) return validationStates.invalid;
+  if (invalid) return "invalid";
 
-  const valid = arrayStatus.some((status) => status === validationStates.valid);
+  const valid = arrayStatus.some((status) => status === "valid");
 
-  if (valid) return validationStates.valid;
+  if (valid) return "valid";
 
-  return validationStates.standBy;
+  return "standBy";
 };
 
 export const knobsValuesToString = (

--- a/packages/core/src/TagsInput/TagsInput.styles.tsx
+++ b/packages/core/src/TagsInput/TagsInput.styles.tsx
@@ -31,9 +31,9 @@ export const { staticClasses, useClasses } = createClasses("HvTagsInput", {
   },
   resizable: { width: "auto", resize: "both", clear: "both", overflow: "auto" },
   invalid: {},
-  labelContainer: { float: "left", display: "flex", alignItems: "flex-start" },
+  labelContainer: {},
   label: {},
-  description: { display: "block", float: "left" },
+  description: {},
   characterCounter: {
     display: "block",
     float: "right",

--- a/packages/core/src/TagsInput/TagsInput.tsx
+++ b/packages/core/src/TagsInput/TagsInput.tsx
@@ -22,7 +22,6 @@ import {
   HvInfoMessage,
   HvLabel,
   HvWarningText,
-  validationStates,
 } from "../FormElement";
 import {
   HvSuggestions,
@@ -197,11 +196,11 @@ export const HvTagsInput = forwardRef<HTMLElement, HvTagsInputProps>(
           maxTagsQuantity !== undefined &&
           currValue.length > maxTagsQuantity
         ) {
-          setValidationState(validationStates.invalid);
+          setValidationState("invalid");
           setValidationMessage(errorMessages.maxCharError);
           setStateValid(false);
         } else {
-          setValidationState(validationStates.valid);
+          setValidationState("valid");
           setValidationMessage("");
           setStateValid(true);
         }
@@ -440,7 +439,7 @@ export const HvTagsInput = forwardRef<HTMLElement, HvTagsInputProps>(
     const onDeleteTagHandler = useCallback(
       (event: React.MouseEvent<HTMLElement>, i: number) => {
         deleteTag(i, event, true);
-        setValidationState(validationStates.standBy);
+        setValidationState("standBy");
       },
       [deleteTag, setValidationState],
     );

--- a/packages/core/src/TagsInput/TagsInput.tsx
+++ b/packages/core/src/TagsInput/TagsInput.tsx
@@ -23,6 +23,7 @@ import {
   HvLabel,
   HvWarningText,
 } from "../FormElement";
+import { HvLabelContainer } from "../FormElement/LabelContainer";
 import {
   HvSuggestions,
   HvSuggestionsProps,
@@ -486,10 +487,9 @@ export const HvTagsInput = forwardRef<HTMLElement, HvTagsInputProps>(
         )}
       >
         {(hasLabel || hasDescription) && (
-          <div className={classes.labelContainer}>
+          <HvLabelContainer className={classes.labelContainer}>
             {hasLabel && (
               <HvLabel
-                showGutter
                 className={classes.label}
                 id={setId(id, "label")}
                 htmlFor={setId(elementId, "input")}
@@ -499,13 +499,14 @@ export const HvTagsInput = forwardRef<HTMLElement, HvTagsInputProps>(
 
             {hasDescription && (
               <HvInfoMessage
+                disableGutter
                 className={classes.description}
                 id={setId(elementId, "description")}
               >
                 {description}
               </HvInfoMessage>
             )}
-          </div>
+          </HvLabelContainer>
         )}
 
         {hasCounter && (

--- a/packages/core/src/TextArea/TextArea.styles.tsx
+++ b/packages/core/src/TextArea/TextArea.styles.tsx
@@ -8,14 +8,12 @@ export const { staticClasses, useClasses } = createClasses("HvTextArea", {
   baseInput: { clear: "both", float: "left" },
   input: {},
   inputResizable: {},
-  labelContainer: { float: "left", display: "flex", alignItems: "flex-start" },
+  labelContainer: {},
   label: {},
-  description: { display: "block", float: "left" },
+  description: {},
   characterCounter: {
-    display: "block",
-    float: "right",
     textAlign: "right",
-    marginBottom: "6px",
+    marginLeft: "auto",
   },
   error: { float: "left" },
 });

--- a/packages/core/src/TextArea/TextArea.tsx
+++ b/packages/core/src/TextArea/TextArea.tsx
@@ -32,6 +32,7 @@ import {
   HvWarningText,
   isInvalid,
 } from "../FormElement";
+import { HvLabelContainer } from "../FormElement/LabelContainer";
 import { useControlled } from "../hooks/useControlled";
 import { useUniqueId } from "../hooks/useUniqueId";
 import type { HvValidationMessages } from "../Input";
@@ -425,38 +426,36 @@ export const HvTextArea = forwardRef<
       )}
       onBlur={onContainerBlurHandler}
     >
-      {(hasLabel || hasDescription) && (
-        <div className={classes.labelContainer}>
+      {(hasLabel || hasDescription || hasCounter) && (
+        <HvLabelContainer className={classes.labelContainer}>
           {hasLabel && (
             <HvLabel
-              showGutter
               className={classes.label}
               id={setId(id, "label")}
               htmlFor={setId(elementId, "input")}
               label={label}
             />
           )}
-
           {hasDescription && (
             <HvInfoMessage
+              disableGutter
               className={classes.description}
               id={setId(elementId, "description")}
             >
               {description}
             </HvInfoMessage>
           )}
-        </div>
-      )}
-
-      {hasCounter && (
-        <HvCharCounter
-          id={setId(elementId, "charCounter")}
-          className={classes.characterCounter}
-          separator={middleCountLabel}
-          currentCharQuantity={String(value).length}
-          maxCharQuantity={maxCharQuantity}
-          {...countCharProps}
-        />
+          {hasCounter && (
+            <HvCharCounter
+              id={setId(elementId, "charCounter")}
+              className={classes.characterCounter}
+              separator={middleCountLabel}
+              currentCharQuantity={String(value).length}
+              maxCharQuantity={maxCharQuantity}
+              {...countCharProps}
+            />
+          )}
+        </HvLabelContainer>
       )}
 
       <HvBaseInput

--- a/packages/core/src/TextArea/TextArea.tsx
+++ b/packages/core/src/TextArea/TextArea.tsx
@@ -20,7 +20,6 @@ import {
   hasBuiltInValidations,
   HvInputValidity,
   validateInput,
-  validationTypes,
 } from "../BaseInput/validations";
 import {
   HvCharCounter,
@@ -253,7 +252,7 @@ export const HvTextArea = forwardRef<
       required,
       minCharQuantity,
       maxCharQuantity,
-      validationTypes.none,
+      "none",
       validation,
     );
 
@@ -389,7 +388,7 @@ export const HvTextArea = forwardRef<
       (status === undefined &&
         hasBuiltInValidations(
           required,
-          validationTypes.none,
+          "none",
           minCharQuantity,
           // If blockMax is true maxCharQuantity will never produce an error
           // unless the value is controlled, so we can't prevent it to overflow maxCharQuantity

--- a/packages/core/src/TextArea/TextArea.tsx
+++ b/packages/core/src/TextArea/TextArea.tsx
@@ -32,7 +32,6 @@ import {
   HvLabel,
   HvWarningText,
   isInvalid,
-  validationStates,
 } from "../FormElement";
 import { useControlled } from "../hooks/useControlled";
 import { useUniqueId } from "../hooks/useUniqueId";
@@ -217,9 +216,9 @@ export const HvTextArea = forwardRef<
 
   const [autoScrolling, setAutoScrolling] = useState(autoScroll);
 
-  const [validationState, setValidationState] = useControlled(
+  const [validationState, setValidationState] = useControlled<HvFormStatus>(
     status,
-    validationStates.standBy,
+    "standBy",
   );
 
   const [validationMessage, setValidationMessage] = useControlled(
@@ -330,7 +329,7 @@ export const HvTextArea = forwardRef<
     setFocused(true);
 
     // Reset validation status to standBy (only when status is uncontrolled)
-    setValidationState(validationStates.standBy);
+    setValidationState("standBy");
 
     onFocus?.(event as any, String(value));
   };

--- a/packages/core/src/TimePicker/TimePicker.styles.ts
+++ b/packages/core/src/TimePicker/TimePicker.styles.ts
@@ -6,10 +6,7 @@ export const { useClasses, staticClasses } = createClasses("HvTimePicker", {
     position: "relative",
   },
 
-  labelContainer: {
-    display: "flex",
-    alignItems: "flex-start",
-  },
+  labelContainer: {},
   label: {},
   description: {},
 

--- a/packages/core/src/TimePicker/TimePicker.tsx
+++ b/packages/core/src/TimePicker/TimePicker.tsx
@@ -21,6 +21,7 @@ import {
   HvLabel,
   HvWarningText,
 } from "../FormElement";
+import { HvLabelContainer } from "../FormElement/LabelContainer";
 import { useControlled } from "../hooks/useControlled";
 import { useUniqueId } from "../hooks/useUniqueId";
 import { HvIcon } from "../icons";
@@ -235,10 +236,9 @@ export const HvTimePicker = forwardRef<HTMLDivElement, HvTimePickerProps>(
         {...others}
       >
         {(label || description) && (
-          <div className={classes.labelContainer}>
+          <HvLabelContainer className={classes.labelContainer}>
             {label && (
               <HvLabel
-                showGutter
                 label={label}
                 className={classes.label}
                 {...labelProps}
@@ -246,13 +246,14 @@ export const HvTimePicker = forwardRef<HTMLDivElement, HvTimePickerProps>(
             )}
             {description && (
               <HvInfoMessage
+                disableGutter
                 className={classes.description}
                 {...descriptionProps}
               >
                 {description}
               </HvInfoMessage>
             )}
-          </div>
+          </HvLabelContainer>
         )}
 
         <HvBaseDropdown

--- a/packages/styles/src/themes/ds3.ts
+++ b/packages/styles/src/themes/ds3.ts
@@ -315,6 +315,13 @@ const ds3 = makeTheme((theme) => ({
         },
       },
     },
+    HvLabelContainer: {
+      classes: {
+        root: {
+          height: "auto",
+        },
+      },
+    },
     HvBaseInput: {
       classes: {
         root: {
@@ -1086,7 +1093,7 @@ const ds3 = makeTheme((theme) => ({
         root: {
           "&::before": {
             width: "21px",
-            height: "39px",
+            height: "36px",
 
             left: `calc( -1 * 21px)`,
           },

--- a/packages/utils/src/hooks/useDefaultProps.ts
+++ b/packages/utils/src/hooks/useDefaultProps.ts
@@ -31,6 +31,7 @@ export function useDefaultProps<T extends Record<string, any>>(
       ...Object.keys(themeClasses),
       ...Object.keys(propsClasses),
     ];
+    if (classKeys.length === 0) return undefined;
     return classKeys.reduce<Record<string, string>>((acc, key) => {
       acc[key] = cx(
         themeClasses[key] && css(themeClasses[key]),
@@ -43,6 +44,6 @@ export function useDefaultProps<T extends Record<string, any>>(
   return {
     ...themeDefaultProps,
     ...filterProps(props),
-    ...(classes ? { classes } : {}),
+    ...(classes && { classes }),
   };
 }


### PR DESCRIPTION
- add `HvLabelContainer` internal component to reuse in our (14!) form components that need a label container
  - add `gap` between elements instead of relying on gutters
  - center label (instead of `flex-start` alignment), which NEXT5/P+ use
  - change from the `6px` gutter gap to the `4px`(`xxs`) defined in NEXT5/P+
- refactor input to leverage `HvFormStatus`/`HvValidationType` instead of enum-like objects