### PR TITLE
fix(Button): icon shrinking

### DIFF
--- a/packages/core/src/Button/Button.styles.ts
+++ b/packages/core/src/Button/Button.styles.ts
@@ -66,6 +66,7 @@ export const { staticClasses, useClasses } = createClasses("HvButton", {
   icon: {
     margin: 0,
     padding: 0,
+    flexShrink: 0,
     width: "var(--HvButton-height, fit-content)",
   },
   /** applied to the root element when using the `contained` variant */


### PR DESCRIPTION
changes it so `icon`-only buttons don't shrink (when there's lack of available "flex space")
![image](https://github.com/user-attachments/assets/7a4f9d36-0e63-43a3-86a4-65aa548de0e4)
![image](https://github.com/user-attachments/assets/bb653618-770c-4b44-b447-188b4e74a8ea)
