### PR TITLE
ci(build): pkg-pr-new only on ubuntu build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,5 +49,6 @@ jobs:
         if: ${{ inputs.build-all || inputs.publish-packages }}
 
       - name: Publish Packages
-        if: ${{ inputs.publish-packages }}
+        # only publish on Linux to avoid duplicate publishes
+        if: ${{ inputs.publish-packages && matrix.os == 'ubuntu-latest' }}
         run: npx -y pkg-pr-new publish './packages/*' --no-template


### PR DESCRIPTION
although this improves build the process, the published artifacts still include some extra files, and `clean-publish` isn't running correctly (updating `package.json`)

<img width="208" height="204" alt="image" src="https://github.com/user-attachments/assets/5116432d-895d-4654-b49f-b9158fd952c7" />
