### PR TITLE
feat(config): bump lib to ES2023

### DIFF
--- a/.config/vite.config.ts
+++ b/.config/vite.config.ts
@@ -39,7 +39,7 @@ export default defineConfig({
     react(),
   ],
   build: {
-    target: "ES2022",
+    target: "baseline-widely-available",
     minify: false,
     emptyOutDir: true,
     lib: {

--- a/packages/config/tsconfig.json
+++ b/packages/config/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     /* Base Options */
-    "target": "ES2022",
+    "target": "ES2023",
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
@@ -22,6 +22,6 @@
 
     /* Others */
     "jsx": "react-jsx",
-    "lib": ["es2022", "dom", "dom.iterable"]
+    "lib": ["ES2023", "DOM", "DOM.Iterable"]
   }
 }

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -9,8 +9,6 @@
     "declarationMap": true,
 
     /* Others */
-    "lib": ["es2022", "dom", "dom.iterable"],
-    "jsx": "react-jsx",
     "types": ["@testing-library/jest-dom", "vite/client", "vitest/globals"]
   },
   "include": ["packages/**/src"]


### PR DESCRIPTION
- bump lib to `es2023` as it has been part of `baseline-widely-available` for a while now
- change vite's build config to `baseline-widely-available` (the default), aligning with our support matrix