### PR TITLE
feat(AppShell): add vite plugin parameter to control importmap normalization [PPUC-199]

### DIFF
--- a/apps/default-app/vite.config.ts
+++ b/apps/default-app/vite.config.ts
@@ -14,6 +14,7 @@ export default defineConfig(({ mode }) => ({
     HvAppShellVitePlugin({
       mode,
       type: "app",
+      disableAppsKeyNormalization: true,
       modules: [
         "src/providers/DefaultAppProvider",
         "src/modules/HelloDefaultApp",

--- a/apps/docs/src/content/app-shell/configuration.mdx
+++ b/apps/docs/src/content/app-shell/configuration.mdx
@@ -90,7 +90,7 @@ If you don't want to add a logo to the header, explicitly set the menu item `log
 
 Key-value object of _Application Bundles_ IDs and their respective locations. Used by the **App Shell** to generate the importmap and thus allowing the import of ES Modules from different _Application Bundles_.
 
-Example:
+Example of the apps object:
 
 ```ts
 const apps = {
@@ -98,6 +98,21 @@ const apps = {
   "@hv-apps/another-app": "http://localhost:5001/",
 };
 ```
+
+Result in the importmap:
+
+```html
+<script type="importmap">
+  {
+    "imports": {
+      "@hv-apps/an-app/": "http://localhost:3001/",
+      "@hv-apps/another-app/": "http://localhost:5001/"
+    }
+  }
+</script>
+```
+
+As per the example above, the `apps` keys will have a trailing forward slash concatenated to it by default, added by the App Shell Vite plugin. In order to provide more control to the developer of the app, the `disableAppsKeyNormalization` parameter of the App Shell Vite plugin can be used to disable this behavior.
 
 In order to reference Views and Shared Modules from other Application Bundles', one must be registered in the App Shell's configuration.
 

--- a/packages/app-shell-vite-plugin/src/vite-plugin.ts
+++ b/packages/app-shell-vite-plugin/src/vite-plugin.ts
@@ -128,6 +128,13 @@ export interface AppShellVitePluginOptions {
    *
    */
   modules?: string[];
+  /**
+   * If true, the keys of the `apps` property in the configuration file will be used as-is in the importmap,
+   * without enforcing a trailing slash. If false, a trailing slash will be appended to each key.
+   *
+   * @default false
+   */
+  disableAppsKeyNormalization?: boolean;
 }
 
 /**
@@ -149,6 +156,7 @@ export function HvAppShellVitePlugin(
     inlineConfig = opts.generateEmptyShell ?? false,
     generateEmptyShell = false,
     modules = [],
+    disableAppsKeyNormalization = false,
   } = opts;
 
   const globalEnv = loadEnv(mode, process.cwd(), "");
@@ -248,7 +256,8 @@ export function HvAppShellVitePlugin(
 
         ...Object.entries(appShellConfiguration?.apps ?? {}).reduce(
           (acc, [key, value]) => {
-            acc[`${key}`] = value;
+            const normalizedKey = disableAppsKeyNormalization ? key : `${key}/`;
+            acc[normalizedKey] = value;
             return acc;
           },
           {} as Record<string, string>,


### PR DESCRIPTION
In a [previous PR](https://github.com/lumada-design/hv-uikit-react/pull/4930), a breaking change was introduced and, to not make it disruptive nor provoke a major release (since we are anticipating more features around the `apps` property), this PR introduces a feature flag around the functionality, keeping the previous behavior while enabling the new.