### PR TITLE
chore(lint): error on unused vars & forbid root @mui/material import

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -12,7 +12,7 @@
     "no-restricted-imports": [
       "error",
       {
-        "patterns": ["@hitachivantara/*/*"],
+        "patterns": ["@hitachivantara/*/*", "@mui/material"],
         "paths": [
           "..",
           "../..",

--- a/apps/app/src/generator/FontFamily.tsx
+++ b/apps/app/src/generator/FontFamily.tsx
@@ -1,5 +1,5 @@
 import { SyntheticEvent, useState } from "react";
-import { SnackbarCloseReason } from "@mui/material";
+import { SnackbarCloseReason } from "@mui/material/Snackbar";
 import {
   HvButton,
   HvDropdown,

--- a/apps/docs/src/app/examples/inputs/TagsSuggestions.tsx
+++ b/apps/docs/src/app/examples/inputs/TagsSuggestions.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from "react";
-import { ClickAwayListener, Popper } from "@mui/material";
+import { ClickAwayListener, Popper } from "@mui/base";
 import {
   HvAdornment,
   HvPanel,

--- a/apps/docs/src/app/examples/inputs/TagsSuggestionsEmpty.tsx
+++ b/apps/docs/src/app/examples/inputs/TagsSuggestionsEmpty.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { ClickAwayListener, Popper } from "@mui/material";
+import { ClickAwayListener, Popper } from "@mui/base";
 import {
   HvAdornment,
   HvInput,

--- a/apps/docs/src/app/examples/login/LoginFull.tsx
+++ b/apps/docs/src/app/examples/login/LoginFull.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { ClickAwayListener, Popper } from "@mui/material";
+import { ClickAwayListener, Popper } from "@mui/base";
 import {
   HvButton,
   HvIconContainer,

--- a/apps/docs/src/app/examples/login/LoginShort.tsx
+++ b/apps/docs/src/app/examples/login/LoginShort.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { ClickAwayListener, Popper } from "@mui/material";
+import { ClickAwayListener, Popper } from "@mui/base";
 import {
   HvButton,
   HvIconContainer,

--- a/apps/docs/src/components/code/utils.ts
+++ b/apps/docs/src/components/code/utils.ts
@@ -10,7 +10,10 @@ import * as DndKitSortable from "@dnd-kit/sortable";
 import * as DndKitUtilities from "@dnd-kit/utilities";
 import * as emotionCss from "@emotion/css";
 import * as hookFormZod from "@hookform/resolvers/zod";
-import * as materialUi from "@mui/material";
+import * as muiBase from "@mui/base";
+// oxlint-disable-next-line no-restricted-imports
+import * as muiMaterial from "@mui/material";
+import * as muiUtils from "@mui/utils";
 import * as clsx from "clsx";
 import * as echartsCharts from "echarts/charts";
 import * as echartsCore from "echarts/core";
@@ -46,7 +49,9 @@ const defaultScope: Scope = {
     "@hitachivantara/uikit-react-pentaho": HvPentaho,
     "@hitachivantara/uikit-styles": HvStyles,
     "@emotion/css": emotionCss,
-    "@mui/material": materialUi,
+    "@mui/base": muiBase,
+    "@mui/material": muiMaterial,
+    "@mui/utils": muiUtils,
     "react-table": reactTable,
     "react-hook-form": reactHookForm,
     "@hookform/resolvers/zod": hookFormZod,

--- a/packages/app-shell-ui/src/components/hoc/withClickAwayListener.tsx
+++ b/packages/app-shell-ui/src/components/hoc/withClickAwayListener.tsx
@@ -1,5 +1,5 @@
 import { createPortal } from "react-dom";
-import { ClickAwayListener } from "@mui/material";
+import ClickAwayListener from "@mui/material/ClickAwayListener";
 
 import createAppContainerElement from "../../utils/documentUtil";
 

--- a/packages/app-shell-ui/src/components/layout/Header/HeaderActions/InternalActions/AppSwitcherToggle/AppSwitcherToggle.tsx
+++ b/packages/app-shell-ui/src/components/layout/Header/HeaderActions/InternalActions/AppSwitcherToggle/AppSwitcherToggle.tsx
@@ -1,7 +1,7 @@
 import { useId, useState } from "react";
 import { createPortal } from "react-dom";
 import { useTranslation } from "react-i18next";
-import { ClickAwayListener } from "@mui/material";
+import ClickAwayListener from "@mui/material/ClickAwayListener";
 import {
   CONFIG_TRANSLATIONS_NAMESPACE,
   HvAppShellAppSwitcherConfig,

--- a/packages/app-shell-ui/src/providers/NavigationProvider.test.tsx
+++ b/packages/app-shell-ui/src/providers/NavigationProvider.test.tsx
@@ -1,5 +1,5 @@
 import { useContext } from "react";
-import { useMediaQuery } from "@mui/material";
+import useMediaQuery from "@mui/material/useMediaQuery";
 import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Mock, vi } from "vitest";
@@ -8,11 +8,11 @@ import { LOCAL_STORAGE_KEYS } from "../hooks/useLocalStorage";
 import renderTestProvider from "../tests/testUtils";
 import { NavigationContext } from "./NavigationProvider";
 
-vi.mock("@mui/material", async () => {
-  const mod = await vi.importActual("@mui/material");
+vi.mock("@mui/material/useMediaQuery", async () => {
+  const mod = await vi.importActual("@mui/material/useMediaQuery");
   return {
     ...(mod as object),
-    useMediaQuery: vi.fn().mockReturnValue(false),
+    default: vi.fn().mockReturnValue(false),
   };
 });
 

--- a/packages/app-shell-ui/src/providers/NavigationProvider.tsx
+++ b/packages/app-shell-ui/src/providers/NavigationProvider.tsx
@@ -7,7 +7,8 @@ import {
   useMemo,
   useState,
 } from "react";
-import { useMediaQuery, useTheme } from "@mui/material";
+import { useTheme } from "@mui/material/styles";
+import useMediaQuery from "@mui/material/useMediaQuery";
 import { useHvAppShellConfig } from "@hitachivantara/app-shell-shared";
 
 import useLocalStorage from "../hooks/useLocalStorage";

--- a/packages/config/oxlint/base.json
+++ b/packages/config/oxlint/base.json
@@ -17,8 +17,15 @@
     "react/rules-of-hooks": "error",
 
     "eslint/no-unused-vars": [
-      "warn",
-      { "ignoreRestSiblings": true, "argsIgnorePattern": "^_" }
+      "error",
+      {
+        "args": "after-used",
+        "ignoreRestSiblings": true,
+        "argsIgnorePattern": "^_",
+        "varsIgnorePattern": "^_",
+        "destructuredArrayIgnorePattern": "^_",
+        "caughtErrors": "none"
+      }
     ],
     "jsx_a11y/no-autofocus": "off",
     "jsx_a11y/role-supports-aria-props": "off",

--- a/packages/core/src/Dialog/Content/Content.tsx
+++ b/packages/core/src/Dialog/Content/Content.tsx
@@ -7,7 +7,6 @@ import {
   useDefaultProps,
   type ExtractNames,
 } from "@hitachivantara/uikit-react-utils";
-import { theme } from "@hitachivantara/uikit-styles";
 
 import { HvTypography } from "../../Typography";
 import { staticClasses, useClasses } from "./Content.styles";

--- a/packages/core/src/Dialog/stories/SemanticVariantsStory.tsx
+++ b/packages/core/src/Dialog/stories/SemanticVariantsStory.tsx
@@ -9,7 +9,6 @@ import {
   HvDialogTitle,
   HvStatusIcon,
 } from "@hitachivantara/uikit-react-core";
-import { Ungroup } from "@hitachivantara/uikit-react-icons";
 
 type SimpleDialogProps = Pick<HvDialogProps, "classes" | "variant"> & {
   buttonMessage?: string;

--- a/packages/core/src/NumberInput/NumberInput.tsx
+++ b/packages/core/src/NumberInput/NumberInput.tsx
@@ -1,5 +1,5 @@
 import { forwardRef, useMemo, useRef } from "react";
-import { useForkRef } from "@mui/material";
+import { useForkRef } from "@mui/material/utils";
 import { useDefaultProps } from "@hitachivantara/uikit-react-utils";
 
 import { HvAdornment } from "../FormElement";

--- a/packages/core/src/Pagination/Pagination.tsx
+++ b/packages/core/src/Pagination/Pagination.tsx
@@ -1,5 +1,6 @@
 import { forwardRef, useCallback, useEffect, useState } from "react";
-import { useMediaQuery, useTheme } from "@mui/material";
+import { useTheme } from "@mui/material/styles";
+import useMediaQuery from "@mui/material/useMediaQuery";
 import {
   clamp,
   useDefaultProps,


### PR DESCRIPTION
- change `unused-vars` to error, but relax rule a bit
  - since this was only `warn`, we'd start accumulating these
- forbid root `@mui/material` imports (for bundling/dev performance reasons)