### PR TITLE
feat(Section): add expandableHeader

### DIFF
--- a/apps/docs/src/content/components/section.mdx
+++ b/apps/docs/src/content/components/section.mdx
@@ -10,16 +10,10 @@ import { Header } from "../../components/Header";
   Component={HvSection}
   componentName="HvSection"
   controls={{
-    title: {
-      type: "text",
-      defaultValue: "Section title",
-    },
-    expandable: {
-      defaultValue: false,
-    },
-    raisedHeader: {
-      defaultValue: false,
-    },
+    title: { defaultValue: "Section title" },
+    expandable: { defaultValue: false },
+    expandableHeader: { defaultValue: false },
+    raisedHeader: { defaultValue: false },
   }}
 >
   <div>My section example content</div>
@@ -62,6 +56,7 @@ export default function Demo() {
       <HvSection
         title="Controlled section"
         expandable
+        expandableHeader
         expanded={expanded}
         onToggle={() => setExpanded((p) => !p)}
       >

--- a/packages/core/src/Section/Section.stories.tsx
+++ b/packages/core/src/Section/Section.stories.tsx
@@ -80,7 +80,13 @@ export const Test: StoryObj = {
           dapibus accumsan est, a pharetra velit consequat et.
         </HvTypography>
       </HvSection>
-      <HvSection raisedHeader expandable title="My Section">
+      <HvSection
+        raisedHeader
+        expandable
+        expandableHeader
+        title="My Section"
+        actions={<HvButton variant="primaryGhost">Action</HvButton>}
+      >
         <HvTypography>
           Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed tempor
           blandit ipsum quis sollicitudin. Aliquam erat volutpat. Praesent nisi

--- a/packages/core/src/Section/Section.styles.tsx
+++ b/packages/core/src/Section/Section.styles.tsx
@@ -8,6 +8,7 @@ export const { staticClasses, useClasses } = createClasses("HvSection", {
     flexDirection: "column",
     backgroundColor: theme.colors.bgContainer,
     borderRadius: theme.radii.round,
+    overflow: "hidden",
     border: `1px solid ${theme.colors.border}`,
   },
   hidden: { height: 0, display: "none" },
@@ -17,11 +18,23 @@ export const { staticClasses, useClasses } = createClasses("HvSection", {
     borderColor: "inherit",
     position: "relative",
     padding: theme.space.sm,
+
+    "+ $content": {
+      borderTopLeftRadius: 0,
+      borderTopRightRadius: 0,
+    },
+  },
+  headerExpandable: {
+    cursor: "pointer",
+    ":hover": {
+      backgroundColor: theme.colors.bgHover,
+    },
   },
   content: {
     padding: theme.space.sm,
     borderRadius: "inherit",
     borderColor: "inherit",
+    flex: 1,
   },
   hasHeader: {
     paddingTop: 0,

--- a/packages/core/src/Section/Section.test.tsx
+++ b/packages/core/src/Section/Section.test.tsx
@@ -1,16 +1,16 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
 import { describe, expect, it } from "vitest";
 
-import { HvButton } from "../Button";
 import { HvSection } from "./Section";
 
 describe("Section", () => {
-  it("should contain all the steps", () => {
+  it("contains all the steps", () => {
     render(<HvSection title="Section Title" />);
     expect(screen.getByText("Section Title")).toBeInTheDocument();
   });
 
-  it("should render the content when it's not expandable", () => {
+  it("renders the content when it's not expandable", () => {
     render(
       <HvSection title="Section Title" expanded>
         <div>Child Content</div>
@@ -19,7 +19,7 @@ describe("Section", () => {
     expect(screen.getByText("Child Content")).toBeInTheDocument();
   });
 
-  it("should render the content when it's expandable and is expanded by default", () => {
+  it("renders the content when it's expandable and is expanded by default", () => {
     render(
       <HvSection title="Section Title" expandable defaultExpanded>
         <div>Child Content</div>
@@ -28,7 +28,7 @@ describe("Section", () => {
     expect(screen.queryByText("Child Content")).toBeInTheDocument();
   });
 
-  it("should not render the content when it's expandable and is not expanded by default", () => {
+  it("doesn't render the content when it's expandable and is not expanded by default", () => {
     render(
       <HvSection title="Section Title" expandable defaultExpanded={false}>
         <div>Child Content</div>
@@ -37,7 +37,7 @@ describe("Section", () => {
     expect(screen.queryByText("Child Content")).not.toBeVisible();
   });
 
-  it("should toggle the expanded state when the expand button is clicked", async () => {
+  it("toggles the expanded state when the expand button is clicked", async () => {
     render(
       <HvSection title="Section Title" expandable defaultExpanded={false}>
         <div>Child Content</div>
@@ -46,18 +46,58 @@ describe("Section", () => {
 
     expect(screen.queryByText("Child Content")).not.toBeVisible();
 
-    const expandButton = screen.getByRole("button");
-    fireEvent.click(expandButton);
-
+    await userEvent.click(screen.getByRole("button"));
     expect(screen.queryByText("Child Content")).toBeVisible();
 
-    fireEvent.click(expandButton);
-
+    await userEvent.click(screen.getByRole("button"));
     expect(screen.queryByText("Child Content")).not.toBeVisible();
   });
 
-  it("should render the actions prop", () => {
-    const actions = <HvButton>Action 1</HvButton>;
+  it("toggles the expanded state when the header is clicked", async () => {
+    const toggleMock = vi.fn();
+    render(
+      <HvSection
+        title="Section Title"
+        expandable
+        expandableHeader
+        defaultExpanded={false}
+        onToggle={toggleMock}
+      >
+        <div>Child Content</div>
+      </HvSection>,
+    );
+
+    expect(screen.queryByText("Child Content")).not.toBeVisible();
+
+    await userEvent.click(screen.getByText("Section Title"));
+    expect(screen.queryByText("Child Content")).toBeVisible();
+    expect(toggleMock).toHaveBeenCalledWith(expect.anything(), true);
+  });
+
+  it("doesn't toggle the expanded state when an action is clicked", async () => {
+    const toggleMock = vi.fn();
+    render(
+      <HvSection
+        title="Section Title"
+        expandable
+        expandableHeader
+        defaultExpanded={false}
+        actions={<button type="button">Action</button>}
+        onToggle={toggleMock}
+      >
+        <div>Child Content</div>
+      </HvSection>,
+    );
+
+    expect(screen.queryByText("Child Content")).not.toBeVisible();
+
+    await userEvent.click(screen.getByRole("button", { name: "Action" }));
+    expect(screen.queryByText("Child Content")).not.toBeVisible();
+    expect(toggleMock).not.toHaveBeenCalled();
+  });
+
+  it("renders the actions prop", () => {
+    const actions = <button type="button">Action 1</button>;
     render(<HvSection title="Section Title" actions={actions} />);
 
     expect(screen.getByText("Action 1")).toBeInTheDocument();

--- a/packages/core/src/Section/Section.tsx
+++ b/packages/core/src/Section/Section.tsx
@@ -1,4 +1,4 @@
-import { forwardRef } from "react";
+import { forwardRef, useRef } from "react";
 import {
   useDefaultProps,
   type ExtractNames,
@@ -20,6 +20,8 @@ export interface HvSectionProps
   title?: React.ReactNode;
   /** Whether or not the section is expandable.  */
   expandable?: boolean;
+  /** Whether or not the section header is expandable. If true, the header will be clickable and will toggle the section content. */
+  expandableHeader?: boolean;
   /** Whether the section is open or not, if this property is defined the accordion must be fully controlled. */
   expanded?: boolean;
   /** When uncontrolled, defines the initial expanded state. */
@@ -53,6 +55,7 @@ export const HvSection = forwardRef<HTMLDivElement, HvSectionProps>(
       title,
       expandable,
       expanded,
+      expandableHeader,
       defaultExpanded = true,
       actions,
       onToggle,
@@ -63,6 +66,7 @@ export const HvSection = forwardRef<HTMLDivElement, HvSectionProps>(
       ...others
     } = useDefaultProps("HvSection", props);
     const { classes, cx } = useClasses(classesProp);
+    const expandButtonRef = useRef<HTMLButtonElement>(null);
 
     const { isOpen, toggleOpen, buttonProps, regionProps } = useExpandable({
       id,
@@ -82,11 +86,22 @@ export const HvSection = forwardRef<HTMLDivElement, HvSectionProps>(
         {...others}
       >
         {hasHeader && (
-          <div className={classes.header}>
+          <div
+            className={cx(classes.header, {
+              [classes.headerExpandable]: expandable && expandableHeader,
+            })}
+            // eslint-disable-next-line click-events-have-key-events
+            onClick={() => {
+              if (!expandableHeader) return;
+              expandButtonRef.current?.click();
+            }}
+          >
             {expandable && (
               <HvButton
+                ref={expandButtonRef}
                 icon
                 onClick={(event) => {
+                  event.stopPropagation();
                   toggleOpen();
                   onToggle?.(event, !isOpen);
                 }}
@@ -98,7 +113,15 @@ export const HvSection = forwardRef<HTMLDivElement, HvSectionProps>(
               </HvButton>
             )}
             {title}
-            <div className={classes.actions}>{actions}</div>
+            <div
+              className={classes.actions}
+              // eslint-disable-next-line click-events-have-key-events
+              onClick={(evt) => {
+                evt.stopPropagation();
+              }}
+            >
+              {actions}
+            </div>
           </div>
         )}
         <div

--- a/packages/core/src/Table/TableSection/TableSection.styles.tsx
+++ b/packages/core/src/Table/TableSection/TableSection.styles.tsx
@@ -10,13 +10,7 @@ import { tableRowClasses } from "../TableRow";
 
 export const { staticClasses, useClasses } = createClasses("HvTableSection", {
   root: {},
-  header: {
-    // Only apply the border to divide the header and content when both are displayed
-    "+ div": {
-      borderTopLeftRadius: 0,
-      borderTopRightRadius: 0,
-    },
-  },
+  header: {},
   actions: {},
   content: {
     marginTop: 0,

--- a/packages/core/src/themes/pentahoPlus.ts
+++ b/packages/core/src/themes/pentahoPlus.ts
@@ -8,6 +8,12 @@ import {
   theme,
 } from "@hitachivantara/uikit-styles";
 
+import type { HvSectionProps } from "../Section";
+
+type CSSClasses<Props extends Record<string, any>> = Omit<Props, "classes"> & {
+  classes?: Record<string, CSSObject>;
+};
+
 /** light-dark alias */
 const ld = (c1: string, c2: string) => `light-dark(${c1}, ${c2})`;
 
@@ -163,6 +169,13 @@ export const pentahoPlus = mergeTheme(pentahoPlusBase, {
         },
       },
     },
+    HvSection: {
+      classes: {
+        content: {
+          backgroundColor: theme.colors.bgPage, // = bgContainerSecondary
+        },
+      },
+    } satisfies CSSClasses<HvSectionProps>,
     HvSelect: {
       classes: {
         root: {


### PR DESCRIPTION
add opt-in `expandableHeader` prop, allowing the whole header to be clickable, to support the new Pentaho+ behaviour

implementation is a bit of a hack (hence the a11y disables) since we [can't have buttons inside buttons](https://accessibilityinsights.io/info-examples/web/nested-interactive/), the "header" is a11y-hidden, and clicking it triggers a click on the accessible expand toggle button