### PR TITLE
feat(AppShell): add support for unocss phosphor icons

### DIFF
--- a/apps/default-app/app-shell.config.ts
+++ b/apps/default-app/app-shell.config.ts
@@ -15,6 +15,7 @@ export default {
     "@hv/user-notifications-client/": VITE_USER_NOTIFICATIONS_URL,
   },
   name: "App Shell",
+  navigationMode: "TOP_AND_LEFT",
   logo: {
     name: "PENTAHO",
     description: "App Shell",
@@ -23,7 +24,6 @@ export default {
     theme: "pentaho",
     colorMode: "light",
   },
-  navigationMode: "TOP_AND_LEFT",
 
   menu: [
     {
@@ -73,10 +73,7 @@ export default {
         {
           label: "notifications",
           target: "/notifications",
-          icon: {
-            iconType: "uikit",
-            name: "Alert",
-          },
+          icon: { iconType: "unocss", name: "i-ph-bell" },
         },
         {
           label: "Multi-level Breadcrumb",
@@ -280,7 +277,7 @@ export default {
               description: "Application 2",
               url: "#",
               target: "SELF",
-              icon: { iconType: "uikit", name: "Warehouse" },
+              icon: { iconType: "unocss", name: "i-ph-warehouse" },
             },
             {
               label: "App 3",

--- a/apps/default-app/src/main.tsx
+++ b/apps/default-app/src/main.tsx
@@ -1,3 +1,5 @@
+import "virtual:uno.css";
+
 import { Suspense } from "react";
 import { createRoot } from "react-dom/client";
 

--- a/apps/default-app/uno.config.ts
+++ b/apps/default-app/uno.config.ts
@@ -1,3 +1,12 @@
-import unoConfig from "../../uno.config";
+import { defineConfig, presetIcons } from "unocss";
+import { presetHv } from "@hitachivantara/uikit-uno-preset";
 
-export default unoConfig;
+export default defineConfig({
+  presets: [presetHv(), presetIcons()],
+  content: {
+    pipeline: {
+      include: [/\.(tsx?|mdx?|html)($|\?)/],
+    },
+    filesystem: ["./app-shell.config.ts"],
+  },
+});

--- a/apps/default-app/vite.config.ts
+++ b/apps/default-app/vite.config.ts
@@ -7,7 +7,7 @@ import { HvAppShellVitePlugin } from "@hitachivantara/app-shell-vite-plugin";
 export default defineConfig(({ mode }) => ({
   plugins: [
     react(),
-    unoCSS({ mode: "per-module" }),
+    unoCSS(),
     cssInjectedByJsPlugin({
       relativeCSSInjection: true,
     }),

--- a/packages/app-shell-shared/src/types/Config.ts
+++ b/packages/app-shell-shared/src/types/Config.ts
@@ -40,7 +40,7 @@ export interface HvAppShellLogo {
 }
 
 export interface HvAppShellIcon {
-  iconType: "uikit";
+  iconType: "uikit" | "unocss";
   name: string;
 }
 

--- a/packages/app-shell-ui/src/components/ConfigIcon.tsx
+++ b/packages/app-shell-ui/src/components/ConfigIcon.tsx
@@ -1,0 +1,26 @@
+import type { HvAppShellIcon } from "@hitachivantara/app-shell-shared";
+import { HvIconContainer } from "@hitachivantara/uikit-react-core";
+
+import IconUiKit from "./IconUiKit";
+
+export interface ConfigIconProps {
+  icon?: HvAppShellIcon;
+}
+
+/** Renders the icons according to the {@link HvAppShellIcon} Config specification */
+export function ConfigIcon({ icon }: ConfigIconProps) {
+  if (icon?.iconType === "unocss") {
+    return (
+      // TODO(minor): remove once "uikit" & ""unocss" icon types aren't used interchangeably
+      <HvIconContainer size="sm" style={{ margin: 4 }}>
+        <div className={icon.name} />
+      </HvIconContainer>
+    );
+  }
+
+  if (icon?.iconType === "uikit") {
+    return <IconUiKit name={icon.name} />;
+  }
+
+  return null;
+}

--- a/packages/app-shell-ui/src/components/layout/AppShellLayout.stories.tsx
+++ b/packages/app-shell-ui/src/components/layout/AppShellLayout.stories.tsx
@@ -75,8 +75,7 @@ export const Main: StoryObj = {
                     {
                       label: "Submenu 2.2",
                       target: "/about/submenu2/submenu2",
-                      // TODO: add uno icon
-                      // icon: { iconType: "uno", name: "i-ph-upload" },
+                      icon: { iconType: "unocss", name: "i-ph-upload" },
                     },
                   ],
                 },
@@ -119,8 +118,7 @@ export const Main: StoryObj = {
                       description: "Application 3",
                       url: "#",
                       target: "SELF",
-                      // TODO: add uno icon
-                      // icon: { iconType: "uno", name: "i-ph-upload" },
+                      icon: { iconType: "unocss", name: "i-ph-upload" },
                     },
                     {
                       label: "App 4",

--- a/packages/app-shell-ui/src/components/layout/HeaderActions/AppSwitcherToggle/AppSwitcherToggle.tsx
+++ b/packages/app-shell-ui/src/components/layout/HeaderActions/AppSwitcherToggle/AppSwitcherToggle.tsx
@@ -15,9 +15,10 @@ import {
   theme,
   type HvAppSwitcherActionApplication,
 } from "@hitachivantara/uikit-react-core";
+import { AppSwitcher } from "@hitachivantara/uikit-react-icons";
 
 import createAppContainerElement from "../../../../utils/documentUtil";
-import IconUiKit from "../../../IconUiKit";
+import { ConfigIcon } from "../../../ConfigIcon";
 import { BrandLogo } from "../../BrandLogo/BrandLogo";
 import StyledAppShellPanelWrapper from "./styles";
 
@@ -42,7 +43,7 @@ const AppSwitcherToggle: React.FC<HvAppShellAppSwitcherConfig> = ({
         : undefined,
       url: app.url?.includes(":") ? app.url : tConfig(app.url).toString(),
       target: app.target === "NEW" ? "_blank" : "_top",
-      iconElement: app.icon && <IconUiKit name={app.icon.name} />,
+      iconElement: app.icon && <ConfigIcon icon={app.icon} />,
     }));
   }, [apps, tConfig]);
 
@@ -59,7 +60,7 @@ const AppSwitcherToggle: React.FC<HvAppShellAppSwitcherConfig> = ({
           onClick={() => setIsPanelOpen(!isPanelOpen)}
           {...(isPanelOpen && { "aria-controls": appSwitcherPanelId })}
         >
-          <IconUiKit name="AppSwitcher" />
+          <AppSwitcher />
           {showLogo && (
             <BrandLogo logo={logo} style={{ paddingRight: theme.space.xs }} />
           )}

--- a/packages/app-shell-ui/src/utils/navigationUtil.tsx
+++ b/packages/app-shell-ui/src/utils/navigationUtil.tsx
@@ -1,6 +1,6 @@
 import type { MenuItem } from "@hitachivantara/app-shell-shared";
 
-import IconUiKit from "../components/IconUiKit";
+import { ConfigIcon } from "../components/ConfigIcon";
 import type { NavigationMenuItem } from "../types";
 
 /**
@@ -27,9 +27,7 @@ const createNavigationMenuItems = (
       const updatedDepth = maxDepth !== undefined ? maxDepth - 1 : undefined;
       const navItem: NavigationMenuItem = {
         ...currentValue,
-        icon: currentValue.icon ? (
-          <IconUiKit name={currentValue.icon?.name || ""} />
-        ) : null,
+        icon: currentValue.icon && <ConfigIcon icon={currentValue.icon} />,
         data: currentValue.data
           ? createNavigationMenuItems(t, currentValue.data, updatedDepth)
           : undefined,


### PR DESCRIPTION
Add support for Phosphor icons in App Shell Vertical Navigation, via UnoCSS's `presetIcons` that we're already using.

This requires the usual setup: UnoCSS + Icons preset + `@iconify-json/ph` loaded