### PR TITLE
fix(IconContainer): numeric `size` being ignored

### DIFF
--- a/packages/core/src/IconContainer/IconContainer.stories.tsx
+++ b/packages/core/src/IconContainer/IconContainer.stories.tsx
@@ -57,6 +57,9 @@ export const Variants: StoryObj<typeof HvIconContainer> = {
           <HvIconContainer {...args} size="xl">
             <FontAwesomeIcon icon={faUser} />
           </HvIconContainer>
+          <HvIconContainer {...args} size={100}>
+            <FontAwesomeIcon icon={faUser} />
+          </HvIconContainer>
         </div>
         <HvTypography variant="title3">Phosphor Icons</HvTypography>
         <div className="flex gap-xs items-center">
@@ -75,6 +78,9 @@ export const Variants: StoryObj<typeof HvIconContainer> = {
           <HvIconContainer {...args} size="xl">
             <User />
           </HvIconContainer>
+          <HvIconContainer {...args} size={100}>
+            <User />
+          </HvIconContainer>
         </div>
         <HvTypography variant="title3">NEXT Icons</HvTypography>
         <div className="flex gap-xs items-center">
@@ -83,6 +89,7 @@ export const Variants: StoryObj<typeof HvIconContainer> = {
           <HvUser {...args} size="md" />
           <HvUser {...args} size="lg" />
           <HvUser {...args} size="xl" />
+          <HvUser {...args} size={100} />
         </div>
       </div>
     );

--- a/packages/core/src/IconContainer/IconContainer.tsx
+++ b/packages/core/src/IconContainer/IconContainer.tsx
@@ -14,7 +14,7 @@ export const { staticClasses, useClasses } = createClasses("HvIconContainer", {
   root: {
     display: "inline-flex",
     flex: "0 0 auto", // ensure icon doesn't flex grow/shrink
-    fontSize: `var(--icsize, 16px)`, // default size of 16px
+    fontSize: `var(--isize, 16px)`, // default size of 16px
     transition: "rotate 0.2s ease",
     justifyContent: "center",
     alignItems: "center",
@@ -87,22 +87,21 @@ export const HvIconContainer = forwardRef<
     classes: classesProp,
     style,
     color,
-    size: sizeProp = "S",
+    size = "S",
     rotate,
     children,
     ...others
   } = useDefaultProps("HvIconContainer", props);
   const { cx, classes } = useClasses(classesProp);
 
-  const size = mapSizes(sizeProp);
-
   return (
     <div
       ref={ref}
       className={cx(classes.root, className, {
-        [classes[size!]]: size,
+        [classes[mapSizes(size)!]]: size,
       })}
       style={mergeStyles(style, {
+        "--isize": typeof size === "number" ? `${size}px` : undefined,
         color: getColor(color),
         rotate: rotate ? "180deg" : undefined,
         ...style,


### PR DESCRIPTION
numeric `size` (eg. `size={100}`) was being ignored