### PR TITLE
docs: add new `HvTable` example showcasing custom cell rendering

### DIFF
--- a/apps/docs/src/app/examples/tables/CustomCellsTable.tsx
+++ b/apps/docs/src/app/examples/tables/CustomCellsTable.tsx
@@ -1,0 +1,172 @@
+import { useMemo, useState } from "react";
+import {
+  HvCellProps,
+  HvIconButton,
+  HvStatusIcon,
+  HvTable,
+  HvTableBody,
+  HvTableCell,
+  HvTableColumnConfig,
+  HvTableContainer,
+  HvTableHead,
+  HvTableHeader,
+  HvTableRow,
+  HvTableSection,
+  HvTag,
+  HvTypography,
+  useHvTable,
+} from "@hitachivantara/uikit-react-core";
+import { Delete } from "@hitachivantara/uikit-react-icons";
+
+import { getPriorityColor, makeData, type AssetEvent } from "./makeData";
+
+export default function Demo() {
+  const [data] = useState(() => makeData(8));
+  const columns = useMemo<HvTableColumnConfig<AssetEvent>[]>(
+    () => [
+      {
+        Header: "Id",
+        accessor: "id",
+        Cell: ({ value }) => (
+          <HvTypography link component="a" href="#">
+            {value}
+          </HvTypography>
+        ),
+      },
+      {
+        Header: "Title",
+        accessor: "name",
+        style: { minWidth: 120 },
+        Cell: TitleDescription,
+      },
+      { Header: "Time", accessor: "createdDate", style: { minWidth: 100 } },
+      {
+        Header: "Event Type",
+        accessor: "eventType",
+        style: { minWidth: 100 },
+        Cell: ({ value }) => <HvTag label={value} color="info" />,
+      },
+      {
+        Header: "Status",
+        accessor: "status",
+        style: { minWidth: 100 },
+        Cell: ({ value }) => (
+          <div className="flex items-center gap-xxs">
+            <HvStatusIcon
+              variant={value === "Open" ? "success" : "error"}
+              type="simple"
+            />
+            {value}
+          </div>
+        ),
+      },
+      {
+        Header: "Probability",
+        accessor: "riskScore",
+        align: "right",
+        Cell: ProgressBar,
+      },
+      { Header: "Severity", accessor: "severity" },
+      {
+        Header: "Priority",
+        accessor: "priority",
+        Cell: ({ value }) => (
+          <HvTag label={value} color={getPriorityColor(value)} />
+        ),
+      },
+      {
+        id: "delete",
+        variant: "actions",
+        Cell: () => (
+          <HvIconButton title="Delete event">
+            <Delete />
+          </HvIconButton>
+        ),
+      },
+    ],
+    [],
+  );
+
+  return <MyTable data={data} columns={columns} />;
+}
+
+/** A simple generic client-side table. */
+export const MyTable = <T extends object>(props: {
+  columns: HvTableColumnConfig<T>[];
+  data: T[] | undefined;
+}) => {
+  const { columns, data } = props;
+
+  const table = useHvTable<T>({ columns, data });
+
+  return (
+    <HvTableSection>
+      <HvTableContainer className="max-h-500px">
+        <HvTable {...table.getTableProps()}>
+          <HvTableHead {...table.getTableHeadProps?.()}>
+            {table.headerGroups.map((headerGroup) => (
+              <HvTableRow
+                {...headerGroup.getHeaderGroupProps()}
+                key={headerGroup.getHeaderGroupProps().key}
+              >
+                {headerGroup.headers.map((col) => (
+                  <HvTableHeader
+                    {...col.getHeaderProps()}
+                    key={col.getHeaderProps().key}
+                  >
+                    {col.render("Header")}
+                  </HvTableHeader>
+                ))}
+              </HvTableRow>
+            ))}
+          </HvTableHead>
+          <HvTableBody {...table.getTableBodyProps()}>
+            {table.rows.map((row) => {
+              table.prepareRow(row);
+              return (
+                <HvTableRow {...row.getRowProps()} key={row.getRowProps().key}>
+                  {row.cells.map((cell) => (
+                    <HvTableCell
+                      className="text-nowrap"
+                      {...cell.getCellProps()}
+                      key={cell.getCellProps().key}
+                    >
+                      {cell.render("Cell")}
+                    </HvTableCell>
+                  ))}
+                </HvTableRow>
+              );
+            })}
+          </HvTableBody>
+        </HvTable>
+      </HvTableContainer>
+    </HvTableSection>
+  );
+};
+
+const TitleDescription = ({ row }: HvCellProps<AssetEvent>) => (
+  <div className="p-xxs">
+    <HvTypography>{row.original.name}</HvTypography>
+    <HvTypography variant="caption1" className="text-textSubtle">
+      {row.original.description}
+    </HvTypography>
+  </div>
+);
+
+const ProgressBar = ({ row }: HvCellProps<AssetEvent>) => (
+  <div className="flex flex-col">
+    <HvTypography variant="caption2">
+      {row.original.riskScore * 10}%
+    </HvTypography>
+    <div className="flex h-4px">
+      <div
+        className="bg-text"
+        style={{ width: `${row.original.riskScore * 10}%` }}
+      />
+      <div
+        className="bg-border"
+        style={{ width: `${100 - row.original.riskScore * 10}%` }}
+      />
+    </div>
+  </div>
+);

--- a/apps/docs/src/app/examples/tables/makeData.ts
+++ b/apps/docs/src/app/examples/tables/makeData.ts
@@ -3,6 +3,7 @@ const getOption = <T>(opts: T[], i: number) => opts[i % opts.length];
 const makeEvent = (i: number) => ({
   id: `${i + 1}`,
   name: `Event ${i + 1}`,
+  description: `Description for event ${i + 1}`,
   createdDate: new Date("2020-03-20").toISOString().slice(0, 10),
   eventType: "Anomaly detection",
   status: getOption(["Closed", "Open"] as const, i),
@@ -14,3 +15,16 @@ const makeEvent = (i: number) => ({
 export type AssetEvent = ReturnType<typeof makeEvent>;
 
 export const makeData = (len = 10) => [...Array(len).keys()].map(makeEvent);
+
+export const getPriorityColor = (priority: string) => {
+  switch (priority.toLowerCase()) {
+    case "high":
+      return "negative";
+    case "medium":
+      return "warning";
+    case "low":
+      return "positive";
+    default:
+      return "neutral";
+  }
+};

--- a/apps/docs/src/app/examples/tables/page.mdx
+++ b/apps/docs/src/app/examples/tables/page.mdx
@@ -4,6 +4,7 @@ title: "Tables"
 
 import { CodeBlock } from "../../../components/code/CodeBlock";
 
+import customCellsTableCode from "./CustomCellsTable?raw";
 import defaultTableCode from "./DefaultTable?raw";
 import filteringTableCode from "./FilteringTable?raw";
 import groupingTableCode from "./GroupingTable?raw";
@@ -57,6 +58,12 @@ Row filtering and global filtering can be configured by leveraging the `useHvFil
 Example of header grouping and row expansion via grouping
 
 <CodeBlock code={{ main: groupingTableCode, "./makeData": makeData }} />
+
+### Custom cell content
+
+Example of custom cell content rendering
+
+<CodeBlock code={{ main: customCellsTableCode, "./makeData": makeData }} />
 
 ### Other examples
 


### PR DESCRIPTION
<img width="1365" height="519" alt="image" src="https://github.com/user-attachments/assets/78707d09-5dc7-4cca-bea9-60c71be3502f" />
