### PR TITLE
ci: bump actions with deprecated node versions

### DIFF
--- a/.github/actions/deploy-artifacts/action.yml
+++ b/.github/actions/deploy-artifacts/action.yml
@@ -14,7 +14,7 @@ runs:
         fi
 
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Start Deployment
       uses: bobheadxi/deployments@v1
@@ -26,7 +26,7 @@ runs:
         ref: ${{ env.DEPLOYMENT_REF }}
 
     - name: Checkout Artifacts Repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         repository: ${{ github.repository_owner }}/${{ github.repository_owner }}.github.io
         ref: master
@@ -39,7 +39,7 @@ runs:
       shell: bash
 
     - name: Fetch Artifact
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: ${{ env.ARTIFACT }}
         path: ${{ github.workspace }}/gh-docs/${{env.PUBLISH_FOLDER}}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Dependencies
         uses: ./.github/actions/install-dependencies

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -35,7 +35,7 @@ jobs:
 
       - name: Archive Nextra Docs
         if: ${{ env.PUBLISH_DOCS == 'true' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: nextra-docs
           path: ${{ github.workspace }}/apps/docs/dist
@@ -47,7 +47,7 @@ jobs:
 
       - name: Archive App
         if: ${{ env.PUBLISH_APP == 'true' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: uikit-app
           path: ${{ github.workspace }}/apps/app/dist
@@ -64,7 +64,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Deploy Docs
         if: ${{ env.PUBLISH_DOCS == 'true' }}

--- a/.github/workflows/pr-close.yml
+++ b/.github/workflows/pr-close.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: ${{ env.PUBLISH_REPO }}
           ref: ${{ env.PUBLISH_BRANCH }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           # Pulls all commits (needed for semantic release to correctly version)
           # See https://github.com/semantic-release/semantic-release/issues/1526
@@ -121,7 +121,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Send Slack message
         uses: slackapi/slack-github-action@v1.27.0

--- a/.github/workflows/tests-visual.yml
+++ b/.github/workflows/tests-visual.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           # Pulls all commits (needed for Chromatic)
           fetch-depth: 0

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Dependencies
         uses: ./.github/actions/install-dependencies
@@ -31,7 +31,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Dependencies
         uses: ./.github/actions/install-dependencies
@@ -48,7 +48,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Dependencies
         uses: ./.github/actions/install-dependencies
@@ -68,7 +68,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Dependencies
         uses: ./.github/actions/install-dependencies


### PR DESCRIPTION
https://github.com/pentaho/hv-uikit-react/actions/runs/24719607838/job/72305294176#step:9:2

> Node.js 20 actions are deprecated. [...] Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026.

<img width="434" height="388" alt="image" src="https://github.com/user-attachments/assets/35e4e372-e313-4f17-92ae-cd7d8414fe5d" />
