### PR TITLE
fix(Avatar): fix border radius styles

### DIFF
--- a/apps/docs/src/pages/components/avatar.mdx
+++ b/apps/docs/src/pages/components/avatar.mdx
@@ -32,6 +32,12 @@ export const getStaticProps = async ({ params }) => {
       type: "color",
       defaultValue: "secondary",
     },
+    status: {
+      type: "color",
+    },
+    badge: {
+      type: "color",
+    },
   }}
 />
 
@@ -181,7 +187,7 @@ An avatar should be interacted with by wrapping it in an interactable element, s
   </HvButton>
   <HvButton
     aria-label="Business Manager"
-    radius="base"
+    radius="round"
     icon
     className="size-fit!"
   >
@@ -209,7 +215,7 @@ An avatar should be interacted with by wrapping it in an interactable element, s
   </HvButton>
   <HvButton
     aria-label="Clara Soul profile"
-    radius="base"
+    radius="round"
     icon
     className="size-fit!"
   >

--- a/packages/core/src/Avatar/Avatar.styles.tsx
+++ b/packages/core/src/Avatar/Avatar.styles.tsx
@@ -26,6 +26,7 @@ export const { staticClasses, useClasses } = createClasses("HvAvatar", {
     alignItems: "center",
     position: "relative",
     padding: theme.space.xxs,
+
     height: "fit-content",
 
     ":focus-visible": {
@@ -38,7 +39,7 @@ export const { staticClasses, useClasses } = createClasses("HvAvatar", {
   md: { width: 40, height: 40, fontSize: "1rem" },
   lg: { width: 52, height: 52, fontSize: "1.5rem" },
   xl: { width: 88, height: 88, fontSize: "2rem" },
-  avatar: {},
+  avatar: { borderRadius: "inherit" },
   badge: {
     width: 8,
     height: 8,

--- a/packages/core/src/Avatar/Avatar.tsx
+++ b/packages/core/src/Avatar/Avatar.tsx
@@ -54,9 +54,9 @@ export interface HvAvatarProps extends HvBaseProps {
   /** A string representing the type of avatar to display, circular or square. */
   variant?: HvAvatarVariant;
   /** A string representing the color of the avatar border that represents its status. */
-  status?: string;
+  status?: HvColorAny;
   /** A string representing the color of the avatar badge. */
-  badge?: string;
+  badge?: HvColorAny;
   /** Attributes applied to the avatar element. */
   avatarProps?: MuiAvatarProps;
   /** A Jss Object used to override or extend the styles applied to the component. */

--- a/packages/styles/src/themes/ds5.ts
+++ b/packages/styles/src/themes/ds5.ts
@@ -172,6 +172,13 @@ const ds5 = makeTheme((theme) => ({
     },
   },
   components: {
+    HvAvatar: {
+      classes: {
+        square: {
+          borderRadius: theme.radii.round,
+        },
+      },
+    },
     HvBannerContent: {
       classes: {
         root: {


### PR DESCRIPTION
- fix the `variant` classes (`square`, `circular`) not being applied in the appropriate element and thus not having effect when users wanted to override the styles of each specific variant.
- Update to NEXT 5.9.5 specs