### PR TITLE
chore: cleanup app-shell package.json

### DIFF
--- a/packages/app-shell-i18next/package.json
+++ b/packages/app-shell-i18next/package.json
@@ -52,12 +52,6 @@
   },
   "clean-publish": {
     "withoutPublish": true,
-    "tempDir": "package",
-    "fields": [
-      "main"
-    ],
-    "files": [
-      "tsconfig.json"
-    ]
+    "tempDir": "package"
   }
 }

--- a/packages/app-shell-ui/package.json
+++ b/packages/app-shell-ui/package.json
@@ -6,7 +6,6 @@
   "author": "Hitachi Vantara UI Kit Team",
   "description": "AppShell Component",
   "homepage": "https://github.com/pentaho/hv-uikit-react",
-  "main": "src/index.ts",
   "sideEffects": false,
   "license": "Apache-2.0",
   "repository": {
@@ -41,6 +40,9 @@
     "react-i18next": "15.7.1",
     "uid": "^2.0.2"
   },
+  "devDependencies": {
+    "vite-plugin-static-copy": "^3.1.2"
+  },
   "peerDependencies": {
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
@@ -70,15 +72,6 @@
   },
   "clean-publish": {
     "withoutPublish": true,
-    "tempDir": "package",
-    "fields": [
-      "main"
-    ],
-    "files": [
-      "tsconfig.json"
-    ]
-  },
-  "devDependencies": {
-    "vite-plugin-static-copy": "^3.1.2"
+    "tempDir": "package"
   }
 }

--- a/packages/app-shell-vite-plugin/package.json
+++ b/packages/app-shell-vite-plugin/package.json
@@ -69,10 +69,6 @@
   },
   "clean-publish": {
     "withoutPublish": true,
-    "tempDir": "package",
-    "fields": [],
-    "files": [
-      "tsconfig.json"
-    ]
+    "tempDir": "package"
   }
 }


### PR DESCRIPTION
sort & clean up unused fields from app-shell's ui/i18next/vite-plugin package.json

this is just to force-bump the packages, which weren't published correctly

```
➜ npx lerna changed
[...]
@hitachivantara/app-shell-i18next
@hitachivantara/app-shell-ui
@hitachivantara/app-shell-vite-plugin
lerna success found 3 packages ready to publish
```