### PR TITLE
chore(release): remove old args & bump lerna

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -6,9 +6,6 @@
   "distTag": "latest",
   "preDistTag": "next",
   "command": {
-    "publish": {
-      "npmClientArgs": ["--legacy-peer-deps", "--production=false"]
-    },
     "version": {
       "preid": "next",
       "message": "chore(release): publish",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1410,13 +1410,13 @@
       }
     },
     "node_modules/@emnapi/core": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.3.1.tgz",
-      "integrity": "sha512-pVGjBIt1Y6gg3EJN8jTcfpP/+uuRksIo055oE/OBkDNcjZqVbfkWCksG1Jp4yZnj3iKWyWX8fdG/j6UDYPbFog==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.4.3.tgz",
+      "integrity": "sha512-4m62DuCE07lw01soJwPiBGC0nAww0Q+RY70VZ+n49yDIO13yyinhbWCeNnaob0lakDtWQzSdtNWzJeOJt2ma+g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@emnapi/wasi-threads": "1.0.1",
+        "@emnapi/wasi-threads": "1.0.2",
         "tslib": "^2.4.0"
       }
     },
@@ -1431,9 +1431,9 @@
       }
     },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.0.1.tgz",
-      "integrity": "sha512-iIBu7mwkq4UQGeMEM8bLwNK962nXdhodeScX4slfQnRhEMMzvYivHhutCIk8uojvmASXXPC2WNEjwxFWk72Oqw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.0.2.tgz",
+      "integrity": "sha512-5n3nTJblwRi8LlXkJ9eBzu+kZR8Yxcc7ubakyQTFzPMtIhFpUBRbsnc2Dv88IZDIbCDlBiWrknhB4Lsz7mg6BA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3683,9 +3683,9 @@
       }
     },
     "node_modules/@lerna/create": {
-      "version": "8.2.1",
-      "resolved": "https://registry.npmjs.org/@lerna/create/-/create-8.2.1.tgz",
-      "integrity": "sha512-Cz2u/fwc03D1EE6VFZCLMmI8FIUtGmxHQ3ECeNblsxv9i0YSKWe4Xm18sjO1xltG/K5ByiH8/HMeY9dlyAv22A==",
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/@lerna/create/-/create-8.2.2.tgz",
+      "integrity": "sha512-1yn1MvWn2Yz0SFgTTQnef2m1YedF7KwqLLVIOrGkgQrkVHzsveAIk1A1RcRa2yyUh+siKI1YcJ7lUZIEt+qQ3Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5315,9 +5315,9 @@
       }
     },
     "node_modules/@nx/devkit": {
-      "version": "20.5.0",
-      "resolved": "https://registry.npmjs.org/@nx/devkit/-/devkit-20.5.0.tgz",
-      "integrity": "sha512-FLHjNRb6VImdlnDsp3ioIdM600y2xPvN88LFV9zPrG2hDXSaD9Np9YBZvvfCr4x46MrPCTTMoAVwWsCXIBgchg==",
+      "version": "20.8.1",
+      "resolved": "https://registry.npmjs.org/@nx/devkit/-/devkit-20.8.1.tgz",
+      "integrity": "sha512-N3nwIg/7RIZeB76iuVo29q+l9WyTtvuBSgDFM2msiIK6Q928ilzoeNPZ/p7w/TE3Gqs5XVhq9ExMvDAOTxdmXA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5361,9 +5361,9 @@
       }
     },
     "node_modules/@nx/nx-darwin-arm64": {
-      "version": "20.5.0",
-      "resolved": "https://registry.npmjs.org/@nx/nx-darwin-arm64/-/nx-darwin-arm64-20.5.0.tgz",
-      "integrity": "sha512-HlMMC4d253kk/yrafiepk8bhXMl+v4BIugftwUzRl7AOznyNgaj5WDaIVXZLZzt+WwYw6CTb+zYxfY4LuPFvOg==",
+      "version": "20.8.1",
+      "resolved": "https://registry.npmjs.org/@nx/nx-darwin-arm64/-/nx-darwin-arm64-20.8.1.tgz",
+      "integrity": "sha512-Gat4Io66cV70Oa1CjrMJPsEx5ICpAGayv9hejOtBUEDb6XjR12L2e4wV+4EHliF0UbEcuZAr8/lTROEPk0RGWQ==",
       "cpu": [
         "arm64"
       ],
@@ -5378,9 +5378,9 @@
       }
     },
     "node_modules/@nx/nx-darwin-x64": {
-      "version": "20.5.0",
-      "resolved": "https://registry.npmjs.org/@nx/nx-darwin-x64/-/nx-darwin-x64-20.5.0.tgz",
-      "integrity": "sha512-+LO8YC5Iy1168saPeItNePChToP2TuRCj3MuxEtTTJXoRlab38rNaOjWaV1itvtcgrzkQi/IohINWMI8WC5b7g==",
+      "version": "20.8.1",
+      "resolved": "https://registry.npmjs.org/@nx/nx-darwin-x64/-/nx-darwin-x64-20.8.1.tgz",
+      "integrity": "sha512-TB9mZk7neGFKgBr2wSBgY6c4kFF9vvChNSp3TrEeXR3FppFcYG5eK4AaKfzWCpYb0wMtseAm7NMX1Lu74utClQ==",
       "cpu": [
         "x64"
       ],
@@ -5395,9 +5395,9 @@
       }
     },
     "node_modules/@nx/nx-freebsd-x64": {
-      "version": "20.5.0",
-      "resolved": "https://registry.npmjs.org/@nx/nx-freebsd-x64/-/nx-freebsd-x64-20.5.0.tgz",
-      "integrity": "sha512-he3VOuj35XDAAmO3s6LqiWx00CsCMgHceNOHziCELQL0tfQlvvyI0Agmhesw68BAbabt+mKH9g+miENiaMknbg==",
+      "version": "20.8.1",
+      "resolved": "https://registry.npmjs.org/@nx/nx-freebsd-x64/-/nx-freebsd-x64-20.8.1.tgz",
+      "integrity": "sha512-7UQu0/Afna5Af2GagEQ6rbKfUh75NfUn+g66wsoQoUGBvDW0U7B8P3Ph5Bk4Urub0BSfMVcNg2X7CgfypLFN/g==",
       "cpu": [
         "x64"
       ],
@@ -5412,9 +5412,9 @@
       }
     },
     "node_modules/@nx/nx-linux-arm-gnueabihf": {
-      "version": "20.5.0",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm-gnueabihf/-/nx-linux-arm-gnueabihf-20.5.0.tgz",
-      "integrity": "sha512-xeysjXvm4xZa/ED7XlbzuS28sCOGZ0AlS7DKWRxEMv60iprxewj0WKPdH7RveiNNauzgHWOW/wxvTWXRu+i36Q==",
+      "version": "20.8.1",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm-gnueabihf/-/nx-linux-arm-gnueabihf-20.8.1.tgz",
+      "integrity": "sha512-Tjh8JkTP+x1jSrzx+ofx1pKpkhIbXd7bi0bPdpYt6NI1lZz2HB/dv8vtdzP80jXEDztHf0AeGnEJVgJKsgI6yg==",
       "cpu": [
         "arm"
       ],
@@ -5429,9 +5429,9 @@
       }
     },
     "node_modules/@nx/nx-linux-arm64-gnu": {
-      "version": "20.5.0",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-gnu/-/nx-linux-arm64-gnu-20.5.0.tgz",
-      "integrity": "sha512-pj+6OA7d1ltkW/ZYFooi3bDtqVFPxi8YYiZlQx7enEuOxbrTvpjEPvBjVyf+oYpCe9rfKlx9ghzufqsI4uGM0w==",
+      "version": "20.8.1",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-gnu/-/nx-linux-arm64-gnu-20.8.1.tgz",
+      "integrity": "sha512-2+qPIwav2vrytH6pe7fukBe8+yN5JGbEDCnDO8wKQsHeeZMLAQJiZ7EJH/+vynRkI7oWf87mihIKNQME19+w6A==",
       "cpu": [
         "arm64"
       ],
@@ -5446,9 +5446,9 @@
       }
     },
     "node_modules/@nx/nx-linux-arm64-musl": {
-      "version": "20.5.0",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-musl/-/nx-linux-arm64-musl-20.5.0.tgz",
-      "integrity": "sha512-gCIJEb/VYv6pxiAcSeizX0jpOmTnPmgYVi2EZLSWus0Pg6FIwMHE4MX5kuqehyvnDt9xInb7Rh8vgz/JBOOsbA==",
+      "version": "20.8.1",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-musl/-/nx-linux-arm64-musl-20.8.1.tgz",
+      "integrity": "sha512-DsKc+DiMsuHqpBWchUUUg6zv4OaexRqpFXys6auZlrpFpn80kSqLQ3S4zZ5AUu+26wxZqEVJs+uxHGwFbhEssQ==",
       "cpu": [
         "arm64"
       ],
@@ -5463,9 +5463,9 @@
       }
     },
     "node_modules/@nx/nx-linux-x64-gnu": {
-      "version": "20.5.0",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-gnu/-/nx-linux-x64-gnu-20.5.0.tgz",
-      "integrity": "sha512-hfCDmfy7TBQJdgBwNvOh55e8Y00Cxcddw2QeKguvy6vsnVa7fesXDWCw2t3m/VPPQDKQGd8cY1lS1JqX3N+wCA==",
+      "version": "20.8.1",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-gnu/-/nx-linux-x64-gnu-20.8.1.tgz",
+      "integrity": "sha512-Kzru44beVKAmSG84ShuMIIfyu2Uu5r8gsHdtiQPBIOGkZa0Z/e6YtUxcN3w1UZ7yvvzoQ4pQLvqU6UZRSWZtEg==",
       "cpu": [
         "x64"
       ],
@@ -5480,9 +5480,9 @@
       }
     },
     "node_modules/@nx/nx-linux-x64-musl": {
-      "version": "20.5.0",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-musl/-/nx-linux-x64-musl-20.5.0.tgz",
-      "integrity": "sha512-RTTCPjZNSDFE5mUdavDFimDw/aXNBY0w+iuRM5q17rDHxwa//DghCY0GEkBdfuxD7wpw+sRwE18mWsNDek5lXA==",
+      "version": "20.8.1",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-musl/-/nx-linux-x64-musl-20.8.1.tgz",
+      "integrity": "sha512-cSVVb7DVMhrxCaj/n55okBZS6lZoP5a5vynOBGIV4z3/OJLev+xI9A+3imn/aXnBl8iS69HogYyrW0YTXv4Xaw==",
       "cpu": [
         "x64"
       ],
@@ -5497,9 +5497,9 @@
       }
     },
     "node_modules/@nx/nx-win32-arm64-msvc": {
-      "version": "20.5.0",
-      "resolved": "https://registry.npmjs.org/@nx/nx-win32-arm64-msvc/-/nx-win32-arm64-msvc-20.5.0.tgz",
-      "integrity": "sha512-nT9WlG0QA8D74UJhEP1feGrV00/bas1nnqS+zkwnpJs0vcPmMuIktdETh3lEnqrGD04R7GtwbKtoGIGiZh5m9w==",
+      "version": "20.8.1",
+      "resolved": "https://registry.npmjs.org/@nx/nx-win32-arm64-msvc/-/nx-win32-arm64-msvc-20.8.1.tgz",
+      "integrity": "sha512-gte5HcvI24CN6b9I6IYTXh/A0CtRfnlAFaJomPpfT8Wcq637aOZzS0arAEZVoU8QZty1350hj6sfu+wSIjoP7A==",
       "cpu": [
         "arm64"
       ],
@@ -5514,9 +5514,9 @@
       }
     },
     "node_modules/@nx/nx-win32-x64-msvc": {
-      "version": "20.5.0",
-      "resolved": "https://registry.npmjs.org/@nx/nx-win32-x64-msvc/-/nx-win32-x64-msvc-20.5.0.tgz",
-      "integrity": "sha512-KQVqFSYfc8ToSBgzhVNV8WcFEvLdy1zp58qwewa0xnE7DDncMbA+6YoVizUcQ/6GZRlMJ9sdVn3kwm5B8eD5mg==",
+      "version": "20.8.1",
+      "resolved": "https://registry.npmjs.org/@nx/nx-win32-x64-msvc/-/nx-win32-x64-msvc-20.8.1.tgz",
+      "integrity": "sha512-6c2fVEPdPwJdnRbckBatRDF/g6JAp6p3Mfl90DpuaEF2DZC5pmCXKOsXE0aSIZ+gODom2JIchM++2KmDZPJUoA==",
       "cpu": [
         "x64"
       ],
@@ -5541,16 +5541,16 @@
       }
     },
     "node_modules/@octokit/core": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-5.2.0.tgz",
