### PR TITLE
chore(AppShell): remove icons.svg sprite bundling

### DIFF
--- a/packages/app-shell-vite-plugin/src/vite-plugin.ts
+++ b/packages/app-shell-vite-plugin/src/vite-plugin.ts
@@ -202,15 +202,6 @@ export function HvAppShellVitePlugin(
             src: resolveModule("es-module-shims"),
             dest: "bundles",
           },
-          // copy the ui kit icons' sprites to the "icons" folder
-          // TODO: remove, no longer used
-          {
-            src: resolveModule(
-              "@hitachivantara/uikit-react-icons",
-              "../sprites/*.svg",
-            ),
-            dest: "icons",
-          },
           ...(!devMode && buildEntryPoint
             ? [
                 {


### PR DESCRIPTION
the .svg sprite is no longer used, and is considered internal