### PR TITLE
feat(Dialog): update Dialog according to P+ specs

### DIFF
--- a/packages/core/src/Dialog/Content/Content.styles.tsx
+++ b/packages/core/src/Dialog/Content/Content.styles.tsx
@@ -4,14 +4,13 @@ import { theme } from "@hitachivantara/uikit-styles";
 export const { staticClasses, useClasses } = createClasses("HvDialog-Content", {
   root: {
     padding: theme.spacing(0, "sm", "sm"),
+    borderColor: theme.colors.borderSubtle,
+    borderTopWidth: "var(--borderW)",
+    borderBottomWidth: "var(--borderW)",
   },
   textContent: {
     paddingLeft: `calc(42px + ${theme.space.sm})`,
     paddingRight: "62px",
     overflowY: "auto",
-  },
-  contentBorder: {
-    borderTop: "var(--content-border)",
-    borderBottom: "var(--content-border)",
   },
 });

--- a/packages/core/src/Dialog/Content/Content.styles.tsx
+++ b/packages/core/src/Dialog/Content/Content.styles.tsx
@@ -6,8 +6,10 @@ export const { staticClasses, useClasses } = createClasses("HvDialog-Content", {
     padding: theme.spacing(0, "sm", "sm"),
   },
   textContent: {
-    marginLeft: "42px",
+    paddingLeft: `calc(42px + ${theme.space.sm})`,
     paddingRight: "62px",
     overflowY: "auto",
+    borderTop: "var(--content-border)",
+    borderBottom: "var(--content-border)",
   },
 });

