### PR TITLE
fix(AppShell): improve external marking and id prefix replacement [PPUC-199]

### DIFF
--- a/packages/app-shell-vite-plugin/src/vite-plugin.ts
+++ b/packages/app-shell-vite-plugin/src/vite-plugin.ts
@@ -276,7 +276,6 @@ export function HvAppShellVitePlugin(
             )
           : {}),
       },
-      packageJson.name,
       [...SHARED_DEPENDENCIES.map((dep) => dep.moduleId), packageJson.name],
       externalImportMap && buildEntryPoint,
       generateEmptyShell,


### PR DESCRIPTION
Because the plugin `vite:react-refresh` has an object for the `resolveId` hook, it was not executing the one on the `replaceIdPrefix` function and thus not marking the importmap elements as external. This PR addresses it by refactoring that function into 2: one to mark as external that forcibly runs before the mentioned plugin, and other to replace the prefixes that keeps the old behavior. What this was doing in reality is that, instead of using the files pointed by the importmap mapping, it was using the ones in the node_modules.

After that, we noticed that the addition of the packageName to the RegExp was failing to find matches and thus this PR reverts the change done [here](https://github.com/lumada-design/hv-app-shell/commit/76798cd8431667443097245c8f584d2e757aa55e) (and also this [fix](https://github.com/lumada-design/hv-app-shell/commit/1049c1263db95ed8623a94a1f44fb5fe2e60587b) later on).
