### PR TITLE
feat(Theme): update shadows on the Pentaho theme to the latest specs

### DIFF
--- a/packages/core/src/themes/pentaho.ts
+++ b/packages/core/src/themes/pentaho.ts
@@ -130,7 +130,7 @@ const popperStyles = {
   backgroundColor: theme.colors.bgContainer,
   border: `1px solid ${theme.colors.borderSubtle}`,
   borderRadius: theme.radii.large,
-  boxShadow: `0px 0px 6px 0px rgba(65, 65, 65, 0.08)`,
+  boxShadow: theme.colors.shadow,
 };
 
 export const pentaho = mergeTheme(pentahoBase, {
@@ -672,6 +672,7 @@ export const pentaho = mergeTheme(pentahoBase, {
       classes: {
         paper: {
           borderRadius: theme.radii.large,
+          boxShadow: `0 32px 32px 0 ${theme.alpha(slate[900], 0.1)}, 0 20px 20px 0 ${theme.alpha(slate[900], 0.08)}, 0 12px 12px 0 ${theme.alpha(slate[900], 0.06)}, 0 5px 5px 0 ${theme.alpha(slate[900], 0.04)}, 0 1px 1px 0 ${theme.alpha(slate[900], 0.02)}`,
         },
         statusBar: {
           border: "none",
@@ -851,6 +852,7 @@ export const pentaho = mergeTheme(pentahoBase, {
       classes: {
         root: {
           outlineColor: theme.colors.borderSubtle,
+          boxShadow: theme.colors.shadow,
           "--rb": theme.radii.large,
           // default non-semantic card
           "&[data-color=sema0]": {
@@ -1058,6 +1060,7 @@ export const pentaho = mergeTheme(pentahoBase, {
       classes: {
         tooltip: {
           padding: theme.spacing("xs", "sm"),
+          boxShadow: `0 16px 16px 0 ${theme.alpha(slate[900], 0.1)}, 0 10px 10px 0 ${theme.alpha(slate[900], 0.08)}, 0 6px 6px 0 ${theme.alpha(slate[900], 0.06)}, 0 3px 3px 0 ${theme.alpha(slate[900], 0.04)}, 0 1px 1px 0 ${theme.alpha(slate[900], 0.02)}`,
         },
       },
     } satisfies CSSClasses<HvTooltipProps>,
@@ -1230,6 +1233,7 @@ export const pentaho = mergeTheme(pentahoBase, {
         root: {
           width: 525,
           minHeight: "unset",
+          boxShadow: theme.colors.shadow,
         },
         messageText: {
           paddingLeft: 0,

--- a/packages/core/src/themes/pentaho.ts
+++ b/packages/core/src/themes/pentaho.ts
@@ -125,12 +125,18 @@ const inputColors = {
   bg: ld("#FFFFFF", "#020617"),
 };
 
+const shadows = {
+  container: theme.colors.shadow,
+  elevated: `0 16px 16px 0 ${theme.alpha(slate[900], 0.1)}, 0 10px 10px 0 ${theme.alpha(slate[900], 0.08)}, 0 6px 6px 0 ${theme.alpha(slate[900], 0.06)}, 0 3px 3px 0 ${theme.alpha(slate[900], 0.04)}, 0 1px 1px 0 ${theme.alpha(slate[900], 0.02)}`,
+  modal: `0 32px 32px 0 ${theme.alpha(slate[900], 0.1)}, 0 20px 20px 0 ${theme.alpha(slate[900], 0.08)}, 0 12px 12px 0 ${theme.alpha(slate[900], 0.06)}, 0 5px 5px 0 ${theme.alpha(slate[900], 0.04)}, 0 1px 1px 0 ${theme.alpha(slate[900], 0.02)}`,
+};
+
 const popperStyles = {
   margin: theme.spacing("xxs", 0),
   backgroundColor: theme.colors.bgContainer,
   border: `1px solid ${theme.colors.borderSubtle}`,
   borderRadius: theme.radii.large,
-  boxShadow: theme.colors.shadow,
+  boxShadow: shadows.container,
 };
 
 export const pentaho = mergeTheme(pentahoBase, {
@@ -672,7 +678,7 @@ export const pentaho = mergeTheme(pentahoBase, {
       classes: {
         paper: {
           borderRadius: theme.radii.large,
-          boxShadow: `0 32px 32px 0 ${theme.alpha(slate[900], 0.1)}, 0 20px 20px 0 ${theme.alpha(slate[900], 0.08)}, 0 12px 12px 0 ${theme.alpha(slate[900], 0.06)}, 0 5px 5px 0 ${theme.alpha(slate[900], 0.04)}, 0 1px 1px 0 ${theme.alpha(slate[900], 0.02)}`,
+          boxShadow: shadows.modal,
         },
         statusBar: {
           border: "none",
@@ -1060,7 +1066,7 @@ export const pentaho = mergeTheme(pentahoBase, {
       classes: {
         tooltip: {
           padding: theme.spacing("xs", "sm"),
-          boxShadow: `0 16px 16px 0 ${theme.alpha(slate[900], 0.1)}, 0 10px 10px 0 ${theme.alpha(slate[900], 0.08)}, 0 6px 6px 0 ${theme.alpha(slate[900], 0.06)}, 0 3px 3px 0 ${theme.alpha(slate[900], 0.04)}, 0 1px 1px 0 ${theme.alpha(slate[900], 0.02)}`,
+          boxShadow: shadows.elevated,
         },
       },
     } satisfies CSSClasses<HvTooltipProps>,

--- a/packages/styles/src/themes/pentaho.ts
+++ b/packages/styles/src/themes/pentaho.ts
@@ -30,8 +30,8 @@ const pentaho = makeTheme((theme) => ({
     warning_20: amber[100],
     positive_20: green[100],
     neutral_20: sky[100],
-    shadow: `0px 2px 4px -1px ${theme.alpha(slate[700], 0.08)}`,
-    shad1: theme.alpha(slate[700], 0.08),
+    shadow: `0 4px 4px 0 ${theme.alpha(slate[900], 0.02)}, 0 3px 3px 0 ${theme.alpha(slate[900], 0.04)}, 0 1px 1px 0 ${theme.alpha(slate[900], 0.06)}, 0 1px 1px 0 ${theme.alpha(slate[900], 0.08)}, 0 0 0 0 ${theme.alpha(slate[900], 0.1)}`,
+    shad1: theme.alpha(slate[900], 0.08),
 
     primary: [blue[600], blue[500]],
     primaryStrong: [blue[700], blue[600]],


### PR DESCRIPTION
- Update default shadow definition on the Pentaho theme to the latest spec
- Add custom overrides to the `HvDialog` and `HvTooltip` components
- Add shadows to components that didn't have shadow before: `HvCard` and `HvSnackbar`