### PR TITLE
chore(prettier): reenable md/mdx formatting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@fortawesome/react-fontawesome": "^0.2.2",
         "@hitachivantara/uikit-config": "*",
         "@hitachivantara/uikit-uno-preset": "*",
-        "@ianvs/prettier-plugin-sort-imports": "^4.5.1",
+        "@ianvs/prettier-plugin-sort-imports": "^4.7.0",
         "@iconify-json/ph": "^1.2.1",
         "@mdx-js/react": "^3.1.0",
         "@mui/material": "^5.14.20",
@@ -2478,9 +2478,9 @@
       "link": true
     },
     "node_modules/@ianvs/prettier-plugin-sort-imports": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/@ianvs/prettier-plugin-sort-imports/-/prettier-plugin-sort-imports-4.5.1.tgz",
-      "integrity": "sha512-vOQwIyQHnHz0ikvHEQDzwUkNfX74o/7qNEpm9LiPtyBvCg/AU/DOkhwe1o92chPS1QzS6G7HeiO+OwIt8a358A==",
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@ianvs/prettier-plugin-sort-imports/-/prettier-plugin-sort-imports-4.7.0.tgz",
+      "integrity": "sha512-soa2bPUJAFruLL4z/CnMfSEKGznm5ebz29fIa9PxYtu8HHyLKNE1NXAs6dylfw1jn/ilEIfO2oLLN6uAafb7DA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/generator": "^7.26.2",
@@ -2492,13 +2492,21 @@
       "peerDependencies": {
         "@prettier/plugin-oxc": "^0.0.4",
         "@vue/compiler-sfc": "2.7.x || 3.x",
-        "prettier": "2 || 3 || ^4.0.0-0"
+        "content-tag": "^4.0.0",
+        "prettier": "2 || 3 || ^4.0.0-0",
+        "prettier-plugin-ember-template-tag": "^2.1.0"
       },
       "peerDependenciesMeta": {
         "@prettier/plugin-oxc": {
           "optional": true
         },
         "@vue/compiler-sfc": {
+          "optional": true
+        },
+        "content-tag": {
+          "optional": true
+        },
+        "prettier-plugin-ember-template-tag": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@fortawesome/react-fontawesome": "^0.2.2",
     "@hitachivantara/uikit-config": "*",
     "@hitachivantara/uikit-uno-preset": "*",
-    "@ianvs/prettier-plugin-sort-imports": "^4.5.1",
+    "@ianvs/prettier-plugin-sort-imports": "^4.7.0",
     "@iconify-json/ph": "^1.2.1",
     "@mdx-js/react": "^3.1.0",
     "@mui/material": "^5.14.20",

--- a/packages/code-editor/README.md
+++ b/packages/code-editor/README.md
@@ -16,7 +16,7 @@ import { HvCodeEditor } from "@hitachivantara/uikit-react-code-editor";
 <HvCodeEditor
   language="javascript"
   defaultValue="console.log('Hello, World!');"
-/>
+/>;
 ```
 
 ## Offline Support
@@ -33,9 +33,9 @@ To prevent Vite from pre-bundling Monaco Editor, add the following to your `vite
 ```js
 export default {
   optimizeDeps: {
-    exclude: ['monaco-editor'],
+    exclude: ["monaco-editor"],
   },
-}
+};
 ```
 
 ## Documentation

--- a/packages/config/prettier.config.json
+++ b/packages/config/prettier.config.json
@@ -1,34 +1,22 @@
 {
   "plugins": ["@ianvs/prettier-plugin-sort-imports"],
 
+  "importOrder": [
+    "<BUILTIN_MODULES>",
+    "^react$",
+    "^react-.*",
+    "<THIRD_PARTY_MODULES>",
+    "^@hitachivantara/(.*)$",
+    "",
+    "^~/(.*)$",
+    "^#/(.*)$",
+    "^[./]"
+  ],
+
   "overrides": [
     {
-      "files": ["*.{js,jsx,ts,tsx}"],
-      "options": {
-        "importOrder": [
-          "<BUILTIN_MODULES>",
-          "^react$",
-          "^react-.*",
-          "<THIRD_PARTY_MODULES>",
-          "^@hitachivantara/(.*)$",
-          "",
-          "^~/(.*)$",
-          "^#/(.*)$",
-          "^[./]"
-        ]
-      }
-    },
-
-    { "files": ["*.hbs"], "options": { "rangeEnd": 0 } },
-
-    {
-      "files": ["*.md"],
-      "options": { "parser": "markdown", "embeddedLanguageFormatting": "off" }
-    },
-
-    {
-      "files": ["*.mdx"],
-      "options": { "parser": "mdx", "embeddedLanguageFormatting": "off" }
+      "files": ["*.hbs", "pnpm-lock.yaml", "yarn.lock"],
+      "options": { "rangeEnd": 0 }
     }
   ]
 }


### PR DESCRIPTION
- bump `@ianvs/prettier-plugin-sort-imports` to fix `md`/`mdx` import order warnings
- revert the changes regarding `mdx` formatting