### PR TITLE
fix(TimeAgo): fix yesterday timestamps showing as today due to incorrect date comparison calculation. CAT-10453

### DIFF
--- a/packages/core/src/TimeAgo/TimeAgo.test.tsx
+++ b/packages/core/src/TimeAgo/TimeAgo.test.tsx
@@ -37,6 +37,17 @@ describe("TimeAgo with timestamp", () => {
     expect(screen.getByText(/^yesterday/)).toBeVisible();
   });
 
+  it("should show yesterday for timestamp less than a day ago from previous day", () => {
+    const yesterday = new Date();
+    yesterday.setDate(yesterday.getDate() - 1);
+    yesterday.setHours(23, 58, 0, 0); // Late night timestamp
+    const timestamp = yesterday.getTime();
+
+    render(<HvTimeAgo timestamp={timestamp} locale="en" />);
+
+    expect(screen.getByText(/^yesterday/i)).toBeVisible();
+  });
+
   it("should contain the relative time when the day is tomorrow", () => {
     const timestamp = new Date().setDate(new Date().getDate() + 1);
     render(<HvTimeAgo timestamp={timestamp} />);

--- a/packages/core/src/TimeAgo/formatUtils.test.ts
+++ b/packages/core/src/TimeAgo/formatUtils.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it } from "vitest";
+
+import { formatTimeAgo } from "./formatUtils";
+
+describe("formatTimeAgo", () => {
+  const referenceDate = new Date("2026-01-15T12:00:00.000Z");
+
+  describe("Past dates", () => {
+    it("should show 'now' for timestamps less than 20 seconds ago", () => {
+      const timestamp = new Date(referenceDate.getTime() - 10 * 1000).getTime();
+      const result = formatTimeAgo(timestamp, "en", false, referenceDate);
+      expect(result).toBe("now");
+    });
+
+    it("should show seconds ago for timestamps less than 2 minutes ago", () => {
+      const timestamp = new Date(referenceDate.getTime() - 90 * 1000).getTime();
+      const result = formatTimeAgo(timestamp, "en", false, referenceDate);
+      expect(result).toBe("90 seconds ago");
+    });
+
+    it("should show minutes ago for timestamps 2-60 minutes ago", () => {
+      const timestamp = new Date(
+        referenceDate.getTime() - 30 * 60 * 1000,
+      ).getTime();
+      const result = formatTimeAgo(timestamp, "en", false, referenceDate);
+      expect(result).toBe("30 minutes ago");
+    });
+
+    it("should show 'today' for timestamps earlier today", () => {
+      const timestamp = new Date(referenceDate);
+      timestamp.setHours(8, 0, 0, 0);
+      const result = formatTimeAgo(
+        timestamp.getTime(),
+        "en",
+        false,
+        referenceDate,
+      );
+      expect(result).toBe("today, 8:00 AM");
+    });
+
+    it("should show yesterday for timestamps from yesterday", () => {
+      const timestamp = new Date(referenceDate);
+      timestamp.setDate(timestamp.getDate() - 1);
+      timestamp.setHours(14, 30, 0, 0);
+      const result = formatTimeAgo(
+        timestamp.getTime(),
+        "en",
+        false,
+        referenceDate,
+      );
+      expect(result).toBe("yesterday, 2:30 PM");
+    });
+
+    it("should show weekday for timestamps within the past week", () => {
+      const timestamp = new Date(referenceDate);
+      timestamp.setDate(timestamp.getDate() - 2);
+      timestamp.setHours(10, 0, 0, 0);
+      const result = formatTimeAgo(
+        timestamp.getTime(),
+        "en",
+        false,
+        referenceDate,
+      );
+      expect(result).toBe("Tue 10:00 AM");
+    });
+
+    it("should show full date for timestamps older than a week", () => {
+      const timestamp = new Date(referenceDate);
+      timestamp.setDate(timestamp.getDate() - 10);
+      timestamp.setHours(10, 0, 0, 0);
+      const result = formatTimeAgo(
+        timestamp.getTime(),
+        "en",
+        false,
+        referenceDate,
+      );
+      expect(result).toBe("Jan 5, 2026, 10:00 AM");
+    });
+  });
+
+  describe("Future dates", () => {
+    it("should show full date for dates 2+ days ahead", () => {
+      const timestamp = new Date(referenceDate);
+      timestamp.setDate(timestamp.getDate() + 3);
+      timestamp.setHours(15, 0, 0, 0);
+      const result = formatTimeAgo(
+        timestamp.getTime(),
+        "en",
+        false,
+        referenceDate,
+      );
+      expect(result).toBe("Jan 18, 2026, 3:00 PM");
+    });
+
+    it("should show 'tomorrow' for dates tomorrow", () => {
+      const timestamp = new Date(referenceDate);
+      timestamp.setDate(timestamp.getDate() + 1);
+      timestamp.setHours(15, 0, 0, 0);
+      const result = formatTimeAgo(
+        timestamp.getTime(),
+        "en",
+        false,
+        referenceDate,
+      );
+      expect(result).toBe("tomorrow, 3:00 PM");
+    });
+
+    it("should show 'today' for future dates today more than 1 hour ahead", () => {
+      const timestamp = new Date(referenceDate);
+      timestamp.setHours(referenceDate.getHours() + 2);
+      const result = formatTimeAgo(
+        timestamp.getTime(),
+        "en",
+        false,
+        referenceDate,
+      );
+      expect(result).toBe("today, 2:00 PM");
+    });
+
+    it("should show minutes for future dates 2-60 minutes ahead", () => {
+      const timestamp = new Date(referenceDate.getTime() + 30 * 60 * 1000);
+      const result = formatTimeAgo(
+        timestamp.getTime(),
+        "en",
+        false,
+        referenceDate,
+      );
+      expect(result).toBe("in 30 minutes");
+    });
+
+    it("should show seconds for future dates less than 2 minutes ahead", () => {
+      const timestamp = new Date(referenceDate.getTime() + 90 * 1000);
+      const result = formatTimeAgo(
+        timestamp.getTime(),
+        "en",
+        false,
+        referenceDate,
+      );
+      expect(result).toBe("in 90 seconds");
+    });
+  });
+});

--- a/packages/core/src/TimeAgo/formatUtils.ts
+++ b/packages/core/src/TimeAgo/formatUtils.ts
@@ -1,26 +1,3 @@
-const isDateInPeriod = (
-  timeAgoMs: number,
-  period: "tomorrow" | "afterTomorrow",
-  referenceDate = new Date(),
-) => {
-  const date = new Date(timeAgoMs);
-
-  const startOfToday = new Date(referenceDate);
-  startOfToday.setHours(0, 0, 0, 0);
-  const startOfTomorrow = new Date(startOfToday);
-  startOfTomorrow.setDate(startOfToday.getDate() + 1);
-  const startOfDayAfterTomorrow = new Date(startOfTomorrow);
-  startOfDayAfterTomorrow.setDate(startOfTomorrow.getDate() + 1);
-
-  if (period === "tomorrow") {
-    return date >= startOfTomorrow && date < startOfDayAfterTomorrow;
-  }
-  if (period === "afterTomorrow") {
-    return date >= startOfDayAfterTomorrow;
-  }
-  return false;
-};
-
 /**
  * Relative time thresholds defined by
  * {@link https://xd.adobe.com/view/1b7df235-5cf8-4b51-a2f0-0be1bb591c55-4e2e/ Design System}
@@ -35,13 +12,13 @@ export const formatTimeAgo = (
   const dayFormatter = new Intl.DateTimeFormat(locale, {
     hour: "numeric",
     minute: "numeric",
-    second: showSeconds ? "numeric" : undefined,
+    ...(showSeconds && { second: "numeric" }),
   });
   const weekFormatter = new Intl.DateTimeFormat(locale, {
     weekday: "short",
     hour: "numeric",
     minute: "numeric",
-    second: showSeconds ? "numeric" : undefined,
+    ...(showSeconds && { second: "numeric" }),
   });
   const fullFormatter = new Intl.DateTimeFormat(locale, {
     year: "numeric",
@@ -49,39 +26,64 @@ export const formatTimeAgo = (
     day: "numeric",
     hour: "numeric",
     minute: "numeric",
-    second: showSeconds ? "numeric" : undefined,
+    ...(showSeconds && { second: "numeric" }),
   });
+
   const date = new Date(timeAgoMs);
+  const secsAgo = Math.floor((referenceDate.getTime() - timeAgoMs) / 1000);
+  const minsAgo = Math.floor(secsAgo / 60);
+
+  const getStartOfDay = (offset: number) => {
+    const d = new Date(referenceDate);
+    d.setHours(0, 0, 0, 0);
+    d.setDate(d.getDate() + offset);
+    return d;
+  };
+
+  const startOfYesterday = getStartOfDay(-1);
+  const startOfToday = getStartOfDay(0);
+  const startOfTomorrow = getStartOfDay(1);
+  const startOfDayAfterTomorrow = getStartOfDay(2);
+
+  // Calculate seconds in week for "this week" check
   const secsInDay =
     date.getHours() * 3600 + date.getMinutes() * 60 + date.getSeconds();
   const secsInWeek = date.getDay() * 86400 + secsInDay;
 
-  const secsAgo = Math.floor((referenceDate.getTime() - timeAgoMs) / 1000);
-  const minsAgo = Math.floor(secsAgo / 60);
-
   switch (true) {
-    case isDateInPeriod(timeAgoMs, "afterTomorrow", referenceDate):
+    case date >= startOfDayAfterTomorrow:
       return fullFormatter.format(date);
-    case isDateInPeriod(timeAgoMs, "tomorrow", referenceDate):
+
+    case date >= startOfTomorrow:
       return `${relFormatter.format(1, "days")}, ${dayFormatter.format(date)}`;
-    case minsAgo < -60: // Future date more than 1 hour ahead
+
+    case minsAgo < -60:
       return `${relFormatter.format(0, "days")}, ${dayFormatter.format(date)}`;
-    case minsAgo < -2: // Future date more than 2 minutes ahead
+
+    case minsAgo < -2:
       return relFormatter.format(-minsAgo, "minutes");
-    case secsAgo < 0: // Future date within 1 minute
-      return `${relFormatter.format(Math.abs(secsAgo), "seconds")}`;
+
+    case secsAgo < 0:
+      return relFormatter.format(Math.abs(secsAgo), "seconds");
+
     case secsAgo < 20:
       return relFormatter.format(0, "seconds");
+
     case minsAgo < 2:
       return relFormatter.format(-secsAgo, "seconds");
+
     case minsAgo < 60:
       return relFormatter.format(-minsAgo, "minutes");
-    case secsAgo < secsInDay: // today
+
+    case date >= startOfToday:
       return `${relFormatter.format(0, "days")}, ${dayFormatter.format(date)}`;
-    case secsAgo < secsInDay + 86400: // yesterday
+
+    case date >= startOfYesterday:
       return `${relFormatter.format(-1, "days")}, ${dayFormatter.format(date)}`;
-    case secsAgo < secsInWeek: // this week
+
+    case secsAgo < secsInWeek:
       return weekFormatter.format(date);
+
     default:
       return fullFormatter.format(date);
   }


### PR DESCRIPTION
Fix flawed comparison logic that compared seconds elapsed in timestamp's day
with time difference, causing incorrect "today"/"yesterday" classification.
Replaced with proper calendar day boundary comparisons.

- Replace seconds-based comparison with calendar day boundary checks
- Add formatUtils.test.ts with comprehensive test coverage 
- Improve code readability and structure