### PR TITLE
fix(Section): align hidden & raisedHeader props

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32116,7 +32116,7 @@
         "vite": "^7.1.1"
       },
       "peerDependencies": {
-        "@hitachivantara/uikit-react-core": "^6.0.0-next.0",
+        "@hitachivantara/uikit-react-core": "^6.0.0",
         "react": "^18.2.0"
       }
     },

--- a/packages/app-shell-events/package.json
+++ b/packages/app-shell-events/package.json
@@ -21,7 +21,7 @@
     "prepublishOnly": "npm run build && npx clean-publish"
   },
   "peerDependencies": {
-    "@hitachivantara/uikit-react-core": "^6.0.0-next.0",
+    "@hitachivantara/uikit-react-core": "^6.0.0",
     "react": "^18.2.0"
   },
   "devDependencies": {

--- a/packages/core/src/Section/Section.tsx
+++ b/packages/core/src/Section/Section.tsx
@@ -78,7 +78,7 @@ export const HvSection = forwardRef<HTMLDivElement, HvSectionProps>(
       <div
         ref={ref}
         className={cx(classes.root, className, {
-          [classes.raisedHeader]: raisedHeader && isOpen,
+          [classes.raisedHeader]: hasHeader && raisedHeader && isOpen,
         })}
         {...others}
       >
@@ -123,7 +123,7 @@ export const HvSection = forwardRef<HTMLDivElement, HvSectionProps>(
         )}
         <div
           ref={contentRef}
-          hidden={!isOpen}
+          hidden={expandable && !isOpen}
           className={cx(classes.content, {
             [classes.hidden]: expandable && !isOpen,
             [classes.hasHeader]: hasHeader,


### PR DESCRIPTION
- align `hidden` & `classes.hidden` values'
- ensure `raisedHeader` is only applied when there is an header
- also bumps minimum app-shell-events version to `6.0.0` release (not a bug)