### PR TITLE
fix(Tag): change default P+ size to sm

### DIFF
--- a/packages/styles/src/themes/pentahoPlus.ts
+++ b/packages/styles/src/themes/pentahoPlus.ts
@@ -556,13 +556,18 @@ const pentahoPlus = makeTheme((theme) => ({
         tagsList: {
           backgroundColor: inputColors.bg,
         },
+        singleLine: {
+          height: 32,
+        },
       },
     },
     HvTag: {
       showSelectIcon: false,
+      size: "sm",
       classes: {
         root: {
           outline: `1px solid ${theme.colors.border}`,
+          outlineOffset: -1,
           borderRadius: theme.radii.round,
           ":where(:not([data-color],.HvTag-disabled))": {
             color: theme.colors.text,


### PR DESCRIPTION
- change `HvTag` default size to `sm` in Pentaho+
- adjust `HvTagsInput` to ensure its 32px height
- update `HvTag` outline offset