### PR TITLE
docs: add HvProvider to the Controls section

### DIFF
--- a/apps/docs/src/components/code/Playground.tsx
+++ b/apps/docs/src/components/code/Playground.tsx
@@ -122,7 +122,7 @@ export const Playground = ({
 
         {/* Controls Area */}
         <div className="rounded-inherit border-l border-color-inherit bg-white h-full">
-          <div className="flex flex-col gap-xs  py-sm px-xs">
+          <div className="flex flex-col gap-xs py-sm px-xs">
             {Object.entries(controls).map(([prop, control]) => {
               if (!control) return null;
 


### PR DESCRIPTION
We originally left the playground controls section out of the inner `HvProvider` but in reality we need it there as some of the controls (the `HvColorPicker`) depend on it to get the correct colors.