### PR TITLE
feat(Input): add `infoMessage` prop

### DIFF
--- a/packages/core/src/Input/Input.stories.tsx
+++ b/packages/core/src/Input/Input.stories.tsx
@@ -53,6 +53,7 @@ export const Main: StoryObj<HvInputProps> = {
     type: "text",
     status: "valid",
     statusMessage: "My status message",
+    infoMessage: "",
     autoFocus: false,
     disableClear: false,
     disableRevealPassword: false,

--- a/packages/core/src/Input/Input.test.tsx
+++ b/packages/core/src/Input/Input.test.tsx
@@ -57,6 +57,33 @@ describe("Input", () => {
     expect(screen.getByText("kg")).toBeVisible();
   });
 
+  it("renders the label and description", () => {
+    render(<HvInput label="LABEL" description="DESCRIPTION" />);
+    expect(screen.getByRole("textbox", { name: "LABEL" })).toBeInTheDocument();
+    expect(screen.getByText("DESCRIPTION")).toBeInTheDocument();
+  });
+
+  it("renders the info message", () => {
+    render(<HvInput infoMessage="INFO" />);
+    expect(screen.getByText("INFO")).toBeInTheDocument();
+  });
+
+  it("renders only the statusMessage when invalid status", () => {
+    render(
+      <HvInput status="invalid" infoMessage="INFO" statusMessage="ERROR" />,
+    );
+    expect(screen.getByText("ERROR")).toBeInTheDocument();
+    expect(screen.queryByText("INFO")).toBeNull();
+  });
+
+  it("renders only the info message when in standby status", () => {
+    render(
+      <HvInput status="standBy" infoMessage="INFO" statusMessage="ERROR" />,
+    );
+    expect(screen.getByText("INFO")).toBeInTheDocument();
+    expect(screen.queryByText("ERROR")).toBeNull();
+  });
+
   it("can press custom endAdornment with keyboard", async () => {
     const clickMock = vi.fn();
     render(

--- a/packages/core/src/Input/Input.tsx
+++ b/packages/core/src/Input/Input.tsx
@@ -21,6 +21,7 @@ import {
   HvFormElement,
   HvFormElementProps,
   HvFormStatus,
+  HvInfoMessage,
   HvWarningText,
   isInvalid,
   isValid,
@@ -105,6 +106,8 @@ export interface HvInputProps<
   status?: HvFormStatus;
   /** The error message to show when `status` is "invalid". */
   statusMessage?: string;
+  /** An informational message, used for error-prevention. Replaces `statusMessage` when it isn't visible. */
+  infoMessage?: React.ReactNode;
   /** @inheritdoc */
   onChange?: (event: React.ChangeEvent<InputElement>, value: string) => void;
   /**
@@ -225,14 +228,15 @@ export const HvInput = fixedForwardRef(function HvInput<
     enablePortal,
     suggestOnFocus,
     label,
+    description,
     "aria-label": ariaLabel,
     "aria-labelledby": ariaLabelledBy,
-    description,
     "aria-describedby": ariaDescribedBy,
     onChange,
     onEnter,
     status,
     statusMessage,
+    infoMessage,
     "aria-errormessage": ariaErrorMessage,
     type = "text",
     placeholder,
@@ -348,6 +352,8 @@ export const HvInput = fixedForwardRef(function HvInput<
         )));
 
   const isStateInvalid = isInvalid(validationState);
+  const willShowError = canShowError && isStateInvalid;
+  const canShowInfo = !!infoMessage && !willShowError;
 
   // Input type related state
   const [revealPassword, setRevealPassword] = useState(false);
@@ -812,6 +818,11 @@ export const HvInput = fixedForwardRef(function HvInput<
         >
           {validationMessage}
         </HvWarningText>
+      )}
+      {canShowInfo && (
+        <HvInfoMessage disableGutter variant="caption1">
+          {infoMessage}
+        </HvInfoMessage>
       )}
     </HvFormElement>
   );

--- a/packages/core/src/Input/Input.tsx
+++ b/packages/core/src/Input/Input.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useForkRef } from "@mui/material/utils";
 import {
   useDefaultProps,
+  useTheme,
   type ExtractNames,
 } from "@hitachivantara/uikit-react-utils";
 
@@ -228,7 +229,7 @@ export const HvInput = fixedForwardRef(function HvInput<
     enablePortal,
     suggestOnFocus,
     label,
-    description,
+    description: descriptionProp,
     "aria-label": ariaLabel,
     "aria-labelledby": ariaLabelledBy,
     "aria-describedby": ariaDescribedBy,
@@ -236,7 +237,7 @@ export const HvInput = fixedForwardRef(function HvInput<
     onEnter,
     status,
     statusMessage,
-    infoMessage,
+    infoMessage: infoMessageProp,
     "aria-errormessage": ariaErrorMessage,
     type = "text",
     placeholder,
@@ -262,10 +263,16 @@ export const HvInput = fixedForwardRef(function HvInput<
   const { classes, cx } = useClasses(classesProp);
   const labels = useLabels(DEFAULT_LABELS, labelsProp);
   const elementId = useUniqueId(id);
+  const { activeTheme } = useTheme();
 
   const inputRef = useRef<HTMLInputElement>(null);
   const forkedRef = useForkRef(ref, inputRef, inputRefProp);
   const suggestionsRef = useRef<HTMLDivElement>(null);
+
+  const [description, infoMessage] =
+    activeTheme?.name === "pentahoPlus"
+      ? [infoMessageProp, descriptionProp]
+      : [descriptionProp, infoMessageProp];
 
   const [focused, setFocused] = useState(false);
 

--- a/packages/core/src/TextArea/TextArea.test.tsx
+++ b/packages/core/src/TextArea/TextArea.test.tsx
@@ -47,6 +47,29 @@ describe("TextArea", () => {
     expect(label).toHaveTextContent("Label*");
   });
 
+  it("renders the label and description", () => {
+    render(<HvTextArea label="Label" description="Description" />);
+
+    expect(screen.getByRole("textbox", { name: "Label" })).toBeInTheDocument();
+    expect(screen.getByText("Description")).toBeInTheDocument();
+  });
+
+  it("renders only the statusMessage when invalid status", () => {
+    render(
+      <HvTextArea status="invalid" infoMessage="INFO" statusMessage="ERROR" />,
+    );
+    expect(screen.getByText("ERROR")).toBeInTheDocument();
+    expect(screen.queryByText("INFO")).toBeNull();
+  });
+
+  it("renders only the info message when in standby status", () => {
+    render(
+      <HvTextArea status="standBy" infoMessage="INFO" statusMessage="ERROR" />,
+    );
+    expect(screen.getByText("INFO")).toBeInTheDocument();
+    expect(screen.queryByText("ERROR")).toBeNull();
+  });
+
   it("should be readonly", () => {
     render(<HvTextArea rows={4} label="Label" readOnly />);
 

--- a/packages/core/src/TextArea/TextArea.tsx
+++ b/packages/core/src/TextArea/TextArea.tsx
@@ -9,6 +9,7 @@ import {
 import { useForkRef } from "@mui/material/utils";
 import {
   useDefaultProps,
+  useTheme,
   type ExtractNames,
 } from "@hitachivantara/uikit-react-utils";
 
@@ -170,11 +171,11 @@ export const HvTextArea = forwardRef<
     classes: classesProp,
     name,
     label,
-    description,
+    description: descriptionProp,
     placeholder,
     status,
     statusMessage,
-    infoMessage,
+    infoMessage: infoMessageProp,
     validationMessages,
     maxCharQuantity,
     minCharQuantity,
@@ -203,18 +204,21 @@ export const HvTextArea = forwardRef<
     onFocus,
     ...others
   } = useDefaultProps("HvTextArea", props);
-
   const { classes, cx } = useClasses(classesProp);
-
   const elementId = useUniqueId(id);
+  const { activeTheme } = useTheme();
 
   // Signals that the user has manually edited the input value
-  const isDirty = useRef<boolean>(false);
-
+  const isDirty = useRef(false);
   const inputRef = useRef<HTMLTextAreaElement>(null);
   const forkedRef = useForkRef(ref, inputRefProp, inputRef);
 
-  const [focused, setFocused] = useState<boolean>(false);
+  const [description, infoMessage] =
+    activeTheme?.name === "pentahoPlus"
+      ? [infoMessageProp, descriptionProp]
+      : [descriptionProp, infoMessageProp];
+
+  const [focused, setFocused] = useState(false);
 
   const [autoScrolling, setAutoScrolling] = useState(autoScroll);
 

--- a/packages/core/src/TextArea/TextArea.tsx
+++ b/packages/core/src/TextArea/TextArea.tsx
@@ -27,6 +27,7 @@ import {
   HvFormElement,
   HvFormElementProps,
   HvFormStatus,
+  HvInfoMessage,
   HvWarningText,
   isInvalid,
 } from "../FormElement";
@@ -72,6 +73,8 @@ export interface HvTextAreaProps
    * The error message to show when `status` is "invalid".
    */
   statusMessage?: React.ReactNode;
+  /** An informational message, used for error-prevention. Replaces `statusMessage` when it isn't visible. */
+  infoMessage?: React.ReactNode;
   /**
    * Text between the current char counter and max value.
    */
@@ -171,6 +174,7 @@ export const HvTextArea = forwardRef<
     placeholder,
     status,
     statusMessage,
+    infoMessage,
     validationMessages,
     maxCharQuantity,
     minCharQuantity,
@@ -179,8 +183,8 @@ export const HvTextArea = forwardRef<
     rows = 1,
     defaultValue = "",
     middleCountLabel = "/",
-    countCharProps = {},
-    inputProps = {},
+    countCharProps,
+    inputProps,
     required,
     readOnly,
     disabled,
@@ -395,6 +399,9 @@ export const HvTextArea = forwardRef<
           inputProps,
         )));
 
+  const willShowError = canShowError && isStateInvalid;
+  const canShowInfo = !!infoMessage && !willShowError;
+
   let errorMessageId;
   if (isStateInvalid) {
     errorMessageId = canShowError
@@ -490,6 +497,11 @@ export const HvTextArea = forwardRef<
         >
           {validationMessage}
         </HvWarningText>
+      )}
+      {canShowInfo && (
+        <HvInfoMessage disableGutter variant="caption1">
+          {infoMessage}
+        </HvInfoMessage>
       )}
     </HvFormElement>
   );


### PR DESCRIPTION
- add new `infoMessage` prop to `HvInput` and `HvTextArea`: an additional "label" that shows in the place of the error message when there isn't one
- switch `description` <-> `infoMessage` positions when in pentahoPlus theme