### PR TITLE
fix(AppShell): address bare module identifiers in the generated bundle [PPUC-187]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30758,7 +30758,7 @@
       "version": "1.1.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "lodash": "^4.17.21"
+        "lodash-es": "^4.17.21"
       },
       "peerDependencies": {
         "react": "^18.2.0"

--- a/packages/app-shell-services/package.json
+++ b/packages/app-shell-services/package.json
@@ -20,7 +20,7 @@
     "prepublishOnly": "npm run build && npx clean-publish"
   },
   "dependencies": {
-    "lodash": "^4.17.21"
+    "lodash-es": "^4.17.21"
   },
   "peerDependencies": {
     "react": "^18.2.0"

--- a/packages/app-shell-services/src/hooks/Hooks.tsx
+++ b/packages/app-shell-services/src/hooks/Hooks.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useRef } from "react";
-import { cloneDeep, isEqual } from "lodash";
+import cloneDeep from "lodash/cloneDeep";
+import isEqual from "lodash/isEqual";
 
 import { ServiceId } from "../types/config";
 import {

--- a/packages/app-shell-services/src/providers/ServiceManagerProvider.tsx
+++ b/packages/app-shell-services/src/providers/ServiceManagerProvider.tsx
@@ -1,4 +1,10 @@
-import { createContext, FC, PropsWithChildren, useMemo } from "react";
+import {
+  createContext,
+  createElement,
+  FC,
+  PropsWithChildren,
+  useMemo,
+} from "react";
 
 import { ServiceId, ServicesConfig } from "../types/config";
 import {
@@ -147,10 +153,10 @@ interface Props extends PropsWithChildren {
 const ServiceManagerProvider: FC<Props> = ({ config, children }) => {
   const serviceManager = useMemo(() => createServiceManager(config), [config]);
 
-  return (
-    <ServicesContext.Provider value={serviceManager}>
-      {children}
-    </ServicesContext.Provider>
+  return createElement(
+    ServicesContext.Provider,
+    { value: serviceManager },
+    children,
   );
 };
 

--- a/packages/app-shell-services/src/utils/serviceReference.tsx
+++ b/packages/app-shell-services/src/utils/serviceReference.tsx
@@ -1,4 +1,4 @@
-import { FC, PropsWithChildren } from "react";
+import { createElement, FC, PropsWithChildren } from "react";
 
 import {
   BundleConfig,
@@ -251,8 +251,7 @@ function bindComponent<
   const BoundComponent = (props: PropsWithChildren<P>) => {
     // Explicitly passed props override the ones from coming from the config
     const mergedProps = { ...configProps, ...props };
-    // @ts-expect-error TODO fix the types!
-    return <Component {...mergedProps} />;
+    return createElement(Component, mergedProps);
   };
 
   return BoundComponent as TComponent;


### PR DESCRIPTION
This PR fixes two bare module identifiers getting into the generated bundle with the error as follows:
```
Uncaught TypeError: Failed to resolve module specifier "lodash". Relative references must start with either "/", "./", or "../".
Uncaught TypeError: Failed to resolve module specifier "react/jsx-runtime". Relative references must start with either "/", "./", or "../".
```
To solve this:

- **lodash** - updating to `lodash-es` solves it (even though lodash had its latest release 5 years ago). And to avoid loading the entire lib, we now individually import each utility needed, most precisely the `cloneDeep` - `import cloneDeep from "lodash/cloneDeep";` - and `isEqual` - `import isEqualfrom "lodash/isEqual";`;

- **react/jsx-runtime** - because `react` is marked as external, jsx is present on the bundled files... As a workaround, this PR makes use of the `React.createElement` in 2 places, removing the jsx import need. **NOTE**: if this becomes cucumbersome in the future, then we will have to think how to handle the JSX runtime in the `app-shell-vite-plugin`.