### PR TITLE
fix(TagsInput): input styles

### DIFF
--- a/packages/core/src/TagsInput/TagsInput.styles.tsx
+++ b/packages/core/src/TagsInput/TagsInput.styles.tsx
@@ -89,10 +89,14 @@ export const { staticClasses, useClasses } = createClasses("HvTagsInput", {
     border: "none",
     margin: 0,
     padding: 0,
-    ...theme.typography.caption1,
+    ...theme.typography.body,
     backgroundColor: "transparent",
     outline: "none",
     boxShadow: "none",
+
+    "&::placeholder": {
+      color: theme.colors.textSubtle,
+    },
   },
   /** @deprecated unused.  use `:focus` or `:focus-visible` instead */
   tagSelected: {},

--- a/packages/core/src/themes/pentahoPlus.ts
+++ b/packages/core/src/themes/pentahoPlus.ts
@@ -220,6 +220,9 @@ export const pentahoPlus = mergeTheme(pentahoPlusBase, {
               borderColor: theme.colors.textDisabled,
             },
           },
+          "& .HvTagsInput-chipRoot": {
+            outlineColor: theme.colors.textDisabled,
+          },
         },
       },
     },

--- a/packages/core/src/themes/pentahoPlus.ts
+++ b/packages/core/src/themes/pentahoPlus.ts
@@ -208,9 +208,18 @@ export const pentahoPlus = mergeTheme(pentahoPlusBase, {
         tagsList: {
           backgroundColor: inputColors.bg,
           padding: theme.space.xxs,
+          borderColor: theme.colors.textDimmed,
         },
         singleLine: {
           height: 32,
+        },
+        disabled: {
+          "& .HvTagsInput-tagsList": {
+            backgroundColor: theme.colors.bgDisabled,
+            "&,:hover": {
+              borderColor: theme.colors.textDisabled,
+            },
+          },
         },
       },
     },


### PR DESCRIPTION
- I fixed some styling discrepancies for the Tags Input (when besides another input, you could see the Tags Input was different):
   - Border color for the Pentaho+ theme
   - Disabled background and border colors for the Pentaho+ theme
   - Placeholder text style

ℹ️ I think I found more stuff but I only fixed the styles: the placeholder disappears when read only or disabled is true; it looks like in Pentaho+ the description should be under the input.