### PR TITLE
style(Tabs): add proper background color to floating tabs

### DIFF
--- a/packages/styles/src/themes/pentahoPlus.ts
+++ b/packages/styles/src/themes/pentahoPlus.ts
@@ -1040,7 +1040,7 @@ const pentahoPlus = makeTheme((theme) => ({
           },
           "& .HvTabs-flexContainer": {
             display: "inline-flex",
-            backgroundColor: theme.colors.bgContainerSecondary,
+            backgroundColor: theme.colors.bgPageSecondary,
             borderRadius: theme.radii.full,
             marginLeft: 0,
           },


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/29ebb923-45dd-48b1-a694-066911364ee7)

After:
![image](https://github.com/user-attachments/assets/2232eb3c-8cd2-4b0e-a3fc-bf1ebca4df85)
