### PR TITLE
docs: review colors pages

### DIFF
--- a/apps/docs/src/components/color/ColorPalette.tsx
+++ b/apps/docs/src/components/color/ColorPalette.tsx
@@ -4,24 +4,24 @@ export const ColorPalette = () => {
   const { palette } = theme;
 
   return (
-    <div className="space-y-10">
+    <div className="space-y-md">
       {Object.entries(palette).map(([colorName, shades]) => (
-        <section key={colorName}>
+        <section key={colorName} id={colorName}>
           <HvTypography className="font-semibold mb-2">
             {colorName.charAt(0).toUpperCase() + colorName.slice(1)}
           </HvTypography>
 
-          <div className="grid grid-cols-4 sm:grid-cols-6 md:grid-cols-11 gap-1">
+          <div className="flex w-full [&>*]:flex-1">
             {Object.entries(shades).map(([shade, value]) => {
               return (
                 <div
                   key={`${colorName}-${shade}`}
+                  title={`${colorName}.${shade}`}
                   className="flex flex-col items-center"
                 >
                   <div
-                    className="h-15 w-full rounded-base"
+                    className="h-15 w-full"
                     style={{ backgroundColor: value }}
-                    aria-label={`Color ${colorName} ${shade}`}
                   />
 
                   <HvTypography className="mt-2 text-sm">{shade}</HvTypography>

--- a/apps/docs/src/components/color/ColorTokens.tsx
+++ b/apps/docs/src/components/color/ColorTokens.tsx
@@ -2,7 +2,11 @@ import { HvTypography, useTheme } from "@hitachivantara/uikit-react-core";
 
 import { DocsProvider } from "../code/DocsProvider";
 import { descriptions } from "./descriptions";
-import { colorTokensSpec, groupColorTokensByCategory } from "./utils";
+import {
+  colorTokensSpec,
+  compatMap,
+  groupColorTokensByCategory,
+} from "./utils";
 
 export const ColorTokens = () => {
   return (
@@ -13,13 +17,10 @@ export const ColorTokens = () => {
 };
 
 export const ColorTokensInternal = () => {
-  const { selectedMode, activeTheme } = useTheme();
-  const activeColors = activeTheme?.colors.modes[selectedMode];
+  const { activeTheme, colors } = useTheme();
 
   const colorTokens = Object.fromEntries(
-    Object.entries(activeColors ?? {}).filter(
-      ([key]) => key in colorTokensSpec,
-    ),
+    Object.entries(colors ?? {}).filter(([key]) => key in colorTokensSpec),
   );
 
   const groupedTokens = groupColorTokensByCategory(colorTokens);
@@ -32,40 +33,46 @@ export const ColorTokensInternal = () => {
         if (!tokens || tokens.length === 0) return null;
 
         return (
-          <section key={categoryKey}>
+          <section key={categoryKey} id={categoryKey}>
             <HvTypography variant="title4" className="font-semibold">
               {label}
             </HvTypography>
 
             {description && (
-              <HvTypography variant="body" className="mb-4">
+              <HvTypography variant="body" className="mb-sm">
                 {description}
               </HvTypography>
             )}
 
-            <div className="w-full grid grid-cols-3 sm:grid-cols-4 md:grid-cols-6 gap-2">
+            <div className="w-full grid grid-cols-2 sm:grid-cols-4 md:grid-cols-6 gap-xs">
               {tokens.map(({ token, value }) => {
+                const compatToken = compatMap[token as keyof typeof compatMap];
+
                 return (
                   <div
                     key={token}
-                    className="flex flex-col items-center"
-                    aria-label={`Color Token ${label} ${token}`}
+                    className="flex flex-col items-center gap-xs"
+                    title={token}
                   >
                     {/* Swatch */}
                     <div
                       className="w-full h-20 rounded-base"
                       style={{ backgroundColor: value }}
-                    ></div>
+                    />
 
-                    {/* Token name */}
-                    <HvTypography className="mt-2 text-md text-center">
-                      {token}
-                    </HvTypography>
+                    <div className="grid text-center gap-xs">
+                      {compatToken && activeTheme?.name !== "pentahoPlus" && (
+                        <code className="text-sm grid-area-[1/1] text-[#0000]">
+                          {compatToken}
+                        </code>
+                      )}
+                      <code className="text-sm grid-area-[1/1]">{token}</code>
 
-                    {/* Color value */}
-                    <HvTypography className="text-xs text-center mt-1">
-                      {value}
-                    </HvTypography>
+                      {/* Color value */}
+                      {value.startsWith("#") && (
+                        <code className="text-xs">{value}</code>
+                      )}
+                    </div>
                   </div>
                 );
               })}

--- a/apps/docs/src/components/color/utils.ts
+++ b/apps/docs/src/components/color/utils.ts
@@ -1,4 +1,37 @@
-import { ColorTokens } from "@hitachivantara/uikit-styles";
+import { ColorTokens, HvThemeColors } from "@hitachivantara/uikit-styles";
+
+/** Compatibility object between UI Kit tokens and NEXT tokens */
+export const compatMap: Partial<
+  Record<keyof ColorTokens, keyof HvThemeColors>
+> = {
+  primaryStrong: "primary_80",
+  primaryDimmed: "primary_20",
+  positiveStrong: "positive_80",
+  positiveDeep: "positive_120",
+  positiveDimmed: "positive_20",
+  warningStrong: "warning_120",
+  warningDeep: "warning_140",
+  warningDimmed: "warning_20",
+  negativeStrong: "negative_80",
+  negativeDeep: "negative_120",
+  negativeDimmed: "negative_20",
+  info: "neutral",
+  infoDimmed: "neutral_20",
+
+  text: "secondary",
+  textSubtle: "secondary_80",
+  textDisabled: "secondary_60",
+  textDimmed: "atmo1",
+  textLight: "base_light",
+  textDark: "base_dark",
+
+  bgHover: "primary_20",
+  bgDisabled: "atmo3",
+  bgPage: "atmo2",
+  bgContainer: "atmo1",
+  bgPageSecondary: "atmo3",
+  border: "atmo4",
+};
 
 // Groups color tokens by their prefix category.
 export const groupColorTokensByCategory = (


### PR DESCRIPTION
- add `id`s for anchor links in color groups (eg [/color-tokens#negative](https://lumada-design.github.io/uikit-docs/master/docs/color-tokens#negative))
- `/color-palette`:
  - change to a more condensed look
- `/color-tokens`:
  - add `<code>` to color keys
  - hide "weird"/alias token values (that don't start with `#`)
  - add _hidden_ compatibility tokens (eg. `primary_20`) in non-`pentahoPlus` themes


![image](https://github.com/user-attachments/assets/5b7bdbbf-12e9-41b3-a155-137418dc87c5)
