### PR TITLE
test(storybook): workaround test brittleness

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -64,7 +64,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: [1, 2]
+        shard: [1, 2, 3]
 
     steps:
       - name: Checkout
@@ -77,7 +77,7 @@ jobs:
         run: npx playwright install --with-deps --only-shell chromium
 
       - name: Run Tests
-        run: npm run test:storybook -- --shard=${{ matrix.shard }}/${{ strategy.job-total }}
+        run: npm run test:storybook -- --no-file-parallelism --retry 1 --shard=${{ matrix.shard }}/${{ strategy.job-total }}
 
   build:
     name: Build

--- a/packages/core/src/QueryBuilder/QueryBuilder.test.tsx
+++ b/packages/core/src/QueryBuilder/QueryBuilder.test.tsx
@@ -1024,23 +1024,20 @@ describe("QueryBuilder", () => {
 
   it("selects a date accordingly", async () => {
     const user = userEvent.setup();
-    render(<HvQueryBuilder attributes={attributes} />);
-
-    await user.click(screen.getByRole("button", { name: /Add condition/i }));
-    await user.click(screen.getByRole("combobox", { name: /Attribute/i }));
-    await user.click(screen.getByRole("option", { name: /Release/i }));
-
-    await user.click(screen.getByRole("combobox", { name: /Operator/i }));
-    await user.click(
-      screen.getAllByRole("option", { name: /Greater than/i })[0],
+    render(
+      <HvQueryBuilder
+        attributes={attributes}
+        defaultValue={{
+          combinator: "and",
+          rules: [{ attribute: "release", operator: "greaterThan" }],
+        }}
+      />,
     );
 
     const dateInput = screen.getByRole("combobox", { name: /Date/i });
-    expect(dateInput).toBeInTheDocument();
     await user.click(dateInput);
 
-    const dayButton = screen.getByRole("button", { name: "15" });
-    await user.click(dayButton);
+    await user.click(screen.getByRole("button", { name: "15" }));
     expect(dateInput).toHaveTextContent(/15/);
   });
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -23,7 +23,6 @@ export default mergeConfig(
           ],
           test: {
             name: { label: "storybook", color: "magenta" },
-            fileParallelism: !process.env.CI,
             browser: {
               enabled: true,
               headless: true,


### PR DESCRIPTION
- workaround sporadic vitest crashes with `--no-file-parallelism --retry 1` and increasing sharding
  - see https://github.com/storybookjs/storybook/issues/33347
- improve flaky QueryBuilder test (was sometimes hitting the `10000ms` timeout)