### PR TITLE
fix(AppShell): prevent preload of shared external modules

### DIFF
--- a/apps/default-app/app-shell.config.ts
+++ b/apps/default-app/app-shell.config.ts
@@ -23,12 +23,33 @@ export default {
 
   menu: [
     {
-      label: "asset",
-      icon: {
-        iconType: "uikit",
-        name: "Desktop",
-      },
+      label: "Default App",
       submenus: [
+        {
+          label: "asset",
+          icon: {
+            iconType: "uikit",
+            name: "Desktop",
+          },
+          submenus: [
+            {
+              label: "asset",
+              target: "/asset-inventory",
+              icon: {
+                iconType: "uikit",
+                name: "Cards",
+              },
+            },
+            {
+              label: "list",
+              target: "/list-view",
+              icon: {
+                iconType: "uikit",
+                name: "List",
+              },
+            },
+          ],
+        },
         {
           label: "asset",
           target: "/asset-inventory",
@@ -45,55 +66,39 @@ export default {
             name: "List",
           },
         },
+        {
+          label: "notifications",
+          target: "/notifications",
+          icon: {
+            iconType: "uikit",
+            name: "Alert",
+          },
+        },
+        {
+          label: "Multi-level Breadcrumb",
+          target: "/breadcrumb",
+        },
+        {
+          label: "Theming",
+          target: "/theming",
+          icon: {
+            iconType: "uikit",
+            name: "ColorPicker",
+          },
+        },
+        {
+          label: "Nested Views",
+          target: "/nested",
+        },
+        {
+          label: "Services Demo",
+          target: "/services-demo",
+          icon: {
+            iconType: "uikit",
+            name: "Settings",
+          },
+        },
       ],
-    },
-    {
-      label: "asset",
-      target: "/asset-inventory",
-      icon: {
-        iconType: "uikit",
-        name: "Cards",
-      },
-    },
-    {
-      label: "list",
-      target: "/list-view",
-      icon: {
-        iconType: "uikit",
-        name: "List",
-      },
-    },
-    {
-      label: "notifications",
-      target: "/notifications",
-      icon: {
-        iconType: "uikit",
-        name: "Alert",
-      },
-    },
-    {
-      label: "Multi-level Breadcrumb",
-      target: "/breadcrumb",
-    },
-    {
-      label: "Theming",
-      target: "/theming",
-      icon: {
-        iconType: "uikit",
-        name: "ColorPicker",
-      },
-    },
-    {
-      label: "Nested Views",
-      target: "/nested",
-    },
-    {
-      label: "Services Demo",
-      target: "/services-demo",
-      icon: {
-        iconType: "uikit",
-        name: "Settings",
-      },
     },
     {
       label: "Providers Demo",

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
       "glob": "^11.1.0"
     }
   },
-  "packageManager": "npm@10.8.1+sha256.b8807aebb9656758e2872fa6e7c564b506aa2faa9297439a478d471d2fe32483",
+  "packageManager": "npm@11.6.2+sha512.ee22b335fcbc95662cdf3ab8a053daf045d9cf9c6df6040d28965abb707512b2c16fa6c5eec049d34c74f78f390cebd14f697919eadb97756564d4f9eccc4954",
   "prettier": "@hitachivantara/uikit-config/prettier",
   "license-compliance": {
     "extends": "@hitachivantara/uikit-config/licenses"

--- a/packages/app-shell-ui/src/components/layout/Header/Header.test.tsx
+++ b/packages/app-shell-ui/src/components/layout/Header/Header.test.tsx
@@ -1,4 +1,4 @@
-import { RenderResult, within } from "@testing-library/react";
+import { screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { vi } from "vitest";
 
@@ -20,11 +20,9 @@ const navigateSpy = vi.fn();
 vi.mock("@hitachivantara/app-shell-navigation", async () => {
   const mod = await vi.importActual("@hitachivantara/app-shell-navigation");
   return {
-    ...(mod as object),
-    useHvNavigation: vi.fn(() => {
-      return {
-        navigate: navigateSpy,
-      };
+    ...mod,
+    useHvNavigation: () => ({
+      navigate: navigateSpy,
     }),
   };
 });
@@ -32,23 +30,18 @@ vi.mock("@hitachivantara/app-shell-navigation", async () => {
 describe("`Header` component", () => {
   describe("with empty menu configuration", () => {
     it("should not have an nav element", async () => {
-      const { getByRole, queryByRole } = await renderTestProvider(<Header />);
+      await renderTestProvider(<Header />);
 
-      expect(getByRole("banner")).toBeInTheDocument();
-      expect(queryByRole("navigation")).not.toBeInTheDocument();
+      expect(await screen.findByRole("banner")).toBeInTheDocument();
+      expect(screen.queryByRole("navigation")).not.toBeInTheDocument();
     });
   });
 
   describe("with valid menu configuration", () => {
     const user = userEvent.setup();
-    let renderResult: RenderResult<
-      typeof import("@testing-library/dom/types/queries"),
-      HTMLElement,
-      HTMLElement
-    >;
 
     beforeEach(async () => {
-      renderResult = await renderTestProvider(<Header />, {
+      await renderTestProvider(<Header />, {
         menu: [
           {
             label: "errors",
@@ -72,7 +65,7 @@ describe("`Header` component", () => {
     });
 
     it("should have a navigation element with the correct menu items", () => {
-      const headerElement = renderResult.getByRole("banner");
+      const headerElement = screen.getByRole("banner");
 
       expect(headerElement).toBeInTheDocument();
 
@@ -97,7 +90,7 @@ describe("`Header` component", () => {
         id: "1",
       };
 
-      const headerNavigationElement = renderResult.getByRole("navigation");
+      const headerNavigationElement = screen.getByRole("navigation");
       const secondMenuItem = within(headerNavigationElement).getAllByRole(
         "link",
       )[1];
@@ -144,13 +137,8 @@ describe("`Header` component", () => {
   });
 
   describe("`Header` component with navigationMode set to `ONLY_LEFT`", () => {
-    let renderResult: RenderResult<
-      typeof import("@testing-library/dom/types/queries"),
-      HTMLElement,
-      HTMLElement
-    >;
-    beforeEach(async () => {
-      renderResult = await renderTestProvider(<Header />, {
+    it("should not have a navigation element", async () => {
+      await renderTestProvider(<Header />, {
         menu: [
           {
             label: "dummyMenu1",
@@ -172,10 +160,8 @@ describe("`Header` component", () => {
         ],
         navigationMode: "ONLY_LEFT",
       });
-    });
 
-    it("should not have a navigation element", () => {
-      const headerElement = renderResult.getByRole("banner");
+      const headerElement = screen.getByRole("banner");
       expect(headerElement).toBeInTheDocument();
 
       const headerNavigationElement =


### PR DESCRIPTION
- fixes https://github.com/pentaho/hv-uikit-react/pull/5014 in dev mode
  - only replaces the known `sharedDependencies`
- upgrades corepack npm version to `npm@11.6.2`
  - we require this version publishing, and older versions have `package-lock.json` differences