### PR TITLE
feat(OverflowTooltip): expose useResizeDetector's props

### DIFF
--- a/packages/core/src/OverflowTooltip/OverflowTooltip.tsx
+++ b/packages/core/src/OverflowTooltip/OverflowTooltip.tsx
@@ -1,5 +1,8 @@
 import { useMemo } from "react";
-import { useResizeDetector } from "react-resize-detector";
+import {
+  useResizeDetector,
+  useResizeDetectorProps,
+} from "react-resize-detector";
 import {
   useDefaultProps,
   type ExtractNames,
@@ -37,6 +40,8 @@ export interface HvOverflowTooltipProps extends HvBaseProps {
   tooltipsProps?: Partial<HvTooltipProps>;
   /** A Jss Object used to override or extend the styles applied to the component. */
   classes?: HvOverflowTooltipClasses;
+  /** Override the default options passed to react-resize-detector's useResizeDetector hook. */
+  resizeDetectorProps?: Partial<useResizeDetectorProps<HTMLDivElement>>;
 }
 
 const isParagraph = (children = "") => /\s/.test(children);
@@ -64,10 +69,12 @@ export const HvOverflowTooltip = (props: HvOverflowTooltipProps) => {
     ref,
   } = useResizeDetector({
     refreshMode: "debounce",
+    handleHeight: false,
+    ...props.resizeDetectorProps,
     refreshOptions: {
       trailing: true,
+      ...props.resizeDetectorProps?.refreshOptions,
     },
-    handleHeight: false,
   });
 
   const isParag = useMemo(


### PR DESCRIPTION
I'm currently working on bringing a component from `pdc-app-server` up to date and the `HvOverflow` component was not working as expected, I was able to make it work as intended by using the component locally but with some different values on this hook. I don't see a reason for the hook props not to be exposed but tell me if I'm missing something