### PR TITLE
style(TagsInput): tag spacing

### DIFF
--- a/packages/core/src/FormElement/InfoMessage/InfoMessage.tsx
+++ b/packages/core/src/FormElement/InfoMessage/InfoMessage.tsx
@@ -32,10 +32,9 @@ export const HvInfoMessage = (props: HvInfoMessageProps) => {
     className,
     children,
     disabled: disabledProp,
-    disableGutter = false,
+    disableGutter,
     ...others
   } = useDefaultProps("HvInfoMessage", props);
-
   const { classes, cx } = useClasses(classesProp);
 
   const context = useContext(HvFormElementContext);

--- a/packages/core/src/FormElement/Label/Label.tsx
+++ b/packages/core/src/FormElement/Label/Label.tsx
@@ -1,4 +1,4 @@
-import { useContext } from "react";
+import { useContext, useMemo } from "react";
 import {
   useDefaultProps,
   type ExtractNames,
@@ -47,16 +47,17 @@ export const HvLabel = (props: HvLabelProps) => {
     htmlFor: htmlForProp,
     ...others
   } = useDefaultProps("HvLabel", props);
-
   const { classes, cx } = useClasses(classesProp);
 
   const context = useContext(HvFormElementContext);
-
   const disabled = disabledProp ?? context.disabled;
   const required = requiredProp ?? context.required;
   const id = idProp ?? setId(context.id, "label");
 
-  const forId = htmlForProp || findDescriptors(children)?.input?.[0]?.id;
+  const forId = useMemo(
+    () => htmlForProp || findDescriptors(children)?.input?.[0]?.id,
+    [children, htmlForProp],
+  );
 
   return (
     <>

--- a/packages/core/src/FormElement/WarningText/WarningText.tsx
+++ b/packages/core/src/FormElement/WarningText/WarningText.tsx
@@ -45,13 +45,12 @@ export const HvWarningText = (props: HvWarningTextProps) => {
     className,
     id: idProp,
     disabled: disabledProp,
-    disableGutter = false,
-    disableBorder = false,
-    disableAdornment = false,
-    hideText = false,
+    disableGutter,
+    disableBorder,
+    disableAdornment,
+    hideText,
     ...others
   } = useDefaultProps("HvWarningText", props);
-
   const { classes, cx } = useClasses(classesProp);
 
   const context = useContext(HvFormElementContext);

--- a/packages/core/src/TagsInput/TagsInput.styles.tsx
+++ b/packages/core/src/TagsInput/TagsInput.styles.tsx
@@ -44,7 +44,7 @@ export const { staticClasses, useClasses } = createClasses("HvTagsInput", {
     display: "flex",
     alignItems: "center",
     alignContent: "flex-start",
-    gap: theme.spacing("xxs", "xs"),
+    gap: theme.space.xxs,
     cursor: "text",
     width: "100%",
     minHeight: 32,

--- a/packages/styles/src/themes/pentahoPlus.ts
+++ b/packages/styles/src/themes/pentahoPlus.ts
@@ -555,6 +555,7 @@ const pentahoPlus = makeTheme((theme) => ({
       classes: {
         tagsList: {
           backgroundColor: inputColors.bg,
+          padding: theme.space.xxs,
         },
         singleLine: {
           height: 32,


### PR DESCRIPTION
- fix `HvTagsInput` spacing (paddingLeft & gaps)
- cleanup default props in other form components