### PR TITLE
fix(cli): add fallback `Project`/`Home` routes

### DIFF
--- a/packages/cli/src/baselines/app-shell/vite/public/locales/en/example.json
+++ b/packages/cli/src/baselines/app-shell/vite/public/locales/en/example.json
@@ -1,0 +1,8 @@
+{
+  "page": {
+    "title": "Example Page"
+  },
+  "section": {
+    "title": "Example section"
+  }
+}

--- a/packages/cli/src/baselines/app-shell/vite/src/pages/Example/index.tsx
+++ b/packages/cli/src/baselines/app-shell/vite/src/pages/Example/index.tsx
@@ -4,10 +4,10 @@ import {
   HvGrid,
   HvTypography,
 } from "@hitachivantara/uikit-react-core";
-{{#if useAppShell}}import { withProvider } from "../../providers/Provider";{{/if}}
+import { withProvider } from "../../providers/Provider";
 
-const {{titleCase name}}: React.FC = () => {
-  const { t } = useTranslation("{{lowerCase name}}");
+const Example = () => {
+  const { t } = useTranslation("example");
 
   return (
     <HvGrid container>
@@ -21,4 +21,4 @@ const {{titleCase name}}: React.FC = () => {
   );
 };
 
-export default {{#if useAppShell}}withProvider({{/if}}{{titleCase name}}{{#if useAppShell}}){{/if}};
+export default withProvider(Example);

--- a/packages/cli/src/baselines/vite/public/locales/en/home.json
+++ b/packages/cli/src/baselines/vite/public/locales/en/home.json
@@ -1,0 +1,4 @@
+{
+  "title": "Homepage",
+  "description": "This is an example homepage"
+}

--- a/packages/cli/src/baselines/vite/src/App.tsx
+++ b/packages/cli/src/baselines/vite/src/App.tsx
@@ -3,7 +3,6 @@ import "virtual:uno.css";
 
 import {
   createBrowserRouter,
-  Navigate,
   RouteObject,
   RouterProvider,
 } from "react-router-dom";
@@ -14,10 +13,7 @@ import { appRoutes } from "./routes";
 export const routes: RouteObject[] = [
   {
     lazy: () => import("./pages/layout/navigation"),
-    children: [
-      ...appRoutes,
-      { index: true, element: <Navigate to={appRoutes[0].path!} replace /> },
-    ],
+    children: appRoutes,
   },
   { path: "*", lazy: () => import("./pages/NotFound") },
 ];

--- a/packages/cli/src/baselines/vite/src/pages/Home/index.tsx
+++ b/packages/cli/src/baselines/vite/src/pages/Home/index.tsx
@@ -1,0 +1,13 @@
+import { HvTypography } from "@hitachivantara/uikit-react-core";
+import { useTranslation } from "react-i18next";
+
+export function Component() {
+  const { t } = useTranslation("home");
+
+  return (
+    <div className="grid gap-sm">
+      <HvTypography variant="title1">{t("title")}</HvTypography>
+      <HvTypography>{t("description")}</HvTypography>
+    </div>
+  );
+}

--- a/packages/cli/src/baselines/vite/src/routes.tsx
+++ b/packages/cli/src/baselines/vite/src/routes.tsx
@@ -2,6 +2,7 @@ import type { NavigationData } from "@hitachivantara/uikit-react-core";
 import type { RouteObject } from "react-router-dom";
 
 export const appRoutes: RouteObject[] = [
+  { index: true, path: "/", lazy: () => import("./pages/Home") },
   // APP ROUTES
 ];
 

--- a/packages/cli/src/contents.js
+++ b/packages/cli/src/contents.js
@@ -47,19 +47,6 @@ const copyTemplateContents = (appPath, templates) => {
   return dependencies;
 };
 
-const createDefaultContents = async (path, useAppShell) => {
-  const createDefault = plop.getGenerator("createDefault");
-
-  console.log(
-    `No templates selected: ${chalk.cyan("Creating default contents")}`,
-  );
-
-  // create default contents from plop template
-  await createDefault.runActions({ path, name: "Project", useAppShell });
-
-  return {};
-};
-
 const createReadMeFile = async (path, name) => {
   await createReadMe.runActions({
     path,
@@ -67,17 +54,10 @@ const createReadMeFile = async (path, name) => {
   });
 };
 
-export const createAppContents = async (
-  appPath,
-  name,
-  templates,
-  useAppShell,
-) => {
+export const createAppContents = async (appPath, name, templates) => {
   console.log(`Creating ${chalk.cyan(name)} contents\n`);
 
   await createReadMeFile(appPath, name);
 
-  return templates?.length
-    ? copyTemplateContents(appPath, templates)
-    : createDefaultContents(appPath, useAppShell);
+  return templates?.length ? copyTemplateContents(appPath, templates) : {};
 };

--- a/packages/cli/src/plop-templates/component.tsx.hbs
+++ b/packages/cli/src/plop-templates/component.tsx.hbs
@@ -1,10 +1,10 @@
 import { useTranslation } from "react-i18next";
 import {
+  HvGlobalActions,
   HvGrid,
   HvTypography,
-  HvGlobalActions,
 } from "@hitachivantara/uikit-react-core";
-{{#if useAppShell}}import { withProvider } from "providers/Provider";{{/if}}
+{{#if useAppShell}}import { withProvider } from "../../providers/Provider";{{/if}}
 
 const {{titleCase name}}: React.FC = () => {
   const { t } = useTranslation("{{lowerCase name}}");

--- a/packages/cli/src/plop-templates/locale.json.hbs
+++ b/packages/cli/src/plop-templates/locale.json.hbs
@@ -1,8 +1,0 @@
-{
-  "page": {
-    "title": "{{titleCase name}} Page"
-  },
-  "section": {
-    "title": "{{titleCase name}} section"
-  }
-}

--- a/packages/cli/src/plopfile.js
+++ b/packages/cli/src/plopfile.js
@@ -7,7 +7,7 @@ const createDefault = {
     },
     {
       type: "add",
-      path: "{{path}}/src/pages/{{name}}/{{name}}.tsx",
+      path: "{{path}}/src/pages/{{name}}/index.tsx",
       templateFile: "plop-templates/component.tsx.hbs",
     },
   ],

--- a/packages/cli/src/plopfile.js
+++ b/packages/cli/src/plopfile.js
@@ -1,18 +1,3 @@
-const createDefault = {
-  actions: [
-    {
-      type: "add",
-      path: "{{path}}/public/locales/en/{{lowerCase name}}.json",
-      templateFile: "plop-templates/locale.json.hbs",
-    },
-    {
-      type: "add",
-      path: "{{path}}/src/pages/{{name}}/index.tsx",
-      templateFile: "plop-templates/component.tsx.hbs",
-    },
-  ],
-};
-
 const createRoute = {
   actions: [
     {
@@ -67,7 +52,6 @@ const createAppShellViteConfig = {
 
 export default (plop) => {
   plop.setHelper("precurly", (t) => `${t}`);
-  plop.setGenerator("createDefault", createDefault);
   plop.setGenerator("createRoute", createRoute);
   plop.setGenerator("createReadMe", createReadMe);
   plop.setGenerator("createAppShellIndexHtml", createAppShellIndexHtml);

--- a/templates/Canvas/dependencies.json
+++ b/templates/Canvas/dependencies.json
@@ -1,0 +1,6 @@
+{
+  "dependencies": {
+    "@dnd-kit/sortable": "^7.0.2",
+    "@dnd-kit/utilities": "^3.2.2"
+  }
+}

--- a/templates/DetailsView/KPIs.tsx
+++ b/templates/DetailsView/KPIs.tsx
@@ -44,7 +44,7 @@ export const KPIs = () => {
         <HvAvatar
           size="xl"
           status="atmo4"
-          classes={{ status: css({ margin: "auto" }) }}
+          classes={{ status: css({ margin: "auto", width: "fit-content" }) }}
           src={imageUrl}
           alt="Asset image"
         />

--- a/templates/KanbanBoard/dependencies.json
+++ b/templates/KanbanBoard/dependencies.json
@@ -1,0 +1,6 @@
+{
+  "dependencies": {
+    "@hitachivantara/uikit-react-lab": "latest",
+    "@hitachivantara/uikit-react-pentaho": "latest"
+  }
+}


### PR DESCRIPTION
1. Fallback route in App Shell (`pages/Project.tsx`) had issues (see first commit)
2. Add static `Example.tsx` and `Home.tsx` pages, instead of relying on the plop script, which can easily hide potential problems (`baselines/*` is also more readable now)
3. add missing `dependencies.json` in some templates, fixing the "dependencies not found" issue