### PR TITLE
refactor(LabelContainer): align components' labels

### DIFF
--- a/packages/core/src/CheckBoxGroup/CheckBoxGroup.tsx
+++ b/packages/core/src/CheckBoxGroup/CheckBoxGroup.tsx
@@ -12,13 +12,7 @@ import {
 } from "@hitachivantara/uikit-react-utils";
 
 import { HvCheckBox } from "../CheckBox";
-import {
-  HvFormElement,
-  HvFormStatus,
-  HvInfoMessage,
-  HvLabel,
-  HvWarningText,
-} from "../FormElement";
+import { HvFormElement, HvFormStatus, HvWarningText } from "../FormElement";
 import { HvLabelContainer } from "../FormElement/LabelContainer";
 import { useControlled } from "../hooks/useControlled";
 import { useUniqueId } from "../hooks/useUniqueId";
@@ -348,21 +342,15 @@ export const HvCheckBoxGroup = forwardRef<HTMLDivElement, HvCheckBoxGroupProps>(
         readOnly={readOnly}
         className={cx(classes.root, className)}
       >
-        <HvLabelContainer>
-          {label && (
-            <HvLabel
-              id={setId(elementId, "label")}
-              label={label}
-              className={classes.label}
-            />
-          )}
-          {description && (
-            <HvInfoMessage disableGutter id={setId(elementId, "description")}>
-              {description}
-            </HvInfoMessage>
-          )}
-        </HvLabelContainer>
-
+        <HvLabelContainer
+          label={label}
+          description={description}
+          labelId={setId(elementId, "label")}
+          descriptionId={setId(elementId, "description")}
+          classes={{
+            label: classes.label,
+          }}
+        />
         <div
           ref={ref}
           role="group"

--- a/packages/core/src/ColorPicker/ColorPicker.tsx
+++ b/packages/core/src/ColorPicker/ColorPicker.tsx
@@ -8,7 +8,7 @@ import { HvColorAny } from "@hitachivantara/uikit-styles";
 
 import { HvBaseDropdown } from "../BaseDropdown";
 import { HvDropdownProps } from "../Dropdown";
-import { HvFormElement, HvInfoMessage, HvLabel } from "../FormElement";
+import { HvFormElement } from "../FormElement";
 import { HvLabelContainer } from "../FormElement/LabelContainer";
 import { useControlled } from "../hooks/useControlled";
 import { useLabels } from "../hooks/useLabels";
@@ -165,8 +165,6 @@ export const HvColorPicker = forwardRef<HTMLDivElement, HvColorPickerProps>(
       defaultSavedColorsValue,
     );
     const elementId = useUniqueId(id);
-    const hasLabel = label != null;
-    const hasDescription = description != null;
 
     const handleToggle: HvDropdownProps["onToggle"] = (_, open) => {
       setIsOpen(open);
@@ -227,26 +225,17 @@ export const HvColorPicker = forwardRef<HTMLDivElement, HvColorPickerProps>(
         required={required}
         className={cx(classes.root, className)}
       >
-        {(hasLabel || hasDescription) && (
-          <HvLabelContainer className={classes.labelContainer}>
-            {hasLabel && (
-              <HvLabel
-                id={setId(elementId, "label")}
-                label={label}
-                className={classes.label}
-              />
-            )}
-            {hasDescription && (
-              <HvInfoMessage
-                disableGutter
-                id={setId(elementId, "description")}
-                className={classes.description}
-              >
-                {description}
-              </HvInfoMessage>
-            )}
-          </HvLabelContainer>
-        )}
+        <HvLabelContainer
+          label={label}
+          description={description}
+          labelId={setId(elementId, "label")}
+          descriptionId={setId(elementId, "description")}
+          classes={{
+            root: classes.labelContainer,
+            label: classes.label,
+            description: classes.description,
+          }}
+        />
         <HvBaseDropdown
           ref={ref}
           variableWidth

--- a/packages/core/src/DatePicker/DatePicker.tsx
+++ b/packages/core/src/DatePicker/DatePicker.tsx
@@ -14,8 +14,6 @@ import {
   HvFormElement,
   HvFormElementProps,
   HvFormStatus,
-  HvInfoMessage,
-  HvLabel,
   HvWarningText,
   isInvalid,
 } from "../FormElement";
@@ -413,9 +411,6 @@ export const HvDatePicker = forwardRef<HTMLDivElement, HvDatePickerProps>(
     const dateValue = rangeMode ? { startDate, endDate } : startDate;
     const dateString = getDateLabel(dateValue, rangeMode, locale);
 
-    const hasLabel = label != null;
-    const hasDescription = description != null;
-
     // the error message area will only be created if:
     // - an external element that provides an error message isn't identified via aria-errormessage AND
     //   - both status and statusMessage properties are being controlled OR
@@ -446,26 +441,17 @@ export const HvDatePicker = forwardRef<HTMLDivElement, HvDatePickerProps>(
         readOnly={readOnly}
         {...others}
       >
-        {(hasLabel || hasDescription) && (
-          <HvLabelContainer className={classes.labelContainer}>
-            {hasLabel && (
-              <HvLabel
-                id={setId(elementId, "label")}
-                label={label}
-                className={classes.label}
-              />
-            )}
-            {hasDescription && (
-              <HvInfoMessage
-                disableGutter
-                id={setId(elementId, "description")}
-                className={classes.description}
-              >
-                {description}
-              </HvInfoMessage>
-            )}
-          </HvLabelContainer>
-        )}
+        <HvLabelContainer
+          label={label}
+          description={description}
+          labelId={setId(elementId, "label")}
+          descriptionId={setId(elementId, "description")}
+          classes={{
+            root: classes.labelContainer,
+            label: classes.label,
+            description: classes.description,
+          }}
+        />
         <HvBaseDropdown
           ref={dropdownForkedRef}
           role="combobox"

--- a/packages/core/src/Dropdown/Dropdown.tsx
+++ b/packages/core/src/Dropdown/Dropdown.tsx
@@ -10,8 +10,6 @@ import {
   HvFormElement,
   HvFormElementProps,
   HvFormStatus,
-  HvInfoMessage,
-  HvLabel,
   HvWarningText,
   isInvalid,
 } from "../FormElement";
@@ -420,9 +418,6 @@ export const HvDropdown = fixedForwardRef(function HvDropdown<
     );
   };
 
-  const hasLabel = label != null;
-  const hasDescription = description != null;
-
   // the error message area will only be created if:
   // - an external element that provides an error message isn't identified via aria-errormessage AND
   //   - both status and statusMessage properties are being controlled OR
@@ -458,26 +453,17 @@ export const HvDropdown = fixedForwardRef(function HvDropdown<
       )}
       {...others}
     >
-      {(hasLabel || hasDescription) && (
-        <HvLabelContainer className={classes.labelContainer}>
-          {hasLabel && (
-            <HvLabel
-              id={setId(elementId, "label")}
-              label={label}
-              className={classes.label}
-            />
-          )}
-          {hasDescription && (
-            <HvInfoMessage
-              disableGutter
-              id={setId(elementId, "description")}
-              className={classes.description}
-            >
-              {description}
-            </HvInfoMessage>
-          )}
-        </HvLabelContainer>
-      )}
+      <HvLabelContainer
+        label={label}
+        description={description}
+        labelId={setId(elementId, "label")}
+        descriptionId={setId(elementId, "description")}
+        classes={{
+          root: classes.labelContainer,
+          label: classes.label,
+          description: classes.description,
+        }}
+      />
       <HvBaseDropdown
         ref={dropdownForkedRef}
         id={setId(id, "dropdown")}
@@ -538,7 +524,7 @@ export const HvDropdown = fixedForwardRef(function HvDropdown<
           hasTooltips={hasTooltips}
           singleSelectionToggle={singleSelectionToggle}
           aria-label={ariaLabel}
-          aria-labelledby={hasLabel ? setId(elementId, "label") : undefined}
+          aria-labelledby={label ? setId(elementId, "label") : undefined}
           height={height}
           maxHeight={maxHeight}
           virtualized={virtualized}

--- a/packages/core/src/FileUploader/DropZone/DropZone.tsx
+++ b/packages/core/src/FileUploader/DropZone/DropZone.tsx
@@ -4,12 +4,7 @@ import {
   type ExtractNames,
 } from "@hitachivantara/uikit-react-utils";
 
-import {
-  HvFormElementContext,
-  HvFormElementProps,
-  HvInfoMessage,
-  HvLabel,
-} from "../../FormElement";
+import { HvFormElementContext, HvFormElementProps } from "../../FormElement";
 import { HvLabelContainer } from "../../FormElement/LabelContainer";
 import { useLabels } from "../../hooks/useLabels";
 import { useUniqueId } from "../../hooks/useUniqueId";
@@ -168,24 +163,30 @@ export const HvDropZone = (props: HvDropZoneProps) => {
     onFilesAdded?.(newFiles);
   };
 
+  const description = (
+    <>
+      {Number.isInteger(maxFileSize) &&
+        `${labels.sizeWarning} ${convertUnits(maxFileSize)}`}
+      {labels.acceptedFiles ||
+        (accept && `\u00A0(${accept?.replaceAll(",", ", ")})`)}
+    </>
+  );
+
   return (
     <>
       {!hideLabels && (
-        <HvLabelContainer id={id} className={classes.dropZoneLabelsGroup}>
-          <HvLabel
-            id={setId(id, "input-file-label")}
-            htmlFor={setId(id, "input-file")}
-            label={label ?? labels?.dropzone}
-            className={classes.dropZoneLabel}
-          />
-          <HvInfoMessage disableGutter id={setId(id, "description")}>
-            {Number.isInteger(maxFileSize) &&
-              `${labels?.sizeWarning} ${convertUnits(maxFileSize)}`}
-            {labels?.acceptedFiles
-              ? labels.acceptedFiles
-              : accept && `\u00A0(${accept?.replaceAll(",", ", ")})`}
-          </HvInfoMessage>
-        </HvLabelContainer>
+        <HvLabelContainer
+          id={id}
+          label={label ?? labels.dropzone}
+          description={description}
+          inputId={setId(id, "input-file")}
+          labelId={setId(id, "input-file-label")}
+          descriptionId={setId(id, "description")}
+          classes={{
+            root: classes.dropZoneLabelsGroup,
+            label: classes.dropZoneLabel,
+          }}
+        />
       )}
       <div
         id={setId(id, "input-file-container")}

--- a/packages/core/src/FilterGroup/FilterGroup.tsx
+++ b/packages/core/src/FilterGroup/FilterGroup.tsx
@@ -8,8 +8,6 @@ import {
   HvFormElement,
   HvFormElementProps,
   HvFormStatus,
-  HvInfoMessage,
-  HvLabel,
   HvWarningText,
 } from "../FormElement";
 import { HvLabelContainer } from "../FormElement/LabelContainer";
@@ -159,10 +157,6 @@ export const HvFilterGroup = forwardRef<HTMLDivElement, HvFilterGroupProps>(
 
     const labels = useLabels(DEFAULT_LABELS, labelsProp);
 
-    const hasLabel = label != null;
-
-    const hasDescription = description != null;
-
     // Error message area will only be needed if the status is being controlled
     // or if required is true
     const canShowError = status !== undefined || required;
@@ -178,28 +172,18 @@ export const HvFilterGroup = forwardRef<HTMLDivElement, HvFilterGroupProps>(
         className={cx(classes.root, className)}
         {...others}
       >
-        {(hasLabel || hasDescription) && (
-          <HvLabelContainer className={classes.labelContainer}>
-            {hasLabel && (
-              <HvLabel
-                id={setId(elementId, "label")}
-                htmlFor={setId(elementId, "input")}
-                label={label}
-                className={classes.label}
-              />
-            )}
-
-            {hasDescription && (
-              <HvInfoMessage
-                disableGutter
-                id={setId(elementId, "description")}
-                className={classes.description}
-              >
-                {description}
-              </HvInfoMessage>
-            )}
-          </HvLabelContainer>
-        )}
+        <HvLabelContainer
+          label={label}
+          description={description}
+          inputId={setId(elementId, "input")}
+          labelId={setId(elementId, "label")}
+          descriptionId={setId(elementId, "description")}
+          classes={{
+            root: classes.labelContainer,
+            label: classes.label,
+            description: classes.description,
+          }}
+        />
         <HvFilterGroupProvider
           defaultValue={defaultValue}
           value={value}

--- a/packages/core/src/FormElement/LabelContainer.tsx
+++ b/packages/core/src/FormElement/LabelContainer.tsx
@@ -5,6 +5,9 @@ import {
 } from "@hitachivantara/uikit-react-utils";
 import { theme } from "@hitachivantara/uikit-styles";
 
+import { HvInfoMessage } from "./InfoMessage/InfoMessage";
+import { HvLabel } from "./Label/Label";
+
 const { useClasses } = createClasses("HvLabelContainer", {
   root: {
     display: "flex",
@@ -13,11 +16,20 @@ const { useClasses } = createClasses("HvLabelContainer", {
     height: 24,
     marginBottom: theme.space.xxs,
   },
+  label: {},
+  description: {},
 });
 
 export interface HvLabelContainerProps
   extends React.HTMLAttributes<HTMLDivElement> {
   classes?: ExtractNames<typeof useClasses>;
+  label?: React.ReactNode;
+  description?: React.ReactNode;
+  inputId?: string;
+  labelId?: string;
+  descriptionId?: string;
+  labelProps?: React.ComponentProps<typeof HvLabel>;
+  descriptionProps?: React.ComponentProps<typeof HvInfoMessage>;
 }
 
 /**
@@ -26,11 +38,43 @@ export interface HvLabelContainerProps
  */
 export const HvLabelContainer = (props: HvLabelContainerProps) => {
   const {
-    className,
+    label,
+    description,
+    inputId,
+    labelId,
+    descriptionId,
     classes: classesProp,
+    labelProps,
+    descriptionProps,
+    children,
     ...others
   } = useDefaultProps("HvLabelContainer", props);
-  const { classes, cx } = useClasses(classesProp, false);
+  const { classes } = useClasses(classesProp, false);
 
-  return <div className={cx(classes.root, className)} {...others} />;
+  if (label == null && description == null && children == null) return null;
+
+  return (
+    <div className={classes.root} {...others}>
+      {label != null && (
+        <HvLabel
+          id={labelId}
+          className={classes.label}
+          htmlFor={inputId}
+          label={label}
+          {...labelProps}
+        />
+      )}
+      {description != null && (
+        <HvInfoMessage
+          disableGutter
+          id={descriptionId}
+          className={classes.description}
+          {...descriptionProps}
+        >
+          {description}
+        </HvInfoMessage>
+      )}
+      {children}
+    </div>
+  );
 };

--- a/packages/core/src/Input/Input.tsx
+++ b/packages/core/src/Input/Input.tsx
@@ -21,8 +21,6 @@ import {
   HvFormElement,
   HvFormElementProps,
   HvFormStatus,
-  HvInfoMessage,
-  HvLabel,
   HvWarningText,
   isInvalid,
   isValid,
@@ -389,7 +387,6 @@ export const HvInput = fixedForwardRef(function HvInput<
 
   // Miscellaneous state
   const hasLabel = label != null;
-  const hasDescription = description != null;
 
   /**
    * Looks for the node that represent the input inside the material tree and focus it.
@@ -715,28 +712,18 @@ export const HvInput = fixedForwardRef(function HvInput<
       )}
       onBlur={onContainerBlurHandler}
     >
-      {(hasLabel || hasDescription) && (
-        <HvLabelContainer className={classes.labelContainer}>
-          {hasLabel && (
-            <HvLabel
-              id={setId(elementId, "label")}
-              className={classes.label}
-              htmlFor={setId(elementId, "input")}
-              label={label}
-            />
-          )}
-
-          {hasDescription && (
-            <HvInfoMessage
-              disableGutter
-              id={setId(elementId, "description")}
-              className={classes.description}
-            >
-              {description}
-            </HvInfoMessage>
-          )}
-        </HvLabelContainer>
-      )}
+      <HvLabelContainer
+        label={label}
+        description={description}
+        inputId={setId(elementId, "input")}
+        labelId={setId(elementId, "label")}
+        descriptionId={setId(elementId, "description")}
+        classes={{
+          root: classes.labelContainer,
+          label: classes.label,
+          description: classes.description,
+        }}
+      />
       <HvBaseInput
         id={
           hasLabel || showClear || showRevealPasswordButton

--- a/packages/core/src/RadioGroup/RadioGroup.tsx
+++ b/packages/core/src/RadioGroup/RadioGroup.tsx
@@ -10,13 +10,7 @@ import {
   type ExtractNames,
 } from "@hitachivantara/uikit-react-utils";
 
-import {
-  HvFormElement,
-  HvFormStatus,
-  HvInfoMessage,
-  HvLabel,
-  HvWarningText,
-} from "../FormElement";
+import { HvFormElement, HvFormStatus, HvWarningText } from "../FormElement";
 import { HvLabelContainer } from "../FormElement/LabelContainer";
 import { useControlled } from "../hooks/useControlled";
 import { useUniqueId } from "../hooks/useUniqueId";
@@ -247,22 +241,15 @@ export const HvRadioGroup = forwardRef<HTMLDivElement, HvRadioGroupProps>(
         readOnly={readOnly}
         className={cx(classes.root, className)}
       >
-        <HvLabelContainer>
-          {label && (
-            <HvLabel
-              id={setId(elementId, "label")}
-              label={label}
-              className={classes.label}
-            />
-          )}
-
-          {description && (
-            <HvInfoMessage disableGutter id={setId(elementId, "description")}>
-              {description}
-            </HvInfoMessage>
-          )}
-        </HvLabelContainer>
-
+        <HvLabelContainer
+          label={label}
+          description={description}
+          labelId={setId(elementId, "label")}
+          descriptionId={setId(elementId, "description")}
+          classes={{
+            label: classes.label,
+          }}
+        />
         <div
           ref={ref}
           role="radiogroup"

--- a/packages/core/src/Select/Select.tsx
+++ b/packages/core/src/Select/Select.tsx
@@ -21,8 +21,6 @@ import {
   HvFormElement,
   HvFormElementProps,
   HvFormStatus,
-  HvInfoMessage,
-  HvLabel,
   HvWarningText,
 } from "../FormElement";
 import { HvLabelContainer } from "../FormElement/LabelContainer";
@@ -239,27 +237,18 @@ export const HvSelect = fixedForwardRef(function HvSelect<
       })}
       {...others}
     >
-      {(label || description) && (
-        <HvLabelContainer className={classes.labelContainer}>
-          {label && (
-            <HvLabel
-              id={labelId}
-              htmlFor={id}
-              label={label}
-              className={classes.label}
-            />
-          )}
-          {description && (
-            <HvInfoMessage
-              disableGutter
-              id={descriptionId}
-              className={classes.description}
-            >
-              {description}
-            </HvInfoMessage>
-          )}
-        </HvLabelContainer>
-      )}
+      <HvLabelContainer
+        label={label}
+        description={description}
+        inputId={id}
+        labelId={labelId}
+        descriptionId={descriptionId}
+        classes={{
+          root: classes.labelContainer,
+          label: classes.label,
+          description: classes.description,
+        }}
+      />
       <HvDropdownButton
         id={id}
         open={isOpen}

--- a/packages/core/src/Slider/Slider.tsx
+++ b/packages/core/src/Slider/Slider.tsx
@@ -13,12 +13,7 @@ import {
   type ExtractNames,
 } from "@hitachivantara/uikit-react-utils";
 
-import {
-  HvFormElement,
-  HvFormStatus,
-  HvLabel,
-  HvWarningText,
-} from "../FormElement";
+import { HvFormElement, HvFormStatus, HvWarningText } from "../FormElement";
 import { HvLabelContainer } from "../FormElement/LabelContainer";
 import { useControlled } from "../hooks/useControlled";
 import { useUniqueId } from "../hooks/useUniqueId";
@@ -237,24 +232,18 @@ export const HvSlider = forwardRef<
       // We always show an error when the value(s) are not between maxPointValue and minPointValue; and when required is true (set by user).
       status === undefined);
 
-  const isSingle: boolean = useMemo(
+  const isSingle = useMemo(
     () => isSingleSlider(valuesProp, defaultValues),
     [defaultValues, valuesProp],
   );
 
-  const value: number[] | undefined = useMemo(
-    () =>
-      valuesProp?.length > 0
-        ? knobsValuesToKnobsPositions(
-            valuesProp,
-            inverseStepValue,
-            minPointValue,
-          )
-        : undefined,
-    [inverseStepValue, minPointValue, valuesProp],
-  );
+  const value = useMemo(() => {
+    return valuesProp?.length > 0
+      ? knobsValuesToKnobsPositions(valuesProp, inverseStepValue, minPointValue)
+      : undefined;
+  }, [inverseStepValue, minPointValue, valuesProp]);
 
-  const defaultKnobsPositions: number[] = useMemo(
+  const defaultKnobsPositions = useMemo(
     () =>
       knobsValuesToKnobsPositions(
         defaultValues,
@@ -605,38 +594,33 @@ export const HvSlider = forwardRef<
       onBlur={onBlurHandler}
       {...others}
     >
-      {(hasLabel || !hideInput) && (
-        <HvLabelContainer
-          className={cx(classes.labelContainer, {
+      <HvLabelContainer
+        label={label}
+        inputId={sliderInputId}
+        labelId={setId(elementId, "label")}
+        descriptionId={setId(elementId, "description")}
+        classes={{
+          root: cx(classes.labelContainer, {
             [classes.labelIncluded]: hasLabel,
             [classes.onlyInput]: !hasLabel,
-          })}
-        >
-          {hasLabel && (
-            <HvLabel
-              id={setId(elementId, "label")}
-              className={classes.label}
-              htmlFor={sliderInputId}
-              label={label}
-            />
-          )}
-
-          {!hideInput && (
-            <HvSliderInput
-              id={sliderInputId}
-              label={label}
-              values={knobsValues}
-              onChange={onInputChangeHandler}
-              status={validationStatus}
-              disabled={disabled}
-              readOnly={readOnly}
-              markDigits={markDigits}
-              inputProps={inputProps}
-            />
-          )}
-        </HvLabelContainer>
-      )}
-
+          }),
+          label: classes.label,
+        }}
+      >
+        {!hideInput && (
+          <HvSliderInput
+            id={sliderInputId}
+            label={label}
+            values={knobsValues}
+            onChange={onInputChangeHandler}
+            status={validationStatus}
+            disabled={disabled}
+            readOnly={readOnly}
+            markDigits={markDigits}
+            inputProps={inputProps}
+          />
+        )}
+      </HvLabelContainer>
       <div className={cx(classes.sliderBase, classes.sliderContainer)}>
         <Slider
           ref={ref}

--- a/packages/core/src/TagsInput/TagsInput.tsx
+++ b/packages/core/src/TagsInput/TagsInput.tsx
@@ -19,8 +19,6 @@ import {
   HvFormElement,
   HvFormElementProps,
   HvFormStatus,
-  HvInfoMessage,
-  HvLabel,
   HvWarningText,
 } from "../FormElement";
 import { HvLabelContainer } from "../FormElement/LabelContainer";
@@ -113,7 +111,7 @@ export const HvTagsInput = forwardRef<HTMLElement, HvTagsInputProps>(
       readOnly,
       disabled,
       required,
-      label: textAreaLabel,
+      label,
       "aria-label": ariaLabel,
       "aria-labelledby": ariaLabelledBy,
       description,
@@ -146,9 +144,6 @@ export const HvTagsInput = forwardRef<HTMLElement, HvTagsInputProps>(
     const { classes, cx } = useClasses(classesProp);
 
     const elementId = useUniqueId(id);
-
-    const hasLabel = textAreaLabel != null;
-    const hasDescription = description != null;
 
     const [value, setValue] = useControlled(valueProp, defaultValue);
 
@@ -486,40 +481,29 @@ export const HvTagsInput = forwardRef<HTMLElement, HvTagsInputProps>(
           className,
         )}
       >
-        {(hasLabel || hasDescription) && (
-          <HvLabelContainer className={classes.labelContainer}>
-            {hasLabel && (
-              <HvLabel
-                className={classes.label}
-                id={setId(id, "label")}
-                htmlFor={setId(elementId, "input")}
-                label={textAreaLabel}
-              />
-            )}
-
-            {hasDescription && (
-              <HvInfoMessage
-                disableGutter
-                className={classes.description}
-                id={setId(elementId, "description")}
-              >
-                {description}
-              </HvInfoMessage>
-            )}
-          </HvLabelContainer>
-        )}
-
-        {hasCounter && (
-          <HvCharCounter
-            id={setId(elementId, "charCounter")}
-            className={classes.characterCounter}
-            separator={middleCountLabel}
-            currentCharQuantity={value.length}
-            maxCharQuantity={maxTagsQuantity}
-            {...countCharProps}
-          />
-        )}
-
+        <HvLabelContainer
+          label={label}
+          description={description}
+          inputId={setId(elementId, "input")}
+          labelId={setId(elementId, "label")}
+          descriptionId={setId(elementId, "description")}
+          classes={{
+            root: classes.labelContainer,
+            label: classes.label,
+            description: classes.description,
+          }}
+        >
+          {hasCounter && (
+            <HvCharCounter
+              id={setId(elementId, "charCounter")}
+              className={classes.characterCounter}
+              separator={middleCountLabel}
+              currentCharQuantity={value.length}
+              maxCharQuantity={maxTagsQuantity}
+              {...countCharProps}
+            />
+          )}
+        </HvLabelContainer>
         {/* eslint-disable jsx-a11y/no-static-element-interactions */}
         <div
           ref={forkedContainerRef}

--- a/packages/core/src/TextArea/TextArea.tsx
+++ b/packages/core/src/TextArea/TextArea.tsx
@@ -27,8 +27,6 @@ import {
   HvFormElement,
   HvFormElementProps,
   HvFormStatus,
-  HvInfoMessage,
-  HvLabel,
   HvWarningText,
   isInvalid,
 } from "../FormElement";
@@ -233,9 +231,6 @@ export const HvTextArea = forwardRef<
   const isEmptyValue = value == null || value === "";
 
   const hasLabel = label != null;
-
-  const hasDescription = description != null;
-
   const hasCounter = maxCharQuantity != null && !hideCounter;
 
   // ValidationMessages reference tends to change, as users will not memorize/useState for it;
@@ -426,38 +421,29 @@ export const HvTextArea = forwardRef<
       )}
       onBlur={onContainerBlurHandler}
     >
-      {(hasLabel || hasDescription || hasCounter) && (
-        <HvLabelContainer className={classes.labelContainer}>
-          {hasLabel && (
-            <HvLabel
-              className={classes.label}
-              id={setId(id, "label")}
-              htmlFor={setId(elementId, "input")}
-              label={label}
-            />
-          )}
-          {hasDescription && (
-            <HvInfoMessage
-              disableGutter
-              className={classes.description}
-              id={setId(elementId, "description")}
-            >
-              {description}
-            </HvInfoMessage>
-          )}
-          {hasCounter && (
-            <HvCharCounter
-              id={setId(elementId, "charCounter")}
-              className={classes.characterCounter}
-              separator={middleCountLabel}
-              currentCharQuantity={String(value).length}
-              maxCharQuantity={maxCharQuantity}
-              {...countCharProps}
-            />
-          )}
-        </HvLabelContainer>
-      )}
-
+      <HvLabelContainer
+        label={label}
+        description={description}
+        inputId={setId(elementId, "input")}
+        labelId={setId(elementId, "label")}
+        descriptionId={setId(elementId, "description")}
+        classes={{
+          root: classes.labelContainer,
+          label: classes.label,
+          description: classes.description,
+        }}
+      >
+        {hasCounter && (
+          <HvCharCounter
+            id={setId(elementId, "charCounter")}
+            className={classes.characterCounter}
+            separator={middleCountLabel}
+            currentCharQuantity={String(value).length}
+            maxCharQuantity={maxCharQuantity}
+            {...countCharProps}
+          />
+        )}
+      </HvLabelContainer>
       <HvBaseInput
         classes={{
           root: classes.baseInput,

--- a/packages/core/src/TimePicker/TimePicker.tsx
+++ b/packages/core/src/TimePicker/TimePicker.tsx
@@ -17,8 +17,6 @@ import {
   HvFormElement,
   HvFormElementProps,
   HvFormStatus,
-  HvInfoMessage,
-  HvLabel,
   HvWarningText,
 } from "../FormElement";
 import { HvLabelContainer } from "../FormElement/LabelContainer";
@@ -235,27 +233,17 @@ export const HvTimePicker = forwardRef<HTMLDivElement, HvTimePickerProps>(
         className={cx(classes.root, className)}
         {...others}
       >
-        {(label || description) && (
-          <HvLabelContainer className={classes.labelContainer}>
-            {label && (
-              <HvLabel
-                label={label}
-                className={classes.label}
-                {...labelProps}
-              />
-            )}
-            {description && (
-              <HvInfoMessage
-                disableGutter
-                className={classes.description}
-                {...descriptionProps}
-              >
-                {description}
-              </HvInfoMessage>
-            )}
-          </HvLabelContainer>
-        )}
-
+        <HvLabelContainer
+          label={label}
+          description={description}
+          classes={{
+            root: classes.labelContainer,
+            label: classes.label,
+            description: classes.description,
+          }}
+          labelProps={labelProps}
+          descriptionProps={descriptionProps}
+        />
         <HvBaseDropdown
           ref={dropdownForkedRef}
           role="combobox"


### PR DESCRIPTION
Change `HvLabelContainer` API so it's more strict, fixing inconsistencies between form components, such as
- `labelContainer` always shown (even if empty)
- `label == null` vs `label === ""` behaviour