-      "integrity": "sha512-1LFfa/qnMQvEOAdzlQymH0ulepxbxnCYAKJZfMci/5XJyIHWgEYnDmgnKakbTh7CH2tFQ5O60oYDvns4i9RAIg==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-5.2.1.tgz",
+      "integrity": "sha512-dKYCMuPO1bmrpuogcjQ8z7ICCH3FP6WmxpwC03yjzGfZhj9fTJg6+bS1+UAplekbN2C+M61UNllGOOoAfGCrdQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@octokit/auth-token": "^4.0.0",
         "@octokit/graphql": "^7.1.0",
-        "@octokit/request": "^8.3.1",
-        "@octokit/request-error": "^5.1.0",
+        "@octokit/request": "^8.4.1",
+        "@octokit/request-error": "^5.1.1",
         "@octokit/types": "^13.0.0",
         "before-after-hook": "^2.2.0",
         "universal-user-agent": "^6.0.0"
@@ -5589,9 +5589,9 @@
       }
     },
     "node_modules/@octokit/openapi-types": {
-      "version": "23.0.1",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-23.0.1.tgz",
-      "integrity": "sha512-izFjMJ1sir0jn0ldEKhZ7xegCTj/ObmEDlEfpFrx4k/JyZSMRHbO3/rBwgE7f3m2DHt+RrNGIVw4wSmwnm3t/g==",
+      "version": "24.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
+      "integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
       "dev": true,
       "license": "MIT"
     },
