### PR TITLE
feat(theme): support only light/dark color modes

### DIFF
--- a/.storybook/addons/mode-selector/ModeSelector.tsx
+++ b/.storybook/addons/mode-selector/ModeSelector.tsx
@@ -1,24 +1,24 @@
 import React from "react";
 import { IconButton } from "storybook/internal/components";
 import { addons, useAddonState, useStorybookApi } from "storybook/manager-api";
-import { colors } from "@hitachivantara/uikit-styles";
+import { colors, HvThemeColorMode } from "@hitachivantara/uikit-styles";
 
 import { themes } from "../../theme";
 import { ADDON_EVENT, ADDON_ID } from "./constants";
-import { getInitialMode, Mode, setLocalMode } from "./utils";
+import { getInitialMode, setLocalMode } from "./utils";
 
 const ModeSelector = () => {
   const api = useStorybookApi();
 
-  const initialMode: Mode = getInitialMode();
+  const initialMode = getInitialMode();
 
-  const [selectedMode, setSelectedMode] = useAddonState<Mode>(
+  const [selectedMode, setSelectedMode] = useAddonState<HvThemeColorMode>(
     "mode-selector",
     initialMode,
   );
 
   const switchMode = () => {
-    const mode: Mode = selectedMode === "wicked" ? "dawn" : "wicked";
+    const mode = selectedMode === "dark" ? "light" : "dark";
 
     setLocalMode(mode);
     setSelectedMode(mode);
@@ -30,16 +30,12 @@ const ModeSelector = () => {
   return (
     <IconButton
       key={ADDON_ID}
-      title={
-        selectedMode === "wicked"
-          ? "Change theme to Dawn"
-          : "Change theme to Wicked"
-      }
+      title={`Change theme to ${selectedMode}`}
       onClick={switchMode}
     >
       <svg viewBox="0 0 16 16" height="16" width="16">
         <path
-          fill={colors[selectedMode === "wicked" ? "dark" : "light"].text}
+          fill={colors[selectedMode].text}
           d="M14.54626 12.57422c.0268-.03833.05713-.07373.08326-.11231.11-.16284.20837-.33239.30584-.50244.03162-.05517.06751-.1073.09784-.16321.086-.15881.16034-.32287.23535-.48693.03364-.07349.07209-.144.10352-.21875.06787-.16126.1239-.32691.18109-.49244.02826-.08166.06165-.16088.08728-.24365.05506-.17773.09754-.359.14014-.54053.01745-.07409.04022-.14611.05554-.22119.0423-.20654.07123-.41626.09717-.62646.00659-.05371.01819-.10571.02374-.15967.02374-.23108.03369-.46435.03717-.69824.00061-.0365.00568-.07178.0058-.1084l-.00024-.00525.00067-.01428A7.98991 7.98991 0 0 0 8.001 0H8a8 8 0 0 0 0 16h.001a7.94253 7.94253 0 0 0 5.649-2.3501c.13953-.13891.26728-.28711.39533-.43506.03924-.04541.08276-.08691.121-.13317.13524-.16346.25872-.33467.37993-.50745zM8 15a6.953 6.953 0 0 1-4.943-2.057A7.02151 7.02151 0 0 1 8.001.95618V15z"
         />
       </svg>

--- a/.storybook/addons/mode-selector/utils.ts
+++ b/.storybook/addons/mode-selector/utils.ts
@@ -1,9 +1,8 @@
+import { HvThemeColorMode } from "@hitachivantara/uikit-styles";
+
 const STORAGE_KEY = "sb-uikit-mode";
 
-const modes = ["dawn", "wicked"] as const;
-export type Mode = (typeof modes)[number];
-
-export const setLocalMode = (value: Mode) => {
+export const setLocalMode = (value: HvThemeColorMode) => {
   localStorage?.setItem(STORAGE_KEY, value);
 };
 
@@ -11,16 +10,14 @@ export const getLocalMode = () => {
   return localStorage?.getItem(STORAGE_KEY);
 };
 
-export const getInitialMode = (): Mode => {
-  const localMode = getLocalMode() as Mode;
+export const getInitialMode = (): HvThemeColorMode => {
+  const localMode = getLocalMode();
 
-  if (localMode) {
-    return localMode;
-  }
+  if (localMode) return localMode as HvThemeColorMode;
 
   const prefersDark = window?.matchMedia?.(
     "(prefers-color-scheme: dark)",
   )?.matches;
 
-  return prefersDark ? "wicked" : "dawn";
+  return prefersDark ? "dark" : "light";
 };

--- a/.storybook/blocks/DocsContainer.tsx
+++ b/.storybook/blocks/DocsContainer.tsx
@@ -1,4 +1,4 @@
-import React, { ComponentType, useEffect, useMemo, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import { MDXProvider } from "@mdx-js/react";
 import {
   DocsContainer,
@@ -8,17 +8,18 @@ import { addons } from "storybook/preview-api";
 import { Global } from "storybook/theming";
 import {
   HvProvider,
+  HvThemeColorMode,
   HvTypography,
   HvTypographyProps,
   theme,
 } from "@hitachivantara/uikit-react-core";
 
 import { ADDON_EVENT } from "../addons/mode-selector/constants";
-import { getInitialMode, Mode } from "../addons/mode-selector/utils";
+import { getInitialMode } from "../addons/mode-selector/utils";
 import { themes } from "../theme";
 import { getDocsStyles } from "../theme/styles/docs";
 
-const components: Record<string, ComponentType> = {
+const components: Record<string, React.ComponentType> = {
   a: (props: HvTypographyProps<"a">) => (
     <HvTypography
       link
@@ -54,7 +55,7 @@ export default ({
   const initialMode = getInitialMode();
   const [mode, setMode] = useState(initialMode);
 
-  const switchMode = (mode: Mode) => {
+  const switchMode = (mode: HvThemeColorMode) => {
     setMode(mode);
   };
 
@@ -67,7 +68,7 @@ export default ({
     };
   }, []);
 
-  const docsStyles = useMemo(() => getDocsStyles(), [mode]);
+  const docsStyles = useMemo(() => getDocsStyles(), []);
 
   return (
     <MDXProvider components={components}>

--- a/.storybook/decorators/utils.ts
+++ b/.storybook/decorators/utils.ts
@@ -1,5 +1,8 @@
 import { useEffect, useRef } from "react";
-import { HvThemeStructure } from "@hitachivantara/uikit-styles";
+import {
+  HvThemeColorMode,
+  HvThemeStructure,
+} from "@hitachivantara/uikit-styles";
 
 const STORAGE_KEY = "sb-uikit-stories-theme";
 const DEFAULT_THEME = "pentaho";
@@ -26,7 +29,7 @@ export const getInitialTheme = (themes: Theme[]) => {
   const initialTheme = localTheme ? localTheme.split(" ")[0] : DEFAULT_THEME;
   const initialMode = localTheme
     ? localTheme.split(" ")[1]
-    : `${prefersDark ? "wicked" : "dawn"}`;
+    : `${prefersDark ? "dark" : "light"}`;
 
   return (
     themes.find((theme) => theme.label === `${initialTheme} ${initialMode}`) ||
@@ -41,7 +44,7 @@ export const useDarkClass = <T extends HTMLElement = HTMLDivElement>(
   const ref = useRef<T>(null);
 
   useEffect(() => {
-    if (mode === "wicked") {
+    if (mode === "dark") {
       ref.current?.classList.add("dark");
     } else {
       ref.current?.classList.remove("dark");
@@ -53,19 +56,14 @@ export const useDarkClass = <T extends HTMLElement = HTMLDivElement>(
 
 /** Returns an array with the available themes */
 export const getThemesList = (themes: Record<string, HvThemeStructure>) => {
-  const themesList: Theme[] = [];
-
-  Object.keys(themes).forEach((themeName) => {
-    const theme = themes[themeName];
-    const colorModes = Object.keys(theme.colors.modes);
+  return Object.keys(themes).reduce<Theme[]>((acc, themeName) => {
+    const colorModes: HvThemeColorMode[] = ["light", "dark"];
     colorModes.forEach((colorMode) => {
-      const isDark = colorMode.includes("dark") || colorMode.includes("wicked");
-      themesList.push({
+      acc.push({
         label: `${themeName} ${colorMode}`,
-        mode: isDark ? "dark" : "light",
+        mode: colorMode,
       });
     });
-  });
-
-  return themesList;
+    return acc;
+  }, []);
 };

--- a/.storybook/decorators/withThemeDecorator.decorator.tsx
+++ b/.storybook/decorators/withThemeDecorator.decorator.tsx
@@ -38,9 +38,7 @@ export const withThemeDecorator = (): Decorator => {
     const [theme, mode] = selected.split(" ");
 
     const base = (themes as any)[theme] ?? themes.ds5;
-    const storyStyles = getStoryStyles(
-      base.colors.modes[mode as "wicked" | "dawn"].bgPage,
-    );
+    const storyStyles = getStoryStyles(base.colors[mode].bgPage);
 
     const containerRef = useDarkClass(mode);
 

--- a/.storybook/theme/index.ts
+++ b/.storybook/theme/index.ts
@@ -33,6 +33,6 @@ const getThemeVars = (base: "light" | "dark"): ThemeVarsPartial => ({
 });
 
 export const themes = {
-  wicked: create(getThemeVars("dark")),
-  dawn: create(getThemeVars("light")),
+  dark: create(getThemeVars("dark")),
+  light: create(getThemeVars("light")),
 };

--- a/apps/default-app/app-shell.config.ts
+++ b/apps/default-app/app-shell.config.ts
@@ -18,7 +18,7 @@ export default {
   },
   theming: {
     theme: "pentaho",
-    colorMode: "dawn",
+    colorMode: "light",
   },
   menu: [
     {

--- a/apps/default-app/src/pages/Theming/Theming.tsx
+++ b/apps/default-app/src/pages/Theming/Theming.tsx
@@ -6,6 +6,7 @@ import {
   HvButton,
   HvGlobalActions,
   HvGrid,
+  HvThemeColorMode,
   HvTypography,
   useTheme,
 } from "@hitachivantara/uikit-react-core";
@@ -23,7 +24,7 @@ const splitAndCapitalize = (inputString: string) => {
 const Theming = () => {
   const { selectedMode, colorModes } = useTheme();
 
-  const renderTriggerColorModeSwitchButton = (colorMode: string) => {
+  const renderTriggerColorModeSwitchButton = (colorMode: HvThemeColorMode) => {
     const triggerColorModeSwitchHandler = () => {
       const customEvent = new CustomEvent<HvAppShellEventTheme>(
         HvAppShellEventThemeTrigger,

--- a/apps/docs/src/components/Main.tsx
+++ b/apps/docs/src/components/Main.tsx
@@ -18,7 +18,7 @@ export const Main = ({ children }: { children: React.ReactNode }) => {
   return (
     <HvProvider
       theme={pentaho}
-      colorMode={resolvedTheme === "dark" ? "wicked" : "dawn"}
+      colorMode={resolvedTheme === "dark" ? "dark" : "light"}
       emotionCache={emotionCache}
     >
       <HvVizProvider>{children}</HvVizProvider>

--- a/apps/docs/src/components/code/DocsProvider.tsx
+++ b/apps/docs/src/components/code/DocsProvider.tsx
@@ -19,7 +19,7 @@ export const DocsProvider = ({
     <div id={id} className={className} data-pagefind-ignore>
       <HvProvider
         theme={theme}
-        colorMode={resolvedTheme === "dark" ? "wicked" : "dawn"}
+        colorMode={resolvedTheme === "dark" ? "dark" : "light"}
         cssTheme="scoped"
         rootElementId={id}
       >

--- a/apps/docs/src/content/app-shell/configuration.mdx
+++ b/apps/docs/src/content/app-shell/configuration.mdx
@@ -300,7 +300,7 @@ The config object for it has the following options:
 
 - `themes`: Array of available themes. Can be one of the built-in UI Kit themes (`"ds5"`, `"pentaho"`), or a custom theme identified by the module.
 - `theme`: The active theme. It is the name defined in the theme definition, not the module name. Defaults to the first theme in the themes array.
-- `colorMode`: The color mode of the theme. Defaults to the default color mode of the theme. UI Kit base themes support "dawn" and "wicked" color modes (defaulting to "dawn"). Custom themes define their own color modes.
+- `colorMode`: The color mode of the theme. Defaults to the default color mode of the theme. UI Kit base themes support `"light"` and `"dark"` color modes (defaults to `"light"`). Custom themes define their own color modes.
 
 Example:
 

--- a/apps/docs/src/content/docs/theming.mdx
+++ b/apps/docs/src/content/docs/theming.mdx
@@ -27,17 +27,15 @@ Use the `HvProvider` to configure the active theme and color mode:
 
 ## Creating a New Theme
 
-Use `createTheme()` to define a custom theme based on existing ones. This allows you to:
+Use `mergeTheme()` to define a custom theme based on existing ones. This allows you to:
 
 - Create custom color modes
 - Override design tokens like colors, spacing, or fonts
 - Extend the theme with new properties
 
 ```tsx
-const myTheme = createTheme({
+const myTheme = mergeTheme(pentaho, {
   name: "myTheme",
-  base: "pentaho",
-  inheritColorModes: false,
   colors: {
     modes: {
       sand: {
@@ -122,9 +120,8 @@ const CssVariables = () => {
 You can globally define default props and custom styles for any component using the `components` key inside your theme. This reduces boilerplate and improves consistency.
 
 ```tsx
-const newTheme = createTheme({
+const newTheme = mergeTheme(ds5, {
   name: "myTheme",
-  base: "ds5",
   components: {
     HvAvatar: {
       variant: "square",

--- a/apps/docs/src/content/docs/theming.mdx
+++ b/apps/docs/src/content/docs/theming.mdx
@@ -16,14 +16,14 @@ The **theme** object serves as the **UI Kit** foundation, defining all styling s
 Use the `HvProvider` to configure the active theme and color mode:
 
 ```tsx
-<HvProvider themes={[pentaho]} theme="pentaho" colorMode="dawn">
+<HvProvider themes={[pentaho]} theme="pentaho" colorMode="light">
   <App />
 </HvProvider>
 ```
 
 - If `themes` is not provided, the default is `ds5`.
 - If only one theme is provided, `theme` can be omitted.
-- If `colorMode` is omitted, `dawn` is used by default.
+- If `colorMode` is omitted, `light` is used by default.
 
 ## Creating a New Theme
 
@@ -83,7 +83,7 @@ const MyComponent = () => {
       icon
       variant="secondaryGhost"
       onClick={() => {
-        changeMode(selectedMode === "dawn" ? "wicked" : "dawn");
+        changeMode(selectedMode === "light" ? "dark" : "light");
       }}
     >
       <ThemeSwitcher />

--- a/examples/uikit-vite-ts/src/Container.tsx
+++ b/examples/uikit-vite-ts/src/Container.tsx
@@ -16,10 +16,10 @@ const globalStyles: GlobalProps["styles"] = {
 };
 
 export const Container = ({ children }: { children: ReactNode }) => {
-  const { selectedMode, changeTheme } = useTheme();
+  const { selectedMode, changeMode } = useTheme();
 
   const handleChangeTheme = () => {
-    changeTheme(undefined, selectedMode === "wicked" ? "dawn" : "wicked");
+    changeMode(selectedMode === "dark" ? "light" : "dark");
   };
 
   return (

--- a/packages/app-shell-shared/src/types/Config.ts
+++ b/packages/app-shell-shared/src/types/Config.ts
@@ -1,6 +1,7 @@
 import type {
   HvBaseTheme,
   HvContainerProps,
+  HvThemeColorMode,
 } from "@hitachivantara/uikit-react-core";
 
 type ViewHvContainerProps = Omit<HvContainerProps, "children">;
@@ -64,7 +65,7 @@ export type HvAppShellConfig = {
 
 export type HvAppShellThemingConfig = {
   theme?: HvBaseTheme | (string & {});
-  colorMode?: string;
+  colorMode?: HvThemeColorMode;
 };
 
 export type HvAppShellAppSwitcherConfig = {

--- a/packages/app-shell-ui/src/components/AppShellProvider/AppShellProvider.test.tsx
+++ b/packages/app-shell-ui/src/components/AppShellProvider/AppShellProvider.test.tsx
@@ -101,7 +101,7 @@ describe("AppShellProvider component", () => {
       const { baseElement } = await renderTestProvider(<div>dummy</div>, {
         theming: {
           theme: "ds5",
-          colorMode: "wicked",
+          colorMode: "dark",
         },
       });
 
@@ -109,7 +109,7 @@ describe("AppShellProvider component", () => {
 
       await waitFor(() => {
         expect(bodyElement.getAttribute("data-theme")).toBe("ds5");
-        expect(bodyElement.getAttribute("data-color-mode")).toBe("wicked");
+        expect(bodyElement.getAttribute("data-color-mode")).toBe("dark");
         expect(bodyElement).toHaveStyle("color-scheme: dark;");
       });
     });

--- a/packages/app-shell-ui/src/components/AppShellProvider/AppShellProvider.tsx
+++ b/packages/app-shell-ui/src/components/AppShellProvider/AppShellProvider.tsx
@@ -12,7 +12,10 @@ import {
   themes as baseThemes,
   HvProvider,
 } from "@hitachivantara/uikit-react-core";
-import { HvThemeStructure } from "@hitachivantara/uikit-styles";
+import {
+  HvThemeColorMode,
+  HvThemeStructure,
+} from "@hitachivantara/uikit-styles";
 
 import useLocalStorage from "../../hooks/useLocalStorage";
 import { addResourceBundles } from "../../i18n";
@@ -137,7 +140,10 @@ const AppShellProvider = ({
       <HvAppShellRuntimeContext.Provider value={runtimeContext}>
         <HvProvider
           theme={theme}
-          colorMode={storedColorModeValue ?? theConfig.theming?.colorMode}
+          colorMode={
+            (storedColorModeValue as HvThemeColorMode) ??
+            theConfig.theming?.colorMode
+          }
         >
           <HvAppShellCombinedProvidersContext.Provider value={providersContext}>
             {children}

--- a/packages/app-shell-ui/src/hooks/useThemeEventListener.test.tsx
+++ b/packages/app-shell-ui/src/hooks/useThemeEventListener.test.tsx
@@ -16,13 +16,8 @@ vi.mock("@hitachivantara/uikit-react-core", async () => {
     useTheme: () => {
       return {
         changeMode: mockedChangeMode,
-        selectedMode: "dummyColor1",
-        colorModes: [
-          "dummyColor1",
-          "dummyColor2",
-          "dummyColor3",
-          "dummyColor4",
-        ],
+        selectedMode: "light",
+        colorModes: ["light", "dark"],
       };
     },
   };
@@ -41,14 +36,12 @@ describe("useThemeEventListener Hook", () => {
 
     themeEventListenerHook.current.handleThemeEvent(
       new CustomEvent<HvAppShellEventTheme>(HvAppShellEventThemeTrigger, {
-        detail: { colorMode: "dummyColor3" },
+        detail: { colorMode: "dark" },
       }),
     );
 
-    expect(mockedChangeMode).toHaveBeenCalledWith("dummyColor3");
-    expect(localStorage.getItem(LOCAL_STORAGE_KEYS.COLOR_MODE)).toBe(
-      "dummyColor3",
-    );
+    expect(mockedChangeMode).toHaveBeenCalledWith("dark");
+    expect(localStorage.getItem(LOCAL_STORAGE_KEYS.COLOR_MODE)).toBe("dark");
   });
 
   it("should call `changeTheme` with selectedTheme and the second color in the array when none is provided, the color should also be stored in the localStorage", () => {
@@ -62,26 +55,7 @@ describe("useThemeEventListener Hook", () => {
       }),
     );
 
-    expect(mockedChangeMode).toHaveBeenCalledWith("dummyColor2");
-    expect(localStorage.getItem(LOCAL_STORAGE_KEYS.COLOR_MODE)).toBe(
-      "dummyColor2",
-    );
-  });
-
-  it("should call `changeTheme` with selectedTheme and the second color in the array when a non existent color is used", () => {
-    const { result: themeEventListenerHook } = renderHook(() =>
-      useThemeEventListenerHook(),
-    );
-
-    themeEventListenerHook.current.handleThemeEvent(
-      new CustomEvent<HvAppShellEventTheme>(HvAppShellEventThemeTrigger, {
-        detail: { colorMode: "wrongColor" },
-      }),
-    );
-
-    expect(mockedChangeMode).toHaveBeenCalledWith("dummyColor2");
-    expect(localStorage.getItem(LOCAL_STORAGE_KEYS.COLOR_MODE)).toBe(
-      "dummyColor2",
-    );
+    expect(mockedChangeMode).toHaveBeenCalledWith("dark");
+    expect(localStorage.getItem(LOCAL_STORAGE_KEYS.COLOR_MODE)).toBe("dark");
   });
 });

--- a/packages/core/src/providers/Provider.test.tsx
+++ b/packages/core/src/providers/Provider.test.tsx
@@ -1,23 +1,11 @@
 import { render } from "@testing-library/react";
+import { mergeTheme } from "@hitachivantara/uikit-styles";
 
-import { createTheme } from "../utils/theme";
+import { ds5 } from "../themes/ds5";
 import { HvProvider } from "./Provider";
 
-const customThemeInherit = createTheme({
+const customTheme = mergeTheme(ds5, {
   name: "custom-theme",
-  inheritColorModes: true,
-});
-
-const customThemeNoInherit = createTheme({
-  name: "custom-theme",
-  inheritColorModes: false,
-  colors: {
-    modes: {
-      purple: {
-        bgContainer: "purple",
-      },
-    },
-  },
 });
 
 describe("Provider", () => {
@@ -63,7 +51,7 @@ describe("Provider", () => {
         <HvProvider
           cssTheme="scoped"
           rootElementId="hv-root"
-          theme={customThemeInherit}
+          theme={customTheme}
         >
           <p>Theme provider test</p>
         </HvProvider>
@@ -72,27 +60,6 @@ describe("Provider", () => {
 
     const theme = container.querySelector("[data-theme=custom-theme]");
     const mode = container.querySelector("[data-color-mode=dawn]");
-
-    expect(theme).toBeInTheDocument();
-    expect(mode).toBeInTheDocument();
-  });
-
-  it("should have the correct theme and color mode selected if themes, theme and colorMode are provided", () => {
-    const { container } = render(
-      <div id="hv-root">
-        <HvProvider
-          cssTheme="scoped"
-          rootElementId="hv-root"
-          theme={customThemeNoInherit}
-          colorMode="purple"
-        >
-          <p>Theme provider test</p>
-        </HvProvider>
-      </div>,
-    );
-
-    const theme = container.querySelector("[data-theme=custom-theme]");
-    const mode = container.querySelector("[data-color-mode=purple]");
 
     expect(theme).toBeInTheDocument();
     expect(mode).toBeInTheDocument();

--- a/packages/core/src/providers/Provider.test.tsx
+++ b/packages/core/src/providers/Provider.test.tsx
@@ -19,7 +19,7 @@ describe("Provider", () => {
     );
 
     const theme = container.querySelector("[data-theme=ds5]");
-    const mode = container.querySelector("[data-color-mode=dawn]");
+    const mode = container.querySelector("[data-color-mode=light]");
 
     expect(theme).toBeInTheDocument();
     expect(mode).toBeInTheDocument();
@@ -28,18 +28,14 @@ describe("Provider", () => {
   it("has the color mode selected if only the colorMode property is provided", () => {
     const { container } = render(
       <div id="hv-root">
-        <HvProvider
-          cssTheme="scoped"
-          rootElementId="hv-root"
-          colorMode="wicked"
-        >
+        <HvProvider cssTheme="scoped" rootElementId="hv-root" colorMode="dark">
           <p>Theme provider test</p>
         </HvProvider>
       </div>,
     );
 
     const theme = container.querySelector("[data-theme=ds5]");
-    const mode = container.querySelector("[data-color-mode=wicked]");
+    const mode = container.querySelector("[data-color-mode=dark]");
 
     expect(theme).toBeInTheDocument();
     expect(mode).toBeInTheDocument();
@@ -59,7 +55,7 @@ describe("Provider", () => {
     );
 
     const theme = container.querySelector("[data-theme=custom-theme]");
-    const mode = container.querySelector("[data-color-mode=dawn]");
+    const mode = container.querySelector("[data-color-mode=light]");
 
     expect(theme).toBeInTheDocument();
     expect(mode).toBeInTheDocument();

--- a/packages/core/src/providers/Provider.tsx
+++ b/packages/core/src/providers/Provider.tsx
@@ -11,6 +11,7 @@ import {
   CssBaseline,
   CssScopedBaseline,
   getThemeVars,
+  HvThemeColorMode,
   HvThemeStructure,
 } from "@hitachivantara/uikit-styles";
 
@@ -72,7 +73,7 @@ export interface HvProviderProps {
    * If no value is provided, the first color mode defined in the active theme is used.
    * For the default themes, the `dawn` color mode is the one used.
    */
-  colorMode?: string;
+  colorMode?: HvThemeColorMode;
 }
 
 /**
@@ -84,7 +85,7 @@ export const HvProvider = ({
   cssBaseline = "global",
   cssTheme = "global",
   theme = ds5,
-  colorMode,
+  colorMode = theme.defaultColorMode || "light",
   emotionCache: emotionCacheProp,
   classNameKey = defaultCacheKey,
 }: HvProviderProps) => {
@@ -118,7 +119,7 @@ export const HvProvider = ({
       <HvThemeProvider
         theme={theme}
         emotionCache={emotionCache}
-        colorMode={colorMode || "dawn"}
+        colorMode={colorMode || "light"}
         themeRootId={
           cssTheme === "scoped" ? rootElementId || scopedRootId : undefined
         }

--- a/packages/core/src/providers/ThemeProvider.tsx
+++ b/packages/core/src/providers/ThemeProvider.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { EmotionCache } from "@emotion/cache";
 import {
-  createTheme,
+  createTheme as createMuiTheme,
   ThemeProvider as MuiThemeProvider,
 } from "@mui/material/styles";
 import {
@@ -82,7 +82,7 @@ export const HvThemeProvider = ({
 
   const muiTheme = useMemo(() => {
     const colors = activeTheme.colors.modes[colorMode];
-    return createTheme({
+    return createMuiTheme({
       colorSchemes: { light: true, dark: true },
       spacing: activeTheme.space.base,
       typography: {

--- a/packages/core/src/providers/ThemeProvider.tsx
+++ b/packages/core/src/providers/ThemeProvider.tsx
@@ -12,8 +12,12 @@ import {
   type HvTheme,
   type HvThemeContextValue,
 } from "@hitachivantara/uikit-react-shared";
-import { HvThemeStructure } from "@hitachivantara/uikit-styles";
+import {
+  HvThemeColorMode,
+  HvThemeStructure,
+} from "@hitachivantara/uikit-styles";
 
+import { getContainerElement } from "../utils/document";
 import { setElementAttrs } from "../utils/theme";
 
 export { HvThemeContext };
@@ -25,7 +29,7 @@ interface HvThemeProviderProps {
   children: React.ReactNode;
   theme: HvTheme | HvThemeStructure;
   emotionCache: EmotionCache;
-  colorMode: string;
+  colorMode: HvThemeColorMode;
   themeRootId?: string;
 }
 
@@ -38,55 +42,37 @@ export const HvThemeProvider = ({
 }: HvThemeProviderProps) => {
   const [colorMode, setColorMode] = useState(colorModeProp);
 
-  const {
-    theme: activeTheme,
-    selectedMode,
-    colorModes,
-    colorScheme,
-  } = useMemo(() => {
-    const colorModes = Object.keys(theme.colors.modes);
-    const selectedMode = colorModes.includes(colorMode)
-      ? colorMode
-      : colorModes[0];
-    const colorScheme = theme.colors.modes[selectedMode].type;
-
-    return {
-      theme,
-      selectedMode,
-      colorModes,
-      colorScheme,
-    };
-  }, [theme, colorMode]);
-
   // review in v6 so that theme/colorMode isn't both controlled & uncontrolled
   useEffect(() => {
     setColorMode(colorModeProp);
   }, [colorModeProp]);
 
   useEffect(() => {
-    setElementAttrs(activeTheme.name, selectedMode, colorScheme, rootId);
-  }, [colorScheme, rootId, selectedMode, activeTheme.name]);
+    const element = getContainerElement(rootId);
+    if (!element) return;
+    setElementAttrs(element, theme.name, colorMode);
+  }, [colorMode, rootId, theme.name]);
 
   const value = useMemo<HvThemeContextValue>(
     () => ({
-      colorModes,
-      activeTheme: activeTheme as HvTheme,
-      selectedMode,
-      changeMode(newMode = selectedMode) {
+      colorModes: ["light", "dark"],
+      activeTheme: theme as HvTheme,
+      selectedMode: colorMode,
+      changeMode(newMode = colorMode) {
         setColorMode(newMode);
       },
       rootId,
     }),
-    [colorModes, activeTheme, selectedMode, rootId],
+    [theme, colorMode, rootId],
   );
 
   const muiTheme = useMemo(() => {
-    const colors = activeTheme.colors.modes[colorMode];
+    const colors = theme.colors[colorMode];
     return createMuiTheme({
       colorSchemes: { light: true, dark: true },
-      spacing: activeTheme.space.base,
+      spacing: theme.space.base,
       typography: {
-        fontFamily: activeTheme.fontFamily.body,
+        fontFamily: theme.fontFamily.body,
       },
       palette: {
         primary: { main: colors.primary },
@@ -120,9 +106,9 @@ export const HvThemeProvider = ({
           },
         },
       },
-      breakpoints: activeTheme.breakpoints,
+      breakpoints: theme.breakpoints,
     });
-  }, [activeTheme, colorMode]);
+  }, [theme, colorMode]);
 
   const emotionCacheValue = useMemo(
     () => ({ cache: emotionCache }),

--- a/packages/core/src/types/generic.ts
+++ b/packages/core/src/types/generic.ts
@@ -40,12 +40,6 @@ export type DeepPartial<T> = T extends {}
     }>
   : T;
 
-/** This type extends DeepPartial to allow any extra properties */
-export type HvExtraDeepPartialProps<T> = Partial<{
-  [P in keyof T]: DeepPartial<T[P]> & Record<string, any>;
-}> &
-  Record<string, any>;
-
 export type Arrayable<T> = T | T[];
 
 /** React.forwardRef with fixed type declarations */

--- a/packages/core/src/utils/theme.ts
+++ b/packages/core/src/utils/theme.ts
@@ -1,28 +1,25 @@
 import { HvTheme } from "@hitachivantara/uikit-react-shared";
-import { HvThemeStructure } from "@hitachivantara/uikit-styles";
+import {
+  HvThemeColorMode,
+  HvThemeStructure,
+} from "@hitachivantara/uikit-styles";
 
 import { themes } from "../themes";
-import { getContainerElement } from "./document";
 
 /**
  * Sets the element attributes and style for a theme and color mode.
  */
 export const setElementAttrs = (
+  element: HTMLElement,
   themeName: string,
-  modeName: string,
-  colorScheme: string,
-  themeRootId?: string,
+  modeName: HvThemeColorMode,
 ) => {
-  const element = getContainerElement(themeRootId);
+  element.dataset.theme = themeName;
+  element.dataset.colorMode = modeName;
 
-  if (element) {
-    element.setAttribute(`data-theme`, themeName);
-    element.setAttribute(`data-color-mode`, modeName);
-
-    // set default styles for child components to inherit
-    element.classList.add(`uikit-root-element`);
-    element.style.colorScheme = colorScheme;
-  }
+  // set default styles for child components to inherit
+  element.classList.add("uikit-root-element");
+  element.style.colorScheme = modeName;
 };
 
 /**

--- a/packages/core/src/utils/theme.ts
+++ b/packages/core/src/utils/theme.ts
@@ -1,50 +1,8 @@
 import { HvTheme } from "@hitachivantara/uikit-react-shared";
-import {
-  HvThemeColorModeStructure,
-  HvThemeStructure,
-} from "@hitachivantara/uikit-styles";
-import type { HvBaseTheme } from "@hitachivantara/uikit-styles";
+import { HvThemeStructure } from "@hitachivantara/uikit-styles";
 
 import { themes } from "../themes";
-import type { HvExtraDeepPartialProps } from "../types/generic";
 import { getContainerElement } from "./document";
-
-/**
- * Create theme props
- */
-export interface HvCreateThemeProps extends HvThemeCustomizationProps {
-  /**
-   * The name used for the theme.
-   *
-   * This is a required property to create a theme.
-   */
-  name: string;
-  /**
-   * The theme to be used as base.
-   *
-   * `"ds5"` will be used as default if no value is provided.
-   */
-  base?: HvBaseTheme;
-  /**
-   * If `true` the default color modes (dawn and wicked) of the base theme will be inherited while creating the theme.
-   * If `false`, the new theme doesn't inherit the default color modes.
-   *
-   * By default the color modes are inherited.
-   */
-  inheritColorModes?: boolean;
-}
-
-// Theme customization
-export type HvThemeCustomizationProps = HvExtraDeepPartialProps<
-  Omit<HvThemeStructure, "colors" | "name" | "base">
-> & {
-  colors?: {
-    modes?: Record<
-      string,
-      Partial<HvThemeColorModeStructure> & Record<string, string>
-    >;
-  };
-};
 
 /**
  * Sets the element attributes and style for a theme and color mode.
@@ -65,86 +23,6 @@ export const setElementAttrs = (
     element.classList.add(`uikit-root-element`);
     element.style.colorScheme = colorScheme;
   }
-};
-
-/**
- * Applies customizations to a theme.
- */
-const applyThemeCustomizations = (obj: any, customizations: any) => {
-  const isObject = (val: any) =>
-    val && typeof val === "object" && !Array.isArray(val);
-
-  // Customized theme
-  const customizedTheme = { ...obj };
-
-  // Add new values to the theme or replace values
-  Object.keys(customizations).forEach((key) => {
-    if (customizedTheme[key]) {
-      if (isObject(customizedTheme[key]) && isObject(customizations[key])) {
-        customizedTheme[key] = applyThemeCustomizations(
-          customizedTheme[key],
-          customizations[key],
-        );
-      } else if (typeof customizedTheme[key] === typeof customizations[key]) {
-        customizedTheme[key] = customizations[key];
-      }
-    } else {
-      customizedTheme[key] = customizations[key];
-    }
-  });
-
-  return customizedTheme;
-};
-
-/**
- * Creates a customized theme based on the base theme and customizations given.
- * For the color modes, the colors that are not defined will be replaced by the values from the dawn mode of the base theme.
- */
-export const createTheme = (
-  props: HvCreateThemeProps,
-): HvTheme | HvThemeStructure => {
-  const {
-    name,
-    base = "ds5",
-    inheritColorModes = true,
-    ...customizations
-  } = props;
-
-  // Apply customizations to the base theme
-  const customizedTheme: HvTheme | HvThemeStructure = customizations
-    ? (applyThemeCustomizations(themes[base], customizations) as HvTheme)
-    : { ...themes[base] };
-
-  // Set theme name
-  customizedTheme.name = name.trim();
-  // Set theme base
-  customizedTheme.base = base;
-
-  // Fill new color modes with missing colors
-  if (customizations) {
-    Object.keys(customizedTheme.colors.modes).forEach((mode) => {
-      // @ts-ignore
-      if (!themes[base].colors.modes[mode]) {
-        customizedTheme.colors.modes[mode] = {
-          ...themes[base].colors.modes.dawn,
-          ...customizedTheme.colors.modes[mode],
-        };
-      }
-    });
-  }
-
-  // If the flag `inheritColorModes` is false and customizations were given for the color modes,
-  // we're removing any color modes that might have been inherited
-  if (!inheritColorModes && customizations.colors?.modes) {
-    Object.keys(customizedTheme.colors.modes).forEach((mode) => {
-      if (!Object.keys(customizations.colors?.modes || {}).includes(mode)) {
-        delete customizedTheme.colors.modes[mode];
-      }
-    });
-  }
-
-  // Created theme
-  return customizedTheme;
 };
 
 /**

--- a/packages/internal/src/utils.ts
+++ b/packages/internal/src/utils.ts
@@ -2,16 +2,16 @@
 
 export const allModes = {
   "Pentaho dawn": {
-    theme: "pentaho dawn",
+    theme: "pentaho light",
   },
   "Pentaho wicked": {
-    theme: "pentaho wicked",
+    theme: "pentaho dark",
   },
   "DS5 dawn": {
-    theme: "ds5 dawn",
+    theme: "ds5 light",
   },
   "DS5 wicked": {
-    theme: "ds5 wicked",
+    theme: "ds5 dark",
   },
 };
 

--- a/packages/shared/src/context/ThemeContext.ts
+++ b/packages/shared/src/context/ThemeContext.ts
@@ -1,19 +1,20 @@
 import { createContext } from "react";
+import { HvThemeColorMode } from "@hitachivantara/uikit-styles";
 
 import { HvTheme } from "../types/theme";
 
 export interface HvThemeContextValue {
-  colorModes: string[];
+  colorModes: HvThemeColorMode[];
   activeTheme?: HvTheme;
-  selectedMode: string;
-  changeMode: (mode?: string) => void;
+  selectedMode: HvThemeColorMode;
+  changeMode: (mode?: HvThemeColorMode) => void;
   rootId?: string;
 }
 
 export const HvThemeContext = createContext<HvThemeContextValue>({
   activeTheme: undefined,
   colorModes: [],
-  selectedMode: "",
+  selectedMode: "light",
   changeMode: () => {},
   rootId: undefined,
 });

--- a/packages/styles/src/makeTheme.ts
+++ b/packages/styles/src/makeTheme.ts
@@ -11,9 +11,9 @@ import { mergeTheme } from "./utils";
  * @param options The options to generate the theme
  * @returns The generated theme
  */
-export const makeTheme = <Mode extends string = string>(
-  options: HvCustomTheme<Mode> | ((theme: HvTheme) => HvCustomTheme<Mode>),
-): HvThemeStructure<Mode> => {
+export const makeTheme = (
+  options: HvCustomTheme | ((theme: HvTheme) => HvCustomTheme),
+): HvThemeStructure => {
   const customTheme = typeof options === "function" ? options(theme) : options;
   const newTheme = mergeTheme(baseTheme, customTheme);
 
@@ -69,7 +69,7 @@ const extendCompatColors = (colors: Partial<HvThemeColors>) => {
  */
 export const makeColors = (
   inputColors: Partial<Record<keyof HvThemeColors, [string, string] | string>>,
-): HvCustomTheme<"dawn" | "wicked">["colors"] => {
+): HvCustomTheme["colors"] => {
   const [lightColors, darkColors] = Object.entries(inputColors).reduce(
     (acc, [key, color]) => {
       const [lightColor, darkColor] =
@@ -87,22 +87,17 @@ export const makeColors = (
   );
 
   return {
-    // TODO: review allowing generic modes vs light/dark only
-    modes: {
-      dawn: {
-        type: "light",
-        ...colors.common,
-        ...colors.light,
-        ...extendCompatColors(lightColors),
-        ...lightColors,
-      },
-      wicked: {
-        type: "dark",
-        ...colors.common,
-        ...colors.dark,
-        ...extendCompatColors(darkColors),
-        ...darkColors,
-      },
+    light: {
+      ...colors.common,
+      ...colors.light,
+      ...extendCompatColors(lightColors),
+      ...lightColors,
+    },
+    dark: {
+      ...colors.common,
+      ...colors.dark,
+      ...extendCompatColors(darkColors),
+      ...darkColors,
     },
   };
 };

--- a/packages/styles/src/types.ts
+++ b/packages/styles/src/types.ts
@@ -21,7 +21,7 @@ export interface HvThemeZIndices
 /** UI Kit static theme tokens */
 export interface HvThemeTokens {
   breakpoints: HvThemeBreakpoints;
-  colors: { type: HvThemeColorModeType } & HvThemeColors;
+  colors: { type: HvThemeColorMode } & HvThemeColors;
   radii: HvThemeRadii;
   space: HvThemeSpace;
   // #region typography
@@ -92,35 +92,32 @@ export type SpacingValue = number | HvThemeBreakpoint | (string & {});
 
 export type HvBaseTheme = "ds5" | "pentaho";
 
-// Theme color modes
-export type HvThemeColorMode = "dawn" | "wicked";
+/** Theme color mode */
+export type HvThemeColorMode = "light" | "dark";
 
-// Theme color mode type
-export type HvThemeColorModeType = "light" | "dark";
-
-// Theme color mode structure
-export interface HvThemeColorModeStructure
+/** extendable `HvThemeColors` type */
+export interface HvThemeColorsAny
   extends HvThemeColors,
-    Record<string, string> {
-  type: HvThemeColorModeType;
-}
+    Record<string, string> {}
 
 /** Complete theme structure and values */
-export interface HvThemeStructure<Mode extends string = string>
+export interface HvThemeStructure
   extends HvThemeComponents,
     HvThemeComponentsProps,
     HvThemeTypography,
     Omit<HvThemeTokens, "colors"> {
   name: string;
   base: HvBaseTheme;
+  defaultColorMode: HvThemeColorMode;
   colors: {
-    modes: Record<Mode, HvThemeColorModeStructure>;
+    light: HvThemeColorsAny;
+    dark: HvThemeColorsAny;
   };
 }
 
 // Custom theme
-export interface HvCustomTheme<Mode extends string = string>
-  extends DeepPartial<Omit<HvThemeStructure<Mode>, "base">> {}
+export interface HvCustomTheme
+  extends DeepPartial<Omit<HvThemeStructure, "base">> {}
 
 // Deep string: set all props to strings
 export type DeepString<T> = {

--- a/packages/styles/src/utils.ts
+++ b/packages/styles/src/utils.ts
@@ -1,6 +1,7 @@
 import type {
   DeepString,
   HvThemeBreakpoint,
+  HvThemeColorMode,
   HvThemeStructure,
   HvThemeVars,
   SpacingValue,
@@ -96,7 +97,7 @@ export const mergeTheme = (...objects: any[]): HvThemeStructure => {
 export const getThemeVars = (theme: HvThemeStructure) => {
   const cssVars: Record<string, any> = {};
 
-  const colorModes = Object.keys(theme.colors.modes);
+  const colorModes: HvThemeColorMode[] = ["light", "dark"];
 
   colorModes.forEach((colorMode) => {
     const styleName = `[data-theme="${theme.name}"][data-color-mode="${colorMode}"]`;
@@ -108,7 +109,7 @@ export const getThemeVars = (theme: HvThemeStructure) => {
 
     cssVars[styleName] = toCSSVars({
       colors: {
-        ...colors.modes[colorMode],
+        ...colors[colorMode],
       },
     });
 

--- a/packages/uno-preset/src/theme.ts
+++ b/packages/uno-preset/src/theme.ts
@@ -3,7 +3,7 @@ import type { Theme } from "@unocss/preset-wind3";
 import { ds5 as hvTheme, theme } from "@hitachivantara/uikit-styles";
 
 // #region theme conversion utils
-const { dawn: defaultColors } = hvTheme.colors.modes;
+const { light: defaultColors } = hvTheme.colors;
 const { base, ...hvSpacing } = hvTheme.space;
 
 /** HV breakpoints with added `px` suffix */

--- a/packages/utils/src/hooks/useTheme.ts
+++ b/packages/utils/src/hooks/useTheme.ts
@@ -1,13 +1,13 @@
 import { useContext, useMemo } from "react";
 import {
   HvThemeContext,
-  type HvTheme,
   type HvThemeContextValue,
 } from "@hitachivantara/uikit-react-shared";
+import type { HvThemeColorsAny } from "@hitachivantara/uikit-styles";
 
 interface ThemeContextValue extends HvThemeContextValue {
   /** Colors of the currently active theme and mode */
-  colors?: HvTheme["colors"]["modes"]["mode"];
+  colors?: HvThemeColorsAny;
 }
 
 export const useTheme = () => {
@@ -15,6 +15,6 @@ export const useTheme = () => {
 
   return useMemo<ThemeContextValue>(() => {
     const { activeTheme, selectedMode } = context;
-    return { ...context, colors: activeTheme?.colors.modes?.[selectedMode] };
+    return { ...context, colors: activeTheme?.colors?.[selectedMode] };
   }, [context]);
 };

--- a/packages/viz/src/utils/registerTheme.ts
+++ b/packages/viz/src/utils/registerTheme.ts
@@ -6,7 +6,7 @@ export const registerTheme = (
   mode: string,
   themeStructure?: HvTheme,
 ) => {
-  const colors = themeStructure?.colors.modes[mode];
+  const colors = themeStructure?.colors[mode];
   // if theme & mode is invalid, exit (to use the default theme)
   if (!colors) return;
 


### PR DESCRIPTION
Change theme to allow only light/dark modes (instead of arbitrary number of color modes), easing integration with light/dark theme toggles

from
```tsx
colors: {
  modes: Record<string, HvThemeColors>
}
```
to:
```tsx
colors: {
  light: HvThemeColors;
  dark: HvThemeColors;
}
```