### PR TITLE
chore(styles): improve conditional classes order

### DIFF
--- a/apps/docs/src/content/docs/guidelines.mdx
+++ b/apps/docs/src/content/docs/guidelines.mdx
@@ -141,12 +141,11 @@ export const HvComp = forwardRef<
       ref={ref} // 👈 always forwarding the ref
       // 👇 merge class names with `cx` provided by `useClasses`
       className={cx(
-        css(/* internal styles */), // 👈 pass internal styles first, using `css`
+        css(), // 👈 AVOID inline classes, but pass them styles first when necessary
         classes.root, // 👈 ensure `classes.root` is on the root element
         {
-          // conditional classes 👇 are based on their *condition*
-          [classes.selected]: selected,
-          [classes.disabled]: disabled,
+          [classes.selected]: selected, // 👈 names are based on their *condition*
+          [classes.disabled]: disabled, // 👈 higher priority classes come after
         },
         className, // 👈 pass user-defined `className` last
       )}

--- a/packages/core/src/AppSwitcher/Action/Action.tsx
+++ b/packages/core/src/AppSwitcher/Action/Action.tsx
@@ -132,7 +132,10 @@ export const HvAppSwitcherAction = ({
       disabled={disabled}
       className={cx(
         classes.root,
-        { [classes.disabled]: disabled, [classes.selected]: isSelected },
+        {
+          [classes.selected]: isSelected,
+          [classes.disabled]: disabled,
+        },
         className,
       )}
     >

--- a/packages/core/src/BaseRadio/BaseRadio.tsx
+++ b/packages/core/src/BaseRadio/BaseRadio.tsx
@@ -153,10 +153,10 @@ export const HvBaseRadio = forwardRef<HTMLButtonElement, HvBaseRadioProps>(
         className={cx(
           classes.root,
           {
-            [classes.disabled]: disabled,
             [classes.focusVisible]: focusVisible,
             [classes.checked]: checked,
             [classes.semantic]: semantic,
+            [classes.disabled]: disabled,
           },
           className,
         )}

--- a/packages/core/src/BaseSwitch/BaseSwitch.tsx
+++ b/packages/core/src/BaseSwitch/BaseSwitch.tsx
@@ -155,9 +155,9 @@ export const HvBaseSwitch = forwardRef<HTMLButtonElement, HvBaseSwitchProps>(
         className={cx(
           classes.root,
           {
-            [classes.disabled]: disabled,
-            [classes.readOnly]: readOnly,
             [classes.focusVisible]: focusVisible,
+            [classes.readOnly]: readOnly,
+            [classes.disabled]: disabled,
           },
           className,
         )}

--- a/packages/core/src/CheckBox/CheckBox.tsx
+++ b/packages/core/src/CheckBox/CheckBox.tsx
@@ -221,8 +221,8 @@ export const HvCheckBox = forwardRef<HTMLButtonElement, HvCheckBoxProps>(
         {hasLabel ? (
           <div
             className={cx(classes.container, {
-              [classes.disabled]: disabled,
               [classes.invalidContainer]: isStateInvalid,
+              [classes.disabled]: disabled,
             })}
           >
             {checkbox}

--- a/packages/core/src/DropdownButton/DropdownButton.tsx
+++ b/packages/core/src/DropdownButton/DropdownButton.tsx
@@ -68,8 +68,8 @@ export const HvDropdownButton = forwardRef<
         classes.root,
         {
           [classes.open]: open,
-          [classes.disabled]: disabled,
           [classes.readOnly]: readOnly,
+          [classes.disabled]: disabled,
         },
         className,
       )}

--- a/packages/core/src/Radio/Radio.tsx
+++ b/packages/core/src/Radio/Radio.tsx
@@ -249,11 +249,11 @@ export const HvRadio = forwardRef<HTMLButtonElement, HvRadioProps>(
         {hasLabel ? (
           <div
             className={cx(classes.container, {
-              [classes.disabled]: disabled,
               [classes.focusVisible]: !!(focusVisible && label),
-              [classes.invalidContainer]: isStateInvalid,
-              [classes.checked]: isChecked,
               [classes.semantic]: semantic,
+              [classes.checked]: isChecked,
+              [classes.invalidContainer]: isStateInvalid,
+              [classes.disabled]: disabled,
             })}
           >
             {radio}

--- a/packages/core/src/Select/Select.tsx
+++ b/packages/core/src/Select/Select.tsx
@@ -232,8 +232,8 @@ export const HvSelect = fixedForwardRef(function HvSelect<
       readOnly={readOnly}
       status={validationState}
       className={cx(classes.root, className, {
-        [classes.disabled]: disabled,
         [classes.readOnly]: readOnly,
+        [classes.disabled]: disabled,
       })}
       {...others}
     >

--- a/packages/core/src/TagsInput/TagsInput.tsx
+++ b/packages/core/src/TagsInput/TagsInput.tsx
@@ -479,8 +479,8 @@ export const HvTagsInput = forwardRef<HTMLElement, HvTagsInputProps>(
         className={cx(
           classes.root,
           {
-            [classes.disabled]: disabled,
             [classes.readOnly]: readOnly,
+            [classes.disabled]: disabled,
           },
           className,
         )}

--- a/packages/core/src/TextArea/TextArea.tsx
+++ b/packages/core/src/TextArea/TextArea.tsx
@@ -422,8 +422,8 @@ export const HvTextArea = forwardRef<
         classes.root,
         {
           [classes.resizable]: resizable,
-          [classes.disabled]: disabled,
           [classes.invalid]: isStateInvalid,
+          [classes.disabled]: disabled,
         },
         className,
       )}

--- a/packages/core/src/VerticalNavigation/TreeView/TreeViewItem.tsx
+++ b/packages/core/src/VerticalNavigation/TreeView/TreeViewItem.tsx
@@ -587,7 +587,6 @@ export const HvVerticalNavigationTreeViewItem = forwardRef(
         className={cx(
           classes.node,
           {
-            [classes.disabled]: disabled,
             [classes.expandable]: expandable,
             [classes.collapsed]: expandable && !expanded,
             [classes.expanded]: expandable && expanded,
@@ -602,6 +601,7 @@ export const HvVerticalNavigationTreeViewItem = forwardRef(
             [classes.unselected]: !disabled && selectable && !selected,
             [classes.focused]: focused,
             [classes.hide]: !isOpen && !useIcons,
+            [classes.disabled]: disabled,
           },
           className,
         )}

--- a/packages/lab/src/Blade/Blade.tsx
+++ b/packages/lab/src/Blade/Blade.tsx
@@ -200,8 +200,8 @@ export const HvBlade = (props: HvBladeProps) => {
         // eslint-disable-next-line prefer-tag-over-role
         role="button"
         className={cx(classes.button, {
-          [classes.disabled]: disabled,
           [classes.textOnlyLabel]: typeof buttonLabel === "string",
+          [classes.disabled]: disabled,
         })}
         style={{ flexShrink: headingLevel === undefined ? 0 : undefined }}
         disabled={disabled}


### PR DESCRIPTION
move conditional classes such as `readOnly`, `invalid`, `disabled` after others (less important), so their styles are prioritised accordingly, allowing for simpler overrides