### PR TITLE
fix(theme): useTheme v5 + v6 compatibility

### DIFF
--- a/packages/utils/src/hooks/useTheme.ts
+++ b/packages/utils/src/hooks/useTheme.ts
@@ -15,6 +15,12 @@ export const useTheme = () => {
 
   return useMemo<ThemeContextValue>(() => {
     const { activeTheme, selectedMode } = context;
-    return { ...context, colors: activeTheme?.colors.modes?.[selectedMode] };
+    return {
+      ...context,
+      colors:
+        activeTheme?.colors.modes?.[selectedMode] ||
+        // workaround for v5 + v6 theme compatibility
+        activeTheme?.colors?.[selectedMode],
+    };
   }, [context]);
 };


### PR DESCRIPTION
- this is affecting any components using `colors` from `useTheme`, specifically `<HvCodeEditor>` & visualisations