### PR TITLE
docs: home BannerContent & examples icons

### DIFF
--- a/apps/docs/src/components/Examples.tsx
+++ b/apps/docs/src/components/Examples.tsx
@@ -1,13 +1,9 @@
 import { clsx } from "clsx";
 import Link from "next/link";
-import { HvTypography } from "@hitachivantara/uikit-react-core";
 import {
-  BarChart,
-  Speedometer,
-  SwipeRight,
-  Table,
-  TextColor,
-} from "@hitachivantara/uikit-react-icons";
+  HvIconContainer,
+  HvTypography,
+} from "@hitachivantara/uikit-react-core";
 
 import charts from "../pages/examples/charts.mdx?raw";
 import inputs from "../pages/examples/inputs.mdx?raw";
@@ -27,15 +23,15 @@ const countCodeBlocks = (fileContent: string): number => {
 const getSectionIcon = (title: string) => {
   switch (title) {
     case "Tables":
-      return <Table size="md" />;
+      return <div className="i-ph-table" />;
     case "Charts":
-      return <BarChart size="md" />;
+      return <div className="i-ph-chart-bar" />;
     case "Inputs":
-      return <TextColor size="md" />;
+      return <div className="i-ph-text-a-underline" />;
     case "KPIs":
-      return <Speedometer size="md" />;
+      return <div className="i-ph-speedometer" />;
     case "Drag and Drop":
-      return <SwipeRight size="md" />;
+      return <div className="i-ph-hand-swipe-right" />;
     default:
       return null;
   }
@@ -119,9 +115,9 @@ export const Examples = () => {
                 "rounded-round mb-sm flex items-center justify-center",
               )}
             >
-              <HvTypography variant="body" className="text-textSubtle">
+              <HvIconContainer color="textSubtle" size="xl">
                 {getSectionIcon(section.title)}
-              </HvTypography>
+              </HvIconContainer>
             </div>
             {/* Section Title */}
             <HvTypography variant="label" className="font-semibold">

--- a/apps/docs/src/components/home/cards/DataConfig.tsx
+++ b/apps/docs/src/components/home/cards/DataConfig.tsx
@@ -1,5 +1,5 @@
 import {
-  HvBanner,
+  HvBannerContent,
   HvButton,
   HvCheckBox,
   HvDropdown,
@@ -8,24 +8,19 @@ import {
 
 import { Card } from "./Card";
 
-export const DataConfig = () => {
-  const backupOptions = [
-    { label: "Daily", value: "daily" },
-    { label: "Weekly", value: "weekly" },
-    { label: "Monthly", value: "monthly" },
-  ];
+const backupOptions = [
+  { label: "Daily", value: "daily" },
+  { label: "Weekly", value: "weekly" },
+  { label: "Monthly", value: "monthly" },
+];
 
+export const DataConfig = () => {
   return (
     <Card title="Data Management Configuration">
       <div className="grid gap-sm">
-        <HvBanner
-          open
-          offset={0}
-          label="Backup impacts storage."
-          showIcon
-          className="relative"
-          variant="info"
-        />
+        <HvBannerContent showIcon variant="info" action={null}>
+          Backup impacts storage.
+        </HvBannerContent>
         <HvInput
           label="Storage Limit (in GB)"
           placeholder="Enter storage limit"


### PR DESCRIPTION
- change home `HvBanner` for `HvBannerContent` (hide close icon that does nothing)
- fix`/examples`'s icons (`div` inside `p` validation).
  - also updates icons to use Phosphor Icons

![image](https://github.com/user-attachments/assets/0937ad6e-68ee-455f-b1bb-28b8ef147300)
