### PR TITLE
fix(app-shell): packages export extension

### DIFF
--- a/.config/vite.config.ts
+++ b/.config/vite.config.ts
@@ -23,7 +23,10 @@ const esmOutput: OutputOptions = {
   preserveModules: true,
   dir: "dist/esm",
   // keep react-based packages as `.js` for backwards compatibility
-  entryFileNames: pkg.name.includes("react") ? "[name].js" : "[name].mjs",
+  entryFileNames:
+    pkg.name.includes("react") || pkg.name.includes("app-shell")
+      ? "[name].js"
+      : "[name].mjs",
   exports: "named",
   interop: "auto",
 };


### PR DESCRIPTION
app-shell packages are generating `.mjs` file extensions, instead `.js`