### PR TITLE
fix(VerticalNavigation): update selected item color no P+ theme

### DIFF
--- a/packages/styles/src/themes/pentahoPlus.ts
+++ b/packages/styles/src/themes/pentahoPlus.ts
@@ -824,7 +824,7 @@ const pentahoPlus = makeTheme((theme) => ({
           "& .HvListItem-endAdornment": { backgroundColor: "transparent" },
         },
         listItemSelected: {
-          background: blue[950],
+          background: blue[800],
           borderLeft: "unset",
         },
         listItemFocus: {
@@ -841,7 +841,7 @@ const pentahoPlus = makeTheme((theme) => ({
           borderLeft: "unset",
           borderRadius: theme.radii.round,
           ".HvVerticalNavigationTreeViewItem-selected>&": {
-            background: blue[950],
+            background: blue[800],
             borderLeft: "unset",
           },
           ":not(.HvVerticalNavigationTreeViewItem-disabled>&):not(.HvVerticalNavigationTreeViewItem-selected>&)":


### PR DESCRIPTION
- Update for P+ v0.5 based on the [new specs](https://www.figma.com/design/aRqtbvWWrPf7asrEbd3g8x/branch/mJgA24tgJ8S13IAKw5JraP/Pentaho--Design-System-v0.5?node-id=17744-8938&m=dev).