### PR TITLE
fix(AppShell): address typecheck errors

### DIFF
--- a/apps/default-app/src/pages/ServicesDemo/ServicesDemo.tsx
+++ b/apps/default-app/src/pages/ServicesDemo/ServicesDemo.tsx
@@ -12,8 +12,8 @@ import {
 
 import { ServiceDefinitions } from "../../services/serviceDefinition";
 import {
-  BasicNotification,
   MessageService,
+  NotificationComponentProps,
   SimpleDataService,
   UseCreateNewContentAction,
 } from "../../services/types";
@@ -30,11 +30,6 @@ const InstanceServiceDemo: FC = () => {
   if (error) {
     const errorMessage = `Failed to load instance type service: ${ServiceDefinitions.SimpleDataService.id}`;
     return <HvTypography>{errorMessage}</HvTypography>;
-  }
-
-  if (!service) {
-    const warnMessage = `No instance service available: ${ServiceDefinitions.SimpleDataService.id}`;
-    return <HvTypography>{warnMessage}</HvTypography>;
   }
 
   return (
@@ -188,12 +183,20 @@ const InstanceBundleServiceDemo: FC = () => {
   return <InstanceBundleServiceDemoInner actionHooks={actionHooks} />;
 };
 
+// The Notification component contract defines 'message' as mandatory prop. However, that is the contract of the service
+// that providers should comply with and assuming that all providers are compliant, we need to use the Partial<>
+// utility type instead because any explicit passed prop overrides the ones from configuration.
+// This is required otherwise Typescript's type checker would complain about missing props if using the contract type: BasicNotification.
+type NotificationComponent = FC<Partial<NotificationComponentProps>>;
+
 const ComponentServiceDemo: FC = () => {
   const {
     service: Notification,
     isPending,
     error,
-  } = useService<BasicNotification>(ServiceDefinitions.BasicNotification.id);
+  } = useService<NotificationComponent>(
+    ServiceDefinitions.BasicNotification.id,
+  );
 
   if (isPending) {
     return <HvLoading>Loading component type services...</HvLoading>;
@@ -213,7 +216,6 @@ const ComponentServiceDemo: FC = () => {
         <HvTypography style={{ marginBottom: "16px" }}>
           This demonstrates a component service that renders React components.
         </HvTypography>
-
         <Notification />
       </HvCardContent>
     </HvCard>

--- a/packages/app-shell-services/src/types/async.ts
+++ b/packages/app-shell-services/src/types/async.ts
@@ -12,7 +12,7 @@ export type UseAsyncBaseResult<
 > = {
   isPending: boolean;
   error: TError | null;
-} & PropertyWithName<TDataProp, TDataPending>;
+} & PropertyWithName<TDataProp, TData | TDataPending | undefined>;
 
 export type UseAsyncResult<
   TData,
@@ -32,9 +32,7 @@ export type UseAsyncPendingResult<
 > = UseAsyncBaseResult<TData, TError, TDataProp> & {
   isPending: true;
   error: null;
-} & {
-  [P in TDataProp]: TDataPending;
-};
+} & PropertyWithName<TDataProp, TDataPending>;
 
 export type UseAsyncErrorResult<
   TData,
@@ -44,9 +42,7 @@ export type UseAsyncErrorResult<
 > = UseAsyncBaseResult<TData, TError, TDataProp, TDataPending> & {
   isPending: false;
   error: TError;
-} & {
-  [P in TDataProp]: undefined;
-};
+} & PropertyWithName<TDataProp, undefined>;
 
 export type UseAsyncSuccessResult<
   TData,
@@ -56,6 +52,4 @@ export type UseAsyncSuccessResult<
 > = UseAsyncBaseResult<TData, TError, TDataProp, TDataPending> & {
   isPending: false;
   error: null;
-} & {
-  [P in TDataProp]: TData;
-};
+} & PropertyWithName<TDataProp, TData>;


### PR DESCRIPTION
In my previous [PR](https://github.com/lumada-design/hv-uikit-react/pull/4895) I missed the typecheck error on the actions and this PR follows to fix them.

These errors were "hidden" on the IDE by other error like explained below:

-> the default-app makes use of the **app-shell-services** package and imports it like `import { useService, useServices } from "@hitachivantara/app-shell-services";` on the ServicesDemo.tsx page.
However, because the this package doesn't have the following config `"main": "./src/index.ts",` on its package.json file, it complains with:
```
TS2307: Cannot find module @hitachivantara/app-shell-services or its corresponding type declarations.
There are types at
/.../hv-uikit-react/node_modules/@hitachivantara/app-shell-services/src/index.ts
, but this result could not be resolved under your current moduleResolution setting. Consider updating to node16, nodenext, or bundler
```
Node cannot load TS files and thats why I'm assuming that the **app-shell-shared** package also doesn't have it, causing DefaultAppProvider.tsx to have the same issue when resolving `import {HvAppShellContext,HvAppShellContextValue,} from "@hitachivantara/app-shell-shared";`...

@lumada-design/imperial Not sure if adding this configuration would actually be the solution or if there could be bigger issues maybe on build/deploy? This is not blocker but would be useful, do you think you could provide your insights on it?