### PR TITLE
fix(notifications): borderRadius

### DIFF
--- a/packages/core/src/Banner/BannerContent/BannerContent.styles.tsx
+++ b/packages/core/src/Banner/BannerContent/BannerContent.styles.tsx
@@ -7,7 +7,6 @@ export const { useClasses, staticClasses } = createClasses("HvBannerContent", {
     width: "100%",
     position: "relative",
     gap: theme.space.xs,
-    borderRadius: 0,
   },
   success: {},
   warning: {},

--- a/packages/core/src/utils/Callout.tsx
+++ b/packages/core/src/utils/Callout.tsx
@@ -22,6 +22,7 @@ const { useClasses } = createClasses("HvCallout", {
     boxShadow: "none",
     flexWrap: "nowrap",
     padding: 0,
+    borderRadius: theme.radii.round,
   },
   success: {
     backgroundColor: theme.colors.positiveDimmed,

--- a/packages/styles/src/themes/ds3.ts
+++ b/packages/styles/src/themes/ds3.ts
@@ -223,6 +223,13 @@ const ds3 = makeTheme((theme) => ({
         },
       },
     },
+    HvCallout: {
+      classes: {
+        root: {
+          borderRadius: 0,
+        },
+      },
+    },
     HvCheckBoxIcon: {
       classes: {
         root: {

--- a/packages/styles/src/themes/ds5.ts
+++ b/packages/styles/src/themes/ds5.ts
@@ -172,6 +172,13 @@ const ds5 = makeTheme((theme) => ({
     },
   },
   components: {
+    HvBannerContent: {
+      classes: {
+        root: {
+          borderRadius: 0,
+        },
+      },
+    },
     HvButton: {
       radius: "round",
       classes: {

--- a/packages/styles/src/themes/pentahoPlus.ts
+++ b/packages/styles/src/themes/pentahoPlus.ts
@@ -340,11 +340,6 @@ const pentahoPlus = makeTheme((theme) => ({
         },
       },
     },
-    HvBannerContent: {
-      classes: {
-        root: { borderRadius: theme.radii.round },
-      },
-    },
     HvSnackbar: {
       anchorOrigin: { vertical: "bottom", horizontal: "center" },
     },


### PR DESCRIPTION
fix Notifications (`HvBanner`/`HvSnackbar`) in all themes
- remove extra border in `ds3`
- align `ds5` & `pentahoPlus` borders. both use `radii.round`, except for `ds5` `HvBanner`, which has none 