### PR TITLE
fix(app-shell-vite-plugin): cross-platform module resolution

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7376,9 +7376,9 @@
       }
     },
     "node_modules/@storybook/core/node_modules/semver": {
-      "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -8957,9 +8957,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "20.17.32",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.32.tgz",
-      "integrity": "sha512-zeMXFn8zQ+UkjK4ws0RiOC9EWByyW1CcVmLe+2rQocXRsGEDxUCwPEIVgpsGcLHS/P8JkT0oa3839BRABS0oPw==",
+      "version": "20.17.50",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.50.tgz",
+      "integrity": "sha512-Mxiq0ULv/zo1OzOhwPqOA13I81CV/W3nvd3ChtQZRT5Cwz3cr0FKo/wMSsbTqL3EXpaBAEQhva2B8ByRkOIh9A==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.19.2"
@@ -9288,9 +9288,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
-      "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -13997,9 +13997,9 @@
       "license": "MIT"
     },
     "node_modules/debug": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
-      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -16010,9 +16010,9 @@
       }
     },
     "node_modules/estree-util-value-to-estree": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/estree-util-value-to-estree/-/estree-util-value-to-estree-3.3.3.tgz",
-      "integrity": "sha512-Db+m1WSD4+mUO7UgMeKkAwdbfNWwIxLt48XF2oFU9emPfXkIu+k5/nlOj313v7wqtAPo0f9REhUvznFrPkG8CQ==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/estree-util-value-to-estree/-/estree-util-value-to-estree-3.4.0.tgz",
+      "integrity": "sha512-Zlp+gxis+gCfK12d3Srl2PdX2ybsEA8ZYy6vQGVQTNNYLEGRQQ56XB64bjemN8kxIKXP1nC9ip4Z+ILy9LGzvQ==",
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0"
@@ -16517,18 +16517,6 @@
       },
       "engines": {
         "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/find-up-simple": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/find-up-simple/-/find-up-simple-1.0.1.tgz",
-      "integrity": "sha512-afd4O7zpqHeRyg4PfDQsXmlDe2PfdHtJt6Akt8jOWaApLOZk5JXs6VMR29lz03pRe9mpykrRCYIYxaJYcfpncQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -18735,9 +18723,9 @@
       }
     },
     "node_modules/is-bun-module/node_modules/semver": {
-      "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -29988,9 +29976,9 @@
       }
     },
     "node_modules/sharp/node_modules/semver": {
-      "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
       "license": "ISC",
       "optional": true,
       "bin": {
@@ -32881,16 +32869,16 @@
       }
     },
     "node_modules/vite-plugin-static-copy": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/vite-plugin-static-copy/-/vite-plugin-static-copy-2.3.0.tgz",
-      "integrity": "sha512-LLKwhhHetGaCnWz4mas4qqjjguDka6/6b4+SeIohRroj8aCE7QTfiZECfPecslFQkWZ3HdQuq5kOPmWZjNYlKA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/vite-plugin-static-copy/-/vite-plugin-static-copy-3.0.0.tgz",
+      "integrity": "sha512-Uki9pPUQ4ZnoMEdIFabvoh9h6Bh9Q1m3iF7BrZvoiF30reREpJh2gZb4jOnW1/uYFzyRiLCmFSkM+8hwiq1vWQ==",
       "license": "MIT",
       "dependencies": {
         "chokidar": "^3.5.3",
-        "fast-glob": "^3.2.11",
-        "fs-extra": "^11.1.0",
+        "fs-extra": "^11.3.0",
         "p-map": "^7.0.3",
-        "picocolors": "^1.0.0"
+        "picocolors": "^1.1.1",
+        "tinyglobby": "^0.2.13"
       },
       "engines": {
         "node": "^18.0.0 || >=20.0.0"
@@ -33839,15 +33827,15 @@
       "license": "ISC"
     },
     "node_modules/yaml": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.1.tgz",
