### PR TITLE
fix(StatusIcon): fix incorrect color on the simple default variant

### DIFF
--- a/apps/docs/src/content/docs/icons.mdx
+++ b/apps/docs/src/content/docs/icons.mdx
@@ -63,3 +63,19 @@ const CustomIcon = () => (
   </svg>
 );
 ```
+
+## `HvStatusIcon`
+
+If you're developing Pentaho applications, you'll most likely need to use the [`HvStatusIcon`](/components/status-icon) component,
+which provides a standardized way to render icons, whether they represent some status or are used as general-purpose icons.
+
+```tsx live
+export default function Demo() {
+  return (
+    <div className="flex gap-sm flex-wrap">
+      <HvStatusIcon variant="success" />
+      <HvStatusIcon variant="info" type="simple" />
+    </div>
+  );
+}
+```

--- a/packages/core/src/StatusIcon/StatusIcon.styles.tsx
+++ b/packages/core/src/StatusIcon/StatusIcon.styles.tsx
@@ -38,10 +38,12 @@ export const { staticClasses, useClasses } = createClasses("HvStatusIcon", {
         },
       ]),
     ),
-    ":where([data-variant=default][data-type=full])": {
+    ":where([data-variant=default])": {
       color: theme.colors.text,
-      backgroundColor: theme.colors.bgPage,
-      outline: `1px solid ${theme.colors.borderSubtle}`,
+      ":where([data-type=full])": {
+        backgroundColor: theme.colors.bgPage,
+        outline: `1px solid ${theme.colors.borderSubtle}`,
+      },
     },
   },
   icon: {


### PR DESCRIPTION
Fixed incorrect color showing when a icon uses the `default` variant and has `type="simple"`. Also added some docs. 

<img width="486" height="300" alt="image" src="https://github.com/user-attachments/assets/18f696bb-0e4e-4511-ba4d-b90e41611d0b" />
