### PR TITLE
docs: review invalid mdx syntax

### DIFF
--- a/apps/docs/src/content/app-shell/configuration.mdx
+++ b/apps/docs/src/content/app-shell/configuration.mdx
@@ -41,13 +41,13 @@ The common structure has the following specification:
 Example:
 
 ```ts
-{
+const moduleConfig = {
   bundle: "@hv-apps/my-app/pages/Hello.js",
   config: {
     name: "John",
     age: 30,
-  }
-}
+  },
+};
 ```
 
 ```tsx
@@ -91,10 +91,10 @@ Key-value object of _Application Bundles_ IDs and their respective locations. Us
 Example:
 
 ```ts
-apps: {
+const apps = {
   "@hv-apps/an-app": "http://localhost:3001/",
-  "@hv-apps/another-app": "http://localhost:5001/"
-}
+  "@hv-apps/another-app": "http://localhost:5001/",
+};
 ```
 
 In order to reference Views and Shared Modules from other Application Bundles', one must be registered in the App Shell's configuration.
@@ -102,7 +102,9 @@ In order to reference Views and Shared Modules from other Application Bundles', 
 When registered, the _Application Bundle_'s contents can then be referenced as "subpaths" of its module ID.
 
 ```ts
-{ route: "/hello", bundle: "@hv-apps/another-app/pages/Other.js" }
+const views = [
+  { route: "/hello", bundle: "@hv-apps/another-app/pages/Other.js" },
+];
 ```
 
 ```tsx
@@ -130,24 +132,24 @@ The `maxWidth` prop defaults to `"xl"`, instead of `false` as in the UI Kit.
 Example:
 
 ```ts
-mainPanel: {
+const mainPanel = {
   maxWidth: "sm",
   views: [
     {
       bundle: "@hv-apps/my-app/pages/Hello.js",
       route: "/hello",
       config: {
-        name: "John"
-      }
+        name: "John",
+      },
     },
     {
       bundle: "@hv-apps/another-app/pages/Person.js",
       route: "/contacts/:name",
       maxWidth: "lg",
-      fixed: true
-    }
-  ]
-}
+      fixed: true,
+    },
+  ],
+};
 ```
 
 See [Routing](./routing) for more information.
@@ -170,7 +172,7 @@ To give more context, when we use the Vertical Navigation panel and perform a me
 Example:
 
 ```ts
-menu: [
+const menu = [
   {
     label: "Page 1",
     icon: { iconType: "uikit", name: "Open" },
@@ -210,17 +212,19 @@ _Header Actions_ that will be displayed on the Header. It follows the [module st
 Example:
 
 ```ts
