### PR TITLE
fix(uno): spacing for xxs token

### DIFF
--- a/packages/uno-preset/src/Uno.stories.tsx
+++ b/packages/uno-preset/src/Uno.stories.tsx
@@ -1,0 +1,51 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { HvTypography } from "@hitachivantara/uikit-react-core";
+
+import { setupChromatic } from ".storybook/setupChromatic";
+
+export default {
+  title: "Tests/Uno",
+} as Meta;
+
+export const Test: StoryObj = {
+  parameters: {
+    ...setupChromatic(["DS5 dawn", "DS5 wicked", "Pentaho+ wicked"]),
+    docs: { disable: true },
+  },
+  render: () => (
+    <>
+      <HvTypography variant="title4">Z-Index & Colors</HvTypography>
+      <section className="flex bg-default [&>div]:-mr-2">
+        <div className="size-12 bg-positive z-modal" />
+        <div className="size-11 bg-warning z-docked" />
+        <div className="size-10 bg-warningDeep z-8" />
+        <div className="size-9 bg-base_dark" />
+        <div className="size-8 bg-negative -z-1" />
+      </section>
+      <br />
+      <HvTypography variant="title4">Radius & Spacing</HvTypography>
+      <section className="flex gap-xs">
+        {[
+          "rounded-none m-1",
+          "rounded-round m-xxs",
+          "rounded-large my-sm",
+          "rounded mr-md",
+          "rounded-2",
+          "rounded-full",
+        ].map((classes) => (
+          <div key={classes} className="bg-secondary p-xs">
+            <div className={`size-64px bg-primary ${classes}`} />
+          </div>
+        ))}
+      </section>
+      <br />
+      <HvTypography variant="title4">Text & icons</HvTypography>
+      <section>
+        <div className="flex gap-xxs items-center text-warning">
+          <div className="i-ph-database" />
+          <span>Text goes here</span>
+        </div>
+      </section>
+    </>
+  ),
+};

--- a/packages/uno-preset/src/rules.ts
+++ b/packages/uno-preset/src/rules.ts
@@ -1,7 +1,11 @@
-import type { Rule } from "@unocss/core";
+import type { UserConfig } from "@unocss/core";
 import type { Theme } from "@unocss/preset-wind3";
 import { theme as hvCssVars } from "@hitachivantara/uikit-styles";
 
-export const rules: Rule<Theme>[] = [
-  ["bg-default", { "background-color": hvCssVars.colors.backgroundColor }],
+export const rules: UserConfig<Theme>["rules"] = [
+  ["bg-default", { "background-color": hvCssVars.colors.bgPage }],
+  // fix for `gap-xxs` being parsed as `gap-x-xs`
+  ["gap-xxs", { gap: hvCssVars.space.xxs }],
+  ["m-xxs", { margin: hvCssVars.space.xxs }],
+  ["p-xxs", { padding: hvCssVars.space.xxs }],
 ];

--- a/packages/uno-preset/src/theme.ts
+++ b/packages/uno-preset/src/theme.ts
@@ -1,4 +1,4 @@
-import { ThemeExtender } from "@unocss/core";
+import type { ThemeExtender } from "@unocss/core";
 import type { Theme } from "@unocss/preset-wind3";
 import { ds5 as hvTheme, theme } from "@hitachivantara/uikit-styles";
 
@@ -29,6 +29,7 @@ export const extendTheme: ThemeExtender<Theme> = (baseTheme) => ({
     hvBreakpoints.map(([k, v]) => [k, `(min-width: ${v})`]),
   ),
   spacing: {
+    ...baseTheme.spacing,
     DEFAULT: hvSpacing.xs,
     ...hvSpacing,
   },
@@ -56,7 +57,7 @@ export const extendTheme: ThemeExtender<Theme> = (baseTheme) => ({
   fontWeight: { DEFAULT: hvTheme.fontWeights.normal, ...hvTheme.fontWeights },
 });
 
-/** UI Kit theme mode variants */
+/** UI Kit theme mode variants. @deprecated unused */
 export const themeModes = {
   light: {
     colors: {


### PR DESCRIPTION
workaround for `gap-xxs` being interpreted as `gap-x-xs` (same for padding/margin)

also recover uno tests (removed by mistake in #4744)