### PR TITLE
style(DropdownMenu): borderRadius

### DIFF
--- a/packages/styles/src/themes/pentahoPlus.ts
+++ b/packages/styles/src/themes/pentahoPlus.ts
@@ -1100,7 +1100,7 @@ const pentahoPlus = makeTheme((theme) => ({
     HvDropDownMenu: {
       classes: {
         root: {
-          "--r": theme.radii.full,
+          "--r": "calc(var(--HvButton-height) / 2)",
         },
         iconSelected: {
           "&[data-color=secondary]": {


### PR DESCRIPTION
Change `HvDropdownMenu` radius to use `calc(var(--HvButton-height) / 2)`. `theme.radii.full` or `50%` won't work, because the adjacent radius don't match.

If we set `border-top-left-radius: 0`, the following is happening (before):

![image](https://github.com/user-attachments/assets/85bf89a9-20e8-4e63-8ca9-9ecf795edeb8)

After:
![image](https://github.com/user-attachments/assets/27940b69-b822-4579-b455-91ad81a610f9)

