### PR TITLE
chore: fix default-app tsconfig build

### DIFF
--- a/apps/default-app/tsconfig.json
+++ b/apps/default-app/tsconfig.json
@@ -1,5 +1,9 @@
 {
   "extends": "../../tsconfig.json",
   "include": ["src"],
-  "references": [{ "path": "./tsconfig.node.json" }]
+  "references": [{ "path": "./tsconfig.node.json" }],
+  "compilerOptions": {
+    // this can't be upgraded because app-shell-config's ts-node loader overrides it
+    "moduleResolution": "Node"
+  }
 }


### PR DESCRIPTION
revert https://github.com/lumada-design/hv-uikit-react/pull/4939's tsconfig.json changes, as `app-shell.config.ts` `ts-node` is forcing it it to `Node` anyways

addresses https://github.com/lumada-design/hv-uikit-react/actions/runs/18550810485/job/52877823915#step:6:14