### PR TITLE
feat(code-editor): move monaco-editor to peerDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22204,6 +22204,7 @@
       "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.54.0.tgz",
       "integrity": "sha512-hx45SEUoLatgWxHKCmlLJH81xBo0uXP4sRkESUpmDQevfi+e7K1VuiSprK6UpQ8u4zOcKNiH0pMvHvlMWA/4cw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "dompurify": "3.1.7",
         "marked": "14.0.0"
@@ -22213,13 +22214,15 @@
       "version": "3.1.7",
       "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.1.7.tgz",
       "integrity": "sha512-VaTstWtsneJY8xzy7DekmYWEOZcmzIe3Qb3zPd4STve1OBTa+e+WmS1ITQec1fZYXI3HCsOZZiSMpG6oxoWMWQ==",
-      "license": "(MPL-2.0 OR Apache-2.0)"
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "peer": true
     },
     "node_modules/monaco-editor/node_modules/marked": {
       "version": "14.0.0",
       "resolved": "https://registry.npmjs.org/marked/-/marked-14.0.0.tgz",
       "integrity": "sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -30919,7 +30922,6 @@
         "@hitachivantara/uikit-react-utils": "^0.2.45",
         "@hitachivantara/uikit-styles": "^5.51.0",
         "@monaco-editor/react": "^4.5.1",
-        "monaco-editor": "^0.54.0",
         "sql-formatter": "^15.4.2",
         "xml-formatter": "^3.6.3",
         "xmllint-wasm": "^4.0.2"
@@ -30936,6 +30938,7 @@
         "@emotion/react": "^11.11.1",
         "@emotion/styled": "^11.11.0",
         "@mui/material": "^5.16.14",
+        "monaco-editor": "^0.54.0",
         "react": ">=17.0.0",
         "react-dom": ">=17.0.0"
       }

--- a/packages/code-editor/README.md
+++ b/packages/code-editor/README.md
@@ -26,7 +26,17 @@ The editor automatically handles offline support:
 - **Vite**: Workers are bundled by default
 - **Other bundlers**: Falls back to CDN
 
-No configuration required!
+### Vite Configuration
+
+To prevent Vite from pre-bundling Monaco Editor, add the following to your `vite.config.js`:
+
+```js
+export default {
+  optimizeDeps: {
+    exclude: ['monaco-editor'],
+  },
+}
+```
 
 ## Documentation
 

--- a/packages/code-editor/package.json
+++ b/packages/code-editor/package.json
@@ -35,6 +35,7 @@
     "@emotion/react": "^11.11.1",
     "@emotion/styled": "^11.11.0",
     "@mui/material": "^5.16.14",
+    "monaco-editor": "^0.54.0",
     "react": ">=17.0.0",
     "react-dom": ">=17.0.0"
   },
@@ -42,7 +43,6 @@
     "@hitachivantara/uikit-react-utils": "^0.2.45",
     "@hitachivantara/uikit-styles": "^5.51.0",
     "@monaco-editor/react": "^4.5.1",
-    "monaco-editor": "^0.54.0",
     "sql-formatter": "^15.4.2",
     "xml-formatter": "^3.6.3",
     "xmllint-wasm": "^4.0.2"


### PR DESCRIPTION
- Move monaco-editor from dependencies to peerDependencies 
- Let consumers control the version and prevent conflicts across projects.