### PR TITLE
feat(styles): add theme .vars to access any variable

### DIFF
--- a/apps/docs/src/content/docs/theming.mdx
+++ b/apps/docs/src/content/docs/theming.mdx
@@ -99,7 +99,14 @@ const MyComponent = () => {
 ## CSS Variables
 
 All theme tokens are exported as CSS variables prefixed with `--uikit-*`.
-You can access them directly via the `theme` object from `@hitachivantara/uikit-react-core`:
+You can access them either via:
+
+- the static `theme` object from `@hitachivantara/uikit-react-core`
+- the `vars` property of the theme instance that you just created (eg. `myTheme.vars`)
+
+```tsx
+myTheme.vars.colors.primary; // "var(--uikit-colors-primary)"
+```
 
 ```tsx
 import { HvTypography, theme } from "@hitachivantara/uikit-react-core";

--- a/packages/styles/src/makeTheme.ts
+++ b/packages/styles/src/makeTheme.ts
@@ -4,6 +4,23 @@ import { colors, HvThemeColors, type ColorTokens } from "./tokens/colors";
 import type { HvCustomTheme, HvThemeStructure } from "./types";
 import { mergeTheme } from "./utils";
 
+const getKey = (...keys: string[]) => keys.filter(Boolean).join("-");
+
+/** Uses a Proxy to output the CSS Vars based on the `themeObject` */
+const makeVarsProxy = (themeObject: Record<string, any>, parentKey = "") => {
+  return new Proxy(themeObject, {
+    get(target, prop) {
+      if (prop === "vars" || typeof prop !== "string") return null;
+
+      if (typeof target[prop] === "object" && target[prop] != null) {
+        return makeVarsProxy(target[prop], getKey(parentKey, prop));
+      }
+
+      return `var(--${getKey("uikit", parentKey, prop)})`;
+    },
+  });
+};
+
 /**
  * Generate a theme base on the options received.
  * Takes an incomplete theme object and adds the missing parts.
@@ -16,6 +33,9 @@ export const makeTheme = <Mode extends string = string>(
 ): HvThemeStructure<Mode> => {
   const customTheme = typeof options === "function" ? options(theme) : options;
   const newTheme = mergeTheme(baseTheme, customTheme);
+
+  // @ts-expect-error type this correctly
+  newTheme.vars = makeVarsProxy(newTheme);
 
   return newTheme;
 };

--- a/packages/styles/src/types.ts
+++ b/packages/styles/src/types.ts
@@ -147,6 +147,8 @@ export interface HvThemeStructure<Mode extends string = string>
   colors: {
     modes: Record<Mode, HvThemeColorModeStructure>;
   };
+  /** Utility to access and theme property as CSS variables */
+  vars: HvThemeVars;
 }
 
 // Custom theme

--- a/packages/styles/src/utils.ts
+++ b/packages/styles/src/utils.ts
@@ -35,6 +35,8 @@ export const spacingUtilOld = (
 const toCSSVars = (obj: object, prefix = "--uikit") => {
   const vars: Record<string, string> = {};
 
+  if (!obj || typeof obj !== "object") return vars;
+
   for (const [key, value] of Object.entries(obj)) {
     if (typeof value === "object") {
       const nestedVars = toCSSVars(value, `${prefix}-${key}`);
@@ -149,7 +151,7 @@ export const getThemesList = (themes: Record<string, any>) => {
 };
 
 export const getThemesVars = (themes: HvThemeStructure[]) => {
-  const vars: Record<string, any> = {};
+  const cssVars: Record<string, any> = {};
 
   themes.forEach((theme) => {
     const colorModes = Object.keys(theme.colors.modes);
@@ -160,19 +162,20 @@ export const getThemesVars = (themes: HvThemeStructure[]) => {
 
       // extract properties that shouldn't be mapped to CSS variables
       // @ts-expect-error align HvTheme <-> HvThemeStructure?
-      const { base, components, name, colors, palette, icons, ...rest } = theme;
+      const { base, components, name, colors, palette, icons, vars, ...rest } =
+        theme;
 
-      vars[styleName] = toCSSVars({
+      cssVars[styleName] = toCSSVars({
         colors: {
           ...colors.modes[colorMode],
         },
       });
 
-      vars[themeName] = toCSSVars({
+      cssVars[themeName] = toCSSVars({
         ...rest,
       });
     });
   });
 
-  return vars;
+  return cssVars;
 };


### PR DESCRIPTION
- add `.vars` property to user created themes, allowing CSS var access to any property.
  -  supports spreading and deep/nested access

eg
```tsx
ds5.vars.colors.primary
...ds5.vars.typography.title2
```