-      "integrity": "sha512-10ULxpnOCQXxJvBgxsn9ptjq6uviG/htZKk9veJGhlqn3w/DxQ631zFF+nlQXLwmImeS5amR2dl2U8sg6U9jsQ==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.0.tgz",
+      "integrity": "sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==",
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"
       },
       "engines": {
-        "node": ">= 14"
+        "node": ">= 14.6"
       }
     },
     "node_modules/yargs": {
@@ -34104,13 +34092,12 @@
         "@rollup/plugin-terser": "^0.4.0",
         "@rollup/plugin-virtual": "^3.0.1",
         "es-module-shims": "^1.6.3",
-        "find-up-simple": "^1.0.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.9.0",
         "rollup": "^4.6.1",
         "ts-node": "^10.9.1",
-        "vite-plugin-static-copy": "^2.0.0"
+        "vite-plugin-static-copy": "^3.0.0"
       },
       "devDependencies": {
         "@types/react": "^18.0.28",

--- a/packages/app-shell-vite-plugin/package.json
+++ b/packages/app-shell-vite-plugin/package.json
@@ -37,13 +37,12 @@
     "@rollup/plugin-terser": "^0.4.0",
     "@rollup/plugin-virtual": "^3.0.1",
     "es-module-shims": "^1.6.3",
-    "find-up-simple": "^1.0.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.9.0",
     "rollup": "^4.6.1",
     "ts-node": "^10.9.1",
-    "vite-plugin-static-copy": "^2.0.0"
+    "vite-plugin-static-copy": "^3.0.0"
   },
   "peerDependencies": {
     "vite": "^4.1.4 || ^5.0.4 || ^6.0.0"

--- a/packages/app-shell-vite-plugin/src/nodeModule.ts
+++ b/packages/app-shell-vite-plugin/src/nodeModule.ts
@@ -1,6 +1,5 @@
 import { createRequire } from "node:module";
-import { join } from "node:path";
-import { findUpSync } from "find-up-simple";
+import { dirname, join } from "node:path";
 
 export const require = createRequire(import.meta.url);
 
@@ -8,27 +7,10 @@ export const require = createRequire(import.meta.url);
  * Resolves the module entrypoint by name and normalizes slashes to be posix/unix-like forward slashes.
  *
  * @param moduleName The name of the module to be searched for
+ * @param suffix to be added after the module path
  * @returns The module path normalized
  */
-export function resolveModule(moduleName: string) {
-  return require.resolve(moduleName).replace(/\\+/g, "/");
-}
-
-/** Resolves the module directory (where `package.json` is) by `moduleName` */
-function resolveModuleDirectory(moduleName: string) {
-  const moduleEntrypoint = resolveModule(moduleName);
-  const modulePackage = findUpSync("package.json", { cwd: moduleEntrypoint });
-  return modulePackage?.slice(0, modulePackage.lastIndexOf("/")) || "";
-}
-
-/**
- * This function will find out the module path using node `require.resolve` function
- * and add the suffix param after the folder with module name.
- *
- * @param moduleName "@module/name"
- * @param suffix to be added after the module path
- * @returns the /path/to/@module/name/<suffix>
- */
-export function getModulePath(moduleName: string, suffix: string) {
-  return join(resolveModuleDirectory(moduleName), suffix);
+export function resolveModule(moduleName: string, suffix?: string) {
+  const entrypoint = require.resolve(moduleName);
+  return suffix ? join(dirname(entrypoint), suffix) : entrypoint;
 }

--- a/packages/app-shell-vite-plugin/src/vite-configuration-processor-plugin.ts
+++ b/packages/app-shell-vite-plugin/src/vite-configuration-processor-plugin.ts
@@ -16,11 +16,6 @@ import {
   startsWithSelf,
 } from "./config-utils.js";
 
-enum ViteCommand {
-  BUILD = "build",
-  SERVE = "serve",
-}
-
 type BundleDefinition =
   | HvAppShellProvidersConfig
   | HvAppShellViewsConfig
@@ -114,7 +109,7 @@ export default function processConfiguration(
           },
         },
         // if serve (preview/dev) it uses the basePath. Otherwise(build), use ./
-        base: command === ViteCommand.SERVE ? basePath : "./",
+        base: command === "serve" ? basePath : "./",
       };
     },
 

--- a/packages/app-shell-vite-plugin/src/vite-plugin.ts
+++ b/packages/app-shell-vite-plugin/src/vite-plugin.ts
@@ -15,7 +15,7 @@ import {
   getFinalModuleName,
   loadConfigFile,
 } from "./config-utils.js";
-import { getModulePath, resolveModule } from "./nodeModule.js";
+import { resolveModule } from "./nodeModule.js";
 import SHARED_DEPENDENCIES from "./shared-dependencies.js";
 import getVirtualEntrypoints from "./virtual-entrypoints.js";
 import processConfiguration from "./vite-configuration-processor-plugin.js";
@@ -28,10 +28,10 @@ import generateImportmap, {
 import injectMetadata from "./vite-metadata-plugin.js";
 import serveAppShellConfig from "./vite-watch-config-plugin.js";
 
-enum ViteBuildMode {
-  PRODUCTION = "production",
-  DEVELOPMENT = "development",
-}
+const ViteBuildMode = {
+  PRODUCTION: "production",
+  DEVELOPMENT: "development",
+} as const;
 
 export type ApplicationBundleType = "app" | "bundle";
 
@@ -199,17 +199,15 @@ export function HvAppShellVitePlugin(
       viteStaticCopy({
         targets: [
           {
-            src: getModulePath("es-module-shims", "dist/*"),
+            src: resolveModule("es-module-shims", "*"),
             dest: "bundles",
           },
           // copy the ui kit icons' sprites to the "icons" folder
           {
-            src: [
-              getModulePath(
-                "@hitachivantara/uikit-react-icons",
-                "dist/sprites/*.svg",
-              ),
-            ],
+            src: resolveModule(
+              "@hitachivantara/uikit-react-icons",
+              "../sprites/*.svg",
+            ),
             dest: "icons",
           },
           ...(!devMode && buildEntryPoint


### PR DESCRIPTION
fix `app-shell-vite-plugin` error on `vite-plugin-static-copy` on Windows:

```
[vite-plugin-static-copy] Error: No file was found to copy on C:\...\node_modules\es-module-shims\package.jso\dist\* src.
[vite-plugin-static-copy] No items found.
```

- replace `slice` at `/` for cross-platform `path.dirname`
- simplify `resolveModule` by leveraging `path.join`:
  - remove `find-up-simple` in favor of using package entrypoint + `../` (when necessary)
  - merge `resolveModule` &. `getModulePath`
- bump `vite-plugin-static-copy`