### PR TITLE
ci: bump node to v24

### DIFF
--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -10,9 +10,9 @@ runs:
   using: "composite"
   steps:
     - name: Install Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
-        node-version: 22
+        node-version: 24
         cache: npm
 
     - name: Install dependencies


### PR DESCRIPTION
we need npm 11.5.1+ to enable [trusted publishing](https://docs.npmjs.com/trusted-publishers)

we could just update `npm`, but `node@24` is the Current version and `node@22` is already in "Maintenance mode"
https://nodejs.org/en/about/previous-releases