### PR TITLE
fix(input): optional chaining for input blur event

### DIFF
--- a/packages/core/src/Input/Input.tsx
+++ b/packages/core/src/Input/Input.tsx
@@ -448,7 +448,7 @@ export const HvInput = fixedForwardRef(function HvInput<
 
     const inputValidity = performValidation();
 
-    onBlur?.(event as any, event.target.value, inputValidity);
+    onBlur?.(event as any, event.target?.value, inputValidity);
   };
 
   /**


### PR DESCRIPTION
In React 19 + Next.js 15, we are facing a problem submitting a form using `HvInput` and pressing the return ` ↵` key.

```
TypeError: Cannot read properties of undefined (reading 'target')
    at onInputBlurHandler (Input.js:200:1)
    at InputBase.InputBase.useEffect (InputBase.js:294:9)
    at Object.react_stack_bottom_frame (react-dom-client.development.js:23953:1)
    at runWithFiberInDEV (react-dom-client.development.js:1519:1)
    at commitHookEffectListMount (react-dom-client.development.js:11905:1)
    at commitHookPassiveMountEffects (react-dom-client.development.js:12026:1)
    at commitPassiveMountOnFiber (react-dom-client.development.js:13841:1)
    at recursivelyTraversePassiveMountEffects (react-dom-client.development.js:13815:1)
    at commitPassiveMountOnFiber (react-dom-client.development.js:13834:1)
    at recursivelyTraversePassiveMountEffects (react-dom-client.development.js:13815:1)
    ...

The above error occurred in the <ForwardRef(InputBase)> component.
```