### PR TITLE
fix(Card): semantic card overrides

### DIFF
--- a/packages/core/src/Card/Card.styles.tsx
+++ b/packages/core/src/Card/Card.styles.tsx
@@ -8,7 +8,9 @@ export const { staticClasses, useClasses } = createClasses("HvCard", {
     overflow: "visible",
     position: "relative",
     outline: `1px solid ${theme.colors.border}`,
-    borderRadius: `0px 0px ${theme.radii.round} ${theme.radii.round}`,
+    "--rt": 0,
+    "--rb": theme.radii.round,
+    borderRadius: `var(--rt) var(--rt) var(--rb) var(--rb)`,
     backgroundColor: "var(--bg-color)",
     "&:focus-visible": {
       ...outlineStyles,
@@ -39,8 +41,8 @@ export const { staticClasses, useClasses } = createClasses("HvCard", {
     right: theme.space.xs,
   },
   semanticBar: {
-    backgroundColor: "var(--bar-color)",
-    height: "var(--bar-height)",
+    backgroundColor: `var(--bar-color, ${theme.colors.border})`,
+    height: "var(--bar-height, 2px)",
     width: "100%",
     top: -1,
     right: 0,

--- a/packages/core/src/Card/Card.tsx
+++ b/packages/core/src/Card/Card.tsx
@@ -22,10 +22,7 @@ export interface HvCardProps extends HvBaseProps {
   selected?: boolean;
   /** The background color of the card. */
   bgcolor?: "sema0" | HvColorAny;
-  /**
-   *  The border color at the top of the card. Must be one of palette semantic or atmosphere colors.
-   *  To set another color, the borderTop should be override.
-   */
+  /** The border color at the top of the card. */
   statusColor?: "sema0" | HvColorAny;
   /** A Jss Object used to override or extend the styles applied to the component. */
   classes?: HvCardClasses;
@@ -48,28 +45,28 @@ export const HvCard = forwardRef<
     className,
     children,
     icon,
-    selectable = false,
-    selected = false,
+    selectable,
+    selected,
     statusColor = "sema0",
     bgcolor,
     ...others
   } = useDefaultProps("HvCard", props);
-
   const { classes, cx } = useClasses(classesProp);
 
   const barColor =
     (statusColor !== "sema0" && statusColor) ||
     (selected && "text") ||
-    "border";
+    undefined;
 
   return (
     <div
       ref={ref}
       style={mergeStyles(style, {
         "--bg-color": getColor(bgcolor),
-        "--bar-height": `${selected ? 4 : 2}px`,
+        "--bar-height": selected && "4px",
         "--bar-color": getColor(barColor),
       })}
+      data-color={statusColor}
       className={cx(
         "HvIsCardGridElement",
         classes.root,

--- a/packages/core/src/Card/Header/Header.styles.tsx
+++ b/packages/core/src/Card/Header/Header.styles.tsx
@@ -5,6 +5,7 @@ export const { staticClasses, useClasses } = createClasses("HvCardHeader", {
   root: {
     position: "relative",
     padding: theme.spacing("12px", "xs", "sm", "sm"),
+    gap: theme.space.xs,
   },
   titleShort: {
     ...theme.typography.label,
@@ -21,6 +22,5 @@ export const { staticClasses, useClasses } = createClasses("HvCardHeader", {
   content: {},
   action: {
     margin: 0,
-    paddingLeft: theme.space.xs,
   },
 });

--- a/packages/core/src/Card/stories/KPICards.tsx
+++ b/packages/core/src/Card/stories/KPICards.tsx
@@ -1,15 +1,11 @@
 import { useState } from "react";
-import { css } from "@emotion/css";
-import { Grid } from "@mui/material";
 import {
   HvActionBar,
   HvCard,
   HvCardContent,
   HvCardHeader,
   HvCheckBox,
-  HvKpi,
   HvTypography,
-  theme,
 } from "@hitachivantara/uikit-react-core";
 import {
   Level1,
@@ -26,24 +22,6 @@ const data = {
     "Shaft may be bent, check for bends. Straighten if possible and replace shaft if necessary.",
 };
 
-const classes = {
-  grid: css({
-    paddingTop: theme.space.sm,
-    paddingRight: 0,
-    paddingBottom: theme.space.sm,
-    paddingLeft: 0,
-  }),
-  card: css({
-    margin: theme.space.sm,
-    backgroundColor: theme.colors.bgContainer,
-  }),
-};
-
-const getKpiLabels = (score: string) => ({
-  title: "Confidence score",
-  indicator: `${score}%`,
-});
-
 const CardContent = ({
   value,
   icon,
@@ -51,22 +29,22 @@ const CardContent = ({
   value: string;
   icon: React.ReactNode;
 }) => (
-  <HvCardContent>
-    <Grid container>
-      <HvKpi labels={getKpiLabels(value)} visualIndicator={icon} />
-    </Grid>
-    <Grid container>
-      <Grid className={classes.grid} item xs={4} sm={8} md={12} lg={12} xl={12}>
-        <HvTypography variant="label">{data.firstTitle}</HvTypography>
-        <HvTypography>{data.firstContent}</HvTypography>
-      </Grid>
-    </Grid>
-    <Grid container>
-      <Grid item xs={4} sm={8} md={12} lg={12} xl={12}>
-        <HvTypography variant="label">{data.secondTitle}</HvTypography>
-        <HvTypography>{data.secondContent}</HvTypography>
-      </Grid>
-    </Grid>
+  <HvCardContent className="grid gap-sm">
+    <div>
+      <HvTypography variant="label">Confidence score</HvTypography>
+      <div className="flex items-center gap-xs">
+        <span>{icon}</span>
+        <HvTypography variant="title1">{value}%</HvTypography>
+      </div>
+    </div>
+    <div>
+      <HvTypography variant="label">{data.firstTitle}</HvTypography>
+      <HvTypography>{data.firstContent}</HvTypography>
+    </div>
+    <div>
+      <HvTypography variant="label">{data.secondTitle}</HvTypography>
+      <HvTypography>{data.secondContent}</HvTypography>
+    </div>
   </HvCardContent>
 );
 
@@ -88,51 +66,37 @@ export const KPICards = () => {
   );
 
   return (
-    <Grid container role="grid" aria-label="Select one card">
-      <Grid container role="row">
-        <Grid item xs={12} md={4}>
-          <HvCard
-            className={classes.card}
-            statusColor="info"
-            selectable
-            selected={checked === 1}
-            role="gridcell"
-            aria-selected={checked === 1}
-          >
-            <HvCardHeader title="Replace contaminated oil" icon={<Tool />} />
-            <CardContent value="85" icon={<Level1 color="info" />} />
-            {renderFooter({ n: 1, value: "85" })}
-          </HvCard>
-        </Grid>
-        <Grid item xs={12} md={4}>
-          <HvCard
-            className={classes.card}
-            statusColor="warning"
-            selectable
-            selected={checked === 2}
-            role="gridcell"
-            aria-selected={checked === 2}
-          >
-            <HvCardHeader title="Replace contaminated oil" icon={<Tool />} />
-            <CardContent value="45" icon={<Level2Average color="warning" />} />
-            {renderFooter({ n: 2, value: "84" })}
-          </HvCard>
-        </Grid>
-        <Grid item xs={12} md={4}>
-          <HvCard
-            className={classes.card}
-            statusColor="negative"
-            selectable
-            selected={checked === 3}
-            role="gridcell"
-            aria-selected={checked === 3}
-          >
-            <HvCardHeader title="Replace contaminated oil" icon={<Tool />} />
-            <CardContent value="19" icon={<Level3Bad color="negative" />} />
-            {renderFooter({ n: 3, value: "19" })}
-          </HvCard>
-        </Grid>
-      </Grid>
-    </Grid>
+    <div className="grid gap-sm grid-cols-1 sm:grid-cols-2 md:grid-cols-3">
+      <HvCard
+        bgcolor="bgContainer"
+        statusColor="info"
+        selectable
+        selected={checked === 1}
+      >
+        <HvCardHeader title="Replace contaminated oil" icon={<Tool />} />
+        <CardContent value="85" icon={<Level1 color="info" />} />
+        {renderFooter({ n: 1, value: "85" })}
+      </HvCard>
+      <HvCard
+        bgcolor="bgContainer"
+        statusColor="warning"
+        selectable
+        selected={checked === 2}
+      >
+        <HvCardHeader title="Replace contaminated oil" icon={<Tool />} />
+        <CardContent value="45" icon={<Level2Average color="warning" />} />
+        {renderFooter({ n: 2, value: "84" })}
+      </HvCard>
+      <HvCard
+        bgcolor="bgContainer"
+        statusColor="negative"
+        selectable
+        selected={checked === 3}
+      >
+        <HvCardHeader title="Replace contaminated oil" icon={<Tool />} />
+        <CardContent value="19" icon={<Level3Bad color="negative" />} />
+        {renderFooter({ n: 3, value: "19" })}
+      </HvCard>
+    </div>
   );
 };

--- a/packages/core/src/Card/stories/Variants.tsx
+++ b/packages/core/src/Card/stories/Variants.tsx
@@ -1,4 +1,3 @@
-import { css } from "@emotion/css";
 import {
   HvActionBar,
   HvButton,
@@ -7,7 +6,6 @@ import {
   HvCardHeader,
   HvCardMedia,
   HvTypography,
-  theme,
 } from "@hitachivantara/uikit-react-core";
 import {
   Level0Good,
@@ -16,52 +14,18 @@ import {
   WorldGlobe,
 } from "@hitachivantara/uikit-react-icons";
 
-const classes = {
-  root: css({
-    display: "flex",
-    gap: theme.space.sm,
-    flexWrap: "wrap",
-  }),
-  card: css({
-    width: 380,
-  }),
-  header: css({
-    display: "flex",
-    alignItems: "center",
-    justifyContent: "space-between",
-  }),
-  subheader: css({
-    display: "flex",
-    alignItems: "center",
-    "& > div": {
-      width: 16,
-      height: 16,
-    },
-  }),
-  content: css({
-    padding: theme.space.xs,
-    display: "flex",
-    alignItems: "center",
-    justifyContent: "center",
-    backgroundColor: theme.colors.bgPage,
-    borderRadius: theme.radii.round,
-  }),
-  actions: css({
-    display: "flex",
-    justifyContent: "space-between",
-    width: "100%",
-  }),
-  sideActions: css({
-    display: "flex",
-    gap: theme.space.xs,
-  }),
-};
+const subheader = (
+  <div className="flex items-center">
+    <LocationPin size="XS" style={{ width: 16, height: 16 }} />
+    <HvTypography variant="caption2">Portugal</HvTypography>
+  </div>
+);
 
 export const Variants = () => {
   return (
-    <div className={classes.root}>
+    <div className="flex flex-wrap gap-sm">
       <HvCard
-        className={classes.card}
+        className="flex flex-col w-380px"
         bgcolor="bgContainer"
         statusColor="positive"
         icon={<Level0Good iconSize="S" color="positive" />}
@@ -82,7 +46,7 @@ export const Variants = () => {
       </HvCard>
 
       <HvCard
-        className={classes.card}
+        className="flex flex-col items-stretch h-fit w-380px"
         bgcolor="bgContainer"
         statusColor="negative"
         icon={<Level3Bad color="negative" />}
@@ -91,14 +55,10 @@ export const Variants = () => {
           title={
             <HvTypography variant="title4">The island of Madeira</HvTypography>
           }
-          subheader={
-            <div className={classes.subheader}>
-              <LocationPin iconSize="XS" />
-              <HvTypography variant="caption2">Portugal</HvTypography>
-            </div>
-          }
+          subheader={subheader}
         />
         <HvCardMedia
+          className="rounded-b-inherit"
           component="img"
           alt="Nature"
           height={140}
@@ -106,32 +66,18 @@ export const Variants = () => {
         />
       </HvCard>
 
-      <HvCard
-        className={classes.card}
-        bgcolor="bgContainer"
-        statusColor="warning"
-      >
+      <HvCard className="flex flex-col w-380px">
         <HvCardHeader
           title="The island of Madeira"
-          subheader={
-            <div className={classes.subheader}>
-              <LocationPin iconSize="XS" />
-              <HvTypography variant="caption2">Portugal</HvTypography>
-            </div>
-          }
+          subheader={subheader}
           icon={<WorldGlobe />}
         />
       </HvCard>
 
-      <HvCard className={classes.card} bgcolor="bgContainer" statusColor="info">
+      <HvCard className="flex flex-col w-380px" bgcolor="bgContainer">
         <HvCardHeader
           title="The island of Madeira"
-          subheader={
-            <div className={classes.subheader}>
-              <LocationPin iconSize="XS" />
-              <HvTypography variant="caption2">Portugal</HvTypography>
-            </div>
-          }
+          subheader={subheader}
           icon={<WorldGlobe />}
         />
         <HvCardContent>
@@ -143,33 +89,29 @@ export const Variants = () => {
         </HvCardContent>
       </HvCard>
 
-      <HvCard className={classes.card} bgcolor="bgContainer" statusColor="cat1">
+      <HvCard
+        className="flex flex-col w-380px"
+        bgcolor="bgContainer"
+        statusColor="cat1"
+      >
         <HvCardHeader
           title={
-            <div className={classes.header}>
-              <HvTypography variant="title4">
-                The island of Madeira
-              </HvTypography>
-            </div>
+            <HvTypography variant="title4">The island of Madeira</HvTypography>
           }
-          subheader={
-            <div className={classes.subheader}>
-              <LocationPin iconSize="XS" />
-              <HvTypography variant="caption2">Portugal</HvTypography>
-            </div>
-          }
+          subheader={subheader}
           icon={<WorldGlobe />}
         />
-
-        <HvActionBar>
-          <div className={classes.actions}>
-            <HvButton variant="secondaryGhost">Add to Wishlist</HvButton>
-            <HvButton variant="secondarySubtle">Book Now</HvButton>
-          </div>
+        <HvActionBar className="justify-between mt-auto">
+          <HvButton variant="secondaryGhost">Add to Wishlist</HvButton>
+          <HvButton variant="secondarySubtle">Book Now</HvButton>
         </HvActionBar>
       </HvCard>
 
-      <HvCard className={classes.card} bgcolor="bgContainer" statusColor="cat2">
+      <HvCard
+        className="flex flex-col w-380px"
+        bgcolor="bgContainer"
+        statusColor="cat2"
+      >
         <HvCardContent>
           <HvTypography>
             Madeira is a stunning Portuguese archipelago known for its lush
@@ -177,11 +119,9 @@ export const Variants = () => {
             Atlantic Ocean.
           </HvTypography>
         </HvCardContent>
-        <HvActionBar className={classes.actions}>
-          <div className={classes.actions}>
-            <HvButton variant="secondaryGhost">Add to Wishlist</HvButton>
-            <HvButton variant="secondarySubtle">Book Now</HvButton>
-          </div>
+        <HvActionBar className="justify-between mt-auto">
+          <HvButton variant="secondaryGhost">Add to Wishlist</HvButton>
+          <HvButton variant="secondarySubtle">Book Now</HvButton>
         </HvActionBar>
       </HvCard>
     </div>

--- a/packages/core/src/Skeleton/Skeleton.stories.tsx
+++ b/packages/core/src/Skeleton/Skeleton.stories.tsx
@@ -111,7 +111,6 @@ export const Card: StoryObj<HvSkeletonProps> = {
               bgcolor="bgContainer"
               key={`card-${i}`}
               style={{ width: "100%" }}
-              statusColor="sema0"
             >
               <HvCardHeader
                 title={

--- a/packages/styles/src/themes/pentahoPlus.ts
+++ b/packages/styles/src/themes/pentahoPlus.ts
@@ -965,10 +965,17 @@ const pentahoPlus = makeTheme((theme) => ({
     HvCard: {
       classes: {
         root: {
-          outline: `1px solid ${theme.colors.borderSubtle}`,
-          overflow: "hidden",
-          height: "fit-content",
-          borderRadius: theme.radii.large,
+          outlineColor: theme.colors.borderSubtle,
+          "--rb": theme.radii.large,
+          // default non-semantic card
+          "&[data-color=sema0]": {
+            overflow: "hidden",
+            height: "fit-content",
+            "--rt": theme.radii.large,
+            "& .HvCard-semanticContainer": {
+              display: "none",
+            },
+          },
           "& > :last-child:not(.HvCardMedia-root)": {
             paddingBottom: theme.space.sm,
           },
@@ -979,15 +986,16 @@ const pentahoPlus = makeTheme((theme) => ({
         },
         selectable: {
           ":hover": {
-            outline: `1px solid ${theme.colors.primary_20}`,
+            outlineColor: theme.colors.bgHover,
             backgroundColor: theme.colors.primaryDimmed,
           },
         },
-        semanticContainer: {
-          display: "none",
-        },
         selected: {
-          outline: `1px solid ${theme.colors.primaryDeep}`,
+          outlineColor: theme.colors.primaryDeep,
+        },
+        semanticBar: {
+          "--bar-height": "2px",
+          borderRadius: `${theme.radii.base} ${theme.radii.base} 0 0`,
         },
       },
     },
@@ -995,17 +1003,15 @@ const pentahoPlus = makeTheme((theme) => ({
       classes: {
         root: {
           flexDirection: "row-reverse",
-          padding: `${theme.space.xs} ${theme.space.sm}`,
-        },
-        action: {
-          paddingLeft: 0,
+          padding: theme.spacing("xs", "sm"),
+          gap: 0,
         },
       },
     },
     HvCardContent: {
       classes: {
         content: {
-          padding: `${theme.space.xs} ${theme.space.sm}`,
+          padding: theme.spacing("xs", "sm"),
           "&:last-child": {
             paddingBottom: theme.space.xs,
           },

--- a/templates/AssetInventory/CardView.tsx
+++ b/templates/AssetInventory/CardView.tsx
@@ -48,8 +48,8 @@ export const CardView = ({ id, instance, loading }: CardViewProps) => {
       ]}
     >
       {items.map((item) => {
-        const rowId = item ? item.id : null;
-        const statusColor = item ? item.statusColor : "sema0";
+        const rowId = item?.id;
+        const statusColor = item?.statusColor;
 
         return (
           <HvCard


### PR DESCRIPTION
- revert P+ Cards to be "KPI-like" when a semantic variant (`statusColor`) is chosen
  - show top semantic border/icon & review radius
- optimize CSS vars usage, only adding overrides when non-default values are set
- improve docs samples

![image](https://github.com/user-attachments/assets/85a8dcb0-1141-4ac0-a72d-03a76f93e118) ![image](https://github.com/user-attachments/assets/721f5d0e-3049-4f28-b3a9-c646e64d837d)

