### PR TITLE
chore: add custom dist-tag to v5.x

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -3,7 +3,7 @@
   "version": "independent",
   "packages": ["packages/*"],
   "yes": true,
-  "distTag": "latest",
+  "distTag": "previous",
   "preDistTag": "next",
   "command": {
     "version": {


### PR DESCRIPTION
add `previous` dist-tag to `v5.x` branch, so that releases don't publish to `latest`

tested in verdaccio:

<img width="787" height="208" alt="image" src="https://github.com/user-attachments/assets/6e8edea2-a097-43a5-b80d-502d61623b5c" />
