### PR TITLE
fix(AppShell): add back navigation for VerticalNavigation [PPUC-192]

### DIFF
--- a/packages/app-shell-ui/src/components/layout/VerticalNavigation/VerticalNavigation.tsx
+++ b/packages/app-shell-ui/src/components/layout/VerticalNavigation/VerticalNavigation.tsx
@@ -71,23 +71,25 @@ const VerticalNavigation = () => {
       useIcons
       slider={isCompactMode}
     >
-      {isPentahoTheme ? (
-        <NavigationHeader isOpen={open} />
-      ) : (
-        <HvVerticalNavigationHeader
-          title={t("title")}
-          onCollapseButtonClick={
-            !isCompactMode ? switchVerticalNavigationMode : undefined
-          }
-          collapseButtonProps={{
-            "aria-label": t(open ? "ariaLabelCollapse" : "ariaLabelExpand"),
-            "aria-expanded": open,
-          }}
-          backButtonProps={{
-            "aria-label": t("ariaLabelHeaderBackButton"),
-          }}
-        />
-      )}
+      <div>
+        {isPentahoTheme && <NavigationHeader isOpen={open} />}
+
+        {(!isPentahoTheme || isCompactMode) && (
+          <HvVerticalNavigationHeader
+            title={t("title")}
+            onCollapseButtonClick={
+              !isCompactMode ? switchVerticalNavigationMode : undefined
+            }
+            collapseButtonProps={{
+              "aria-label": t(open ? "ariaLabelCollapse" : "ariaLabelExpand"),
+              "aria-expanded": open,
+            }}
+            backButtonProps={{
+              "aria-label": t("ariaLabelHeaderBackButton"),
+            }}
+          />
+        )}
+      </div>
 
       <HvVerticalNavigationTree
         key={rootMenuItemId}


### PR DESCRIPTION
On small screens or mobile, vertical navigation changes to slider mode and we couldn't go back from sub menus when using the PentahoPlus theme