### PR TITLE
build: change packages to ESM-only

### DIFF
--- a/.config/vite.config.ts
+++ b/.config/vite.config.ts
@@ -20,21 +20,8 @@ const external = [
 const esmOutput: OutputOptions = {
   format: "esm",
   preserveModules: true,
-  dir: "dist/esm",
-  // keep react-based packages as `.js` for backwards compatibility
-  entryFileNames:
-    pkg.name.includes("react") || pkg.name.includes("app-shell")
-      ? "[name].js"
-      : "[name].mjs",
-  exports: "named",
-  interop: "auto",
-};
-
-const cjsOutput: OutputOptions = {
-  format: "cjs",
-  preserveModules: true,
-  dir: "dist/cjs",
-  entryFileNames: "[name].cjs",
+  dir: "dist",
+  entryFileNames: "[name].js",
   exports: "named",
   interop: "auto",
 };
@@ -42,7 +29,7 @@ const cjsOutput: OutputOptions = {
 export default defineConfig({
   plugins: [
     dts({
-      outDir: "dist/types",
+      outDir: "dist",
       rollupTypes: true,
       tsconfigPath: resolve(__dirname, "../tsconfig.build.json"),
     }),
@@ -57,10 +44,7 @@ export default defineConfig({
       entry: resolve(process.cwd(), "src/index.ts"),
     },
     rollupOptions: {
-      // TODO: align with AppShell's ESM-only approach
-      output: pkg.name.includes("/app-shell")
-        ? [esmOutput]
-        : [esmOutput, cjsOutput],
+      output: [esmOutput],
       external,
     },
   },

--- a/packages/app-shell-events/package.json
+++ b/packages/app-shell-events/package.json
@@ -33,13 +33,13 @@
   "publishConfig": {
     "access": "public",
     "directory": "package",
-    "module": "dist/esm/index.js",
-    "types": "./dist/types/index.d.ts",
+    "module": "dist/index.js",
+    "types": "./dist/index.d.ts",
     "exports": {
       ".": {
-        "types": "./dist/types/index.d.ts",
-        "import": "./dist/esm/index.js",
-        "default": "./dist/esm/index.js"
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       },
       "./package.json": "./package.json"
     }

--- a/packages/app-shell-navigation/package.json
+++ b/packages/app-shell-navigation/package.json
@@ -45,13 +45,13 @@
   "publishConfig": {
     "access": "public",
     "directory": "package",
-    "module": "dist/esm/index.js",
-    "types": "./dist/types/index.d.ts",
+    "module": "dist/index.js",
+    "types": "./dist/index.d.ts",
     "exports": {
       ".": {
-        "types": "./dist/types/index.d.ts",
-        "import": "./dist/esm/index.js",
-        "default": "./dist/esm/index.js"
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       },
       "./package.json": "./package.json"
     }

--- a/packages/app-shell-shared/package.json
+++ b/packages/app-shell-shared/package.json
@@ -45,13 +45,13 @@
   "publishConfig": {
     "access": "public",
     "directory": "package",
-    "module": "dist/esm/index.js",
+    "module": "dist/index.js",
     "types": "./dist/types/index.d.ts",
     "exports": {
       ".": {
-        "types": "./dist/types/index.d.ts",
-        "import": "./dist/esm/index.js",
-        "default": "./dist/esm/index.js"
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       },
       "./package.json": "./package.json",
       "./bundles/*": "./dist/bundles/*"

--- a/packages/app-shell-ui/package.json
+++ b/packages/app-shell-ui/package.json
@@ -57,13 +57,13 @@
   "publishConfig": {
     "access": "public",
     "directory": "package",
-    "module": "dist/esm/index.js",
+    "module": "dist/index.js",
     "types": "./dist/types/index.d.ts",
     "exports": {
       ".": {
-        "types": "./dist/types/index.d.ts",
-        "import": "./dist/esm/index.js",
-        "default": "./dist/esm/index.js"
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       },
       "./package.json": "./package.json"
     }

--- a/packages/app-shell-vite-plugin/src/vite-plugin.ts
+++ b/packages/app-shell-vite-plugin/src/vite-plugin.ts
@@ -207,8 +207,9 @@ export function HvAppShellVitePlugin(
           {
             src: resolveModule(
               "@hitachivantara/uikit-react-icons",
-              "../sprites/*.svg",
+              "./sprites/*.svg",
             ),
+
             dest: "icons",
           },
           ...(!devMode && buildEntryPoint

--- a/packages/code-editor/package.json
+++ b/packages/code-editor/package.json
@@ -60,14 +60,13 @@
   "publishConfig": {
     "access": "public",
     "directory": "package",
-    "main": "dist/cjs/index.cjs",
-    "module": "dist/esm/index.js",
-    "types": "dist/types/index.d.ts",
+    "main": "dist/index.js",
+    "module": "dist/index.js",
+    "types": "dist/index.d.ts",
     "exports": {
       ".": {
-        "types": "./dist/types/index.d.ts",
-        "require": "./dist/cjs/index.cjs",
-        "import": "./dist/esm/index.js"
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
       }
     }
   },
@@ -75,8 +74,7 @@
     "withoutPublish": true,
     "tempDir": "package",
     "fields": [
-      "main",
-      "type"
+      "main"
     ],
     "files": [
       "tsconfig.json"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -79,14 +79,13 @@
   "publishConfig": {
     "access": "public",
     "directory": "package",
-    "main": "dist/cjs/index.cjs",
-    "module": "dist/esm/index.js",
-    "types": "dist/types/index.d.ts",
+    "main": "dist/index.js",
+    "module": "dist/index.js",
+    "types": "dist/index.d.ts",
     "exports": {
       ".": {
-        "types": "./dist/types/index.d.ts",
-        "require": "./dist/cjs/index.cjs",
-        "import": "./dist/esm/index.js"
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
       }
     }
   },
@@ -94,8 +93,7 @@
     "withoutPublish": true,
     "tempDir": "package",
     "fields": [
-      "main",
-      "type"
+      "main"
     ],
     "files": [
       "tsconfig.json"

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -61,14 +61,13 @@
   "publishConfig": {
     "access": "public",
     "directory": "package",
-    "main": "dist/cjs/index.cjs",
-    "module": "dist/esm/index.js",
-    "types": "dist/types/index.d.ts",
+    "main": "dist/index.js",
+    "module": "dist/index.js",
+    "types": "dist/index.d.ts",
     "exports": {
       ".": {
-        "types": "./dist/types/index.d.ts",
-        "require": "./dist/cjs/index.cjs",
-        "import": "./dist/esm/index.js"
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
       }
     }
   },
@@ -76,8 +75,7 @@
     "withoutPublish": true,
     "tempDir": "package",
     "fields": [
-      "main",
-      "type"
+      "main"
     ],
     "files": [
       "tsconfig.json"

--- a/packages/lab/package.json
+++ b/packages/lab/package.json
@@ -68,14 +68,13 @@
   "publishConfig": {
     "access": "public",
     "directory": "package",
-    "main": "dist/cjs/index.cjs",
-    "module": "dist/esm/index.js",
-    "types": "dist/types/index.d.ts",
+    "main": "dist/index.js",
+    "module": "dist/index.js",
+    "types": "dist/index.d.ts",
     "exports": {
       ".": {
-        "types": "./dist/types/index.d.ts",
-        "require": "./dist/cjs/index.cjs",
-        "import": "./dist/esm/index.js"
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
       }
     }
   },
@@ -83,8 +82,7 @@
     "withoutPublish": true,
     "tempDir": "package",
     "fields": [
-      "main",
-      "type"
+      "main"
     ],
     "files": [
       "tsconfig.json"

--- a/packages/pentaho/package.json
+++ b/packages/pentaho/package.json
@@ -59,14 +59,13 @@
   "publishConfig": {
     "access": "public",
     "directory": "package",
-    "main": "dist/cjs/index.cjs",
-    "module": "dist/esm/index.js",
-    "types": "dist/types/index.d.ts",
+    "main": "dist/index.js",
+    "module": "dist/index.js",
+    "types": "dist/index.d.ts",
     "exports": {
       ".": {
-        "types": "./dist/types/index.d.ts",
-        "require": "./dist/cjs/index.cjs",
-        "import": "./dist/esm/index.js"
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
       }
     }
   },
@@ -74,8 +73,7 @@
     "withoutPublish": true,
     "tempDir": "package",
     "fields": [
-      "main",
-      "type"
+      "main"
     ],
     "files": [
       "tsconfig.json"

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -53,14 +53,13 @@
   "publishConfig": {
     "access": "public",
     "directory": "package",
-    "main": "dist/cjs/index.cjs",
-    "module": "dist/esm/index.js",
-    "types": "dist/types/index.d.ts",
+    "main": "dist/index.js",
+    "module": "dist/index.js",
+    "types": "dist/index.d.ts",
     "exports": {
       ".": {
-        "types": "./dist/types/index.d.ts",
-        "require": "./dist/cjs/index.cjs",
-        "import": "./dist/esm/index.js"
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
       },
       "./package.json": "./package.json",
       "./bundles/*": "./dist/bundles/*"
@@ -70,8 +69,7 @@
     "withoutPublish": true,
     "tempDir": "package",
     "fields": [
-      "main",
-      "type"
+      "main"
     ],
     "files": [
       "tsconfig.json"

--- a/packages/styles/package.json
+++ b/packages/styles/package.json
@@ -41,14 +41,13 @@
   "publishConfig": {
     "access": "public",
     "directory": "package",
-    "main": "dist/cjs/index.cjs",
-    "module": "dist/esm/index.mjs",
-    "types": "dist/types/index.d.ts",
+    "main": "dist/index.js",
+    "module": "dist/index.js",
+    "types": "dist/index.d.ts",
     "exports": {
       ".": {
-        "types": "./dist/types/index.d.ts",
-        "require": "./dist/cjs/index.cjs",
-        "import": "./dist/esm/index.mjs"
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
       }
     }
   },
@@ -56,8 +55,7 @@
     "withoutPublish": true,
     "tempDir": "package",
     "fields": [
-      "main",
-      "type"
+      "main"
     ],
     "files": [
       "tsconfig.json"

--- a/packages/uno-preset/package.json
+++ b/packages/uno-preset/package.json
@@ -48,14 +48,13 @@
   "publishConfig": {
     "access": "public",
     "directory": "package",
-    "main": "dist/cjs/index.cjs",
-    "module": "dist/esm/index.mjs",
-    "types": "dist/types/index.d.ts",
+    "main": "dist/index.js",
+    "module": "dist/index.js",
+    "types": "dist/index.d.ts",
     "exports": {
       ".": {
-        "types": "./dist/types/index.d.ts",
-        "require": "./dist/cjs/index.cjs",
-        "import": "./dist/esm/index.mjs"
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
       }
     }
   },
@@ -63,8 +62,7 @@
     "withoutPublish": true,
     "tempDir": "package",
     "fields": [
-      "main",
-      "type"
+      "main"
     ],
     "files": [
       "tsconfig.json"

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -50,14 +50,13 @@
   "publishConfig": {
     "access": "public",
     "directory": "package",
-    "main": "dist/cjs/index.cjs",
-    "module": "dist/esm/index.js",
-    "types": "dist/types/index.d.ts",
+    "main": "dist/index.js",
+    "module": "dist/index.js",
+    "types": "dist/index.d.ts",
     "exports": {
       ".": {
-        "types": "./dist/types/index.d.ts",
-        "require": "./dist/cjs/index.cjs",
-        "import": "./dist/esm/index.js"
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
       }
     }
   },
@@ -65,8 +64,7 @@
     "withoutPublish": true,
     "tempDir": "package",
     "fields": [
-      "main",
-      "type"
+      "main"
     ],
     "files": [
       "tsconfig.json"

--- a/packages/viz/package.json
+++ b/packages/viz/package.json
@@ -57,14 +57,13 @@
   "publishConfig": {
     "access": "public",
     "directory": "package",
-    "main": "dist/cjs/index.cjs",
-    "module": "dist/esm/index.js",
-    "types": "dist/types/index.d.ts",
+    "main": "dist/index.js",
+    "module": "dist/index.js",
+    "types": "dist/index.d.ts",
     "exports": {
       ".": {
-        "types": "./dist/types/index.d.ts",
-        "require": "./dist/cjs/index.cjs",
-        "import": "./dist/esm/index.js"
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
       }
     }
   },
@@ -72,8 +71,7 @@
     "withoutPublish": true,
     "tempDir": "package",
     "fields": [
-      "main",
-      "type"
+      "main"
     ],
     "files": [
       "tsconfig.json"


### PR DESCRIPTION
Change UI Kit packages to be published as ESM-only, aligning with App Shell & simplifying packaging

See:
- https://antfu.me/posts/move-on-to-esm-only
- https://gist.github.com/sindresorhus/a39789f98801d908bbc7ff3ecc99d99c