### PR TITLE
docs: fix broken links

### DIFF
--- a/packages/core/src/Table/stories/TableHooks/TableHooks.mdx
+++ b/packages/core/src/Table/stories/TableHooks/TableHooks.mdx
@@ -28,14 +28,14 @@ The following plugin hooks are available:
 - `useHvTableStyles`: Ensures the correct styling of the table by injecting the column's `variant` and `align` options into the `HvTableHeader` and
   `HvTableCell` components (via `getHeaderProps` and `getCellProps`, respectively). Also adds support for injecting the `styles`, `className` and
   `classes` into the `HvTable`, `HvTableHeader`, and `HvTableCell` components.
-- `useHvPagination`: Eases the wiring of the `HvPagination` component when using pagination. [See pagination](./?path=/docs/visualizations-table-table-hooks-usehvpagination).
-- `useHvRowSelection`: Creates and manages the UI for selecting rows. [See selection](./?path=/docs/visualizations-table-table-hooks-usehvrowselection).
-- `useHvBulkActions`: Eases the wiring of the `HvBulkActions` component. [See bulk selection and actions](./?path=/docs/visualizations-table-table-hooks-usehvbulkactions).
-- `useHvSortBy`: Manages the table's header sorting functionality. [See sorting](./?path=/docs/visualizations-table-table-hooks-usehvsortby).
-- `useHvRowExpand`: Manages the row expanding functionality. [See row expanding](./?path=/docs/visualizations-table-table-hooks-usehvrowexpand).
-- `useHvGroupBy`: Allows defining header groups. [See selection](./?path=/docs/visualizations-table-table-hooks-usehvgroupby).
-- `useHvTableSticky`: Allows defining sticky headers and columns. [See sticky headers and columns](./?path=/docs/visualizations-table-table-hooks-usehvtablesticky).
-- `useHvHeaderGroups`: Allows defining grouped headers. [See grouped headers](./?path=/docs/visualizations-table-table-hooks-usehvheadergroups).
+- `useHvPagination`: Eases the wiring of the `HvPagination` component when using pagination. [See pagination](./?path=/docs/visualizations-table-table-hooks--usehvpagination).
+- `useHvRowSelection`: Creates and manages the UI for selecting rows. [See selection](./?path=/docs/visualizations-table-table-hooks--usehvrowselection).
+- `useHvBulkActions`: Eases the wiring of the `HvBulkActions` component. [See bulk selection and actions](./?path=/docs/visualizations-table-table-hooks--usehvbulkactions).
+- `useHvSortBy`: Manages the table's header sorting functionality. [See sorting](./?path=/docs/visualizations-table-table-hooks--usehvsortby).
+- `useHvRowExpand`: Manages the row expanding functionality. [See row expanding](./?path=/docs/visualizations-table-table-hooks--usehvrowexpand).
+- `useHvGroupBy`: Allows defining header groups. [See selection](./?path=/docs/visualizations-table-table-hooks--usehvgroupby).
+- `useHvTableSticky`: Allows defining sticky headers and columns. [See sticky headers and columns](./?path=/docs/visualizations-table-table-hooks--usehvtablesticky).
+- `useHvHeaderGroups`: Allows defining grouped headers. [See grouped headers](./?path=/docs/visualizations-table-table-hooks--usehvheadergroups).
 - `useHvRowState`: Implements basic state management for prepared rows and their cells. [See row state management](./?path=/docs/visualizations-table-table-hooks--usehvrowstate)
 
 <Canvas of={TableHooksStories.UseHvHooksStory} />


### PR DESCRIPTION
I found some links in table hook links that were not working properly. I couldn't launch the storybook locally due to an error (`SB_CORE-SERVER_0005 (MainFileESMOnlyImportError): Storybook failed to load .storybook/main.ts`) to verify the fix but it should be it.