### PR TITLE
fix(Provider): align MUI Provider colorMode with UI Kit

### DIFF
--- a/packages/core/src/providers/utils.ts
+++ b/packages/core/src/providers/utils.ts
@@ -1,0 +1,56 @@
+import { createTheme, PaletteOptions } from "@mui/material/styles";
+import type { HvTheme } from "@hitachivantara/uikit-react-shared";
+import type {
+  HvThemeColorsAny,
+  HvThemeStructure,
+} from "@hitachivantara/uikit-styles";
+
+export function createMuiTheme(theme: HvTheme | HvThemeStructure) {
+  return createTheme({
+    colorSchemes: {
+      light: { palette: makePalette(theme.colors.light) },
+      dark: { palette: makePalette(theme.colors.dark) },
+    },
+    // palette: makePalette(colors),
+    spacing: theme.space.base,
+    typography: {
+      fontFamily: theme.fontFamily.body,
+    },
+    breakpoints: theme.breakpoints,
+    components: {
+      MuiButtonBase: {
+        defaultProps: {
+          disableRipple: true,
+          disableTouchRipple: true,
+        },
+      },
+    },
+  });
+}
+
+function makePalette(colors: HvThemeColorsAny): PaletteOptions {
+  return {
+    primary: { main: colors.primary },
+    success: { main: colors.positive },
+    warning: { main: colors.warning },
+    error: { main: colors.negative },
+    info: { main: colors.info },
+    text: {
+      primary: colors.text,
+      secondary: colors.textSubtle,
+      disabled: colors.textDisabled,
+    },
+    background: {
+      default: colors.bgPage,
+      paper: colors.bgContainer,
+    },
+    divider: colors.border,
+    action: {
+      active: colors.primary,
+      hover: colors.primaryStrong,
+      selected: colors.primaryStrong,
+      disabled: colors.textDisabled,
+      disabledBackground: colors.bgDisabled,
+    },
+  };
+}


### PR DESCRIPTION
Align MUI's and UI Kit's Provider's color modes. MUI's was defaulting to `system` (media query)

- change MUI's theme to use `colorSchemes` instead of `palette` ([docs](https://mui.com/material-ui/customization/palette/#color-schemes))
- align MUI <-> UI Kit `colorModes`: needed to use `useColorScheme` hook, as `defaultMode` prop is uncontrolled and wouldn't update accordingly