### PR TITLE
feat(Snackbar): add close button

### DIFF
--- a/apps/docs/src/content/components/snackbar.mdx
+++ b/apps/docs/src/content/components/snackbar.mdx
@@ -13,6 +13,7 @@ import { Header } from "../../components/Header";
     label: { defaultValue: "This is a success message." },
     variant: { defaultValue: "success" },
     showIcon: { defaultValue: true },
+    showClose: { defaultValue: true },
     open: { defaultValue: true },
   }}
   componentProps={{
@@ -119,9 +120,7 @@ export default function Demo() {
         transitionDirection={transitionDirection}
         autoHideDuration={autoHideDuration}
         onClose={(evt, reason) => {
-          if (reason === "timeout") {
-            setOpen(false);
-          }
+          setOpen(false);
         }}
       />
       <div className="flex flex-col gap-md">

--- a/packages/core/src/Snackbar/Snackbar.tsx
+++ b/packages/core/src/Snackbar/Snackbar.tsx
@@ -51,6 +51,8 @@ export interface HvSnackbarProps
   customIcon?: React.ReactNode;
   /** Controls if the associated icon to the variant should be shown. */
   showIcon?: boolean;
+  /** Controls whether to show the close icon */
+  showClose?: boolean;
   /** Action to display. */
   action?: React.ReactNode | HvActionGeneric;
   /**
@@ -102,6 +104,7 @@ export const HvSnackbar = forwardRef<
     autoHideDuration = 5000,
     variant,
     showIcon,
+    showClose,
     customIcon,
     action,
     actionCallback, // TODO - remove in v6
@@ -161,6 +164,7 @@ export const HvSnackbar = forwardRef<
         variant={variant}
         customIcon={customIcon}
         showIcon={showIcon}
+        showClose={showClose}
         action={action}
         actionCallback={actionCallback}
         onAction={onAction}

--- a/packages/core/src/Snackbar/SnackbarContent/SnackbarContent.tsx
+++ b/packages/core/src/Snackbar/SnackbarContent/SnackbarContent.tsx
@@ -27,6 +27,8 @@ export interface HvSnackbarContentProps
   variant?: HvSnackbarVariant;
   /** Controls if the associated icon to the variant should be shown. */
   showIcon?: boolean;
+  /** Controls whether to show the close icon */
+  showClose?: boolean;
   /** Custom icon to replace the variant default. */
   customIcon?: React.ReactNode;
   /** Action to display. */
@@ -56,6 +58,7 @@ export const HvSnackbarContent = forwardRef<
     label,
     variant = "default",
     showIcon,
+    showClose,
     customIcon,
     action,
     actionCallback, // TODO - remove in v6
@@ -78,6 +81,7 @@ export const HvSnackbarContent = forwardRef<
         action: classes.action,
       }}
       showIcon={showIcon}
+      showClose={showClose}
       customIcon={customIcon}
       actions={isActionGeneric(action) ? [action] : action}
       onClose={onClose}


### PR DESCRIPTION
Add a `showClose` prop to the `HvSnackbar` component.

There's already a way of achieving this result, which is to pass `showClose: true` in the `snackbarContentProps` prop which is then passed on to the `HvSnackbarContent` component. I opted to add the explicitely to the `Snackbar` component for a couple reasons:
- showing or hiding the close button is something that exists as a functionality of the component so the user should have a clear way of doing it.
- the `HvSnackbarContent` is semi-public in a sense that we don't refer it in our documentation besides listing its props. It feels a bit hacky to suggest that to show the close button the user should go that way.

If adding the prop is not ok then we can add a new section to the documentation to explain out to achieve this behavior.