@@ -5695,13 +5695,13 @@
       }
     },
     "node_modules/@octokit/types": {
-      "version": "13.8.0",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.8.0.tgz",
-      "integrity": "sha512-x7DjTIbEpEWXK99DMd01QfWy0hd5h4EN+Q7shkdKds3otGQP+oWE/y0A76i1OvH9fygo4ddvNf7ZvF0t78P98A==",
+      "version": "13.10.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
+      "integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@octokit/openapi-types": "^23.0.1"
+        "@octokit/openapi-types": "^24.2.0"
       }
     },
     "node_modules/@phosphor-icons/react": {
@@ -8958,9 +8958,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "20.17.30",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.30.tgz",
-      "integrity": "sha512-7zf4YyHA+jvBNfVrk2Gtvs6x7E8V+YDW05bNfG2XkWDJfYRXrTiP/DsB2zSYTaHX0bGIujTBQdMVAhb+j7mwpg==",
+      "version": "20.17.32",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.32.tgz",
+      "integrity": "sha512-zeMXFn8zQ+UkjK4ws0RiOC9EWByyW1CcVmLe+2rQocXRsGEDxUCwPEIVgpsGcLHS/P8JkT0oa3839BRABS0oPw==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.19.2"
@@ -21368,13 +21368,13 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/lerna": {
-      "version": "8.2.1",
-      "resolved": "https://registry.npmjs.org/lerna/-/lerna-8.2.1.tgz",
-      "integrity": "sha512-Xwjv9/4ixp7fpBWhtvp7dz4NoQT8DEf7hzibHKCgu/8kmZUHeXsTn+TKspHqhI+p4YDmdkDnkg8xmymz73kVOg==",
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/lerna/-/lerna-8.2.2.tgz",
+      "integrity": "sha512-GkqBELTG4k7rfzAwRok2pKBvhNo046Hfwcj7TuhDah3q58/BBBAqvIFLfqEI5fglnNOs6maMSn6/MWjccQE55A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@lerna/create": "8.2.1",
+        "@lerna/create": "8.2.2",
         "@npmcli/arborist": "7.5.4",
         "@npmcli/package-json": "5.2.0",
         "@npmcli/run-script": "8.1.0",
@@ -25663,9 +25663,9 @@
       "license": "MIT"
     },
     "node_modules/nx": {
-      "version": "20.5.0",
-      "resolved": "https://registry.npmjs.org/nx/-/nx-20.5.0.tgz",
-      "integrity": "sha512-KuAzhTj1NHu3iOVsTBrzu7cboO69UgwzUMoAb8KfszV5FwQD5dARrkR7Ew4NZzFdB+arUr2rvo1ik9f1O19keg==",
+      "version": "20.8.1",
+      "resolved": "https://registry.npmjs.org/nx/-/nx-20.8.1.tgz",
+      "integrity": "sha512-73Uw8YXpsjeLqHSl7NMCmGdCs+8ynPzoNJFWAqVanPETEY9zPd5wevVQmeyzYtNNQU35uj6Os4iUzYunmwnFaA==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -25674,7 +25674,7 @@
         "@yarnpkg/lockfile": "^1.1.0",
         "@yarnpkg/parsers": "3.0.2",
         "@zkochan/js-yaml": "0.0.7",
-        "axios": "^1.7.4",
+        "axios": "^1.8.3",
         "chalk": "^4.1.0",
         "cli-cursor": "3.1.0",
         "cli-spinners": "2.6.1",
@@ -25710,16 +25710,16 @@
         "nx-cloud": "bin/nx-cloud.js"
       },
       "optionalDependencies": {
-        "@nx/nx-darwin-arm64": "20.5.0",
-        "@nx/nx-darwin-x64": "20.5.0",
-        "@nx/nx-freebsd-x64": "20.5.0",
-        "@nx/nx-linux-arm-gnueabihf": "20.5.0",
-        "@nx/nx-linux-arm64-gnu": "20.5.0",
-        "@nx/nx-linux-arm64-musl": "20.5.0",
-        "@nx/nx-linux-x64-gnu": "20.5.0",
-        "@nx/nx-linux-x64-musl": "20.5.0",
-        "@nx/nx-win32-arm64-msvc": "20.5.0",
-        "@nx/nx-win32-x64-msvc": "20.5.0"
+        "@nx/nx-darwin-arm64": "20.8.1",
+        "@nx/nx-darwin-x64": "20.8.1",
+        "@nx/nx-freebsd-x64": "20.8.1",
+        "@nx/nx-linux-arm-gnueabihf": "20.8.1",
+        "@nx/nx-linux-arm64-gnu": "20.8.1",
+        "@nx/nx-linux-arm64-musl": "20.8.1",
+        "@nx/nx-linux-x64-gnu": "20.8.1",
+        "@nx/nx-linux-x64-musl": "20.8.1",
+        "@nx/nx-win32-arm64-msvc": "20.8.1",
+        "@nx/nx-win32-x64-msvc": "20.8.1"
       },
       "peerDependencies": {
         "@swc-node/register": "^1.8.0",
@@ -26883,9 +26883,9 @@
       }
     },
     "node_modules/parse-path": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/parse-path/-/parse-path-7.0.1.tgz",
-      "integrity": "sha512-6ReLMptznuuOEzLoGEa+I1oWRSj2Zna5jLWC+l6zlfAI4dbbSaIES29ThzuPkbhNahT65dWzfoZEO6cfJw2Ksg==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/parse-path/-/parse-path-7.1.0.tgz",
+      "integrity": "sha512-EuCycjZtfPcjWk7KTksnJ5xPMvWGA/6i4zrLYhRG0hGvC3GPU/jGUj3Cy+ZR0v30duV3e23R95T1lE2+lsndSw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -31703,9 +31703,9 @@
       }
     },
     "node_modules/tr46": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.0.tgz",
-      "integrity": "sha512-IUWnUK7ADYR5Sl1fZlO1INDUhVhatWl7BtJWsIhwJ0UAK7ilzzIa8uIqOO/aYVWHZPJkKbEL+362wrzoeRF7bw==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
bump `lerna` & remove old `npmClientArgs`, which fixes the lockfile issues we've been having (eg. #4671)
it seems to be caused by the `--legacy-peer-deps`, which we're not longer using (nor [lerna](https://github.com/lerna/lerna/releases/tag/v8.2.2)).