### PR TITLE
fix(Accordion): default disableEventHandling

### DIFF
--- a/packages/core/src/Accordion/Accordion.test.tsx
+++ b/packages/core/src/Accordion/Accordion.test.tsx
@@ -183,7 +183,7 @@ describe("Accordion", () => {
     expect(analyticsContent).not.toBeVisible();
   });
 
-  it("disables the internal usage of `preventDefault` and `stopPropagation` when disableEventHandling is true", async () => {
+  it("doesn't use `preventDefault` and `stopPropagation`", async () => {
     const user = userEvent.setup();
     const toggleSpy = vi.fn();
     render(
@@ -191,20 +191,11 @@ describe("Accordion", () => {
         <HvAccordion label="Analytics">
           <HvTypography>Views</HvTypography>
         </HvAccordion>
-        <HvAccordion label="System" disableEventHandling>
-          <HvTypography>item 2</HvTypography>
-        </HvAccordion>
         <HvDropdown defaultExpanded onToggle={toggleSpy} />
       </>,
     );
 
-    const analyticsItem = screen.getByRole("button", { name: /Analytics/i });
-    const systemItem = screen.getByRole("button", { name: /System/i });
-
-    await user.click(analyticsItem);
-    expect(toggleSpy).not.toHaveBeenCalled();
-
-    await user.click(systemItem);
+    await user.click(screen.getByRole("button", { name: /Analytics/i }));
     expect(toggleSpy).toHaveBeenCalledOnce();
   });
 });

--- a/packages/core/src/Accordion/Accordion.tsx
+++ b/packages/core/src/Accordion/Accordion.tsx
@@ -1,4 +1,5 @@
-import { forwardRef, useCallback, useMemo } from "react";
+import { forwardRef, useMemo } from "react";
+import { useEventCallback } from "@mui/material/utils";
 import {
   useDefaultProps,
   type ExtractNames,
@@ -37,8 +38,6 @@ export interface HvAccordionProps
   labelVariant?: HvTypographyVariants;
   /** A Jss Object used to override or extend the styles applied. */
   classes?: HvAccordionClasses;
-  /** Whether to disable the internal usage of `preventDefault` and `stopPropagation` when the `onChange` event is triggered. */
-  disableEventHandling?: boolean; // TODO - remove in v6 as this should be the default behavior: `preventDefault` and `stopPropagation` shouldn't be triggered internally
 }
 
 /**
@@ -60,7 +59,6 @@ export const HvAccordion = forwardRef<
     defaultExpanded = false,
     containerProps,
     labelVariant = "label",
-    disableEventHandling,
     ...others
   } = useDefaultProps("HvAccordion", props);
   const { classes, cx } = useClasses(classesProp);
@@ -71,20 +69,11 @@ export const HvAccordion = forwardRef<
     defaultExpanded,
   });
 
-  const handleClick = useCallback(
-    (event: React.SyntheticEvent) => {
-      if (!disabled) {
-        onChange?.(event, isOpen);
-        toggleOpen();
-      }
-
-      if (!disableEventHandling) {
-        event.preventDefault();
-        event.stopPropagation();
-      }
-    },
-    [disableEventHandling, disabled, isOpen, onChange, toggleOpen],
-  );
+  const handleClick = useEventCallback((event: React.SyntheticEvent) => {
+    if (disabled) return;
+    onChange?.(event, isOpen);
+    toggleOpen();
+  });
 
   const accordionHeader = useMemo(() => {
     const accordionButton = (
@@ -110,7 +99,8 @@ export const HvAccordion = forwardRef<
     );
   }, [
     cx,
-    classes,
+    classes.label,
+    classes.disabled,
     handleClick,
     label,
     buttonProps,

--- a/packages/core/src/TimeAgo/useTimeAgo.ts
+++ b/packages/core/src/TimeAgo/useTimeAgo.ts
@@ -1,17 +1,8 @@
 import { useEffect, useState } from "react";
 
-import { formatTimeAgo } from "./formatUtils";
+import { formatTimeAgo as fmt } from "./formatUtils";
 import type { HvTimeAgoProps } from "./TimeAgo";
 import { useTimeout } from "./useTimeout";
-
-/**
- * Calls `formatTimeAgo` with timestamp conversion
- */
-const fmt = (timestamp: any, locale: any, showSeconds?: boolean) => {
-  const timestampMs =
-    String(timestamp).length > 11 ? timestamp : timestamp * 1000;
-  return formatTimeAgo(timestampMs, locale, showSeconds);
-};
 
 export default function useTimeAgo(
   timestamp = Date.now(),

--- a/packages/core/src/hooks/useExpandable.ts
+++ b/packages/core/src/hooks/useExpandable.ts
@@ -1,4 +1,4 @@
-import { useId } from "react";
+import { useCallback, useId } from "react";
 
 import type { HvAccordionProps } from "../Accordion";
 import { useControlled } from "./useControlled";
@@ -16,9 +16,14 @@ export function useExpandable({
   const buttonId = useId();
   const regionId = useId();
 
+  const toggleOpen = useCallback(
+    (newOpen?: boolean) => setIsOpen((o) => newOpen ?? !o),
+    [setIsOpen],
+  );
+
   return {
     isOpen,
-    toggleOpen: (newOpen?: boolean) => setIsOpen((o) => newOpen ?? !o),
+    toggleOpen,
     buttonProps: {
       id: buttonId,
       "aria-disabled": disabled,


### PR DESCRIPTION
- remove `disableEventHandling` (make it default)
- remove problematic `useTimeAgo` seconds to milliseconds conversions