### PR TITLE
fix(Select): invalid border color

### DIFF
--- a/packages/core/src/Select/Select.styles.ts
+++ b/packages/core/src/Select/Select.styles.ts
@@ -10,13 +10,13 @@ export const { staticClasses, useClasses } = createClasses("HvSelect", {
   },
   disabled: {},
   readOnly: {},
-  invalid: {
-    borderColor: theme.form.errorColor,
-  },
+  invalid: {},
   labelContainer: {},
   label: {},
   description: {},
-  select: {},
+  select: {
+    "&&$invalid": { borderColor: theme.form.errorColor },
+  },
   popper: {
     zIndex: theme.zIndices.popover,
 


### PR DESCRIPTION
- `HvSelect` didn't have a red border when invalid.

Before:

![Screenshot 2025-05-08 at 12 24 50](https://github.com/user-attachments/assets/78efe13a-f14a-4052-8647-8b6773bcbc3f)

After:

![Screenshot 2025-05-08 at 12 31 47](https://github.com/user-attachments/assets/c40250b6-7d59-4044-b931-32b0ad1284a6)
