### PR TITLE
fix(DialogTitle): render icon when `customIcon` or `variant` is defined

### DIFF
--- a/packages/core/src/Dialog/Dialog.stories.tsx
+++ b/packages/core/src/Dialog/Dialog.stories.tsx
@@ -107,6 +107,14 @@ export const LongContent: StoryObj<HvDialogProps> = {
           "With very long content the dialog grows in height, up to a maximum where a margin of 100px is left on top and bottom.",
       },
     },
+    ...setupChromatic(["DS5 dawn", "Pentaho dawn"]),
+  },
+  // For visual testing and a11y
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const button = canvas.getByRole("button", { name: /open dialog/i });
+    await userEvent.click(button);
+    await expect(canvas.getByRole("dialog")).toBeInTheDocument();
   },
   decorators: [(Story) => <div style={{ minHeight: 400 }}>{Story()}</div>],
   render: () => <LongContentStory />,

--- a/packages/core/src/Dialog/Dialog.test.tsx
+++ b/packages/core/src/Dialog/Dialog.test.tsx
@@ -5,7 +5,7 @@ import { HvDialog } from "./Dialog";
 import { HvDialogActions, HvDialogContent, HvDialogTitle } from "./index";
 
 describe("Dialog", () => {
-  it("should render all components correctly", () => {
+  it("renders all components correctly", () => {
     render(
       <HvDialog open>
         <HvDialogTitle>mockTitle</HvDialogTitle>
@@ -18,7 +18,7 @@ describe("Dialog", () => {
     expect(screen.getByText("mockActions")).toBeInTheDocument();
   });
 
-  it("should call the onClose function when the close button is clicked", () => {
+  it("calls the onClose function when the close button is clicked", () => {
     const mockFn = vi.fn();
     const mockBtnTitle = "closeBtn";
 
@@ -28,5 +28,43 @@ describe("Dialog", () => {
     const btn = getByRole("button", { name: mockBtnTitle });
     fireEvent.click(btn);
     expect(mockFn).toHaveBeenCalled();
+  });
+
+  it("renders title icon when variant is specified", () => {
+    render(
+      <HvDialog open>
+        <HvDialogTitle variant="success">mockTitle</HvDialogTitle>
+      </HvDialog>,
+    );
+    const titleElement = screen.queryByRole("heading");
+    expect(titleElement).toBeInTheDocument();
+    expect(
+      titleElement?.querySelector(".HvStatusIcon-root"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders a custom icon", () => {
+    render(
+      <HvDialog open>
+        <HvDialogTitle customIcon={<div data-testid="icon-id" />}>
+          mockTitle
+        </HvDialogTitle>
+      </HvDialog>,
+    );
+    expect(screen.queryByTestId("icon-id")).toBeInTheDocument();
+  });
+
+  it("doesn't render a status icon by default", () => {
+    render(
+      <HvDialog open>
+        <HvDialogTitle>mockTitle</HvDialogTitle>
+      </HvDialog>,
+    );
+
+    const titleElement = screen.queryByRole("heading");
+    expect(titleElement).toBeInTheDocument();
+    expect(
+      titleElement?.querySelector(".HvStatusIcon-root"),
+    ).not.toBeInTheDocument();
   });
 });

--- a/packages/core/src/Dialog/Title/Title.tsx
+++ b/packages/core/src/Dialog/Title/Title.tsx
@@ -39,8 +39,8 @@ export const HvDialogTitle = (props: HvDialogTitleProps) => {
     classes: classesProp,
     className,
     children,
-    variant = "default",
-    showIcon = true,
+    variant,
+    showIcon = variant != null,
     customIcon,
     ...others
   } = useDefaultProps("HvDialogTitle", props);

--- a/packages/core/src/Dialog/stories/LongContentStory.tsx
+++ b/packages/core/src/Dialog/stories/LongContentStory.tsx
@@ -16,8 +16,8 @@ export const LongContentStory = () => {
         Open dialog
       </HvButton>
       <HvDialog disableBackdropClick open={open} onClose={() => setOpen(false)}>
-        <HvDialogTitle variant="warning">Terms and Conditions</HvDialogTitle>
-        <HvDialogContent indentContent>
+        <HvDialogTitle>Terms and Conditions</HvDialogTitle>
+        <HvDialogContent indentContent tabIndex={0} role="region">
           Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce ut sem
           mattis, finibus tellus et, fringilla erat. Nulla justo lacus, pharetra
           at fringilla eget, interdum sit amet mauris. Pellentesque metus ex,


### PR DESCRIPTION
- renders the `HvDialogTitle` icon only when a `customIcon` or a `variant` is defined
- add unit tests & Chromatic test