### PR TITLE
chore: review misc todos

### DIFF
--- a/packages/core/src/Button/Button.styles.ts
+++ b/packages/core/src/Button/Button.styles.ts
@@ -103,16 +103,6 @@ export const { staticClasses, useClasses } = createClasses("HvButton", {
       backgroundColor: theme.alpha("textLight", 0.1),
     },
   },
-
-  // TODO - remove in v6
-  primary: {},
-  primarySubtle: {},
-  primaryGhost: {},
-  secondarySubtle: {},
-  secondaryGhost: {},
-
-  // Deprecated (DS3)
-  secondary: {},
 });
 
 // TODO - remove xs and xl in v6 since they are not DS spec

--- a/packages/core/src/Card/Header/Header.styles.tsx
+++ b/packages/core/src/Card/Header/Header.styles.tsx
@@ -9,10 +9,6 @@ export const { staticClasses, useClasses } = createClasses("HvCardHeader", {
     alignItems: "center",
     display: "flex",
   },
-  titleShort: {
-    ...theme.typography.label,
-    fontFamily: theme.fontFamily.body,
-  },
   title: {
     ...theme.typography.label,
     fontFamily: theme.fontFamily.body,

--- a/packages/core/src/Card/Header/Header.tsx
+++ b/packages/core/src/Card/Header/Header.tsx
@@ -45,11 +45,7 @@ export const HvCardHeader = (props: HvCardHeaderProps) => {
       onClick={onClick}
       className={cx(classes.root, className)}
       classes={{
-        title: cx({
-          // TODO: review conditional in v6
-          [classes.titleShort]: icon,
-          [classes.title]: !icon,
-        }),
+        title: classes.title,
         subheader: classes.subheader,
         action: classes.action,
         content: classes.content,

--- a/packages/core/src/DatePicker/DatePicker.stories.tsx
+++ b/packages/core/src/DatePicker/DatePicker.stories.tsx
@@ -19,7 +19,6 @@ const containerDecorator: Decorator = (Story) => (
 
 const meta: Meta<typeof HvDatePicker> = {
   title: "Components/Date Picker",
-  // TODO: HvCalendar should have its own docs
   // @ts-ignore https://github.com/storybookjs/storybook/issues/23170
   subcomponents: { HvCalendar },
   component: HvDatePicker,

--- a/packages/core/src/Dialog/Dialog.styles.tsx
+++ b/packages/core/src/Dialog/Dialog.styles.tsx
@@ -13,7 +13,7 @@ export const { staticClasses, useClasses } = createClasses("HvDialog", {
     borderColor: theme.colors.border,
     borderRadius: theme.radii.round,
   },
-  fullscreen: {
+  fullScreen: {
     borderRadius: 0,
   },
 

--- a/packages/core/src/Dialog/Dialog.tsx
+++ b/packages/core/src/Dialog/Dialog.tsx
@@ -17,7 +17,7 @@ export { staticClasses as dialogClasses };
 export type HvDialogClasses = ExtractNames<typeof useClasses>;
 
 export interface HvDialogProps
-  extends Omit<MuiDialogProps, "fullScreen" | "classes" | "open"> {
+  extends Omit<MuiDialogProps, "classes" | "open"> {
   /** Current state of the Dialog. */
   open?: boolean;
   /** Callback fired when the component requests to be closed. */
@@ -33,8 +33,6 @@ export interface HvDialogProps
   fullHeight?: boolean;
   /** Title for the button close. */
   buttonTitle?: string;
-  /** Set the dialog to fullscreen mode. */
-  fullscreen?: boolean;
   /** Prevent closing the dialog when clicking on the backdrop. */
   disableBackdropClick?: boolean;
   /** A Jss Object used to override or extend the styles applied to the component. */
@@ -64,7 +62,7 @@ export const HvDialog = forwardRef<
     onClose,
     buttonTitle = "Close",
     fullHeight,
-    fullscreen: fullScreen = false, // TODO: rename to `fullScreen` in v6
+    fullScreen = false,
     disableBackdropClick = false,
     ...others
   } = useDefaultProps("HvDialog", props);
@@ -83,7 +81,7 @@ export const HvDialog = forwardRef<
         paper: cx(classes.paper, classes[variant!], {
           [classes.fullHeight]: fullHeight,
           [classes.statusBar]: !!variant,
-          [classes.fullscreen]: fullScreen,
+          [classes.fullScreen]: fullScreen,
         }),
       }}
       ref={ref}

--- a/packages/core/src/Dialog/Title/Title.styles.tsx
+++ b/packages/core/src/Dialog/Title/Title.styles.tsx
@@ -10,7 +10,5 @@ export const { staticClasses, useClasses } = createClasses("HvDialogTitle", {
     alignItems: "center",
     gap: theme.space.xs,
   },
-  fullscreen: {},
-  // TODO: consider deprecating
-  textWithIcon: {},
+  fullScreen: {},
 });

--- a/packages/core/src/Dialog/Title/Title.tsx
+++ b/packages/core/src/Dialog/Title/Title.tsx
@@ -57,8 +57,7 @@ export const HvDialogTitle = (props: HvDialogTitleProps) => {
       className={cx(
         classes.root,
         {
-          [classes.fullscreen]: fullScreen,
-          [classes.textWithIcon]: icon,
+          [classes.fullScreen]: fullScreen,
         },
         className,
       )}

--- a/packages/core/src/FileUploader/DropZone/DropZone.tsx
+++ b/packages/core/src/FileUploader/DropZone/DropZone.tsx
@@ -142,10 +142,7 @@ export const HvDropZone = (props: HvDropZoneProps) => {
       newFile.id = uniqueId("uploaded-file-data-");
 
       const isSizeAllowed = file.size <= maxFileSize;
-      const isFileAccepted =
-        !accept ||
-        accept.includes(file.type?.split("/")[1]) || // TODO: remove in v6
-        validateAccept(file, accept);
+      const isFileAccepted = !accept || validateAccept(file, accept);
 
       if (!isFileAccepted) {
         newFile.errorMessage = labels?.fileTypeError;

--- a/packages/core/src/IconButton/IconButton.test.tsx
+++ b/packages/core/src/IconButton/IconButton.test.tsx
@@ -23,7 +23,6 @@ const assertTooltipWhenHovered = async () => {
   });
 };
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const assertTooltipWhenTabbed = async () => {
   const user = userEvent.setup();
   await user.tab();
@@ -70,13 +69,11 @@ describe("HvIconButton", () => {
 
   it("renders tooltip when focused with the keyboard", async () => {
     renderIconButton();
-    // TODO: re-enable
-    // await assertTooltipWhenTabbed();
+    await assertTooltipWhenTabbed();
   });
 
   it("renders tooltip when disabled and focused with the keyboard", async () => {
     renderIconButton({ disabled: true });
-    // TODO: re-enable
-    // await assertTooltipWhenTabbed();
+    await assertTooltipWhenTabbed();
   });
 });

--- a/packages/core/src/ListContainer/ListItem/ListItem.tsx
+++ b/packages/core/src/ListContainer/ListItem/ListItem.tsx
@@ -120,32 +120,16 @@ export const HvListItem = forwardRef<
   const clonedStartAdornment = useMemo(() => {
     if (!isValidElement(startAdornment)) return startAdornment;
     return cloneElement(startAdornment as ReactElement, {
-      className: cx(classes.startAdornment, startAdornment.props.className, {
-        // TODO: remove 👇 props below
-        [classes.disabled]: disabled,
-      }),
-      checked: !!selected,
-      disabled,
-      onChange: handleClick,
+      className: cx(classes.startAdornment, startAdornment.props.className),
     });
-  }, [
-    cx,
-    classes?.startAdornment,
-    classes?.disabled,
-    disabled,
-    handleClick,
-    selected,
-    startAdornment,
-  ]);
+  }, [cx, classes?.startAdornment, startAdornment]);
 
   const clonedEndAdornment = useMemo(() => {
     if (!isValidElement(endAdornment)) return endAdornment;
     return cloneElement(endAdornment as ReactElement, {
-      className: cx(classes.endAdornment, endAdornment.props.className, {
-        [classes.disabled]: disabled,
-      }),
+      className: cx(classes.endAdornment, endAdornment.props.className),
     });
-  }, [cx, classes?.endAdornment, classes?.disabled, disabled, endAdornment]);
+  }, [cx, classes?.endAdornment, endAdornment]);
 
   const roleOptionAriaProps =
     role === "option" || role === "menuitem"

--- a/packages/core/src/Loading/Loading.styles.tsx
+++ b/packages/core/src/Loading/Loading.styles.tsx
@@ -48,12 +48,4 @@ export const { staticClasses, useClasses } = createClasses("HvLoading", {
   overlay: {},
   blur: {},
   hidden: { display: "none" },
-  /** @deprecated use data-size=small instead */
-  small: {},
-  /** @deprecated use data-size=regular instead */
-  regular: {},
-  /** @deprecated leverage data-size=small instead */
-  smallColor: {},
-  /** @deprecated leverage data-size=regular instead */
-  regularColor: {},
 });

--- a/packages/core/src/Loading/Loading.tsx
+++ b/packages/core/src/Loading/Loading.tsx
@@ -49,7 +49,6 @@ export const HvLoading = forwardRef<
   const { classes, cx } = useClasses(classesProp);
 
   const size = small ? "small" : "regular";
-  const colorVariant = color && (`${size}Color` as const);
 
   return (
     <div
@@ -71,15 +70,7 @@ export const HvLoading = forwardRef<
     >
       <div className={classes.barContainer}>
         {range(3).map((e) => (
-          <div
-            key={e}
-            className={cx(
-              classes.loadingBar,
-              // TODO: hoist to parent & remove unused `colorVariant` in v6
-              classes[size],
-              classes[colorVariant!],
-            )}
-          />
+          <div key={e} className={classes.loadingBar} />
         ))}
       </div>
       {label && <div className={classes.label}>{label}</div>}

--- a/packages/core/src/MultiButton/MultiButton.styles.tsx
+++ b/packages/core/src/MultiButton/MultiButton.styles.tsx
@@ -137,12 +137,4 @@ export const { staticClasses, useClasses } = createClasses("HvMultiButton", {
   // TODO - review the need for these classes in v6 (use :first-child and :last-child instead)
   firstButton: {},
   lastButton: {},
-
-  // TODO - review the need for these classes in v6
-  primary: {},
-  primarySubtle: {},
-  primaryGhost: {},
-  secondary: {},
-  secondarySubtle: {},
-  secondaryGhost: {},
 });

--- a/packages/core/src/MultiButton/MultiButton.tsx
+++ b/packages/core/src/MultiButton/MultiButton.tsx
@@ -62,7 +62,6 @@ export const HvMultiButton = (props: HvMultiButtonProps) => {
         {
           [classes.multiple]: !split,
           [classes.vertical]: !split && vertical,
-          [classes[variant as keyof HvMultiButtonClasses]]: variant, // TODO - remove in v6
           [classes.splitGroup]: split,
           [classes.splitGroupDisabled]: split && disabled,
         },

--- a/packages/core/src/QueryBuilder/Context.tsx
+++ b/packages/core/src/QueryBuilder/Context.tsx
@@ -317,7 +317,6 @@ export const defaultLabels: HvQueryBuilderLabels = {
 export interface HvQueryBuilderContextValue {
   dispatchAction: React.Dispatch<QueryAction>;
   askAction: React.Dispatch<React.SetStateAction<AskAction | undefined>>;
-  selectLocation?: React.Dispatch<unknown>; // TODO - remove in v6 (not used)
   attributes?: Record<string, HvQueryBuilderAttribute>;
   operators: Record<string, HvQueryBuilderQueryOperator[]>;
   combinators: HvQueryBuilderQueryCombinator[];
@@ -334,7 +333,6 @@ export interface HvQueryBuilderContextValue {
 export const HvQueryBuilderContext = createContext<HvQueryBuilderContextValue>({
   dispatchAction: () => ({}),
   askAction: () => ({}),
-  selectLocation: () => ({}), // TODO - remove in v6 (not used)
   attributes: {},
   operators: defaultOperators,
   combinators: defaultCombinators,

--- a/packages/core/src/ScrollToVertical/VerticalScrollListItem/VerticalScrollListItem.styles.ts
+++ b/packages/core/src/ScrollToVertical/VerticalScrollListItem/VerticalScrollListItem.styles.ts
@@ -27,8 +27,6 @@ export const { staticClasses, useClasses } = createClasses(name, {
     fontSize: 4,
     color: theme.colors.textDisabled,
   },
-  /** @deprecated: use classes.button instead */
-  text: {},
   button: {
     display: "flex",
     justifyContent: "center",

--- a/packages/core/src/ScrollToVertical/VerticalScrollListItem/VerticalScrollListItem.tsx
+++ b/packages/core/src/ScrollToVertical/VerticalScrollListItem/VerticalScrollListItem.tsx
@@ -54,7 +54,7 @@ export const HvVerticalScrollListItem = (
         <Component
           role={href == null ? "button" : undefined}
           tabIndex={0}
-          className={cx(classes.button, classes.text)}
+          className={classes.button}
           href={href}
           {...others}
         >

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -6,11 +6,6 @@ export type {
   // BREAKPOINTS
   HvBreakpoints,
   // COLORS
-  HvAccentColor,
-  HvAtmosphereColor,
-  HvBaseColor,
-  HvSemanticColor,
-  HvCategoricalColor,
   HvColor,
   HvColorAny,
   HvRadius,

--- a/packages/core/src/themes/pentaho.ts
+++ b/packages/core/src/themes/pentaho.ts
@@ -183,7 +183,7 @@ export const pentaho = mergeTheme(pentahoBase, {
       classes: {
         root: {
           borderRadius: theme.radii.round,
-          "&& .HvButton-secondarySubtle": {
+          "& .HvButton-subtle[data-color=secondary]": {
             borderColor: theme.colors.textDimmed,
             backgroundColor: inputColors.bg,
           },

--- a/packages/core/src/types/generic.ts
+++ b/packages/core/src/types/generic.ts
@@ -44,9 +44,8 @@ export type Arrayable<T> = T | T[];
 
 /** React.forwardRef with fixed type declarations */
 export function fixedForwardRef<T, P = {}>(
-  // TODO: change `React.ReactElement | null` to `React.ReactNode` in v6 (requires ts@5+)
-  render: (props: P, ref: React.Ref<T>) => React.ReactElement<any> | null,
-): (props: P & React.RefAttributes<T>) => React.ReactElement<any> | null {
+  render: (props: P, ref: React.Ref<T>) => React.ReactNode,
+): (props: P & React.RefAttributes<T>) => React.ReactNode {
   // https://github.com/DefinitelyTyped/DefinitelyTyped/pull/70361#issuecomment-2327456092
   return forwardRef(render as any) as any;
 }

--- a/packages/styles/package.json
+++ b/packages/styles/package.json
@@ -25,6 +25,8 @@
   },
   "scripts": {
     "build": "npm run clean && vite build",
+    "test": "vitest",
+    "test:ui": "vitest --ui",
     "clean": "npx rimraf dist package",
     "prepublishOnly": "npm run build && npx clean-publish"
   },

--- a/packages/styles/src/theme.test.ts
+++ b/packages/styles/src/theme.test.ts
@@ -1,0 +1,72 @@
+import { theme } from "./theme";
+
+it("returns the expected colors values", () => {
+  expect(theme.colors.primary).toBe("var(--uikit-colors-primary)");
+  expect(theme.colors.positive).toBe("var(--uikit-colors-positive)");
+  expect(theme.colors.text).toBe("var(--uikit-colors-text)");
+});
+
+it("returns the expected space values", () => {
+  expect(theme.space.xs).toBe("var(--uikit-space-xs)");
+  expect(theme.space.sm).toBe("var(--uikit-space-sm)");
+  expect(theme.space.md).toBe("var(--uikit-space-md)");
+  expect(theme.space.lg).toBe("var(--uikit-space-lg)");
+  expect(theme.space.xl).toBe("var(--uikit-space-xl)");
+});
+
+it("returns the expected spacing() values", () => {
+  expect(theme.spacing("md", "2px", "0")).toBe("var(--uikit-space-md) 2px 0");
+  expect(theme.spacing("lg", "4px")).toBe("var(--uikit-space-lg) 4px");
+  expect(theme.spacing("xl")).toBe("var(--uikit-space-xl)");
+});
+
+it("returns the correct alpha transparency values", () => {
+  expect(theme.alpha("primary", 0.5)).toBe(
+    "color-mix(in srgb, var(--uikit-colors-primary) 50%, transparent)",
+  );
+  expect(theme.alpha("warning", 0.8)).toBe(
+    "color-mix(in srgb, var(--uikit-colors-warning) 80%, transparent)",
+  );
+
+  expect(theme.alpha("secondary", "60%")).toBe(
+    "color-mix(in srgb, var(--uikit-colors-secondary) 60%, transparent)",
+  );
+
+  expect(theme.alpha("#ff0000", 0.3)).toBe(
+    "color-mix(in srgb, #ff0000 30%, transparent)",
+  );
+  expect(theme.alpha("rgb(255, 0, 0)", "25%")).toBe(
+    "color-mix(in srgb, rgb(255, 0, 0) 25%, transparent)",
+  );
+});
+
+it("returns the correct color-mix values", () => {
+  expect(theme.mix("primary", 0.7, "secondary")).toBe(
+    "color-mix(in srgb, var(--uikit-colors-primary) 70%, var(--uikit-colors-secondary))",
+  );
+  expect(theme.mix("warning", 0.5, "positive")).toBe(
+    "color-mix(in srgb, var(--uikit-colors-warning) 50%, var(--uikit-colors-positive))",
+  );
+
+  expect(theme.mix("primary", "60%", "secondary")).toBe(
+    "color-mix(in srgb, var(--uikit-colors-primary) 60%, var(--uikit-colors-secondary))",
+  );
+
+  expect(theme.mix("primary", 0.8)).toBe(
+    "color-mix(in srgb, var(--uikit-colors-primary) 80%, transparent)",
+  );
+
+  expect(theme.mix("#ff0000", 0.6, "#00ff00")).toBe(
+    "color-mix(in srgb, #ff0000 60%, #00ff00)",
+  );
+  expect(theme.mix("rgb(255, 0, 0)", "75%", "blue")).toBe(
+    "color-mix(in srgb, rgb(255, 0, 0) 75%, blue)",
+  );
+
+  expect(theme.mix("primary", 0.4, "white")).toBe(
+    "color-mix(in srgb, var(--uikit-colors-primary) 40%, white)",
+  );
+  expect(theme.mix("#000000", "30%", "negative")).toBe(
+    "color-mix(in srgb, #000000 30%, var(--uikit-colors-negative))",
+  );
+});

--- a/packages/styles/src/theme.ts
+++ b/packages/styles/src/theme.ts
@@ -9,12 +9,7 @@ import {
   HvThemeVars,
   SpacingValue,
 } from "./types";
-import {
-  hasMultipleArgs,
-  mapCSSVars,
-  spacingUtil,
-  spacingUtilOld,
-} from "./utils";
+import { hasMultipleArgs, mapCSSVars, spacingUtil } from "./utils";
 
 const componentsSpec: DeepString<HvThemeComponents> = {
   header: {
@@ -84,9 +79,9 @@ export function getColor(color?: HvColorAny, fallbackColor?: HvColorAny) {
  * theme.spacing(2) // 16px (2*8px)
  * theme.spacing("md", "inherit", "42px") // 24px inherit 42px
  */
-const spacing = (...args: [SpacingValue[]] | SpacingValue[]) => {
+const spacing = (...args: [SpacingValue[]] | SpacingValue[]): string => {
   if (hasMultipleArgs(args)) {
-    return args.map((arg) => spacingUtil(arg, themeVars)).join(" ");
+    return args.map((arg) => spacing(arg)).join(" ");
   }
 
   const [value] = args;
@@ -95,11 +90,6 @@ const spacing = (...args: [SpacingValue[]] | SpacingValue[]) => {
     case "number":
     case "string":
       return spacingUtil(value, themeVars);
-    // TODO: remove in v6
-    case "object":
-      return value && value.length > 0
-        ? value.map((val) => spacingUtilOld(val, themeVars)).join(" ")
-        : "0px";
     default:
       return "0px";
   }

--- a/packages/styles/src/tokens/colors.ts
+++ b/packages/styles/src/tokens/colors.ts
@@ -434,13 +434,6 @@ type AllColors = typeof colors.common & typeof colors.light;
 /** @experimental extendable theme colors */
 export interface HvThemeColors extends ColorTokens, AllColors {}
 
-// TODO: remove in favour of `HvColor`/`HvColorAny`
-export type HvAccentColor = keyof typeof accentLight;
-export type HvAtmosphereColor = keyof typeof atmosphereLight;
-export type HvBaseColor = keyof typeof base;
-export type HvSemanticColor = keyof typeof semanticLight;
-export type HvCategoricalColor = keyof typeof categorical;
-
 /** A type with all the accepted colors from the color palette */
 export type HvColor = keyof HvThemeColors;
 

--- a/packages/styles/src/utils.ts
+++ b/packages/styles/src/utils.ts
@@ -18,21 +18,6 @@ export const spacingUtil = (value: SpacingValue, vars: HvThemeVars): string => {
   }
 };
 
-// TODO: remove in favour or `spacingUtil` in v6
-export const spacingUtilOld = (
-  value: SpacingValue,
-  vars: HvThemeVars,
-): string => {
-  switch (typeof value) {
-    case "number":
-      return `${value}px`;
-    case "string":
-      return vars.space[value as HvThemeBreakpoint] || value;
-    default:
-      return "0px";
-  }
-};
-
 const toCSSVars = (obj: object, prefix = "--uikit") => {
   const vars: Record<string, string> = {};
 

--- a/packages/viz/src/BarChart/BarChart.tsx
+++ b/packages/viz/src/BarChart/BarChart.tsx
@@ -26,7 +26,7 @@ import {
   useXAxis,
   useYAxis,
 } from "../hooks";
-import { HvBarChartMeasures } from "../types";
+import { HvBarChartMeasure } from "../types";
 import {
   Arrayable,
   HvAxisChartCommonProps,
@@ -51,7 +51,7 @@ export interface HvBarChartProps
   extends HvAxisChartCommonProps,
     HvChartCommonProps {
   /**  Columns to measure on the chart. */
-  measures: Arrayable<HvBarChartMeasures>;
+  measures: Arrayable<HvBarChartMeasure>;
   /** Whether the bar chart should be horizontal. Defaults to `false`. */
   horizontal?: boolean;
   /** A Jss Object used to override or extend the styles applied to the component. */

--- a/packages/viz/src/LineChart/LineChart.tsx
+++ b/packages/viz/src/LineChart/LineChart.tsx
@@ -26,7 +26,7 @@ import {
   useXAxis,
   useYAxis,
 } from "../hooks";
-import { HvChartEmptyCellMode, HvLineChartMeasures } from "../types";
+import { HvChartEmptyCellMode, HvLineChartMeasure } from "../types";
 import {
   Arrayable,
   HvAxisChartCommonProps,
@@ -51,7 +51,7 @@ export interface HvLineChartProps
   extends HvAxisChartCommonProps,
     HvChartCommonProps {
   /** Columns to measure on the chart. */
-  measures: Arrayable<HvLineChartMeasures>;
+  measures: Arrayable<HvLineChartMeasure>;
   /** Strategy to use when there are empty cells. Defaults to `void`. */
   emptyCellMode?: HvChartEmptyCellMode;
   /** Whether the area under the lines should be filled. Defaults to `false`. */

--- a/packages/viz/src/hooks/useData.tsx
+++ b/packages/viz/src/hooks/useData.tsx
@@ -2,13 +2,13 @@ import { useMemo } from "react";
 import { desc, escape, not } from "arquero";
 
 import {
-  HvBarChartMeasures,
+  HvBarChartMeasure,
   HvChartAggregation,
   HvChartData,
   HvChartOrder,
   HvConfusionMatrixMeasure,
   HvDonutChartMeasure,
-  HvLineChartMeasures,
+  HvLineChartMeasure,
   HvScatterPlotMeasure,
 } from "../types";
 import {
@@ -31,7 +31,7 @@ interface HvDataHookProps {
   data: HvChartData;
   groupBy: HvChartCommonProps["groupBy"];
   measures:
-    | Arrayable<HvLineChartMeasures | HvBarChartMeasures | HvScatterPlotMeasure>
+    | Arrayable<HvLineChartMeasure | HvBarChartMeasure | HvScatterPlotMeasure>
     | HvDonutChartMeasure
     | HvConfusionMatrixMeasure;
   splitBy?: HvAxisChartCommonProps["splitBy"];

--- a/packages/viz/src/types/index.ts
+++ b/packages/viz/src/types/index.ts
@@ -11,8 +11,8 @@ export type {
   HvChartAxisNameLocation,
 } from "./axis";
 export type {
-  HvBarChartMeasures,
-  HvLineChartMeasures,
+  HvBarChartMeasure,
+  HvLineChartMeasure,
   HvDonutChartMeasure,
   HvChartSampling,
   HvChartAggregation,

--- a/packages/viz/src/types/measures.ts
+++ b/packages/viz/src/types/measures.ts
@@ -69,11 +69,9 @@ export interface ScatterPlotMeasure
   extends BaseMeasure,
     Pick<AxisMeasure, "yAxis"> {}
 
-// TODO - remove unnecessary plural (HvLineChartMeasure) in v6
-export type HvLineChartMeasures = string | LineFullMeasure;
+export type HvLineChartMeasure = string | LineFullMeasure;
 
-// TODO - remove unnecessary plural (HvBarChartMeasure) in v6
-export type HvBarChartMeasures = string | BarFullMeasure;
+export type HvBarChartMeasure = string | BarFullMeasure;
 
 export type HvDonutChartMeasure = string | DonutFullMeasure;
 

--- a/packages/viz/src/utils/index.ts
+++ b/packages/viz/src/utils/index.ts
@@ -2,14 +2,14 @@ import { from, internal, table } from "arquero";
 import type ColumnTable from "arquero/dist/types/table/column-table";
 
 import type {
-  HvBarChartMeasures,
+  HvBarChartMeasure,
   HvChartAxisType,
   HvChartData,
   HvChartFilter,
   HvChartFilterOperation,
   HvConfusionMatrixMeasure,
   HvDonutChartMeasure,
-  HvLineChartMeasures,
+  HvLineChartMeasure,
 } from "../types";
 import { HvChartCommonProps } from "../types/common";
 import { HvChartLegendIcon } from "../types/legend";
@@ -44,8 +44,8 @@ export const getLegendIcon = (icon: HvChartLegendIcon) => {
 };
 
 export type SingleMeasure =
-  | HvLineChartMeasures
-  | HvBarChartMeasures
+  | HvLineChartMeasure
+  | HvBarChartMeasure
   | HvScatterPlotMeasure
   | HvDonutChartMeasure
   | HvConfusionMatrixMeasure;


### PR DESCRIPTION
- remove more deprecated classes
- rename `HvDialog` `fullscreen` to `fullScreen`
- remove `HvListItem` adornment overrides
- review loading classes
- remove unnecessary `HvMultiButton` classes
- remove old color category types
- ~remove custom "Semantic" icon size overrides~ reverted
- remove old `theme.spacing()` options
- rename viz types from *Measures to *Measure