### PR TITLE
fix(AppShell): vite plugin windows build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,12 @@ on:
 
 jobs:
   Build:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+
+    runs-on: ${{ matrix.os }}
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/packages/app-shell-vite-plugin/src/nodeModule.ts
+++ b/packages/app-shell-vite-plugin/src/nodeModule.ts
@@ -1,5 +1,6 @@
 import { createRequire } from "node:module";
 import { dirname, join } from "node:path";
+import { normalizePath } from "vite";
 
 export const require = createRequire(import.meta.url);
 
@@ -12,5 +13,5 @@ export const require = createRequire(import.meta.url);
  */
 export function resolveModule(moduleName: string, suffix?: string) {
   const entrypoint = require.resolve(moduleName);
-  return suffix ? join(dirname(entrypoint), suffix) : entrypoint;
+  return normalizePath(suffix ? join(dirname(entrypoint), suffix) : entrypoint);
 }

--- a/packages/app-shell-vite-plugin/src/vite-plugin.ts
+++ b/packages/app-shell-vite-plugin/src/vite-plugin.ts
@@ -199,10 +199,11 @@ export function HvAppShellVitePlugin(
       viteStaticCopy({
         targets: [
           {
-            src: resolveModule("es-module-shims", "*"),
+            src: resolveModule("es-module-shims"),
             dest: "bundles",
           },
           // copy the ui kit icons' sprites to the "icons" folder
+          // TODO: remove, no longer used
           {
             src: resolveModule(
               "@hitachivantara/uikit-react-icons",


### PR DESCRIPTION
- fix App Shell build in windows (`es-module-shims` [static copy](https://github.com/sapphi-red/vite-plugin-static-copy?tab=readme-ov-file#usage))
- enable (Nightly only) build test in Windows