### PR TITLE
fix(app-shell-events): inherit types & docs from core

### DIFF
--- a/packages/app-shell-events/src/types/notifications.ts
+++ b/packages/app-shell-events/src/types/notifications.ts
@@ -1,22 +1,15 @@
-import type {
-  HvActionGeneric,
-  HvBannerVariant,
-  HvSnackbarVariant,
-} from "@hitachivantara/uikit-react-core";
+import type { HvBannerProps } from "@hitachivantara/uikit-react-core";
 
 export const HvAppShellEventNotificationTrigger =
   "@hv/app-shell:notifications:trigger";
 
 export type HvAppShellEventNotificationType = "snackbar" | "banner";
 
-export type HvAppShellEventNotification = {
+export interface HvAppShellEventNotification
+  extends Pick<
+    HvBannerProps,
+    "actions" | "variant" | "message" | "actionsCallback"
+  > {
   type: HvAppShellEventNotificationType;
   message?: string;
-  variant?: HvBannerVariant | HvSnackbarVariant;
-  actions?: React.ReactNode | HvActionGeneric[];
-  actionsCallback?: (
-    event: React.SyntheticEvent<Element, Event>,
-    id: string,
-    action: HvActionGeneric,
-  ) => void;
-};
+}

--- a/packages/app-shell-events/src/types/theming.ts
+++ b/packages/app-shell-events/src/types/theming.ts
@@ -1,6 +1,6 @@
+import type { HvProviderProps } from "@hitachivantara/uikit-react-core";
+
 export const HvAppShellEventThemeTrigger = "@hv/app-shell:theme:trigger";
 
-export type HvAppShellEventTheme = {
-  theme?: string;
-  colorMode?: string;
-};
+export interface HvAppShellEventTheme
+  extends Pick<HvProviderProps, "theme" | "colorMode"> {}


### PR DESCRIPTION
dedupe types from `app-shell-events`, `extend` from core instead (also improves docs as core's properties are documented)

this PR is primarily meant for the `app-shell-events` package to be bumped, as it didn't yet get the https://github.com/lumada-design/hv-uikit-react/pull/4678 fix