### PR TITLE
chore(lint): bump oxlint & fix issues

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -47,12 +47,6 @@
       "rules": {
         "react-hooks/rules-of-hooks": "off"
       }
-    },
-    {
-      "files": ["packages/cli/src/**/*"],
-      "rules": {
-        "no-console": "off"
-      }
     }
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -6139,9 +6139,9 @@
       }
     },
     "node_modules/@oxlint/darwin-arm64": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/darwin-arm64/-/darwin-arm64-1.1.0.tgz",
-      "integrity": "sha512-sSnR3SOxIU/QfaqXrcQ0UVUkzJO0bcInQ7dMhHa102gVAgWjp1fBeMVCM0adEY0UNmEXrRkgD/rQtQgn9YAU+w==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/darwin-arm64/-/darwin-arm64-1.7.0.tgz",
+      "integrity": "sha512-51vhCSQO4NSkedwEwOyqThiYqV0DAUkwNdqMQK0d29j5zmtNJJJRRBLeQuLGdstNmn3F7WMQ75Ci0/3Nq4ff8A==",
       "cpu": [
         "arm64"
       ],
@@ -6153,9 +6153,9 @@
       ]
     },
     "node_modules/@oxlint/darwin-x64": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/darwin-x64/-/darwin-x64-1.1.0.tgz",
-      "integrity": "sha512-Jvd3fHnzY2OYbmsg9NSGPoBkGViDGHSFnBKyJQ9LOIw7lxAyQBG2Quxc3GYPFR/f9OYho9C3p4+dIaAJfKhnsw==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/darwin-x64/-/darwin-x64-1.7.0.tgz",
+      "integrity": "sha512-c0GN52yehYZ4TYuh4lBH9wYbBOI/RDOxZhJdBsttG0GwfvKYg/tiPNrNEsPzu0/rd1j6x3yT0zt6vezDMeC1sQ==",
       "cpu": [
         "x64"
       ],
@@ -6167,9 +6167,9 @@
       ]
     },
     "node_modules/@oxlint/linux-arm64-gnu": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/linux-arm64-gnu/-/linux-arm64-gnu-1.1.0.tgz",
-      "integrity": "sha512-MgW4iskOdXuoR+wDXIJUfbdnTg2eo2FnQRaD6ZqhnDTDa7LnV+06rp/Cg3aGj2X9jSEcKDv/bMbYQuot7WRs6Q==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/linux-arm64-gnu/-/linux-arm64-gnu-1.7.0.tgz",
+      "integrity": "sha512-pam/lbzbzVMDzc3f1hoRPtnUMEIqkn0dynlB5nUll/MVBSIvIPLS9kJLrRA48lrlqbkS9LGiF37JvpwXA58A9A==",
       "cpu": [
         "arm64"
       ],
@@ -6181,9 +6181,9 @@
       ]
     },
     "node_modules/@oxlint/linux-arm64-musl": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/linux-arm64-musl/-/linux-arm64-musl-1.1.0.tgz",
-      "integrity": "sha512-a+pkEKmDRdrW+y0gtZ/m68ElVW2VZgATGbMxDgDYFpdiMx9Y0pUPwTMZ2EX/17Aslop4c1BiDSFDK7aEBxKR2g==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/linux-arm64-musl/-/linux-arm64-musl-1.7.0.tgz",
+      "integrity": "sha512-LTyPy9FYS3SZ2XxJx+ITvlAq/ek5PtZK9Z2m3W72TA8hchGhJy5eQ+aotYjd/YVXOpGRpB12RdOpOTsZRu50bA==",
       "cpu": [
         "arm64"
       ],
@@ -6195,9 +6195,9 @@
       ]
     },
     "node_modules/@oxlint/linux-x64-gnu": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/linux-x64-gnu/-/linux-x64-gnu-1.1.0.tgz",
-      "integrity": "sha512-wNBsXCKVZMvUTcFitrV1wTsdhUAv8l+XQxHxciZ2SO6dpNnWEb2YCxSAIOXeyzBLdO4pIODYcSy38CvGue7TwA==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/linux-x64-gnu/-/linux-x64-gnu-1.7.0.tgz",
+      "integrity": "sha512-YtZ4DiAgjaEiqUiwnvtJ/znZMAAVPKR7pnsi6lqbA3BfXJ/IwMaNpdoGlCGVdDGeN4BuGCwnFtBVqKVvVg3DDg==",
       "cpu": [
         "x64"
       ],
@@ -6209,9 +6209,9 @@
       ]
     },
     "node_modules/@oxlint/linux-x64-musl": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/linux-x64-musl/-/linux-x64-musl-1.1.0.tgz",
-      "integrity": "sha512-pZD0lt6A5j2Wp70fgIYk4GoPfKTZ8mHWamWIpKFT7aSkFkiOi6nhLWDFvMEIHWRTK3LgkWUNcnWPp4brvin4wQ==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/linux-x64-musl/-/linux-x64-musl-1.7.0.tgz",
+      "integrity": "sha512-5aIpemNUBvwMMk4MCx1V3M6R9eMB1/SS6/24Orax9FqaI1lDX08tySdv696sr4Lms9ocA+rotxIPW9NP9439vA==",
       "cpu": [
         "x64"
       ],
