### PR TITLE
fix(types): ReactNode labels in Accordion & Banner

### DIFF
--- a/packages/core/src/Accordion/Accordion.tsx
+++ b/packages/core/src/Accordion/Accordion.tsx
@@ -20,7 +20,7 @@ export interface HvAccordionProps
   /** Content to be rendered. */
   children: React.ReactNode;
   /** The accordion label button. */
-  label?: string;
+  label?: React.ReactNode;
   /** The function that will be executed whenever the accordion toggles. It will receive the state of the accordion. */
   onChange?: (event: React.SyntheticEvent, value: boolean) => void;
   /** Whether the accordion is open or not. If this property is defined the accordion must be fully controlled. */

--- a/packages/core/src/Banner/Banner.tsx
+++ b/packages/core/src/Banner/Banner.tsx
@@ -34,7 +34,7 @@ export interface HvBannerProps
    * */
   onClose?: (event: React.MouseEvent<HTMLButtonElement>) => void;
   /** The message to display. */
-  label?: string;
+  label?: React.ReactNode;
   /** The anchor of the Snackbar. */
   anchorOrigin?: "top" | "bottom";
   /** Variant of the snackbar. */


### PR DESCRIPTION
- allows for `ReactNode` (instead of `string`) in Accordion and Banner