### PR TITLE
refactor(StatusIcon): update Phosphor imports to use explicit CSR paths

### DIFF
--- a/packages/core/src/StatusIcon/StatusIcon.tsx
+++ b/packages/core/src/StatusIcon/StatusIcon.tsx
@@ -1,9 +1,9 @@
 import { forwardRef } from "react";
 import { IconWeight } from "@phosphor-icons/react";
-import { CheckCircle } from "@phosphor-icons/react/CheckCircle";
-import { Question } from "@phosphor-icons/react/Question";
-import { Warning } from "@phosphor-icons/react/Warning";
-import { WarningDiamond } from "@phosphor-icons/react/WarningDiamond";
+import { CheckCircle } from "@phosphor-icons/react/dist/csr/CheckCircle";
+import { Question } from "@phosphor-icons/react/dist/csr/Question";
+import { Warning } from "@phosphor-icons/react/dist/csr/Warning";
+import { WarningDiamond } from "@phosphor-icons/react/dist/csr/WarningDiamond";
 import {
   useDefaultProps,
   useTheme,


### PR DESCRIPTION
- Change icon imports from @phosphor-icons/react/IconName to @phosphor-icons/react/dist/csr/IconName
- Improves build consistency and explicit dependency resolution