--- a/packages/core/src/Dialog/Content/Content.styles.tsx
+++ b/packages/core/src/Dialog/Content/Content.styles.tsx
@@ -9,6 +9,8 @@ export const { staticClasses, useClasses } = createClasses("HvDialog-Content", {
     paddingLeft: `calc(42px + ${theme.space.sm})`,
     paddingRight: "62px",
     overflowY: "auto",
+  },
+  contentBorder: {
     borderTop: "var(--content-border)",
     borderBottom: "var(--content-border)",
   },

--- a/packages/core/src/Dialog/Content/Content.tsx
+++ b/packages/core/src/Dialog/Content/Content.tsx
@@ -34,16 +34,28 @@ export const HvDialogContent = (props: HvDialogContentProps) => {
 
   const { classes, cx } = useClasses(classesProp);
   const [hasBorder, setHasBorder] = useState(false);
-
   const elRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    const el = elRef.current as HTMLElement | null;
-    if (el) {
-      const hasOverflow = el.scrollHeight > el.clientHeight;
-      setHasBorder(hasOverflow);
+    if (typeof ResizeObserver !== "undefined") {
+      const resizeObserver = new ResizeObserver(() => {
+        const el = elRef.current as HTMLElement | null;
+        if (el) {
+          const hasOverflow = el.scrollHeight > el.clientHeight;
+          setHasBorder(hasOverflow);
+        }
+      });
+
+      if (elRef.current) {
+        resizeObserver.observe(elRef.current as HTMLElement);
+      }
+
+      return () => {
+        resizeObserver.disconnect();
+      };
     }
-  }, [elRef]);
+    return undefined;
+  }, []);
 
   return (
     <HvTypography
@@ -52,6 +64,7 @@ export const HvDialogContent = (props: HvDialogContentProps) => {
       className={cx(
         classes.root,
         { [classes.textContent]: !!indentContent },
+        { [classes.contentBorder]: hasBorder },
         className,
       )}
       style={{

--- a/packages/core/src/Dialog/Content/Content.tsx
+++ b/packages/core/src/Dialog/Content/Content.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef, useState } from "react";
 import MuiDialogContent, {
   DialogContentProps as MuiDialogContentProps,
 } from "@mui/material/DialogContent";
@@ -5,6 +6,7 @@ import {
   useDefaultProps,
   type ExtractNames,
 } from "@hitachivantara/uikit-react-utils";
+import { theme } from "@hitachivantara/uikit-styles";
 
 import { HvTypography } from "../../Typography";
 import { staticClasses, useClasses } from "./Content.styles";
@@ -31,15 +33,32 @@ export const HvDialogContent = (props: HvDialogContentProps) => {
   } = useDefaultProps("HvDialogContent", props);
 
   const { classes, cx } = useClasses(classesProp);
+  const [hasBorder, setHasBorder] = useState(false);
+
+  const elRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const el = elRef.current as HTMLElement | null;
+    if (el) {
+      const hasOverflow = el.scrollHeight > el.clientHeight;
+      setHasBorder(hasOverflow);
+    }
+  }, [elRef]);
 
   return (
     <HvTypography
+      ref={elRef}
       component={MuiDialogContent}
       className={cx(
         classes.root,
         { [classes.textContent]: !!indentContent },
         className,
       )}
+      style={{
+        ["--content-border" as string]: hasBorder
+          ? `1px solid ${theme.colors.borderSubtle}`
+          : "none",
+      }}
       {...others}
     >
       {children}

--- a/packages/core/src/Dialog/Content/Content.tsx
+++ b/packages/core/src/Dialog/Content/Content.tsx
@@ -3,6 +3,7 @@ import MuiDialogContent, {
   DialogContentProps as MuiDialogContentProps,
 } from "@mui/material/DialogContent";
 import {
+  mergeStyles,
   useDefaultProps,
   type ExtractNames,
 } from "@hitachivantara/uikit-react-utils";
@@ -29,6 +30,7 @@ export const HvDialogContent = (props: HvDialogContentProps) => {
     className,
     children,
     indentContent = false,
+    style,
     ...others
   } = useDefaultProps("HvDialogContent", props);
 
@@ -64,14 +66,11 @@ export const HvDialogContent = (props: HvDialogContentProps) => {
       className={cx(
         classes.root,
         { [classes.textContent]: !!indentContent },
-        { [classes.contentBorder]: hasBorder },
         className,
       )}
-      style={{
-        ["--content-border" as string]: hasBorder
-          ? `1px solid ${theme.colors.borderSubtle}`
-          : "none",
-      }}
+      style={mergeStyles(style, {
+        "--borderW": hasBorder ? "1px" : "0px",
+      })}
       {...others}
     >
       {children}

--- a/packages/core/src/Dialog/Dialog.styles.tsx
+++ b/packages/core/src/Dialog/Dialog.styles.tsx
@@ -13,7 +13,10 @@ export const { staticClasses, useClasses } = createClasses("HvDialog", {
     borderColor: theme.colors.border,
     borderRadius: theme.radii.round,
   },
-  fullscreen: {},
+  fullscreen: {
+    borderRadius: 0,
+  },
+
   fullHeight: {
     height: "100%",
   },

--- a/packages/core/src/Dialog/Title/Title.tsx
+++ b/packages/core/src/Dialog/Title/Title.tsx
@@ -8,7 +8,6 @@ import {
 
 import { HvStatusIcon } from "../../StatusIcon";
 import { HvTypography } from "../../Typography";
-import { iconVariant } from "../../utils/iconVariant";
 import { useDialogContext } from "../context";
 import { staticClasses, useClasses } from "./Title.styles";
 

--- a/packages/core/src/Dialog/Title/Title.tsx
+++ b/packages/core/src/Dialog/Title/Title.tsx
@@ -6,6 +6,7 @@ import {
   type ExtractNames,
 } from "@hitachivantara/uikit-react-utils";
 
+import { HvStatusIcon } from "../../StatusIcon";
 import { HvTypography } from "../../Typography";
 import { iconVariant } from "../../utils/iconVariant";
 import { useDialogContext } from "../context";
@@ -48,7 +49,7 @@ export const HvDialogTitle = (props: HvDialogTitleProps) => {
   const { classes, cx } = useClasses(classesProp);
   const { fullScreen } = useDialogContext();
 
-  const icon = customIcon || (showIcon && iconVariant(variant));
+  const icon = customIcon || (showIcon && <HvStatusIcon variant={variant} />);
 
   return (
     <HvTypography

--- a/packages/core/src/Dialog/stories/FormStory.tsx
+++ b/packages/core/src/Dialog/stories/FormStory.tsx
@@ -64,11 +64,11 @@ export const FormStory = () => {
           </form>
         </HvDialogContent>
         <HvDialogActions>
-          <HvButton type="submit" form="create-post">
-            Create
-          </HvButton>
           <HvButton variant="secondaryGhost" onClick={() => setOpen(false)}>
             Cancel
+          </HvButton>
+          <HvButton type="submit" form="create-post">
+            Create
           </HvButton>
         </HvDialogActions>
       </HvDialog>

--- a/packages/core/src/Dialog/stories/MainStory.tsx
+++ b/packages/core/src/Dialog/stories/MainStory.tsx
@@ -23,15 +23,15 @@ export const MainStory = (props: HvDialogProps) => {
           visualization. You will need to re-select your fields.
         </HvDialogContent>
         <HvDialogActions>
-          <HvButton variant="secondaryGhost" onClick={() => setOpen(false)}>
-            Apply
-          </HvButton>
           <HvButton
             autoFocus
             variant="secondaryGhost"
             onClick={() => setOpen(false)}
           >
             Cancel
+          </HvButton>
+          <HvButton variant="secondaryGhost" onClick={() => setOpen(false)}>
+            Apply
           </HvButton>
         </HvDialogActions>
       </HvDialog>

--- a/packages/core/src/Dialog/stories/SemanticVariantsStory.tsx
+++ b/packages/core/src/Dialog/stories/SemanticVariantsStory.tsx
@@ -7,6 +7,7 @@ import {
   HvDialogContent,
   HvDialogProps,
   HvDialogTitle,
+  HvStatusIcon,
 } from "@hitachivantara/uikit-react-core";
 import { Ungroup } from "@hitachivantara/uikit-react-icons";
 
@@ -50,16 +51,16 @@ const SimpleDialog = ({
         </HvDialogContent>
         <HvDialogActions>
           <HvButton
-            variant={variant ? buttonVariantMap[variant] : "secondaryGhost"}
-            onClick={() => setOpen(false)}
-          >
-            Apply
-          </HvButton>
-          <HvButton
             variant={variant ? "secondarySubtle" : "secondaryGhost"}
             onClick={() => setOpen(false)}
           >
             Cancel
+          </HvButton>
+          <HvButton
+            variant={variant ? buttonVariantMap[variant] : "secondaryGhost"}
+            onClick={() => setOpen(false)}
+          >
+            Apply
           </HvButton>
         </HvDialogActions>
       </HvDialog>
@@ -72,7 +73,7 @@ export const SemanticVariantsStory = () => (
     <SimpleDialog
       buttonMessage="Warning"
       variant="warning"
-      title={<HvDialogTitle variant="error">Warning</HvDialogTitle>}
+      title={<HvDialogTitle variant="warning">Warning</HvDialogTitle>}
     />
     <SimpleDialog
       buttonMessage="Success"
@@ -91,7 +92,14 @@ export const SemanticVariantsStory = () => (
     <SimpleDialog
       buttonMessage="Custom"
       title={
-        <HvDialogTitle customIcon={<Ungroup iconSize="S" />}>
+        <HvDialogTitle
+          customIcon={
+            <HvStatusIcon
+              variant="default"
+              customIcon={<div className="i-ph-tree-structure" />}
+            />
+          }
+        >
           Custom
         </HvDialogTitle>
       }

--- a/packages/core/src/Drawer/Drawer.stories.tsx
+++ b/packages/core/src/Drawer/Drawer.stories.tsx
@@ -70,7 +70,11 @@ export const Main: StoryObj<HvDrawerProps> = {
           open={open}
           {...args}
         >
-          <HvDialogTitle component="div" className={classes.drawerTitle}>
+          <HvDialogTitle
+            component="div"
+            className={classes.drawerTitle}
+            showIcon={false}
+          >
             Lorem Ipsum
           </HvDialogTitle>
           <HvDialogContent className={classes.drawerContent}>

--- a/packages/core/src/FileUploader/FileUploader.stories.tsx
+++ b/packages/core/src/FileUploader/FileUploader.stories.tsx
@@ -306,7 +306,7 @@ export const WithPreviewThumbnails: StoryObj<HvFileUploaderProps> = {
           }}
         />
         <HvDialog open={open} onClose={() => setOpen(false)}>
-          <HvDialogTitle>{previewTitle}</HvDialogTitle>
+          <HvDialogTitle showIcon={false}>{previewTitle}</HvDialogTitle>
           <HvDialogContent>
             <img
               alt="Preview of the uploaded file"

--- a/packages/core/src/QueryBuilder/ConfirmationDialog/ConfirmationDialog.tsx
+++ b/packages/core/src/QueryBuilder/ConfirmationDialog/ConfirmationDialog.tsx
@@ -45,7 +45,9 @@ export const ConfirmationDialog = ({
       firstFocusable="confirmation-dialog-cancel"
       buttonTitle={closeButtonTooltip}
     >
-      <HvDialogTitle variant="warning">{title}</HvDialogTitle>
+      <HvDialogTitle variant="warning" showIcon={false}>
+        {title}
+      </HvDialogTitle>
       <HvDialogContent indentContent>{message}</HvDialogContent>
       <HvDialogActions>
         <HvButton variant="primaryGhost" onClick={onConfirm}>

--- a/packages/core/src/themes/ds3.ts
+++ b/packages/core/src/themes/ds3.ts
@@ -508,6 +508,9 @@ export const ds3 = mergeTheme(ds3Base, {
           ...theme.typography.xxsTitle,
         },
         root: {
+          "& .HvStatusIcon-root": {
+            padding: 0,
+          },
           "& .HvIconContainer-root": {
             color: `${theme.colors.secondary}!important`,
           },

--- a/packages/core/src/themes/ds3.ts
+++ b/packages/core/src/themes/ds3.ts
@@ -514,6 +514,14 @@ export const ds3 = mergeTheme(ds3Base, {
         },
       },
     },
+    HvDialogContent: {
+      classes: {
+        root: {
+          borderTop: "none!important",
+          borderBottom: "none!important",
+        },
+      },
+    },
     HvDropdown: {
       classes: {
         readOnly: {

--- a/packages/core/src/themes/ds3.ts
+++ b/packages/core/src/themes/ds3.ts
@@ -507,6 +507,11 @@ export const ds3 = mergeTheme(ds3Base, {
         titleText: {
           ...theme.typography.xxsTitle,
         },
+        root: {
+          "& .HvIconContainer-root": {
+            color: `${theme.colors.secondary}!important`,
+          },
+        },
       },
     },
     HvDropdown: {

--- a/packages/core/src/themes/ds5.ts
+++ b/packages/core/src/themes/ds5.ts
@@ -151,6 +151,15 @@ export const ds5 = mergeTheme(ds5Base, {
         },
       },
     },
+    HvDialogTitle: {
+      classes: {
+        root: {
+          "& .HvIconContainer-root": {
+            color: `${theme.colors.secondary}!important`,
+          },
+        },
+      },
+    },
   } satisfies Record<
     string,
     Record<string, any> | { classes?: React.CSSProperties }

--- a/packages/core/src/themes/ds5.ts
+++ b/packages/core/src/themes/ds5.ts
@@ -154,6 +154,9 @@ export const ds5 = mergeTheme(ds5Base, {
     HvDialogTitle: {
       classes: {
         root: {
+          "& .HvStatusIcon-root": {
+            padding: 0,
+          },
           "& .HvIconContainer-root": {
             color: `${theme.colors.secondary}!important`,
           },

--- a/packages/core/src/themes/ds5.ts
+++ b/packages/core/src/themes/ds5.ts
@@ -166,8 +166,8 @@ export const ds5 = mergeTheme(ds5Base, {
     HvDialogContent: {
       classes: {
         root: {
-          borderTop: "none!important",
-          borderBottom: "none!important",
+          borderTop: "none",
+          borderBottom: "none",
         },
       },
     },

--- a/packages/core/src/themes/ds5.ts
+++ b/packages/core/src/themes/ds5.ts
@@ -160,6 +160,14 @@ export const ds5 = mergeTheme(ds5Base, {
         },
       },
     },
+    HvDialogContent: {
+      classes: {
+        root: {
+          borderTop: "none!important",
+          borderBottom: "none!important",
+        },
+      },
+    },
   } satisfies Record<
     string,
     Record<string, any> | { classes?: React.CSSProperties }

--- a/packages/core/src/themes/pentahoPlus.ts
+++ b/packages/core/src/themes/pentahoPlus.ts
@@ -452,6 +452,25 @@ export const pentahoPlus = mergeTheme(pentahoPlusBase, {
         },
       },
     },
+    HvDialog: {
+      classes: {
+        paper: {
+          borderRadius: theme.radii.large,
+        },
+        statusBar: {
+          border: "none",
+          borderTopLeftRadius: theme.radii.large,
+          borderTopRightRadius: theme.radii.large,
+        },
+      },
+    },
+    HvDialogActions: {
+      classes: {
+        root: {
+          borderTop: "none",
+        },
+      },
+    },
     HvDropdownButton: {
       classes: {
         disabled: {

--- a/packages/lab/src/Wizard/WizardTitle/WizardTitle.tsx
+++ b/packages/lab/src/Wizard/WizardTitle/WizardTitle.tsx
@@ -94,6 +94,7 @@ export const HvWizardTitle = ({
         classes.messageContainer,
         classes.titleContainer,
       )}
+      showIcon={false}
     >
       {title && (
         <HvTypography variant="title3" component="div">


### PR DESCRIPTION
Notable changes Dialog component in this PR:

- no more semantic bar on the top of the semantic dialogs
- use HvStatusIcon on the dialog title
- no more top border on the dialog actions bar
- updated border radius on the dialogs
- fixed border radius on the fullscreen dialog (some unwanted border radius was showing)
- changed order of buttons on sample stories to adhere to PD norms