-actions: [
-  {
-    bundle: "@hv/user-notifications-client/index.js",
-    config: {
-      showCount: false,
+const header = {
+  actions: [
+    {
+      bundle: "@hv/user-notifications-client/index.js",
+      config: {
+        showCount: false,
+      },
     },
-  },
-  {
-    bundle: "@hv/theming-client/colorModeSwitcher.js",
-  },
-];
+    {
+      bundle: "@hv/theming-client/colorModeSwitcher.js",
+    },
+  ],
+};
 ```
 
 See [Header actions](./header-actions) for more information and see the available **App Shell** built-in actions.
@@ -230,7 +234,7 @@ See [Header actions](./header-actions) for more information and see the availabl
 This prop defines the _Providers_ that will wrap all the _Views_ and _Shared Modules_:
 
 ```ts
-providers: [
+const providers = [
   { bundle: "@hv-apps/some-app/providers/SomeProvider.js" },
   { bundle: "@hv-apps/other-app/providers/OtherProvider.js" },
 ];
@@ -250,29 +254,31 @@ These are **NOT** available to the _Views_.
 Being an object, it is required to have as root the language (en, pt, etc.) of the bundle:
 
 ```ts
-name: "translationKey",
-logo: {
-  name: "HITACHI",
-  description: "logoDesc"
-},
-menu: [
-  {
-    label: "pageOne",
-    target: "/page1"
-  }
-],
-translations: {
-  en: {
-    translationKey: "An Amazing App",
-    logoDesc: "Company logo",
-    pageOne: "Page One"
+const config = {
+  name: "translationKey",
+  logo: {
+    name: "HITACHI",
+    description: "logoDesc",
   },
-  pt: {
-    translationKey: "Uma App Fantástica",
-    logoDesc: "Logo da empresa",
-    pageOne: "Página Um"
-  }
-}
+  menu: [
+    {
+      label: "pageOne",
+      target: "/page1",
+    },
+  ],
+  translations: {
+    en: {
+      translationKey: "An Amazing App",
+      logoDesc: "Company logo",
+      pageOne: "Page One",
+    },
+    pt: {
+      translationKey: "Uma App Fantástica",
+      logoDesc: "Logo da empresa",
+      pageOne: "Página Um",
+    },
+  },
+};
 ```
 
 In the example above, the name of the application, that appears on the browser tab and on the header,
@@ -299,11 +305,11 @@ The config object for it has the following options:
 Example:
 
 ```ts
-theming: {
+const theming = {
   themes: ["ds5", "@hv-apps/my-app/tatooine.js"],
   theme: "tatooine",
-  colorMode: "sand"
-}
+  colorMode: "sand",
+};
 ```
 
 #### Custom theme
@@ -315,9 +321,11 @@ Custom themes are a _Shared Module_ that exports a UI Kit theme definition. For 
 The configuration can use environment variables that are to be replaced at build time.
 
 ```ts
-apps: {
-  "@hv/user-notifications-client": process.env.VITE_USER_NOTIFICATIONS_URL || "http://localhost:8080"
-}
+const { VITE_USER_NOTIFICATIONS_URL = "http://localhost:8080" } = process.env;
+
+const apps = {
+  "@hv/user-notifications-client": VITE_USER_NOTIFICATIONS_URL,
+};
 ```
 
 These variables should be set at `.env` files like explained [here](https://vite.dev/guide/env-and-mode).

--- a/apps/docs/src/content/app-shell/header-actions.md
+++ b/apps/docs/src/content/app-shell/header-actions.md
@@ -16,7 +16,7 @@ export default function Hello({ planet = "Earth" }: { planet: string }) {
 Add the _Header Action_ to your configuration:
 
 ```ts
-header: {
+const header = {
   actions: [
     {
       bundle: "@hv-apps/my-app/header/SayHelloButton.js",
@@ -24,8 +24,8 @@ header: {
         planet: "Mars",
       },
     },
-  ];
-}
+  ],
+};
 ```
 
 ## Built-in Header Actions
@@ -49,7 +49,7 @@ To use this action, the bundle must be defined as `@hv/app-switcher-client/toggl
 Example:
 
 ```ts
-{
+const headerAction = {
   bundle: "@hv/app-switcher-client/toggle.js",
   config: {
     title: "Apps",
@@ -75,7 +75,7 @@ Example:
       },
     ],
   },
-}
+};
 ```
 
 ### Help Button
@@ -88,13 +88,13 @@ To use this action, the bundle must be defined as `@hv/help-client/button.js` an
 Example:
 
 ```ts
-{
+const headerAction = {
   bundle: "@hv/help-client/button.js",
   config: {
     url: "https://www.hitachivantara.com/",
     description: "Hitachi Vantara Help Link",
   },
-}
+};
 ```
 
 ### Color Mode Switcher
@@ -105,7 +105,7 @@ It will cycle through the available color modes of the active theme, effectively
 To use this action, the bundle must be defined as `@hv/theming-client/colorModeSwitcher.js`. It has no config options:
 
 ```ts
-{
-  bundle: "@hv/theming-client/colorModeSwitcher.js";
-}
+const headerAction = {
+  bundle: "@hv/theming-client/colorModeSwitcher.js",
+};
 ```

--- a/apps/docs/src/content/app-shell/installation.md
+++ b/apps/docs/src/content/app-shell/installation.md
@@ -76,12 +76,12 @@ For more information about the **App Shell** configuration check the [configurat
 4. The file `src/App.tsx` can be removed as the vite plugin will add it automatically as a virtual resource if not present.
    However, if you still see the need to have it in your app, then replace its content with the code below:
 
-```ts
+```tsx
 import HvAppShell from "@hitachivantara/app-shell-ui";
 
-export default function App () {
+export default function App() {
   return <HvAppShell configUrl={`${document.baseURI}app-shell.config.json`} />;
-};
+}
 ```
 
 5. You are good to go! Run your brand new **App Shell** app! 🚀

--- a/apps/docs/src/content/charts/index.mdx
+++ b/apps/docs/src/content/charts/index.mdx
@@ -40,15 +40,32 @@ The `data` prop in visualizations supports the **columns format**:
 Both examples below represent a table with 3 columns (`Month`, `Sales Target`, and `Monthly Sales`) and 12 rows.
 
 ```tsx
-{
-    Month: ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"],
-    "Sales Target": [5929, 2393, 1590, 7817, 4749, 1702, 2381, 2909, 6732, 3098, 2119, 2146],
-    "Monthly Sales": [4563, 1920, 6738, 1832, 7346, 1938, 7261, 1938, 2739, 5729, 9028, 4562]
-}
+const data = {
+  Month: [
+    "January",
+    "February",
+    "March",
+    "April",
+    "May",
+    "June",
+    "July",
+    "August",
+    "September",
+    "October",
+    "November",
+    "December",
+  ],
+  "Sales Target": [
+    5929, 2393, 1590, 7817, 4749, 1702, 2381, 2909, 6732, 3098, 2119, 2146,
+  ],
+  "Monthly Sales": [
+    4563, 1920, 6738, 1832, 7346, 1938, 7261, 1938, 2739, 5729, 9028, 4562,
+  ],
+};
 ```
 
 ```tsx
-new Map()
+const data = new Map()
   .set("Month", [
     "January",
     "February",
@@ -78,28 +95,12 @@ new Map()
 
 Example illustrating a table with 3 columns (`Country`, `Population`, and `Area`) and 4 rows.
 
-```tsx
+```ts
 [
-  {
-    Country: "Portugal",
-    Population: 10.33,
-    Area: 92212,
-  },
-  {
-    Country: "Spain",
-    Population: 47.42,
-    Area: 505990,
-  },
-  {
-    Country: "US",
-    Population: 331.9,
-    Area: 9834000,
-  },
-  {
-    Country: "Canada",
-    Population: 38.25,
-    Area: 9984670,
-  },
+  { Country: "Portugal", Population: 10.33, Area: 92212 },
+  { Country: "Spain", Population: 47.42, Area: 505990 },
+  { Country: "US", Population: 331.9, Area: 9834000 },
+  { Country: "Canada", Population: 38.25, Area: 9984670 },
 ];
 ```
 

--- a/apps/docs/src/content/components/query-builder.mdx
+++ b/apps/docs/src/content/components/query-builder.mdx
@@ -297,14 +297,12 @@ In the example above, 4 renderers were provided:
 If necessary, it's also possible to define value renderers at a more broad level using the `DEFAULT` key at the root of the `renderers` object like shown below. You should be aware that `DEFAULT` is a reserved key, you shouldn't use to define your own attribute or operator types.
 
 ```tsx
-// Example 1
-const renderers: HvQueryBuilderProps["renderers"] = {
+const renderers1: HvQueryBuilderProps["renderers"] = {
   // Renderer to customize all attribute types and operators
   DEFAULT: DefaultRenderer,
 };
 
-// Example 2
-const renderers: HvQueryBuilderProps["renderers"] = {
+const renderers2: HvQueryBuilderProps["renderers"] = {
   DEFAULT: {
     // Renderer to customize all attribute types and operators
     DEFAULT: DefaultRenderer,
@@ -644,11 +642,7 @@ const renderers = {
 `dispatchAction` is needed to update the query and can be accessed through the `useQueryBuilderContext` hook exported by the `core` package. This utility can be used to dispatch several action types such as: `reset-query`, `reset-group`, `add-rule`, `add-group`, `remove-node`, `set-combinator`, `set-attribute`, `set-operator`, and `set-value`. However, you'll most likely only need the `set-value` action that enables you to set the value of a condition. This action has the following specification:
 
 ```tsx
-{
-  type: "set-value";
-  id: React.Key;
-  value: any;
-}
+dispatchAction({ type: "set-value", id: "123", value: "myValue" });
 ```
 
 ### Controlled

--- a/apps/docs/src/content/components/table.mdx
+++ b/apps/docs/src/content/components/table.mdx
@@ -194,13 +194,11 @@ We recommend that you separate the table definition (`HvTable*` and `useHvTable`
 You should strive to have simple API that allows passing the `data` and `columns`, and not worrying about the layout or hook logic:
 
 ```tsx
-// simple usage
-<Table data={data} columns={columns} />
-
-// or with extra configuration
 <Table
+  // required parameters
   data={data}
   columns={columns}
+  // optional extra configuration
   actions={[
     { id: "delete", label: "Delete" },
     { id: "clone", label: "Clone" },
@@ -245,7 +243,7 @@ The `useHvPagination` hook makes the `getHvPaginationProps` function available o
 ```tsx
 const table = useHvTable({ columns, data }, useHvPagination);
 
-return <HvPagination {...table?.getHvPaginationProps()} />;
+<HvPagination {...table?.getHvPaginationProps()} />;
 ```
 
 ### `useHvSortBy`
@@ -276,7 +274,7 @@ The `useHvBulkActions` hook makes the `getHvBulkActionsProps` function available
 ```tsx
 const table = useHvTable({ columns, data }, useHvBulkActions);
 
-return <HvBulkActions {...table?.getHvBulkActionsProps()} />;
+<HvBulkActions {...table?.getHvBulkActionsProps()} />;
 ```
 
 ### `useHvTableSticky`
@@ -334,10 +332,10 @@ This is implemented using the `useHvHeaderGroups` custom React Table hook provid
 
 Note: When using grouped columns, all header group columns text will be centered.
 
-```tsx
+```ts
 const columns = [
   {
-    id: "name"
+    id: "name",
     Header: "Name",
     // 👇 nested columns under "name"
     columns: [

--- a/apps/docs/src/content/docs/icons.mdx
+++ b/apps/docs/src/content/docs/icons.mdx
@@ -30,9 +30,11 @@ export default function Demo() {
 Given a `<CustomIcon />` SVG React component, usage would look like this:
 
 ```tsx
-<HvButton startIcon={<CustomIcon />} />
-<HvInput endAdornment={<CustomIcon />} />
-<HvCardHeader icon={<CustomIcon />} />
+<div>
+  <HvButton startIcon={<CustomIcon />} />
+  <HvInput endAdornment={<CustomIcon />} />
+  <HvCardHeader icon={<CustomIcon />} />
+</div>
 ```
 
 ## `HvIconContainer`

--- a/apps/docs/src/content/docs/theming.mdx
+++ b/apps/docs/src/content/docs/theming.mdx
@@ -6,8 +6,6 @@
 
 The **theme** object serves as the **UI Kit** foundation, defining all styling specifications — including colors, font sizes, spacing, shadows, and more.
 
-[Sample]
-
 ## Theme Configuration
 
 **UI Kit** includes three default themes, each available in two color modes: **dawn** (light) and **wicked** (dark):
@@ -125,7 +123,7 @@ const CssVariables = () => {
 
 You can globally define default props and custom styles for any component using the `components` key inside your theme. This reduces boilerplate and improves consistency.
 
-```ts
+```tsx
 const newTheme = createTheme({
   name: "myTheme",
   base: "ds5",

--- a/docs/overview/migration/MigrationV5.mdx
+++ b/docs/overview/migration/MigrationV5.mdx
@@ -182,7 +182,7 @@ You'll need to remove all TypeScript types definitions previously defined for MU
 
 In your project you most likely have definitions like the one below and they should be removed.
 
-```ts
+```diff
 - declare module "@mui/material/styles" {
 -   interface Theme {
 -     hv: HvTheme;
@@ -342,7 +342,7 @@ export default withStyles(styles)(CustomButton);
 If you want to stop using MUI's JSS styling system, you'll need to uninstall `@mui/styles` from your project by running the command below. Ensure that
 you are not using this package for other purposes on your project and that you'll only need to use the UI Kit theme object on your application.
 
-```
+```sh
 npm uninstall @mui/styles
 ```
 
@@ -642,7 +642,7 @@ inside `avatarProps`.
 Since the `HvPanel` component was previously using MUI's `Box` component as its root element it was possible to use CSS properties directly on the
 component as properties. This is no longer possible and you must style the panel using the `style`, `classes`, or `className` properties.
 
-```tsx
+```diff
 + import { css } from "@emotion/css";
   import { HvPanel } from "@hitachivantara/uikit-react-core";
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "@fortawesome/free-solid-svg-icons": "^6.6.0",
         "@fortawesome/react-fontawesome": "^0.2.2",
         "@hitachivantara/uikit-config": "*",
-        "@ianvs/prettier-plugin-sort-imports": "^4.1.1",
+        "@ianvs/prettier-plugin-sort-imports": "^4.5.1",
         "@iconify-json/ph": "^1.2.1",
         "@mdx-js/react": "^3.1.0",
         "@mui/material": "^5.14.20",
@@ -1637,7 +1637,7 @@
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.4.3.tgz",
       "integrity": "sha512-4m62DuCE07lw01soJwPiBGC0nAww0Q+RY70VZ+n49yDIO13yyinhbWCeNnaob0lakDtWQzSdtNWzJeOJt2ma+g==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@emnapi/wasi-threads": "1.0.2",
@@ -1658,7 +1658,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.0.2.tgz",
       "integrity": "sha512-5n3nTJblwRi8LlXkJ9eBzu+kZR8Yxcc7ubakyQTFzPMtIhFpUBRbsnc2Dv88IZDIbCDlBiWrknhB4Lsz7mg6BA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.4.0"
@@ -2510,9 +2510,9 @@
       "link": true
     },
     "node_modules/@ianvs/prettier-plugin-sort-imports": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/@ianvs/prettier-plugin-sort-imports/-/prettier-plugin-sort-imports-4.4.2.tgz",
-      "integrity": "sha512-KkVFy3TLh0OFzimbZglMmORi+vL/i2OFhEs5M07R9w0IwWAGpsNNyE4CY/2u0YoMF5bawKC2+8/fUH60nnNtjw==",
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/@ianvs/prettier-plugin-sort-imports/-/prettier-plugin-sort-imports-4.5.1.tgz",
+      "integrity": "sha512-vOQwIyQHnHz0ikvHEQDzwUkNfX74o/7qNEpm9LiPtyBvCg/AU/DOkhwe1o92chPS1QzS6G7HeiO+OwIt8a358A==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/generator": "^7.26.2",
@@ -2522,10 +2522,14 @@
         "semver": "^7.5.2"
       },
       "peerDependencies": {
+        "@prettier/plugin-oxc": "^0.0.4",
         "@vue/compiler-sfc": "2.7.x || 3.x",
         "prettier": "2 || 3 || ^4.0.0-0"
       },
       "peerDependenciesMeta": {
+        "@prettier/plugin-oxc": {
+          "optional": true
+        },
         "@vue/compiler-sfc": {
           "optional": true
         }
@@ -5844,6 +5848,296 @@
         "@octokit/openapi-types": "^24.2.0"
       }
     },
+    "node_modules/@oxc-parser/binding-android-arm64": {
+      "version": "0.74.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm64/-/binding-android-arm64-0.74.0.tgz",
+      "integrity": "sha512-lgq8TJq22eyfojfa2jBFy2m66ckAo7iNRYDdyn9reXYA3I6Wx7tgGWVx1JAp1lO+aUiqdqP/uPlDaETL9tqRcg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-darwin-arm64": {
+      "version": "0.74.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-arm64/-/binding-darwin-arm64-0.74.0.tgz",
+      "integrity": "sha512-xbY/io/hkARggbpYEMFX6CwFzb7f4iS6WuBoBeZtdqRWfIEi7sm/uYWXfyVeB8uqOATvJ07WRFC2upI8PSI83g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-darwin-x64": {
+      "version": "0.74.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-x64/-/binding-darwin-x64-0.74.0.tgz",
+      "integrity": "sha512-FIj2gAGtFaW0Zk+TnGyenMUoRu1ju+kJ/h71D77xc1owOItbFZFGa+4WSVck1H8rTtceeJlK+kux+vCjGFCl9Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-freebsd-x64": {
+      "version": "0.74.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-freebsd-x64/-/binding-freebsd-x64-0.74.0.tgz",
+      "integrity": "sha512-W1I+g5TJg0TRRMHgEWNWsTIfe782V3QuaPgZxnfPNmDMywYdtlzllzclBgaDq6qzvZCCQc/UhvNb37KWTCTj8A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-arm-gnueabihf": {
+      "version": "0.74.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.74.0.tgz",
+      "integrity": "sha512-gxqkyRGApeVI8dgvJ19SYe59XASW3uVxF1YUgkE7peW/XIg5QRAOVTFKyTjI9acYuK1MF6OJHqx30cmxmZLtiQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-arm-musleabihf": {
+      "version": "0.74.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.74.0.tgz",
+      "integrity": "sha512-jpnAUP4Fa93VdPPDzxxBguJmldj/Gpz7wTXKFzpAueqBMfZsy9KNC+0qT2uZ9HGUDMzNuKw0Se3bPCpL/gfD2Q==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-arm64-gnu": {
+      "version": "0.74.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.74.0.tgz",
+      "integrity": "sha512-fcWyM7BNfCkHqIf3kll8fJctbR/PseL4RnS2isD9Y3FFBhp4efGAzhDaxIUK5GK7kIcFh1P+puIRig8WJ6IMVQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-arm64-musl": {
+      "version": "0.74.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.74.0.tgz",
+      "integrity": "sha512-AMY30z/C77HgiRRJX7YtVUaelKq1ex0aaj28XoJu4SCezdS8i0IftUNTtGS1UzGjGZB8zQz5SFwVy4dRu4GLwg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-riscv64-gnu": {
+      "version": "0.74.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.74.0.tgz",
+      "integrity": "sha512-/RZAP24TgZo4vV/01TBlzRqs0R7E6xvatww4LnmZEBBulQBU/SkypDywfriFqWuFoa61WFXPV7sLcTjJGjim/w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-s390x-gnu": {
+      "version": "0.74.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.74.0.tgz",
+      "integrity": "sha512-620J1beNAlGSPBD+Msb3ptvrwxu04B8iULCH03zlf0JSLy/5sqlD6qBs0XUVkUJv1vbakUw1gfVnUQqv0UTuEg==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-x64-gnu": {
+      "version": "0.74.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.74.0.tgz",
+      "integrity": "sha512-WBFgQmGtFnPNzHyLKbC1wkYGaRIBxXGofO0+hz1xrrkPgbxbJS1Ukva1EB8sPaVBBQ52Bdc2GjLSp721NWRvww==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-x64-musl": {
+      "version": "0.74.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-musl/-/binding-linux-x64-musl-0.74.0.tgz",
+      "integrity": "sha512-y4mapxi0RGqlp3t6Sm+knJlAEqdKDYrEue2LlXOka/F2i4sRN0XhEMPiSOB3ppHmvK4I2zY2XBYTsX1Fel0fAg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-wasm32-wasi": {
+      "version": "0.74.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-wasm32-wasi/-/binding-wasm32-wasi-0.74.0.tgz",
+      "integrity": "sha512-yDS9bRDh5ymobiS2xBmjlrGdUuU61IZoJBaJC5fELdYT5LJNBXlbr3Yc6m2PWfRJwkH6Aq5fRvxAZ4wCbkGa8w==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@napi-rs/wasm-runtime": "^0.2.11"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
+      "integrity": "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/core": "^1.4.3",
+        "@emnapi/runtime": "^1.4.3",
+        "@tybys/wasm-util": "^0.10.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-wasm32-wasi/node_modules/@tybys/wasm-util": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.0.tgz",
+      "integrity": "sha512-VyyPYFlOMNylG45GoAe0xDoLwWuowvf92F9kySqzYh8vmYm7D2u4iUJKa1tOUpS70Ku13ASrOkS4ScXFsTaCNQ==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-win32-arm64-msvc": {
+      "version": "0.74.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.74.0.tgz",
+      "integrity": "sha512-XFWY52Rfb4N5wEbMCTSBMxRkDLGbAI9CBSL24BIDywwDJMl31gHEVlmHdCDRoXAmanCI6gwbXYTrWe0HvXJ7Aw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-win32-x64-msvc": {
+      "version": "0.74.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.74.0.tgz",
+      "integrity": "sha512-1D3x6iU2apLyfTQHygbdaNbX3nZaHu4yaXpD7ilYpoLo7f0MX0tUuoDrqJyJrVGqvyXgc0uz4yXz9tH9ZZhvvg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.74.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.74.0.tgz",
+      "integrity": "sha512-KOw/RZrVlHGhCXh1RufBFF7Nuo7HdY5w1lRJukM/igIl6x9qtz8QycDvZdzb4qnHO7znrPyo2sJrFJK2eKHgfQ==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
     "node_modules/@oxlint/darwin-arm64": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@oxlint/darwin-arm64/-/darwin-arm64-1.1.0.tgz",
@@ -6080,6 +6374,23 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
+      }
+    },
+    "node_modules/@prettier/plugin-oxc": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/@prettier/plugin-oxc/-/plugin-oxc-0.0.4.tgz",
+      "integrity": "sha512-UGXe+g/rSRbglL0FOJiar+a+nUrst7KaFmsg05wYbKiInGWP6eAj/f8A2Uobgo5KxEtb2X10zeflNH6RK2xeIQ==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "oxc-parser": "0.74.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/@rc-component/portal": {
@@ -19542,9 +19853,9 @@
       }
     },
     "node_modules/libnpmpublish/node_modules/ci-info": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.2.0.tgz",
-      "integrity": "sha512-cYY9mypksY8NRqgDB1XD1RiJL338v/551niynFTGkZOO2LHuB2OmOYxDIe/ttN9AHwrqdum1360G3ald0W9kCg==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.3.0.tgz",
+      "integrity": "sha512-l+2bNRMiQgcfILUi33labAZYIWlH1kWDp+ecNo5iisRKrbm0xcRyCww71/YU0Fkw0mAFpz9bJayXPjey6vkmaQ==",
       "dev": true,
       "funding": [
         {
@@ -23853,6 +24164,40 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/oxc-parser": {
+      "version": "0.74.0",
+      "resolved": "https://registry.npmjs.org/oxc-parser/-/oxc-parser-0.74.0.tgz",
+      "integrity": "sha512-2tDN/ttU8WE6oFh8EzKNam7KE7ZXSG5uXmvX85iNzxdJfMssDWcj3gpYzZi1E04XuE7m3v1dVWl/8BE886vPGw==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@oxc-project/types": "^0.74.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      },
+      "optionalDependencies": {
+        "@oxc-parser/binding-android-arm64": "0.74.0",
+        "@oxc-parser/binding-darwin-arm64": "0.74.0",
+        "@oxc-parser/binding-darwin-x64": "0.74.0",
+        "@oxc-parser/binding-freebsd-x64": "0.74.0",
+        "@oxc-parser/binding-linux-arm-gnueabihf": "0.74.0",
+        "@oxc-parser/binding-linux-arm-musleabihf": "0.74.0",
+        "@oxc-parser/binding-linux-arm64-gnu": "0.74.0",
+        "@oxc-parser/binding-linux-arm64-musl": "0.74.0",
+        "@oxc-parser/binding-linux-riscv64-gnu": "0.74.0",
+        "@oxc-parser/binding-linux-s390x-gnu": "0.74.0",
+        "@oxc-parser/binding-linux-x64-gnu": "0.74.0",
+        "@oxc-parser/binding-linux-x64-musl": "0.74.0",
+        "@oxc-parser/binding-wasm32-wasi": "0.74.0",
+        "@oxc-parser/binding-win32-arm64-msvc": "0.74.0",
+        "@oxc-parser/binding-win32-x64-msvc": "0.74.0"
       }
     },
     "node_modules/oxlint": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@fortawesome/free-solid-svg-icons": "^6.6.0",
     "@fortawesome/react-fontawesome": "^0.2.2",
     "@hitachivantara/uikit-config": "*",
-    "@ianvs/prettier-plugin-sort-imports": "^4.1.1",
+    "@ianvs/prettier-plugin-sort-imports": "^4.5.1",
     "@iconify-json/ph": "^1.2.1",
     "@mdx-js/react": "^3.1.0",
     "@mui/material": "^5.14.20",

--- a/packages/lab/src/Flow/stories/Usage.mdx
+++ b/packages/lab/src/Flow/stories/Usage.mdx
@@ -68,7 +68,7 @@ interface HvFlowGroupItem {
 
 Example:
 
-```typescript
+```tsx
 const nodeGroups = {
   assets: {
     label: "Assets",
@@ -268,7 +268,7 @@ type HvFlowNodeParam =
 Whenever a change is made on a parameter while using the flow, that change is saved on the node's `data` property in the `reactflow` instance.
 It's saved in the form of:
 
-```typescript
+```
 data: {
   [parameterId]: [parameterValue]
 }


### PR DESCRIPTION
- fix invalid `md`/`mdx` codeblock syntax that's leading to issues in prettier & highlighting
  - mostly JSX in `.ts` code & invalid JS objects (added vars for clarity)