### PR TITLE
feat(Tooltip): update to PD 0.9 specs

### DIFF
--- a/apps/docs/src/content/components/tooltip.mdx
+++ b/apps/docs/src/content/components/tooltip.mdx
@@ -108,15 +108,21 @@ Since it labels the target element and isn’t keyboard-navigable, avoid complex
   </HvTooltip>
   <HvTooltip
     title={
-      <div className={"flex flex-col gap-xs"}>
-        <HvTypography variant="label">January</HvTypography>
-        <div className="border-b-3px border-bgPage m-xs -mx-sm" />
+      <div className="w-160px flex flex-col gap-xs">
+        <div>
+          <HvTypography variant="label">January</HvTypography>
+          <HvTypography>Total sales</HvTypography>
+        </div>
+        <div className="border-b-3px border-bgPage -mx-sm" />
         {[
           ["Sales", "52,000 units"],
           ["Profit", "50%"],
         ].map(([name, value]) => (
-          <div key={name} className={"flex justify-between g-xs"}>
-            <HvTypography variant="label">{name}</HvTypography>
+          <div key={name} className="flex items-center gap-xxs">
+            <div className="size-8px bg-positive" />
+            <HvTypography className="flex-1" variant="label">
+              {name}
+            </HvTypography>
             <HvTypography>{value}</HvTypography>
           </div>
         ))}

--- a/packages/core/src/themes/pentahoPlus.ts
+++ b/packages/core/src/themes/pentahoPlus.ts
@@ -41,6 +41,7 @@ import type { HvSwitchProps } from "../Switch";
 import type { HvTabsProps } from "../Tabs";
 import type { HvTagProps } from "../Tag";
 import type { HvTagsInputProps } from "../TagsInput";
+import { HvTooltipProps } from "../Tooltip";
 import type { HvCalloutProps } from "../utils/Callout";
 import type {
   HvVerticalNavigationActionProps,
@@ -931,5 +932,14 @@ export const pentahoPlus = mergeTheme(pentahoPlusBase, {
         },
       },
     } satisfies CSSClasses<HvNumberInputProps>,
+    HvTooltip: {
+      classes: {
+        popper: {
+          "& .HvTooltip-tooltip": {
+            padding: theme.spacing("xs", "sm"),
+          },
+        },
+      },
+    } satisfies CSSClasses<HvTooltipProps>,
   },
 });


### PR DESCRIPTION
- Adjust paddings for tooltips according to PD 0.9 specs
- Also included is a slight change to one of the samples in the docs to align with the PD samples