### PR TITLE
ci(release): fix publish output & update actions

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -33,24 +33,16 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: technote-space/workflow-conclusion-action@v1
-
-      - name: Notify Fail
-        uses: hbfernandes/slack-action@1.0
-        env:
-          SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}
-          CONCLUSION: ${{ env.WORKFLOW_CONCLUSION }}
-          COLOR: "#C62828"
+      - name: Notify Failure
+        uses: slackapi/slack-github-action@v3.0.1
         with:
-          args: |
-            {
-              "channel": "ui-kit-internal",
-              "attachments": [
-                {
-                  "mrkdwn_in": ["text"],
-                  "color": "${{env.COLOR}}",
-                  "title": "${{ github.workflow }} finished: ${{ env.CONCLUSION }}",
-                  "title_link": "${{ env.RUN_URL }}"
-                }
-              ]
-            }
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_TOKEN }}
+          payload: |
+            channel: "ui-kit-internal"
+            attachments:
+              - mrkdwn_in:
+                  - text
+                color: "#C62828"
+                title: "${{ github.workflow }} finished: failure"
+                title_link: "${{ env.RUN_URL }}"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -27,3 +27,38 @@ jobs:
     secrets: inherit
     with:
       publish-folder: pr-${{ github.event.number }}
+
+  test-stuff:
+    runs-on: ubuntu-latest
+
+    env:
+      RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+    steps:
+      - name: Message
+        id: example
+        run: |
+          echo "SLACK_MESSAGE={\"text\": \"Tests completed for PR #${{ github.event.number }}\"}" >> "$GITHUB_OUTPUT"
+
+      - name: Send Release Message
+        uses: slackapi/slack-github-action@v3.0.1
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_TOKEN }}
+          payload: |
+            channel: "ui-kit-internal"
+            blocks: ${{ steps.example.outputs.SLACK_MESSAGE }}
+
+      - name: Notify Failure
+        uses: slackapi/slack-github-action@v3.0.1
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_TOKEN }}
+          payload: |
+            channel: "ui-kit-internal"
+            attachments:
+              - mrkdwn_in:
+                  - text
+                color: "#C62828"
+                title: "${{ github.workflow }} finished: failure"
+                title_link: "${{ env.RUN_URL }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,36 +58,28 @@ jobs:
       - name: Check for package changes
         run: npx lerna changed
 
+      - name: Set CURRENT_VERSION
+        run: |
+          CORE_VERSION=v$(npm pkg get version --ws | sed -n 's/.*uikit-react-core": "\(.*\)".*/\1/p')
+          echo "CURRENT_VERSION=$CORE_VERSION" >> "$GITHUB_ENV"
+
       - name: Publish to NPM
         id: publish-npm
-        run: |
-          VERSION=v$(npm pkg get version -ws | sed -n 's/.*uikit-react-core": "\(.*\)".*/\1/p')
-          echo "CURRENT_VERSION=$VERSION" >> "$GITHUB_ENV"
-          npm run publish 2>&1 | tee publish_logs.txt
-
-      - name: Check if packages were updated
-        run: |
-          if grep -q "lerna success published" publish_logs.txt; then
-            echo "New packages were published successfully"
-          elif grep -q "lerna Command failed" publish_logs.txt; then
-            echo "lerna Command failed"
-            exit 1
-          else
-            echo "No packages were updated - skipping release"
-            exit 1
-          fi
+        run: npm run publish
+        env:
+          HUSKY: 0
 
       - name: Set NEW_VERSION
         id: version
         # Outputs the NEW_VERSION if there is one, or exits otherwise
         # We only tag+publish+notify if there a new core package version
         run: |
-          VERSION=v$(npm pkg get version -ws | sed -n 's/.*uikit-react-core": "\(.*\)".*/\1/p')
-          if [ "$CURRENT_VERSION" = "$VERSION" ]; then
+          CORE_VERSION=v$(npm pkg get version --ws | sed -n 's/.*uikit-react-core": "\(.*\)".*/\1/p')
+          if [ "$CURRENT_VERSION" = "$CORE_VERSION" ]; then
             echo "No new uikit-react-core version to release. Exiting"
             exit 1
           fi
-          echo "NEW_VERSION=$VERSION" >> "$GITHUB_ENV"
+          echo "NEW_VERSION=$CORE_VERSION" >> "$GITHUB_ENV"
 
       - name: Tag Release
         run: |
@@ -124,10 +116,10 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Send Slack message
-        uses: slackapi/slack-github-action@v1.27.0
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_TOKEN }}
+        uses: slackapi/slack-github-action@v3.0.1
         with:
-          channel-id: "ui-kit"
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_TOKEN }}
           payload: |
-            { "blocks": ${{ needs.publish.outputs.SLACK_MESSAGE }} }
+            channel: "ui-kit"
+            blocks: ${{ needs.publish.outputs.SLACK_MESSAGE }}


### PR DESCRIPTION
- use `--ws` flag (`-ws` is deprecated)
- keep `lerna publish` error codes if it fails
  - `lerna changed` already covers "no packages were updated"
- bump actions with older node versions