### PR TITLE
feat(deps): bump notistack to v3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17296,6 +17296,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/goober": {
+      "version": "2.1.16",
+      "resolved": "https://registry.npmjs.org/goober/-/goober-2.1.16.tgz",
+      "integrity": "sha512-erjk19y1U33+XAMe1VTvIONHYoSqE4iS7BYUZfHaqeohLmnC0FdxEh7rQU+6MZ4OajItzjZFSRtVANrQwNq6/g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "csstype": "^3.0.10"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -24932,32 +24941,25 @@
       }
     },
     "node_modules/notistack": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/notistack/-/notistack-2.0.8.tgz",
-      "integrity": "sha512-/IY14wkFp5qjPgKNvAdfL5Jp6q90+MjgKTPh4c81r/lW70KeuX6b9pE/4f8L4FG31cNudbN9siiFS5ql1aSLRw==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/notistack/-/notistack-3.0.2.tgz",
+      "integrity": "sha512-0R+/arLYbK5Hh7mEfR2adt0tyXJcCC9KkA2hc56FeWik2QN6Bm/S4uW+BjzDARsJth5u06nTjelSw/VSnB1YEA==",
       "license": "MIT",
       "dependencies": {
         "clsx": "^1.1.0",
-        "hoist-non-react-statics": "^3.3.0"
+        "goober": "^2.0.33"
+      },
+      "engines": {
+        "node": ">=12.0.0",
+        "npm": ">=6.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/notistack"
       },
       "peerDependencies": {
-        "@emotion/react": "^11.4.1",
-        "@emotion/styled": "^11.3.0",
-        "@mui/material": "^5.0.0",
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@emotion/react": {
-          "optional": true
-        },
-        "@emotion/styled": {
-          "optional": true
-        }
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/notistack/node_modules/clsx": {
@@ -33524,7 +33526,7 @@
         "dayjs": "^1.11.10",
         "detect-browser": "^5.3.0",
         "embla-carousel-react": "^8.1.3",
-        "notistack": "^2.0.8",
+        "notistack": "^3.0.2",
         "rc-slider": "^10.5.0",
         "rc-tooltip": "~6.3.0",
         "react-color": "^2.19.3",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -54,7 +54,7 @@
     "dayjs": "^1.11.10",
     "detect-browser": "^5.3.0",
     "embla-carousel-react": "^8.1.3",
-    "notistack": "^2.0.8",
+    "notistack": "^3.0.2",
     "rc-slider": "^10.5.0",
     "rc-tooltip": "~6.3.0",
     "react-color": "^2.19.3",

--- a/packages/core/src/SnackbarProvider/SnackbarProvider.tsx
+++ b/packages/core/src/SnackbarProvider/SnackbarProvider.tsx
@@ -122,7 +122,7 @@ export const useHvSnackbar = () => {
  * A snackbar provider to control the stacking of multiple snackbars in the app.
  *
  * This component uses of the [Notistack](https://github.com/iamhosseindhv/notistack) library.
- * Please refer to its [API Reference](https://notistack.com/v2.x/api-reference) for more complex usage scenarios.
+ * Please refer to its [API Reference](https://notistack.com/api-reference) for more complex usage scenarios.
  */
 export const HvSnackbarProvider = (props: HvSnackbarProviderProps) => {
   const {


### PR DESCRIPTION
- migrate `notistack` used in `HvSnackbarProvider` to v3
- https://notistack.com/migration (`resumeHideDuration`, `onEntering`, `onExisting` removed)