### PR TITLE
docs: add DocsContainer utility

### DIFF
--- a/apps/docs/src/components/code/DocsProvider.tsx
+++ b/apps/docs/src/components/code/DocsProvider.tsx
@@ -1,3 +1,4 @@
+import { useId } from "react";
 import {
   ds3,
   ds5,
@@ -7,17 +8,50 @@ import {
 
 import { useDocsTheme } from "../../hooks/useDocsTheme";
 
-export const DocsProvider = ({ children }: { children: React.ReactNode }) => {
+export const DocsProvider = ({
+  children,
+  className,
+}: React.HTMLAttributes<HTMLDivElement>) => {
+  const id = useId();
   const { docsTheme, docsMode } = useDocsTheme();
 
   return (
-    <HvProvider
-      themes={[pentahoPlus, ds5, ds3]}
-      theme={docsTheme}
-      colorMode={docsMode}
-      cssTheme="scoped"
-    >
-      {children}
-    </HvProvider>
+    // ensures docs container styles change according to theme
+    <div id={id} className={className}>
+      <HvProvider
+        themes={[pentahoPlus, ds5, ds3]}
+        theme={docsTheme}
+        colorMode={docsMode}
+        cssTheme="scoped"
+        rootElementId={id}
+      >
+        {children}
+      </HvProvider>
+    </div>
+  );
+};
+
+export const DocsContainer = ({
+  element,
+  error,
+  className,
+}: {
+  /** render-able element provided by `react-live` */
+  element: React.ReactElement | null;
+  /** error message provided by `react-live */
+  error?: string | null;
+  /** container styles `className` */
+  className?: string;
+}) => {
+  return (
+    <DocsProvider className={className}>
+      {error ? (
+        // render errors or the live preview
+        <div className="text-negative">{error}</div>
+      ) : (
+        // an unstyled `div` must wrap `element` to ensure predictable layout
+        <div className="sample-container">{element}</div>
+      )}
+    </DocsProvider>
   );
 };

--- a/apps/docs/src/components/code/ExpandableLayout.tsx
+++ b/apps/docs/src/components/code/ExpandableLayout.tsx
@@ -3,7 +3,7 @@ import { CodeEditor, useLiveRunner, type Scope } from "react-live-runner";
 import { clsx } from "clsx";
 
 import useEditorTheme from "../../hooks/useEditorTheme";
-import { DocsProvider } from "./DocsProvider";
+import { DocsContainer } from "./DocsProvider";
 import { ExpandableControls } from "./ExpandableControls";
 
 type ExpandableLayoutProps = {
@@ -32,7 +32,7 @@ export const ExpandableLayout = ({ scope, code }: ExpandableLayoutProps) => {
   });
 
   return (
-    <section className="relative mt-md rounded-round [&>*]:border-border">
+    <section className="relative mt-md rounded-round">
       {/* Compact Controls */}
       <ExpandableControls
         onToggle={() => setIsExpanded((prev) => !prev)}
@@ -42,20 +42,14 @@ export const ExpandableLayout = ({ scope, code }: ExpandableLayoutProps) => {
       />
 
       {/* Preview Section */}
-      <DocsProvider>
-        <div
-          className={clsx(
-            "p-md py-[40px] bg-bgPage border rounded-inherit",
-            isExpanded && "rounded-b-0",
-          )}
-        >
-          {liveError ? (
-            <div className="text-negative">{liveError}</div>
-          ) : (
-            <div>{element}</div>
-          )}
-        </div>
-      </DocsProvider>
+      <DocsContainer
+        className={clsx(
+          "px-md py-40px bg-bgPage border border-border rounded-round",
+          isExpanded && "rounded-b-0",
+        )}
+        error={liveError}
+        element={element}
+      />
 
       {/* Code Editor Section */}
       <div

--- a/apps/docs/src/components/code/Playground.tsx
+++ b/apps/docs/src/components/code/Playground.tsx
@@ -4,7 +4,7 @@ import { CodeEditor } from "react-live-runner";
 
 import useEditorTheme from "../../hooks/useEditorTheme";
 import { Controls, type Control } from "./Controls";
-import { DocsProvider } from "./DocsProvider";
+import { DocsContainer } from "./DocsProvider";
 
 type PlaygroundProps = {
   Component: React.ComponentType<{ children?: React.ReactNode }>;
@@ -12,7 +12,7 @@ type PlaygroundProps = {
   componentProps?: Record<string, unknown>;
   controls: Record<string, Control>;
   children?: React.ReactNode;
-  decorator?: (children: React.ReactNode) => React.ReactNode;
+  decorator?: (children: React.ReactNode) => React.ReactElement;
 };
 
 const parseChildren = (child: React.ReactNode) =>
@@ -106,12 +106,10 @@ export const Playground = ({
       {/* Component preview and controls */}
       <div className="grid grid-cols-[2fr_1fr] border rounded-t-round">
         {/* Preview Area */}
-
-        <DocsProvider>
-          <div className={"grid place-items-center p-sm h-full"}>
-            {decorator ? decorator(componentElement) : componentElement}
-          </div>
-        </DocsProvider>
+        <DocsContainer
+          className="grid place-items-center p-sm h-full"
+          element={decorator ? decorator(componentElement) : componentElement}
+        />
 
         {/* Controls Area */}
         <div className="flex flex-col gap-xs border-l border-color-inherit py-sm px-xs">

--- a/apps/docs/src/components/code/PopupLayout.tsx
+++ b/apps/docs/src/components/code/PopupLayout.tsx
@@ -9,7 +9,7 @@ import {
 } from "@hitachivantara/uikit-react-core";
 
 import useEditorTheme from "../../hooks/useEditorTheme";
-import { DocsProvider } from "./DocsProvider";
+import { DocsContainer } from "./DocsProvider";
 
 type PopupLayoutProps = {
   id?: string;
@@ -29,7 +29,11 @@ export const PopupLayout = ({ id, scope, code }: PopupLayoutProps) => {
 
   const initialCode = Object.values(code)[0];
 
-  const { element, code: editorCode } = useLiveRunner({
+  const {
+    element,
+    error,
+    code: editorCode,
+  } = useLiveRunner({
     initialCode,
     scope: scope || {},
   });
@@ -83,12 +87,12 @@ export const PopupLayout = ({ id, scope, code }: PopupLayoutProps) => {
         </HvIconButton>
       </div>
       <div className="h-full [&>*]:h-full [&>*]:bg-transparent">
-        <DocsProvider>
-          {/* Preview Section */}
-          <div className="p-md flex items-center justify-center h-full [&>div]:w-full">
-            <div>{element}</div>
-          </div>
-        </DocsProvider>
+        {/* Preview Section */}
+        <DocsContainer
+          className="p-md flex items-center justify-center h-full [&>div]:w-full"
+          error={error}
+          element={element}
+        />
       </div>
     </section>
   );

--- a/apps/docs/src/components/code/ToggableLayout.tsx
+++ b/apps/docs/src/components/code/ToggableLayout.tsx
@@ -4,7 +4,7 @@ import { clsx } from "clsx";
 import { HvTab, HvTabs, HvTypography } from "@hitachivantara/uikit-react-core";
 
 import useEditorTheme from "../../hooks/useEditorTheme";
-import { DocsProvider } from "./DocsProvider";
+import { DocsContainer } from "./DocsProvider";
 import { ToggableControls } from "./ToggableControls";
 
 type ToggableLayoutProps = {
@@ -58,22 +58,15 @@ export const ToggableLayout = ({ title, scope, code }: ToggableLayoutProps) => {
 
       {/* Main content: Preview or Editor */}
       {showPreview ? (
-        <DocsProvider>
-          <div
-            className={clsx(
-              "p-md pt-lg min-h-100px mb-lg",
-              "border border-atmo3 rounded-round",
-              "bg-bgContainer [&_tr]:table-row",
-            )}
-          >
-            {/* Render errors or the live preview */}
-            {error ? (
-              <div className="text-negative">{error}</div>
-            ) : (
-              <div>{element}</div>
-            )}
-          </div>
-        </DocsProvider>
+        <DocsContainer
+          className={clsx(
+            "p-md pt-lg min-h-100px mb-lg",
+            "border border-atmo3 rounded-round",
+            "bg-bgContainer [&_tr]:table-row",
+          )}
+          error={error}
+          element={element}
+        />
       ) : (
         <>
           {/* Code editor for active tab */}


### PR DESCRIPTION
- add `DocsContainer` to dedupe layout container styles & `react-live` `error` & `element` management
- fix `ExpandableLayout` container styles (border color & radius)

![image](https://github.com/user-attachments/assets/47f32be0-6959-4491-9715-7582965457be)
![image](https://github.com/user-attachments/assets/86ec26c2-8355-4e8f-b37c-1be1345cebaf)
