### PR TITLE
fix(Avatar): fix container height

### DIFF
--- a/packages/core/src/Avatar/Avatar.styles.tsx
+++ b/packages/core/src/Avatar/Avatar.styles.tsx
@@ -26,6 +26,7 @@ export const { staticClasses, useClasses } = createClasses("HvAvatar", {
     alignItems: "center",
     position: "relative",
     padding: theme.space.xxs,
+    height: "fit-content",
 
     ":focus-visible": {
       ...outlineStyles,


### PR DESCRIPTION
Fixes the container height of the `Avatar` to adapt to its content.

Before:
<img width="349" alt="image" src="https://github.com/user-attachments/assets/6fcfd30e-4aa4-4c18-88a4-d4fc25524ad6" />

After:
<img width="349" alt="image" src="https://github.com/user-attachments/assets/45b4da23-4da7-4703-aa54-4a3db02badbc" />
