### PR TITLE
fix(TagsInput): add start adornment

### DIFF
--- a/apps/docs/src/components/code/PopupLayout.tsx
+++ b/apps/docs/src/components/code/PopupLayout.tsx
@@ -33,6 +33,7 @@ export const PopupLayout = ({ id, scope, code }: PopupLayoutProps) => {
     element,
     error,
     code: editorCode,
+    onChange,
   } = useLiveRunner({
     initialCode,
     scope: scope || {},
@@ -72,6 +73,7 @@ export const PopupLayout = ({ id, scope, code }: PopupLayoutProps) => {
           <CodeEditor
             value={editorCode}
             theme={editorTheme}
+            onChange={onChange}
             className="font-mono text-[.85em] rounded-round border border-color-inherit"
           />
         </HvDialogContent>
@@ -89,7 +91,7 @@ export const PopupLayout = ({ id, scope, code }: PopupLayoutProps) => {
       <div className="h-full [&>*]:h-full [&>*]:bg-transparent">
         {/* Preview Section */}
         <DocsContainer
-          className="p-md flex items-center justify-center h-full [&>div]:w-full"
+          className="p-md flex items-center justify-center h-full [&>div]:w-full [&>div]:flex-wrap"
           error={error}
           element={element}
         />

--- a/apps/docs/src/examples/inputs/TagsSuggestions.tsx
+++ b/apps/docs/src/examples/inputs/TagsSuggestions.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from "react";
-import { Popper } from "@mui/material";
+import { ClickAwayListener, Popper } from "@mui/material";
 import {
   HvAdornment,
   HvPanel,
@@ -66,7 +66,7 @@ export default function Demo() {
           handleRemoveColor(value as string);
         }}
         value={selectedColors}
-        commitTagOn={["Comma"]}
+        commitTagOn={["Comma", "Enter"]}
         endAdornment={
           <HvAdornment
             tabIndex={0}
@@ -75,38 +75,45 @@ export default function Demo() {
           />
         }
         classes={{
-          tagsList: "h-32px pr-0 overflow-hidden",
+          tagsList: "h-32px pr-0! overflow-hidden",
         }}
       />
-      <Popper anchorEl={containerRef.current} open={open}>
-        <HvPanel className="flex flex-wrap flex-col gap-xs w-300px border rounded-round">
-          <HvTypography variant="caption1">Last Used:</HvTypography>
-          <div className="flex gap-xs">
-            {lastUsed.map((color, idx) => (
-              <HvTag
-                autoFocus={idx === 0}
-                key={color}
-                label={color}
-                onClick={() => handleAddColor(color)}
-              />
-            ))}
-          </div>
-          <HvTypography variant="caption1">More colors:</HvTypography>
-          <div className="flex flex-wrap gap-xs">
-            {colors
-              .filter(
-                (color) =>
-                  !selectedColors.includes(color) && !lastUsed.includes(color),
-              )
-              .map((color) => (
+      <Popper
+        anchorEl={containerRef.current}
+        open={open}
+        placement="bottom-start"
+      >
+        <ClickAwayListener onClickAway={() => setOpen(false)}>
+          <HvPanel className="grid gap-xs w-300px border rounded-large!">
+            <HvTypography variant="caption1">Last Used:</HvTypography>
+            <div className="flex gap-xs">
+              {lastUsed.map((color, idx) => (
                 <HvTag
+                  autoFocus={idx === 0}
                   key={color}
                   label={color}
                   onClick={() => handleAddColor(color)}
                 />
               ))}
-          </div>
-        </HvPanel>
+            </div>
+            <HvTypography variant="caption1">More colors:</HvTypography>
+            <div className="flex flex-wrap gap-xs">
+              {colors
+                .filter(
+                  (color) =>
+                    !selectedColors.includes(color) &&
+                    !lastUsed.includes(color),
+                )
+                .map((color) => (
+                  <HvTag
+                    key={color}
+                    label={color}
+                    onClick={() => handleAddColor(color)}
+                  />
+                ))}
+            </div>
+          </HvPanel>
+        </ClickAwayListener>
       </Popper>
     </div>
   );

--- a/apps/docs/src/examples/inputs/TagsSuggestionsEmpty.tsx
+++ b/apps/docs/src/examples/inputs/TagsSuggestionsEmpty.tsx
@@ -1,0 +1,98 @@
+import { useRef, useState } from "react";
+import { ClickAwayListener, Popper } from "@mui/material";
+import {
+  HvAdornment,
+  HvInput,
+  HvPanel,
+  HvTag,
+  HvTypography,
+} from "@hitachivantara/uikit-react-core";
+import { Add } from "@hitachivantara/uikit-react-icons";
+
+const colors = [
+  "Blue",
+  "Red",
+  "Green",
+  "Yellow",
+  "Purple",
+  "White",
+  "Black",
+  "Orange",
+  "Pink",
+  "Brown",
+  "Gray",
+  "Cyan",
+  "Magenta",
+  "Lime",
+  "Teal",
+  "Lavender",
+];
+
+export default function Demo() {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [selectedColors, setSelectedColors] = useState<string[]>([]);
+  const [open, setOpen] = useState(false);
+
+  const handleAddColor = (color: string) => {
+    setSelectedColors((prev) => [...new Set([...prev, color])]);
+  };
+
+  const handleRemoveColor = (color: string) => {
+    setSelectedColors((prev) => prev.filter((c) => c !== color));
+  };
+
+  return (
+    <>
+      <div className="w-300px">
+        <HvInput
+          label="Tags with suggestions and empty input"
+          onEnter={(event, value) => {
+            handleAddColor(value);
+          }}
+          startAdornment={
+            <HvAdornment
+              tabIndex={0}
+              icon={<Add rotate={open} size="xs" />}
+              onClick={() => setOpen((o) => !o)}
+              ref={containerRef}
+            />
+          }
+          className="mb-sm"
+        />
+
+        <Popper
+          anchorEl={containerRef.current}
+          open={open}
+          placement="bottom-start"
+          className="top-1px!"
+        >
+          <ClickAwayListener onClickAway={() => setOpen(false)}>
+            <HvPanel className="grid gap-xs w-300px border rounded-large!">
+              <HvTypography variant="caption1">More colors:</HvTypography>
+              <div className="flex flex-wrap gap-xs">
+                {colors
+                  .filter((color) => !selectedColors.includes(color))
+                  .map((color) => (
+                    <HvTag
+                      key={color}
+                      label={color}
+                      onClick={() => handleAddColor(color)}
+                    />
+                  ))}
+              </div>
+            </HvPanel>
+          </ClickAwayListener>
+        </Popper>
+      </div>
+      <div className="flex flex-wrap gap-xs">
+        {selectedColors.map((color) => (
+          <HvTag
+            key={color}
+            label={color}
+            onDelete={() => handleRemoveColor(color)}
+          />
+        ))}
+      </div>
+    </>
+  );
+}

--- a/apps/docs/src/pages/examples/inputs.mdx
+++ b/apps/docs/src/pages/examples/inputs.mdx
@@ -5,19 +5,15 @@ import dropdownPrefix from "../../examples/inputs/DropdownPrefix?raw";
 import editableValue from "../../examples/inputs/EditableInput?raw";
 import tagsDropdown from "../../examples/inputs/TagsDropdown?raw";
 import tagsSuggestions from "../../examples/inputs/TagsSuggestions?raw";
+import tagsSuggestionsEmpty from "../../examples/inputs/TagsSuggestionsEmpty?raw";
 
 <div className="overflow-hidden mt-20">
-  <div className="w-101% grid divide-border [grid-template-columns:repeat(auto-fit,minmax(360px,1fr))] -mt-px -mb-px auto-rows-min">
-    {[
-      dropdownPrefix,
-      copyButton,
-      tagsDropdown,
-      tagsSuggestions,
-      editableValue,
-    ].map((code, i) => (
-      <div key={i} className="min-h-[200px]">
-        <CodeBlock code={{ main: code }} layout="popup" />
-      </div>
-    ))}
+  <div className="w-101% grid divide-border [grid-template-columns:repeat(auto-fit,minmax(360px,1fr))] -mt-px -mb-px auto-rows-min [&>*]:min-h-[200px]">
+    <CodeBlock code={{ main: dropdownPrefix }} layout="popup" />
+    <CodeBlock code={{ main: copyButton }} layout="popup" />
+    <CodeBlock code={{ main: tagsDropdown }} layout="popup" />
+    <CodeBlock code={{ main: tagsSuggestions }} layout="popup" />
+    <CodeBlock code={{ main: tagsSuggestionsEmpty }} layout="popup" />
+    <CodeBlock code={{ main: editableValue }} layout="popup" />
   </div>
 </div>

--- a/packages/core/src/TagsInput/TagsInput.test.tsx
+++ b/packages/core/src/TagsInput/TagsInput.test.tsx
@@ -95,8 +95,14 @@ describe("TagsInput Component", () => {
   });
 
   it("renders a custom adornment", () => {
-    render(<HvTagsInput endAdornment={<div>endAdornment</div>} />);
+    render(
+      <HvTagsInput
+        startAdornment={<div>startAdornment</div>}
+        endAdornment={<div>endAdornment</div>}
+      />,
+    );
 
+    expect(screen.getByText("startAdornment")).toBeInTheDocument();
     expect(screen.getByText("endAdornment")).toBeInTheDocument();
   });
 

--- a/packages/core/src/TagsInput/TagsInput.tsx
+++ b/packages/core/src/TagsInput/TagsInput.tsx
@@ -122,6 +122,7 @@ export const HvTagsInput = forwardRef<HTMLElement, HvTagsInputProps>(
       onBlur,
       onFocus,
       placeholder,
+      startAdornment,
       endAdornment,
       hideCounter,
       middleCountLabel = "/",
@@ -536,6 +537,7 @@ export const HvTagsInput = forwardRef<HTMLElement, HvTagsInputProps>(
               />
             );
           })}
+          {!disabled && !readOnly && startAdornment}
           {!disabled && !readOnly && (
             <input
               id={setId(elementId, "input")}


### PR DESCRIPTION
- Add a start adornment to the `TagsInput` component (it will be needed in the future and we already support an end adornment
- Add a new example that illustrates how to keep the tags input empty while adding tags (based on the real use case scenario from PD)
- Small fixes to samples layout
- Revert inputs samples layout because the Examples index page counts the number of `<CodeBlock>` elements to tell the number of samples