### PR TITLE
fix(BaseDropdown): Pentaho popper spacing

### DIFF
--- a/packages/core/src/themes/pentahoPlus.ts
+++ b/packages/core/src/themes/pentahoPlus.ts
@@ -69,6 +69,7 @@ const inputColors = {
 };
 
 const popperStyles = {
+  margin: theme.spacing("xxs", 0),
   backgroundColor: theme.colors.bgContainer,
   border: `1px solid ${theme.colors.borderSubtle}`,
   borderRadius: theme.radii.large,


### PR DESCRIPTION
add the spacing between the "header" and the popper