### PR TITLE
fix(code-editor): add theme mode mapping for v5 compatibility

### DIFF
--- a/packages/code-editor/src/CodeEditor/CodeEditor.tsx
+++ b/packages/code-editor/src/CodeEditor/CodeEditor.tsx
@@ -83,6 +83,9 @@ export const HvCodeEditor = ({
 
   const { colors, selectedMode, activeTheme, colorModes } = useTheme();
 
+  // TODO: remove this mapping when backward compatibility is no longer needed
+  const mappedMode = selectedMode === "dark" ? "wicked" : "dawn";
+
   // Configure Monaco with optional offline support
   useEffect(() => {
     configureMonaco()
@@ -228,7 +231,7 @@ export const HvCodeEditor = ({
       {monacoInstance ? (
         <Editor
           options={mergedOptions}
-          theme={`hv-${themeName}-${selectedMode}`}
+          theme={`hv-${themeName}-${mappedMode}`}
           language={languageProp}
           defaultLanguage={defaultLanguage}
           beforeMount={handleBeforeMount}


### PR DESCRIPTION
- Add temporary mapping to convert `light/dark` theme modes  to legacy `wicked/dawn` modes for backward compatibility with v5 Monaco Editor theme configurations.