### PR TITLE
fix(BaseDropdown): memo onContainerCreation to avoid re-calls

### DIFF
--- a/packages/core/src/BaseDropdown/BaseDropdown.tsx
+++ b/packages/core/src/BaseDropdown/BaseDropdown.tsx
@@ -9,6 +9,7 @@ import {
 } from "react";
 import type { ClickAwayListenerProps } from "@mui/material/ClickAwayListener";
 import type { PopperProps } from "@mui/material/Popper";
+import useEventCallback from "@mui/utils/useEventCallback";
 import useForkRef from "@mui/utils/useForkRef";
 import type { Placement, State } from "@popperjs/core";
 import {
@@ -303,6 +304,11 @@ export const HvBaseDropdown = forwardRef<
   const HeaderComponent = HeaderComponentProp || "div";
   const RootComponent = HeaderComponentProp ? Fragment : "div";
 
+  const onFirstUpdate = useEventCallback((state: Partial<State>) => {
+    setComputedPlacement(state.placement);
+    onContainerCreation?.(state.elements?.popper ?? null, state);
+  });
+
   return (
     <RootComponent {...(!hasCustomHeader && { className: classes.root })}>
       <HeaderComponent
@@ -338,10 +344,7 @@ export const HvBaseDropdown = forwardRef<
         disablePortal={disablePortal}
         anchorEl={referenceElement}
         onToggle={handleToggle}
-        onFirstUpdate={(state) => {
-          setComputedPlacement(state.placement);
-          onContainerCreation?.(state.elements?.popper ?? null, state);
-        }}
+        onFirstUpdate={onFirstUpdate}
         popperOptions={popperProps}
       >
         {children}

--- a/packages/core/src/BaseDropdown/BaseDropdownPanel.test.tsx
+++ b/packages/core/src/BaseDropdown/BaseDropdownPanel.test.tsx
@@ -1,4 +1,4 @@
-import { useRef } from "react";
+import { useRef, useState } from "react";
 import { render, screen } from "@testing-library/react";
 import { userEvent } from "@testing-library/user-event";
 
@@ -7,7 +7,7 @@ import {
   type HvDropdownPanelProps,
 } from "./BaseDropdownPanel";
 
-const PanelFixture = ({
+const PanelStatic = ({
   open = true,
   ...props
 }: Partial<HvDropdownPanelProps>) => {
@@ -28,35 +28,64 @@ const PanelFixture = ({
   );
 };
 
+const PanelDynamic = ({ ...props }: Partial<HvDropdownPanelProps>) => {
+  const [anchorEl, setAnchorEl] = useState<HTMLButtonElement>();
+  const open = Boolean(anchorEl);
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={(evt) => setAnchorEl(anchorEl ? undefined : evt.currentTarget)}
+      >
+        Anchor
+      </button>
+      <HvDropdownPanel
+        open={open}
+        anchorEl={anchorEl}
+        onClickAway={vi.fn()}
+        disablePortal
+        {...props}
+      />
+    </>
+  );
+};
+
 describe("HvDropdownPanel", () => {
   it("renders children when open", () => {
-    render(<PanelFixture>Content</PanelFixture>);
+    render(<PanelStatic>Content</PanelStatic>);
 
     expect(screen.getByText("Content")).toBeInTheDocument();
   });
 
   it("does not render children when closed", () => {
-    render(<PanelFixture open={false}>Content</PanelFixture>);
+    render(<PanelStatic open={false}>Content</PanelStatic>);
 
     expect(screen.queryByText("Content")).not.toBeInTheDocument();
   });
 
   it("applies containerId as id on the panel element", () => {
-    render(<PanelFixture containerId="my-panel-id">Content</PanelFixture>);
+    render(<PanelStatic containerId="my-panel-id">Content</PanelStatic>);
 
     expect(document.getElementById("my-panel-id")).toBeInTheDocument();
   });
 
   it("calls onToggle when Escape is pressed inside the panel", async () => {
     const onToggle = vi.fn();
+    const onFirstUpdate = vi.fn();
+
     render(
-      <PanelFixture onToggle={onToggle}>
+      <PanelDynamic onToggle={onToggle} onFirstUpdate={onFirstUpdate}>
         <button type="button" autoFocus />
-      </PanelFixture>,
+      </PanelDynamic>,
     );
+
+    await userEvent.click(screen.getByRole("button", { name: "Anchor" }));
+    expect(onToggle).toHaveBeenCalledTimes(0);
 
     await userEvent.keyboard("{Escape}");
 
     expect(onToggle).toHaveBeenCalledTimes(1);
+    expect(onFirstUpdate).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/core/src/BaseDropdown/BaseDropdownPanel.tsx
+++ b/packages/core/src/BaseDropdown/BaseDropdownPanel.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from "react";
+import { useMemo, useRef, useState } from "react";
 import ClickAwayListener, {
   type ClickAwayListenerProps,
 } from "@mui/material/ClickAwayListener";
@@ -53,7 +53,7 @@ export const HvDropdownPanel = (props: HvDropdownPanelProps) => {
     anchorEl,
     disablePortal,
     modifiers: modifiersProp,
-    popperOptions,
+    popperOptions: popperOptionsProp,
     onToggle,
     onClickAway,
     onFirstUpdate,
@@ -69,6 +69,11 @@ export const HvDropdownPanel = (props: HvDropdownPanelProps) => {
     modifiers: modifiersProp,
     onPlacementChange: setPlacement,
   });
+
+  const popperOptions = useMemo(() => {
+    // memo popperOptions to ensure `onFirstUpdate` isn't re-created
+    return { ...popperOptionsProp, onFirstUpdate };
+  }, [onFirstUpdate, popperOptionsProp]);
 
   /** Handle keyboard inside children container. */
   const handleKeyDown: React.KeyboardEventHandler = (event) => {
@@ -95,10 +100,7 @@ export const HvDropdownPanel = (props: HvDropdownPanelProps) => {
       className={cx(classes.container, className)}
       modifiers={modifiers}
       onKeyDown={handleKeyDown}
-      popperOptions={{
-        onFirstUpdate,
-        ...popperOptions,
-      }}
+      popperOptions={popperOptions}
       {...others}
     >
       <ClickAwayListener onClickAway={onClickAway}>

--- a/packages/core/src/DatePicker/DatePicker.tsx
+++ b/packages/core/src/DatePicker/DatePicker.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, useEffect, useRef } from "react";
+import { forwardRef, useEffect, useMemo, useRef } from "react";
 import { useForkRef } from "@mui/material/utils";
 import {
   useDefaultProps,
@@ -215,6 +215,12 @@ export const HvDatePicker = forwardRef<HTMLDivElement, HvDatePickerProps>(
 
     const { ref: refProp, ...otherDropdownProps } = dropdownProps;
     const dropdownForkedRef = useForkRef(ref, refProp);
+
+    const popperProps = useMemo(() => {
+      return {
+        modifiers: [{ name: "preventOverflow", enabled: escapeWithReference }],
+      };
+    }, [escapeWithReference]);
 
     useEffect(() => {
       setStartDate(rangeMode ? startValue : value, true);
@@ -474,11 +480,7 @@ export const HvDatePicker = forwardRef<HTMLDivElement, HvDatePickerProps>(
           onContainerCreation={focusOnContainer}
           placeholder={dateString || placeholder || ""}
           adornment={<HvIcon name="Calendar" className={classes.icon} />}
-          popperProps={{
-            modifiers: [
-              { name: "preventOverflow", enabled: escapeWithReference },
-            ],
-          }}
+          popperProps={popperProps}
           aria-haspopup="dialog"
           aria-label={ariaLabel}
           aria-labelledby={

--- a/packages/core/src/TimePicker/TimePicker.stories.tsx
+++ b/packages/core/src/TimePicker/TimePicker.stories.tsx
@@ -128,6 +128,8 @@ export const Format12Hours: StoryObj<HvTimePickerProps> = {
     await expect(
       canvas.getByRole("button", { name: /pm/i }),
     ).toBeInTheDocument();
+    const numberInputs = canvas.getAllByRole("spinbutton");
+    await userEvent.type(numberInputs[2], "16");
   },
   render: () => {
     return (

--- a/packages/core/src/TimePicker/TimePicker.tsx
+++ b/packages/core/src/TimePicker/TimePicker.tsx
@@ -193,6 +193,12 @@ export const HvTimePicker = forwardRef<HTMLDivElement, HvTimePickerProps>(
       timeFieldRef,
     );
 
+    const popperProps = useMemo(() => {
+      return {
+        modifiers: [{ name: "preventOverflow", enabled: escapeWithReference }],
+      };
+    }, [escapeWithReference]);
+
     const [open, setOpen] = useState(false);
 
     const [validationMessage] = useControlled(statusMessage, "Required");
@@ -290,17 +296,13 @@ export const HvTimePicker = forwardRef<HTMLDivElement, HvTimePickerProps>(
           aria-invalid={isStateInvalid ? true : undefined}
           aria-errormessage={errorMessageId}
           disablePortal={disablePortal}
-          popperProps={{
-            modifiers: [
-              { name: "preventOverflow", enabled: escapeWithReference },
-            ],
-          }}
+          popperProps={popperProps}
           {...otherDropdownProps}
         >
           <div ref={timeFieldRef} className={classes.timePopperContainer}>
-            {state.segments.map((segment) => (
+            {state.segments.map((segment, i) => (
               <Unit
-                key={segment.type}
+                key={segment.type === "literal" ? `literal-${i}` : segment.type}
                 state={state}
                 segment={segment}
                 placeholder={placeholders[segment.type]}


### PR DESCRIPTION
- memo `onFirstUpdate`/`onContainerCreation` so they're not called more than once (which is hyjacking user-defined focus state)
- memo `popperOptions`