### PR TITLE
fix(ListItem): start + end adornment positioning

### DIFF
--- a/packages/core/src/ListContainer/ListContainer.stories.tsx
+++ b/packages/core/src/ListContainer/ListContainer.stories.tsx
@@ -214,6 +214,12 @@ export const WithIcons: StoryObj<HvListContainerProps> = {
               Last month
             </HvListItem>
             <HvListItem endAdornment={<DropRightXS />}>Last year</HvListItem>
+            <HvListItem
+              startAdornment={<Calendar />}
+              endAdornment={<DropRightXS />}
+            >
+              Custom Date
+            </HvListItem>
           </HvListContainer>
         </HvPanel>
       </>

--- a/packages/core/src/ListContainer/ListItem/ListItem.styles.tsx
+++ b/packages/core/src/ListContainer/ListItem/ListItem.styles.tsx
@@ -32,15 +32,13 @@ export const { staticClasses, useClasses } = createClasses("HvListItem", {
     },
   },
   focus: { backgroundColor: theme.colors.bgPageSecondary, zIndex: 2 },
-  startAdornment: {},
-  endAdornment: {},
   gutters: {
     padding: `0 ${theme.space.xs}`,
 
-    "&$withStartAdornment": {
+    ":has($startAdornment)": {
       paddingLeft: 0,
     },
-    "&$withEndAdornment": {
+    ":has($endAdornment)": {
       paddingRight: 0,
     },
   },
@@ -59,22 +57,14 @@ export const { staticClasses, useClasses } = createClasses("HvListItem", {
     color: theme.colors.textDisabled,
     backgroundColor: theme.colors.bgDisabled,
   },
-  withStartAdornment: {
-    "& > div": {
-      float: "left",
-    },
-
-    "& svg": {
-      boxShadow: "none !important",
-      outline: "none !important",
-    },
+  startAdornment: {
+    float: "left",
   },
-  withEndAdornment: {
-    "& > div": { float: "right" },
-
-    "& svg": {
-      boxShadow: "none !important",
-      outline: "none !important",
-    },
+  endAdornment: {
+    float: "right",
   },
+  /** @deprecated use `:has($startAdornment)` instead */
+  withStartAdornment: {},
+  /** @deprecated use `:has($endAdornment)` instead */
+  withEndAdornment: {},
 });

--- a/packages/core/src/ListContainer/ListItem/ListItem.tsx
+++ b/packages/core/src/ListContainer/ListItem/ListItem.tsx
@@ -66,34 +66,6 @@ export interface HvListItemProps extends HvBaseProps<HTMLLIElement> {
   classes?: HvListItemClasses;
 }
 
-const applyClassNameAndStateToElement = (
-  element: React.ReactNode,
-  selected: boolean | undefined,
-  disabled: boolean | undefined,
-  onClick: React.MouseEventHandler<HTMLLIElement>,
-  className?: string,
-) => {
-  if (element == null) return null;
-
-  return cloneElement(element as ReactElement, {
-    className,
-    checked: !!selected,
-    disabled,
-    onChange: onClick,
-  });
-};
-
-const applyClassNameToElement = (
-  element: React.ReactNode,
-  className?: string,
-) => {
-  if (element == null) return null;
-
-  return cloneElement(element as ReactElement, {
-    className,
-  });
-};
-
 /**
  * Implements the listitem pattern, akin to the `<li>` element.
  * Should be composed within a `<HvListContainer>` component.
@@ -145,45 +117,35 @@ export const HvListItem = forwardRef<
     [disabled, onClick],
   );
 
-  const clonedStartAdornment = useMemo(
-    () =>
-      applyClassNameAndStateToElement(
-        startAdornment,
-        selected,
-        disabled,
-        handleClick,
-        cx(
-          classes.startAdornment,
-          { [classes.disabled]: disabled },
-          isValidElement(startAdornment)
-            ? startAdornment.props.className
-            : undefined,
-        ),
-      ),
-    [
-      cx,
-      classes?.startAdornment,
-      classes?.disabled,
+  const clonedStartAdornment = useMemo(() => {
+    if (!isValidElement(startAdornment)) return startAdornment;
+    return cloneElement(startAdornment as ReactElement, {
+      className: cx(classes.startAdornment, startAdornment.props.className, {
+        // TODO: remove 👇 props below
+        [classes.disabled]: disabled,
+      }),
+      checked: !!selected,
       disabled,
-      handleClick,
-      selected,
-      startAdornment,
-    ],
-  );
-  const clonedEndAdornment = useMemo(
-    () =>
-      applyClassNameToElement(
-        endAdornment,
-        cx(
-          classes.endAdornment,
-          { [classes.disabled]: disabled },
-          isValidElement(endAdornment)
-            ? endAdornment.props.className
-            : undefined,
-        ),
-      ),
-    [cx, classes?.endAdornment, classes?.disabled, disabled, endAdornment],
-  );
+      onChange: handleClick,
+    });
+  }, [
+    cx,
+    classes?.startAdornment,
+    classes?.disabled,
+    disabled,
+    handleClick,
+    selected,
+    startAdornment,
+  ]);
+
+  const clonedEndAdornment = useMemo(() => {
+    if (!isValidElement(endAdornment)) return endAdornment;
+    return cloneElement(endAdornment as ReactElement, {
+      className: cx(classes.endAdornment, endAdornment.props.className, {
+        [classes.disabled]: disabled,
+      }),
+    });
+  }, [cx, classes?.endAdornment, classes?.disabled, disabled, endAdornment]);
 
   const roleOptionAriaProps =
     role === "option" || role === "menuitem"


### PR DESCRIPTION
when using both `startAdornment` and `endAdornment`, the icons are misaligned:

![image](https://github.com/user-attachments/assets/9ef65cc7-3c2e-4835-94bf-7907a1cd4e5d)