@@ -6223,9 +6223,9 @@
       ]
     },
     "node_modules/@oxlint/win32-arm64": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/win32-arm64/-/win32-arm64-1.1.0.tgz",
-      "integrity": "sha512-rT6uXQvE80+B+L04HJf30uF26426FPI9i9DAY2AxBUhrpNwhqkDEhQdd9ilFWVC7SSbpHgAs50lo+ImSAAkHPQ==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/win32-arm64/-/win32-arm64-1.7.0.tgz",
+      "integrity": "sha512-fpFpkHwbAu0NcR5bc1WapCPcM9qSYi5lCRVOp1WwDoFLKI2b9/UWB8OEg8UHWV5dnBu7HZAWH/SEslYGkZNsbQ==",
       "cpu": [
         "arm64"
       ],
@@ -6237,9 +6237,9 @@
       ]
     },
     "node_modules/@oxlint/win32-x64": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/win32-x64/-/win32-x64-1.1.0.tgz",
-      "integrity": "sha512-x6r5yvM3wEty93Bx0NuNK+kutUyS/K55itkUrxdExoK6GcmVDboGGuhju9HyU2cM/IWLEWO8RHcXSyaxr9GR5g==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/win32-x64/-/win32-x64-1.7.0.tgz",
+      "integrity": "sha512-0EPWBWOiD3wZHgeWDlTUaiFzhzIonXykxYUC+NRerPQFkO/G+bd9uLMJddHDKqfP/7g8s3E5V6KvBvvFpb7U6g==",
       "cpu": [
         "x64"
       ],
@@ -24201,9 +24201,9 @@
       }
     },
     "node_modules/oxlint": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.1.0.tgz",
-      "integrity": "sha512-OVNpaoaQCUHHhCv5sYMPJ7Ts5k7ziw0QteH1gBSwF3elf/8GAew2Uh/0S7HsU1iGtjhlFy80+A8nwIb3Tq6m1w==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.7.0.tgz",
+      "integrity": "sha512-krJN1fIRhs3xK1FyVyPtYIV9tkT4WDoIwI7eiMEKBuCjxqjQt5ZemQm1htPvHqNDOaWFRFt4btcwFdU8bbwgvA==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -24217,14 +24217,14 @@
         "url": "https://github.com/sponsors/Boshen"
       },
       "optionalDependencies": {
-        "@oxlint/darwin-arm64": "1.1.0",
-        "@oxlint/darwin-x64": "1.1.0",
-        "@oxlint/linux-arm64-gnu": "1.1.0",
-        "@oxlint/linux-arm64-musl": "1.1.0",
-        "@oxlint/linux-x64-gnu": "1.1.0",
-        "@oxlint/linux-x64-musl": "1.1.0",
-        "@oxlint/win32-arm64": "1.1.0",
-        "@oxlint/win32-x64": "1.1.0"
+        "@oxlint/darwin-arm64": "1.7.0",
+        "@oxlint/darwin-x64": "1.7.0",
+        "@oxlint/linux-arm64-gnu": "1.7.0",
+        "@oxlint/linux-arm64-musl": "1.7.0",
+        "@oxlint/linux-x64-gnu": "1.7.0",
+        "@oxlint/linux-x64-musl": "1.7.0",
+        "@oxlint/win32-arm64": "1.7.0",
+        "@oxlint/win32-x64": "1.7.0"
       }
     },
     "node_modules/p-event": {

--- a/packages/app-shell-vite-plugin/src/index.ts
+++ b/packages/app-shell-vite-plugin/src/index.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line extensions review need of .js extensions
 export * from "./vite-plugin.js";
 
 // reexport types from shared package

--- a/packages/cli/.oxlintrc.json
+++ b/packages/cli/.oxlintrc.json
@@ -1,17 +1,5 @@
 {
   "rules": {
-    "no-alert": "off",
-    "no-console": "off",
-    "import/extensions": "off",
-    "ssr-friendly/no-dom-globals-in-module-scope": "off"
-  },
-  "overrides": [
-    {
-      "files": ["src/baselines/**/*"],
-      "rules": {
-        "import/no-extraneous-dependencies": "off",
-        "import/no-relative-packages": "off"
-      }
-    }
-  ]
+    "no-console": "off"
+  }
 }

--- a/packages/config/oxlint/default.json
+++ b/packages/config/oxlint/default.json
@@ -33,6 +33,7 @@
     "typescript/no-empty-object-type": "off",
     "typescript/no-explicit-any": "off",
     "typescript/no-non-null-assertion": "off",
+    "unicorn/consistent-function-scoping": "off",
     "unicorn/no-anonymous-default-export": "off",
     "unicorn/no-array-for-each": "off",
     "unicorn/no-array-reduce": "off",


### PR DESCRIPTION
- bump oxlint
- fix issues found in new version (eg. `ssr-friendly` not existing as a plugin)
- remove redundant config rules