### PR TITLE
chore(styles): remove excessive vars & use interfaces

### DIFF
--- a/packages/styles/src/types.ts
+++ b/packages/styles/src/types.ts
@@ -19,15 +19,15 @@ interface CSSProperties extends StandardProperties<string | number> {}
 export type HvThemeTokens = typeof flattenTokens;
 
 /** Theme components props */
-export type HvThemeComponentsProps<ComponentNames extends string = string> = {
+export interface HvThemeComponentsProps {
   /** Component properties to override */
-  components?: Record<ComponentNames, Record<string, any>>;
+  components?: Record<string, Record<string, any>>;
   /** Record of icon names and their path, to override the default icons */
   icons?: Record<string, string> & { viewBox: string };
-};
+}
 
 /** Theme components */
-export type HvThemeComponents = {
+export interface HvThemeComponents {
   header: {
     height: string;
     secondLevelHeight: string;
@@ -65,19 +65,20 @@ export type HvThemeComponents = {
   snackbar: {
     actionButtonVariant: string;
   };
-};
+}
 
 // Theme typography
 // TODO: allow arbitrary `CSSProperties` overrides
-export type HvThemeTypographyProps = Pick<
-  CSSProperties,
-  | "color"
-  | "fontSize"
-  | "letterSpacing"
-  | "lineHeight"
-  | "fontWeight"
-  | "textDecoration"
->;
+export interface HvThemeTypographyProps
+  extends Pick<
+    CSSProperties,
+    | "color"
+    | "fontSize"
+    | "letterSpacing"
+    | "lineHeight"
+    | "fontWeight"
+    | "textDecoration"
+  > {}
 
 type TypographyVariants =
   | "display"
@@ -92,9 +93,9 @@ type TypographyVariants =
   | "caption2"
   | (string & {});
 
-export type HvThemeTypography = {
+export interface HvThemeTypography {
   typography: Record<TypographyVariants, HvThemeTypographyProps>;
-};
+}
 
 // Breakpoints
 export type HvThemeBreakpoint = Exclude<keyof typeof tokens.space, "base">;
@@ -151,6 +152,7 @@ export type DeepString<T> = {
 };
 
 // Theme CSS vars
-export type HvThemeVars = DeepString<HvThemeTokens> &
-  DeepString<HvThemeComponents> &
-  DeepString<HvThemeTypography>;
+export interface HvThemeVars
+  extends DeepString<HvThemeTokens>,
+    DeepString<HvThemeComponents>,
+    DeepString<HvThemeTypography> {}

--- a/packages/styles/src/utils.ts
+++ b/packages/styles/src/utils.ts
@@ -71,12 +71,12 @@ export const mapCSSVars = <T extends object>(
   return vars;
 };
 
+const isObject = (obj: unknown) => obj && typeof obj === "object";
+
 // TODO: review in v6:
 // - typings: accept any or theme object?
 // - arguments: source/target themes, or any number of theme objects?
-export const mergeTheme = (...objects: any[]) => {
-  const isObject = (obj: unknown) => obj && typeof obj === "object";
-
+export const mergeTheme = (...objects: any[]): HvThemeStructure => {
   return objects.reduce((prev, obj) => {
     Object.keys(obj).forEach((key) => {
       const pVal = prev[key];
@@ -123,6 +123,7 @@ export const parseTheme = (
   };
 };
 
+/** @deprecated unused */
 export const getThemesList = (themes: Record<string, any>) => {
   const list: Record<string, any> = {};
 
@@ -159,7 +160,7 @@ export const getThemesVars = (themes: HvThemeStructure[]) => {
 
       // extract properties that shouldn't be mapped to CSS variables
       // @ts-expect-error align HvTheme <-> HvThemeStructure?
-      const { components, name, colors, palette, ...rest } = theme;
+      const { base, components, name, colors, palette, icons, ...rest } = theme;
 
       vars[styleName] = toCSSVars({
         colors: {


### PR DESCRIPTION
- remove `icons` & `base` from injected CSS vars
- use `interface` instead of `type` in theme base so they can be more easily extended


<img width="569" height="247" alt="image" src="https://github.com/user-attachments/assets/d8fd50bb-0bfe-4a47-8159-1b35e1bc5d1b" />
