### PR TITLE
fix(Provider): ensure `colorMode` is valid

### DIFF
--- a/packages/core/src/providers/Provider.test.tsx
+++ b/packages/core/src/providers/Provider.test.tsx
@@ -1,4 +1,4 @@
-import { render } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { mergeTheme } from "@hitachivantara/uikit-styles";
 
 import { next } from "../themes/next";
@@ -41,7 +41,20 @@ describe("Provider", () => {
     expect(mode).toBeInTheDocument();
   });
 
-  it("should have the correct theme and color mode selected if the themes and theme properties are provided", () => {
+  it("falls back to a valid color mode if an invalid value is provided", () => {
+    const { container } = render(
+      <HvProvider cssTheme="scoped" colorMode={"invalid-mode" as any}>
+        <p>Theme provider test</p>
+      </HvProvider>,
+    );
+
+    const mode = container.querySelector("[data-color-mode=light]");
+
+    expect(screen.getByRole("paragraph")).toBeInTheDocument();
+    expect(mode).toBeInTheDocument();
+  });
+
+  it("has the correct theme and color mode selected when theme properties are provided", () => {
     const { container } = render(
       <div id="hv-root">
         <HvProvider

--- a/packages/core/src/providers/Provider.tsx
+++ b/packages/core/src/providers/Provider.tsx
@@ -119,7 +119,7 @@ export const HvProvider = ({
       <HvThemeProvider
         theme={theme}
         emotionCache={emotionCache}
-        colorMode={colorMode || "light"}
+        colorMode={colorMode}
         themeRootId={
           cssTheme === "scoped" ? rootElementId || scopedRootId : undefined
         }

--- a/packages/core/src/providers/ThemeProvider.tsx
+++ b/packages/core/src/providers/ThemeProvider.tsx
@@ -40,11 +40,14 @@ export const HvThemeProvider = ({
   colorMode: colorModeProp,
   themeRootId: rootId,
 }: HvThemeProviderProps) => {
-  const [colorMode, setColorMode] = useState(colorModeProp);
+  const [colorModeValue, setColorModeValue] = useState(colorModeProp);
+
+  /** safe `colorMode`, ensuring no invalid values are used */
+  const colorMode = colorModeValue === "dark" ? "dark" : "light";
 
   // review in v6 so that theme/colorMode isn't both controlled & uncontrolled
   useEffect(() => {
-    setColorMode(colorModeProp);
+    setColorModeValue(colorModeProp);
   }, [colorModeProp]);
 
   useEffect(() => {
@@ -59,7 +62,7 @@ export const HvThemeProvider = ({
       activeTheme: theme as HvTheme,
       selectedMode: colorMode,
       changeMode(newMode = colorMode) {
-        setColorMode(newMode);
+        setColorModeValue(newMode);
       },
       rootId,
     }),


### PR DESCRIPTION
add a safeguard to `colorMode` to ensure a valid (`"light" | "dark"`) is always used