### PR TITLE
ci(release): exit early if nothing to release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,6 +51,9 @@ jobs:
       - name: Install Dependencies
         uses: ./.github/actions/install-dependencies
 
+      - name: Check for package changes
+        run: npx lerna changed
+
       - name: Publish to NPM
         id: publish-npm
         run: |


### PR DESCRIPTION
run `lerna changed` to check if there are updates to packages before attempting to build + publish;
it's a less brittle check than `grep`'ing the output logs after build