### PR TITLE
chore: add preserveModulesRoot to fix package exports resolution

### DIFF
--- a/.config/vite.config.ts
+++ b/.config/vite.config.ts
@@ -9,6 +9,7 @@ import dts from "vite-plugin-dts";
 const require = createRequire(import.meta.url);
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
+// eslint-disable-next-line import/no-dynamic-require
 const pkg = require(resolve(process.cwd(), "package.json"));
 
 // dependencies that should not be bundled.
@@ -20,6 +21,7 @@ const external = [
 const esmOutput: OutputOptions = {
   format: "esm",
   preserveModules: true,
+  preserveModulesRoot: "src",
   dir: "dist/esm",
   // keep react-based packages as `.js` for backwards compatibility
   entryFileNames:
@@ -33,6 +35,7 @@ const esmOutput: OutputOptions = {
 const cjsOutput: OutputOptions = {
   format: "cjs",
   preserveModules: true,
+  preserveModulesRoot: "src",
   dir: "dist/cjs",
   entryFileNames: "[name].cjs",
   exports: "named",


### PR DESCRIPTION
- Add preserveModulesRoot: "src" to both ESM and CJS output configurations
- Fixes Vite import analysis error for @hitachivantara/uikit-react-core
- Ensures build output structure matches package.json exports paths