### PR TITLE
feat: explicit supported-locales.json file filters translations [PPUC-512]

### DIFF
--- a/apps/docs/src/content/app-shell/internationalization.md
+++ b/apps/docs/src/content/app-shell/internationalization.md
@@ -70,10 +70,19 @@ When present, translation backends (such as `HttpResourcesBackend` from `@hitach
 manifest to skip network requests for unsupported languages, letting i18next follow the `fallbackLng` chain instead.
 If the file is missing or malformed, all languages are allowed.
 
-When building with the **App Shell Vite Plugin**, the plugin automatically generates a `supported-locales.json` manifest,
-with the list of locales discovered on disk based on the locale directories found in `public/locales/`, plus the stock
-ones provided by the App Shell's base code (from the `app-shell-ui` package). Any `supported-locales.json` file provided
-by the application is ignored and overwritten by the plugin.
+When building with the **App Shell Vite Plugin**, the plugin generates the final `supported-locales.json` manifest
+(always sorted alphabetically) based on the following logic:
+
+- **If the application provides a `supported-locales.json`** in `public/locales/`, it acts as a **filter**: only the
+  locales listed there will be included in the output. Upstream locale directories from the `app-shell-ui` package that
+  are not in this list are excluded from the build. This gives the application full control over which languages are
+  shipped, while still inheriting the upstream translations for the selected locales.
+- **If no `supported-locales.json` is provided**, all upstream locales from `app-shell-ui` are included alongside any
+  local locale directories. This is the default behavior when the application does not need to restrict the set of
+  available languages.
+
+In both cases, locales listed in the manifest but without a corresponding language directory (in either the app's
+`public/locales/` or the upstream `app-shell-ui` package) are warned about and ignored.
 
 ### Overriding App Shell translations
 

--- a/apps/docs/src/content/app-shell/internationalization.md
+++ b/apps/docs/src/content/app-shell/internationalization.md
@@ -46,12 +46,18 @@ Each JSON file contains a flat or nested object with translation keys and their 
 At runtime, these files are resolved relative to the [`translationsBaseUrl`](./configuration#translationsbaseurl) (which
 defaults to `"./"`).
 
-When using the **App Shell Vite Plugin**, locale files are placed in the application's `public/locales/` directory. The
-plugin automatically merges the App Shell's stock resource bundles (for the `appShell` namespace) with the application's
-locale files, in both development and production. Local keys always take priority over the stock translations.
+When using the **App Shell Vite Plugin** with `type: "app"`, locale files are placed in the application's
+`public/locales/` directory. The plugin automatically merges the App Shell's stock resource bundles (for the `appShell`
+namespace) with the application's locale files, in both development and production. Local keys always take priority over
+the stock translations.
 
 This means that applications only need to provide locale files for the `app` namespace — the `appShell` namespace is
 handled automatically by the plugin.
+
+When `type` is `"bundle"`, no upstream merging occurs — the `appShell` namespace translations are **not** copied into
+the output. The hosting App Shell (i.e., the `type: "app"` project that loads the bundle at runtime) is responsible for
+providing the `appShell` translations. However, the `supported-locales.json` manifest is still generated from the local
+locale directories (see [below](#supported-locales-manifest)).
 
 > [!NOTE]
 > The `appShell` namespace for English is pre-bundled directly in the App Shell code, so the App Shell chrome works even

--- a/packages/app-shell-vite-plugin/src/locales-utils.ts
+++ b/packages/app-shell-vite-plugin/src/locales-utils.ts
@@ -63,64 +63,26 @@ export function discoverLanguageDirs(localesDir: string): string[] {
 }
 
 /**
- * Computes the merged supported-locales list respecting ordering:
+ * Computes the effective supported-locales list.
  *
- * 1. Entries from the **app's** `supported-locales.json` (in their original order).
- * 2. Entries from the **shell's** `supported-locales.json` not already listed
- *    (in their original order).
- * 3. Any language directories discovered on disk that are not in either
- *    manifest (alphabetical order).
+ * Discovers all language directories from both sources (upstream shell and
+ * local app). If the app provides a `supported-locales.json`, it acts as a
+ * **filter**: only locales listed there are kept. Otherwise all discovered
+ * locales are included.
  *
- * @param shellLocalesDir - The app-shell-ui locales directory (lower priority).
- * @param appLocalesDir   - The app's locales directory (higher priority).
+ * The result is always sorted alphabetically.
+ *
+ * Locales listed in the local manifest but without a matching language
+ * directory are warned about and dropped.
+ *
+ * @param shellLocalesDir - The app-shell-ui locales directory (upstream).
+ * @param appLocalesDir   - The app's locales directory (downstream / local).
  */
 export function computeSupportedLocales(
   shellLocalesDir: string | undefined,
   appLocalesDir: string | undefined,
 ): string[] {
-  const seen = new Set<string>();
-  const result: string[] = [];
-
-  const addUnique = (lng: string) => {
-    if (!seen.has(lng)) {
-      seen.add(lng);
-      result.push(lng);
-    }
-  };
-
-  // 1. App manifest entries first (highest priority order)
-  if (appLocalesDir) {
-    for (const lng of readSupportedLocales(
-      path.join(appLocalesDir, SUPPORTED_LOCALES_FILE),
-    )) {
-      addUnique(lng);
-    }
-  }
-
-  // 2. Shell manifest entries that weren't already listed
-  if (shellLocalesDir) {
-    for (const lng of readSupportedLocales(
-      path.join(shellLocalesDir, SUPPORTED_LOCALES_FILE),
-    )) {
-      addUnique(lng);
-    }
-  }
-
-  // 3. Discovered language directories not in either manifest (alphabetical)
-  const discoveredDirs: string[] = [];
-  for (const dir of [shellLocalesDir, appLocalesDir]) {
-    if (dir) {
-      for (const lng of discoverLanguageDirs(dir)) {
-        if (!seen.has(lng)) discoveredDirs.push(lng);
-      }
-    }
-  }
-  // deduplicate and sort before appending
-  for (const lng of [...new Set(discoveredDirs)].toSorted()) {
-    addUnique(lng);
-  }
-
-  // Validate: warn and drop manifest entries without a matching language directory
+  // Collect all language directories that actually exist on disk
   const allDirs = new Set<string>();
   for (const dir of [shellLocalesDir, appLocalesDir]) {
     if (dir) {
@@ -130,13 +92,30 @@ export function computeSupportedLocales(
     }
   }
 
-  return result.filter((lng) => {
-    if (allDirs.has(lng)) return true;
-    console.warn(
-      `[app-shell-locales] Locale "${lng}" is listed in ${SUPPORTED_LOCALES_FILE} but has no corresponding language directory — ignoring.`,
-    );
-    return false;
-  });
+  // Read the local (app) manifest — if it exists it acts as a filter
+  const localManifest = appLocalesDir
+    ? readSupportedLocales(path.join(appLocalesDir, SUPPORTED_LOCALES_FILE))
+    : [];
+  const hasLocalManifest = localManifest.length > 0;
+
+  // Determine the effective set of locales
+  let result: string[];
+
+  if (hasLocalManifest) {
+    // Filter: only keep locales from the manifest that have a directory
+    result = localManifest.filter((lng) => {
+      if (allDirs.has(lng)) return true;
+      console.warn(
+        `[app-shell-locales] Locale "${lng}" is listed in ${SUPPORTED_LOCALES_FILE} but has no corresponding language directory — ignoring.`,
+      );
+      return false;
+    });
+  } else {
+    // No local manifest → include everything discovered
+    result = [...allDirs];
+  }
+
+  return result.toSorted();
 }
 
 /**
@@ -161,10 +140,18 @@ export function readJsonFile(filePath: string): unknown {
  * Non-JSON files are skipped (locale bundles are always JSON).
  *
  * `supported-locales.json` is skipped — it is handled separately after the
- * merge so it can reflect the union of both sources plus any discovered
- * language directories.
+ * merge so it can reflect the computed list.
+ *
+ * When `allowedLocales` is provided, only top-level directories whose name
+ * is in the set are merged; all others are skipped. This allows the app's
+ * `supported-locales.json` to act as a filter over upstream locale dirs.
+ * Sub-directories (namespace folders) are always merged recursively.
  */
-export function mergeDirs(src: string, dest: string) {
+export function mergeDirs(
+  src: string,
+  dest: string,
+  allowedLocales?: Set<string>,
+) {
   fs.mkdirSync(dest, { recursive: true });
 
   for (const entry of fs.readdirSync(src, { withFileTypes: true })) {
@@ -172,6 +159,9 @@ export function mergeDirs(src: string, dest: string) {
     const destPath = path.join(dest, entry.name);
 
     if (entry.isDirectory()) {
+      // At the top level, skip locale dirs not in the allowed set
+      if (allowedLocales && !allowedLocales.has(entry.name)) continue;
+      // Sub-directories are always merged (no further filtering)
       mergeDirs(srcPath, destPath);
     } else if (entry.name === SUPPORTED_LOCALES_FILE) {
       // Handled after the full merge — skip here.

--- a/packages/app-shell-vite-plugin/src/locales-utils.ts
+++ b/packages/app-shell-vite-plugin/src/locales-utils.ts
@@ -92,18 +92,25 @@ export function computeSupportedLocales(
     }
   }
 
-  // Read the local (app) manifest — if it exists it acts as a filter
-  const localManifest = appLocalesDir
-    ? readSupportedLocales(path.join(appLocalesDir, SUPPORTED_LOCALES_FILE))
-    : [];
-  const hasLocalManifest = localManifest.length > 0;
+  // Determine if the app provides a supported-locales.json file.
+  // Physical existence of the file is what matters — even if it's empty,
+  // malformed, or contains no valid entries, it still acts as a filter
+  // (resulting in an empty effective locale list).
+  const manifestPath = appLocalesDir
+    ? path.join(appLocalesDir, SUPPORTED_LOCALES_FILE)
+    : undefined;
+  const hasLocalManifest = manifestPath ? fs.existsSync(manifestPath) : false;
+
+  // Read the manifest entries (empty if file is missing/invalid)
+  const localManifest = manifestPath ? readSupportedLocales(manifestPath) : [];
 
   // Determine the effective set of locales
   let result: string[];
 
   if (hasLocalManifest) {
-    // Filter: only keep locales from the manifest that have a directory
-    result = localManifest.filter((lng) => {
+    // Filter: only keep unique locales from the manifest that have a directory.
+    // If the manifest is empty/malformed, this correctly yields an empty list.
+    result = [...new Set(localManifest)].filter((lng) => {
       if (allDirs.has(lng)) return true;
       console.warn(
         `[app-shell-locales] Locale "${lng}" is listed in ${SUPPORTED_LOCALES_FILE} but has no corresponding language directory — ignoring.`,

--- a/packages/app-shell-vite-plugin/src/tests/vite-locales-plugin.test.ts
+++ b/packages/app-shell-vite-plugin/src/tests/vite-locales-plugin.test.ts
@@ -348,4 +348,58 @@ describe("vite-locales-plugin helpers", () => {
       expect(fs.existsSync(path.join(targetLocales, "ja"))).toBe(false);
     });
   });
+
+  describe("bundle build flow (no upstream merge)", () => {
+    it("should generate supported-locales.json from local dirs when no manifest", () => {
+      const targetLocales = path.join(tmpDir, "dist/locales");
+
+      mkLocalesDir(targetLocales, {
+        "en/app.json": JSON.stringify({ hello: "Hello" }),
+        "pt/app.json": JSON.stringify({ hello: "Olá" }),
+        "fr/app.json": JSON.stringify({ hello: "Bonjour" }),
+      });
+
+      // No upstream, no manifest → all local dirs
+      const finalLocales = computeSupportedLocales(undefined, targetLocales);
+
+      expect(finalLocales).toEqual(["en", "fr", "pt"]);
+    });
+
+    it("should filter local dirs by manifest when present", () => {
+      const targetLocales = path.join(tmpDir, "dist/locales");
+
+      mkLocalesDir(targetLocales, {
+        "supported-locales.json": JSON.stringify(["en", "pt"]),
+        "en/app.json": JSON.stringify({ hello: "Hello" }),
+        "pt/app.json": JSON.stringify({ hello: "Olá" }),
+        "fr/app.json": JSON.stringify({ hello: "Bonjour" }),
+      });
+
+      // No upstream, manifest filters to en and pt only
+      const finalLocales = computeSupportedLocales(undefined, targetLocales);
+
+      expect(finalLocales).toEqual(["en", "pt"]);
+    });
+
+    it("should warn and drop manifest entries without a directory", () => {
+      const targetLocales = path.join(tmpDir, "dist/locales");
+
+      mkLocalesDir(targetLocales, {
+        "supported-locales.json": JSON.stringify(["en", "de", "ja"]),
+        "en/app.json": JSON.stringify({ hello: "Hello" }),
+        // de and ja have no directories
+      });
+
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+      const finalLocales = computeSupportedLocales(undefined, targetLocales);
+
+      expect(finalLocales).toEqual(["en"]);
+      expect(warnSpy).toHaveBeenCalledTimes(2);
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('"de"'));
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('"ja"'));
+
+      warnSpy.mockRestore();
+    });
+  });
 });

--- a/packages/app-shell-vite-plugin/src/tests/vite-locales-plugin.test.ts
+++ b/packages/app-shell-vite-plugin/src/tests/vite-locales-plugin.test.ts
@@ -39,7 +39,7 @@ afterEach(() => {
 
 describe("vite-locales-plugin helpers", () => {
   describe("computeSupportedLocales", () => {
-    it("should use app order first, then shell additions", () => {
+    it("should use app manifest as a filter over upstream locales", () => {
       const shellDir = path.join(tmpDir, "shell");
       const appDir = path.join(tmpDir, "app");
 
@@ -55,9 +55,9 @@ describe("vite-locales-plugin helpers", () => {
         "en/app.json": JSON.stringify({}),
       });
 
-      // App order: pt, en — then shell additions: fr, de
+      // App manifest acts as filter: only pt and en are included (sorted)
       const result = computeSupportedLocales(shellDir, appDir);
-      expect(result).toEqual(["pt", "en", "fr", "de"]);
+      expect(result).toEqual(["en", "pt"]);
     });
 
     it("should use shell order when app has no manifest", () => {
@@ -73,7 +73,7 @@ describe("vite-locales-plugin helpers", () => {
       fs.mkdirSync(appDir, { recursive: true });
 
       const result = computeSupportedLocales(shellDir, appDir);
-      expect(result).toEqual(["fr", "en", "de"]);
+      expect(result).toEqual(["de", "en", "fr"]);
     });
 
     it("should append discovered dirs alphabetically after manifest entries", () => {
@@ -103,9 +103,9 @@ describe("vite-locales-plugin helpers", () => {
         "de/common.json": JSON.stringify({}),
       });
 
-      // en from shell manifest, then discovered: de, fr, zh-CN (alphabetical)
+      // No app manifest → all discovered dirs, sorted alphabetically
       const result = computeSupportedLocales(shellDir, appDir);
-      expect(result).toEqual(["en", "de", "fr", "zh-CN"]);
+      expect(result).toEqual(["de", "en", "fr", "zh-CN"]);
     });
 
     it("should handle missing manifests gracefully", () => {
@@ -166,12 +166,10 @@ describe("vite-locales-plugin helpers", () => {
 
       const result = computeSupportedLocales(shellDir, appDir);
 
-      // pt, fr, de should be dropped — only en has a directory
+      // pt has no directory — only en passes the filter
       expect(result).toEqual(["en"]);
-      expect(warnSpy).toHaveBeenCalledTimes(3);
+      expect(warnSpy).toHaveBeenCalledTimes(1);
       expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('"pt"'));
-      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('"fr"'));
-      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('"de"'));
 
       warnSpy.mockRestore();
     });
@@ -245,7 +243,7 @@ describe("vite-locales-plugin helpers", () => {
   });
 
   describe("full build flow", () => {
-    it("should produce correct supported-locales.json after merge", () => {
+    it("should produce correct supported-locales.json after merge (with filter)", () => {
       const shellLocales = path.join(tmpDir, "shell-locales");
       const targetLocales = path.join(tmpDir, "dist/locales");
 
@@ -257,39 +255,48 @@ describe("vite-locales-plugin helpers", () => {
         "de/appShell.json": JSON.stringify({ title: "Schale" }),
       });
 
-      // App has pt, en (in that order — app controls priority)
+      // App has pt, en (in that order — app controls the filter)
       mkLocalesDir(targetLocales, {
         "supported-locales.json": JSON.stringify(["pt", "en"]),
         "en/common.json": JSON.stringify({ hello: "Hello" }),
         "pt/common.json": JSON.stringify({ hello: "Olá" }),
       });
 
-      // Simulate closeBundle logic
-      mergeDirs(shellLocales, targetLocales);
-      const merged = computeSupportedLocales(shellLocales, targetLocales);
+      // Simulate closeBundle logic: compute filter, merge, re-compute
+      const supportedLocales = computeSupportedLocales(
+        shellLocales,
+        targetLocales,
+      );
+      const allowedLocales = new Set(supportedLocales);
+      mergeDirs(shellLocales, targetLocales, allowedLocales);
+      const finalLocales = computeSupportedLocales(shellLocales, targetLocales);
       fs.writeFileSync(
         path.join(targetLocales, SUPPORTED_LOCALES_FILE),
-        `${JSON.stringify(merged)}\n`,
+        `${JSON.stringify(finalLocales)}\n`,
       );
 
-      // Verify the manifest: app order (pt, en), then shell additions (fr, de)
+      // Verify the manifest: only the locales listed in the app's filter (sorted)
       const result = JSON.parse(
         fs.readFileSync(
           path.join(targetLocales, SUPPORTED_LOCALES_FILE),
           "utf-8",
         ),
       );
-      expect(result).toEqual(["pt", "en", "fr", "de"]);
+      expect(result).toEqual(["en", "pt"]);
 
-      // Verify bundles were merged correctly
+      // Verify only filtered locale bundles were merged
       expect(fs.existsSync(path.join(targetLocales, "en/appShell.json"))).toBe(
-        true,
-      );
-      expect(fs.existsSync(path.join(targetLocales, "fr/appShell.json"))).toBe(
         true,
       );
       expect(fs.existsSync(path.join(targetLocales, "en/common.json"))).toBe(
         true,
+      );
+      // fr and de should NOT be merged (filtered out)
+      expect(fs.existsSync(path.join(targetLocales, "fr/appShell.json"))).toBe(
+        false,
+      );
+      expect(fs.existsSync(path.join(targetLocales, "de/appShell.json"))).toBe(
+        false,
       );
     });
 
@@ -312,7 +319,7 @@ describe("vite-locales-plugin helpers", () => {
       expect(merged).toEqual(["en", "pt"]);
     });
 
-    it("should append new language dirs after manifest entries", () => {
+    it("should filter upstream dirs when app has manifest", () => {
       const shellLocales = path.join(tmpDir, "shell-locales");
       const targetLocales = path.join(tmpDir, "dist/locales");
 
@@ -327,12 +334,18 @@ describe("vite-locales-plugin helpers", () => {
         "en/common.json": JSON.stringify({}),
       });
 
-      mergeDirs(shellLocales, targetLocales);
-      const merged = computeSupportedLocales(shellLocales, targetLocales);
+      // App manifest filters to pt and en — ja is not included
+      const supportedLocales = computeSupportedLocales(
+        shellLocales,
+        targetLocales,
+      );
+      const allowedLocales = new Set(supportedLocales);
+      mergeDirs(shellLocales, targetLocales, allowedLocales);
+      const finalLocales = computeSupportedLocales(shellLocales, targetLocales);
 
-      // App order (pt, en), no new shell manifest entries,
-      // then discovered ja (alphabetical)
-      expect(merged).toEqual(["pt", "en", "ja"]);
+      expect(finalLocales).toEqual(["en", "pt"]);
+      // ja should NOT have been merged
+      expect(fs.existsSync(path.join(targetLocales, "ja"))).toBe(false);
     });
   });
 });

--- a/packages/app-shell-vite-plugin/src/tests/vite-locales-plugin.test.ts
+++ b/packages/app-shell-vite-plugin/src/tests/vite-locales-plugin.test.ts
@@ -60,7 +60,7 @@ describe("vite-locales-plugin helpers", () => {
       expect(result).toEqual(["en", "pt"]);
     });
 
-    it("should use shell order when app has no manifest", () => {
+    it("should include all upstream locales sorted alphabetically when app has no manifest", () => {
       const shellDir = path.join(tmpDir, "shell");
       const appDir = path.join(tmpDir, "app");
 
@@ -172,6 +172,60 @@ describe("vite-locales-plugin helpers", () => {
       expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('"pt"'));
 
       warnSpy.mockRestore();
+    });
+
+    it("should deduplicate manifest entries", () => {
+      const shellDir = path.join(tmpDir, "shell");
+      const appDir = path.join(tmpDir, "app");
+
+      mkLocalesDir(shellDir, {
+        "en/appShell.json": JSON.stringify({}),
+        "pt/appShell.json": JSON.stringify({}),
+      });
+      mkLocalesDir(appDir, {
+        "supported-locales.json": JSON.stringify(["en", "pt", "en", "pt"]),
+        "en/app.json": JSON.stringify({}),
+        "pt/app.json": JSON.stringify({}),
+      });
+
+      const result = computeSupportedLocales(shellDir, appDir);
+      expect(result).toEqual(["en", "pt"]);
+    });
+
+    it("should treat an empty-array manifest as a filter (returning nothing)", () => {
+      const shellDir = path.join(tmpDir, "shell");
+      const appDir = path.join(tmpDir, "app");
+
+      mkLocalesDir(shellDir, {
+        "en/appShell.json": JSON.stringify({}),
+        "fr/appShell.json": JSON.stringify({}),
+      });
+      mkLocalesDir(appDir, {
+        "supported-locales.json": JSON.stringify([]),
+        "en/app.json": JSON.stringify({}),
+      });
+
+      // File exists with empty array → acts as filter, nothing passes
+      const result = computeSupportedLocales(shellDir, appDir);
+      expect(result).toEqual([]);
+    });
+
+    it("should treat a malformed local manifest as a filter (returning nothing)", () => {
+      const shellDir = path.join(tmpDir, "shell");
+      const appDir = path.join(tmpDir, "app");
+
+      mkLocalesDir(shellDir, {
+        "en/appShell.json": JSON.stringify({}),
+        "fr/appShell.json": JSON.stringify({}),
+      });
+      mkLocalesDir(appDir, {
+        "supported-locales.json": "not valid json{",
+        "en/app.json": JSON.stringify({}),
+      });
+
+      // File exists but is malformed → acts as filter with no entries
+      const result = computeSupportedLocales(shellDir, appDir);
+      expect(result).toEqual([]);
     });
   });
 
@@ -346,6 +400,56 @@ describe("vite-locales-plugin helpers", () => {
       expect(finalLocales).toEqual(["en", "pt"]);
       // ja should NOT have been merged
       expect(fs.existsSync(path.join(targetLocales, "ja"))).toBe(false);
+    });
+
+    it("should not merge upstream dirs when manifest exists but all entries are invalid", () => {
+      const shellLocales = path.join(tmpDir, "shell-locales");
+      const targetLocales = path.join(tmpDir, "dist/locales");
+
+      mkLocalesDir(shellLocales, {
+        "supported-locales.json": JSON.stringify(["en", "fr"]),
+        "en/appShell.json": JSON.stringify({ title: "Shell" }),
+        "fr/appShell.json": JSON.stringify({ title: "Coquille" }),
+      });
+      mkLocalesDir(targetLocales, {
+        // Manifest lists locales that have no directories
+        "supported-locales.json": JSON.stringify(["xx", "yy"]),
+      });
+
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+      // Simulate closeBundle logic: manifest exists → always filter
+      const hasLocalManifest = fs.existsSync(
+        path.join(targetLocales, SUPPORTED_LOCALES_FILE),
+      );
+      const supportedLocales = computeSupportedLocales(
+        shellLocales,
+        targetLocales,
+      );
+      const allowedLocales = hasLocalManifest
+        ? new Set(supportedLocales)
+        : undefined;
+      mergeDirs(shellLocales, targetLocales, allowedLocales);
+
+      // Nothing should have been merged — empty filter means nothing passes
+      expect(fs.existsSync(path.join(targetLocales, "en"))).toBe(false);
+      expect(fs.existsSync(path.join(targetLocales, "fr"))).toBe(false);
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('"xx"'));
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('"yy"'));
+
+      // Simulate manifest cleanup: stale file should be removed
+      const finalLocales = computeSupportedLocales(shellLocales, targetLocales);
+      const manifestPath = path.join(targetLocales, SUPPORTED_LOCALES_FILE);
+      if (finalLocales.length > 0) {
+        fs.writeFileSync(manifestPath, `${JSON.stringify(finalLocales)}\n`);
+      } else if (fs.existsSync(manifestPath)) {
+        fs.unlinkSync(manifestPath);
+      }
+
+      // The stale manifest with ["xx","yy"] should have been removed
+      expect(fs.existsSync(manifestPath)).toBe(false);
+
+      warnSpy.mockRestore();
     });
   });
 

--- a/packages/app-shell-vite-plugin/src/vite-locales-plugin.ts
+++ b/packages/app-shell-vite-plugin/src/vite-locales-plugin.ts
@@ -8,7 +8,6 @@ import {
   deepMerge,
   mergeDirs,
   readJsonFile,
-  readSupportedLocales,
   SUPPORTED_LOCALES_FILE,
 } from "./locales-utils.js";
 
@@ -30,6 +29,33 @@ function resolveAppShellUiLocales(): string | undefined {
     // app-shell-ui not installed or locales not available
   }
   return undefined;
+}
+
+/**
+ * Computes the effective set of allowed locales for a given locales directory.
+ *
+ * When a local `supported-locales.json` exists, it acts as a filter — even if
+ * it resolves to an empty list (all entries invalid), so that an invalid
+ * manifest doesn't accidentally allow everything.
+ *
+ * @returns The effective locale list (sorted, deduplicated) and the
+ *   corresponding `Set` to use as a filter (or `undefined` when no local
+ *   manifest exists — meaning "allow all").
+ */
+function resolveEffectiveLocales(
+  shellLocalesDir: string | undefined,
+  appLocalesDir: string,
+): { locales: string[]; allowedSet: Set<string> | undefined } {
+  const hasLocalManifest = fs.existsSync(
+    path.join(appLocalesDir, SUPPORTED_LOCALES_FILE),
+  );
+
+  const locales = computeSupportedLocales(shellLocalesDir, appLocalesDir);
+
+  // When a local manifest exists, always filter — even with an empty set.
+  const allowedSet = hasLocalManifest ? new Set(locales) : undefined;
+
+  return { locales, allowedSet };
 }
 
 /**
@@ -74,6 +100,19 @@ export default function copyAppShellLocales(
     configureServer(server) {
       const appShellUiLocalesDir = resolveAppShellUiLocales();
 
+      const localLocalesDir = path.resolve(
+        server.config.root,
+        "public/locales",
+      );
+
+      // Compute the effective locale set once at server start, using the
+      // same logic as the build path. A server restart is needed when the
+      // locale directory structure or supported-locales.json changes.
+      const { locales: effectiveLocales, allowedSet } = resolveEffectiveLocales(
+        appShellUiLocalesDir,
+        localLocalesDir,
+      );
+
       server.middlewares.use((req, res, next) => {
         // Parse the pathname, stripping the Vite base and any query string
         // so locale requests work under non-root base paths (e.g. /myapp/).
@@ -89,28 +128,16 @@ export default function copyAppShellLocales(
 
         const relativePath = pathname.slice(base.length);
 
-        // Handle supported-locales.json separately — it's an array, not a
-        // key/value bundle, and must reflect the union of both sources plus
-        // any language directories that exist on disk.
+        // Serve the computed supported-locales.json
         if (relativePath === `locales/${SUPPORTED_LOCALES_FILE}`) {
-          const localLocalesDir = path.resolve(
-            server.config.root,
-            "public/locales",
-          );
-
-          const merged = computeSupportedLocales(
-            appShellUiLocalesDir,
-            localLocalesDir,
-          );
-
-          if (merged.length === 0) {
+          if (effectiveLocales.length === 0) {
             res.statusCode = 404;
             res.end();
             return;
           }
 
           res.setHeader("Content-Type", "application/json");
-          res.end(JSON.stringify(merged));
+          res.end(JSON.stringify(effectiveLocales));
           return;
         }
 
@@ -122,22 +149,11 @@ export default function copyAppShellLocales(
         // Guard against path traversal (e.g. `..` segments)
         if (lng.includes("..") || nsFile.includes("..")) return next();
 
-        const localLocalesBase = path.resolve(
-          server.config.root,
-          "public/locales",
-        );
+        // Filter by the effective locale set (same logic as build)
+        if (allowedSet && !allowedSet.has(lng)) return next();
 
-        // If the app provides a supported-locales.json, use it as a filter:
-        // only serve locale bundles for listed languages.
-        const localManifest = readSupportedLocales(
-          path.join(localLocalesBase, SUPPORTED_LOCALES_FILE),
-        );
-        if (localManifest.length > 0 && !localManifest.includes(lng)) {
-          return next();
-        }
-
-        const localPath = path.join(localLocalesBase, lng, nsFile);
-        if (!localPath.startsWith(localLocalesBase + path.sep)) return next();
+        const localPath = path.join(localLocalesDir, lng, nsFile);
+        if (!localPath.startsWith(localLocalesDir + path.sep)) return next();
 
         const shellPath = appShellUiLocalesDir
           ? path.join(appShellUiLocalesDir, lng, nsFile)
@@ -188,33 +204,33 @@ export default function copyAppShellLocales(
         : undefined;
 
       if (appShellUiLocales) {
-        // Compute supported locales first — if the app provides a
-        // supported-locales.json it acts as a filter over upstream dirs.
-        const supportedLocales = computeSupportedLocales(
+        const { allowedSet } = resolveEffectiveLocales(
           appShellUiLocales,
           targetLocales,
         );
-        const allowedLocales =
-          supportedLocales.length > 0 ? new Set(supportedLocales) : undefined;
 
         // Recursive merge: app-shell-ui files are merged into target,
         // with existing (local) keys taking priority in JSON files.
         // supported-locales.json is skipped during this step.
         // Only locale dirs in the allowed set are merged (if filtering).
-        mergeDirs(appShellUiLocales, targetLocales, allowedLocales);
+        mergeDirs(appShellUiLocales, targetLocales, allowedSet);
       }
 
       // Generate supported-locales.json from the (possibly merged) output.
       // When no upstream is involved, this is purely based on local dirs.
-      const finalLocales = computeSupportedLocales(
+      const { locales: finalLocales } = resolveEffectiveLocales(
         appShellUiLocales,
         targetLocales,
       );
+      // Always write/normalize the output supported-locales.json so that any
+      // stale copy from public/ (already placed into dist/ by Vite) is
+      // overwritten with the computed result. If the effective list is empty,
+      // remove the file entirely so the output doesn't ship invalid entries.
+      const manifestPath = path.join(targetLocales, SUPPORTED_LOCALES_FILE);
       if (finalLocales.length > 0) {
-        fs.writeFileSync(
-          path.join(targetLocales, SUPPORTED_LOCALES_FILE),
-          `${JSON.stringify(finalLocales)}\n`,
-        );
+        fs.writeFileSync(manifestPath, `${JSON.stringify(finalLocales)}\n`);
+      } else if (fs.existsSync(manifestPath)) {
+        fs.unlinkSync(manifestPath);
       }
     },
   };

--- a/packages/app-shell-vite-plugin/src/vite-locales-plugin.ts
+++ b/packages/app-shell-vite-plugin/src/vite-locales-plugin.ts
@@ -8,6 +8,7 @@ import {
   deepMerge,
   mergeDirs,
   readJsonFile,
+  readSupportedLocales,
   SUPPORTED_LOCALES_FILE,
 } from "./locales-utils.js";
 
@@ -38,8 +39,9 @@ function resolveAppShellUiLocales(): string | undefined {
  *
  * Local locale files (from the app's public/locales/) always take priority.
  *
- * `supported-locales.json` is merged by taking the union of both arrays and
- * adding any language directories discovered during the merge.
+ * If the app provides a `supported-locales.json`, it acts as a filter:
+ * only listed locales are included from upstream. If no local file is
+ * provided, all upstream locales are merged in.
  */
 export default function copyAppShellLocales(): PluginOption {
   let resolvedOutDir: string | undefined;
@@ -110,6 +112,16 @@ export default function copyAppShellLocales(): PluginOption {
           server.config.root,
           "public/locales",
         );
+
+        // If the app provides a supported-locales.json, use it as a filter:
+        // only serve locale bundles for listed languages.
+        const localManifest = readSupportedLocales(
+          path.join(localLocalesBase, SUPPORTED_LOCALES_FILE),
+        );
+        if (localManifest.length > 0 && !localManifest.includes(lng)) {
+          return next();
+        }
+
         const localPath = path.join(localLocalesBase, lng, nsFile);
         if (!localPath.startsWith(localLocalesBase + path.sep)) return next();
 
@@ -161,18 +173,30 @@ export default function copyAppShellLocales(): PluginOption {
 
       const targetLocales = path.resolve(resolvedOutDir, "locales");
 
+      // Compute supported locales first — if the app provides a
+      // supported-locales.json it acts as a filter over upstream dirs.
+      const supportedLocales = computeSupportedLocales(
+        appShellUiLocales,
+        targetLocales,
+      );
+      const allowedLocales =
+        supportedLocales.length > 0 ? new Set(supportedLocales) : undefined;
+
       // Recursive merge: app-shell-ui files are merged into target,
       // with existing (local) keys taking priority in JSON files.
       // supported-locales.json is skipped during this step.
-      mergeDirs(appShellUiLocales, targetLocales);
+      // Only locale dirs in the allowed set are merged (if filtering).
+      mergeDirs(appShellUiLocales, targetLocales, allowedLocales);
 
-      // Compute the union of supported locales from both sources and from
-      // the language directories that now exist in the merged output.
-      const merged = computeSupportedLocales(appShellUiLocales, targetLocales);
-      if (merged.length > 0) {
+      // Re-compute after merge so newly created dirs are included
+      const finalLocales = computeSupportedLocales(
+        appShellUiLocales,
+        targetLocales,
+      );
+      if (finalLocales.length > 0) {
         fs.writeFileSync(
           path.join(targetLocales, SUPPORTED_LOCALES_FILE),
-          `${JSON.stringify(merged)}\n`,
+          `${JSON.stringify(finalLocales)}\n`,
         );
       }
     },

--- a/packages/app-shell-vite-plugin/src/vite-locales-plugin.ts
+++ b/packages/app-shell-vite-plugin/src/vite-locales-plugin.ts
@@ -42,8 +42,19 @@ function resolveAppShellUiLocales(): string | undefined {
  * If the app provides a `supported-locales.json`, it acts as a filter:
  * only listed locales are included from upstream. If no local file is
  * provided, all upstream locales are merged in.
+ *
+ * When `mergeUpstream` is false (e.g. `type: "bundle"`), the build skips
+ * upstream merging entirely but still generates `supported-locales.json`
+ * from the local locale directories, filtering by the local manifest when
+ * present. In dev mode, upstream locales are always served regardless of
+ * this flag, since the full app runs locally and needs the shell translations.
+ *
+ * @param mergeUpstream - Whether to merge upstream app-shell-ui locales.
+ *   Defaults to `true` (for `type: "app"`).
  */
-export default function copyAppShellLocales(): PluginOption {
+export default function copyAppShellLocales(
+  mergeUpstream = true,
+): PluginOption {
   let resolvedOutDir: string | undefined;
   let isBuild = false;
 
@@ -57,6 +68,9 @@ export default function copyAppShellLocales(): PluginOption {
     },
 
     // --- DEV MODE: serve merged locales via middleware ---
+    // In dev, always resolve upstream locales regardless of `mergeUpstream`,
+    // because the full app runs locally and needs the shell translations.
+    // The `mergeUpstream` flag only affects the build output.
     configureServer(server) {
       const appShellUiLocalesDir = resolveAppShellUiLocales();
 
@@ -168,27 +182,30 @@ export default function copyAppShellLocales(): PluginOption {
       // guard, locale files would be written to that folder on disk.
       if (!isBuild || !resolvedOutDir) return;
 
-      const appShellUiLocales = resolveAppShellUiLocales();
-      if (!appShellUiLocales) return;
-
       const targetLocales = path.resolve(resolvedOutDir, "locales");
+      const appShellUiLocales = mergeUpstream
+        ? resolveAppShellUiLocales()
+        : undefined;
 
-      // Compute supported locales first — if the app provides a
-      // supported-locales.json it acts as a filter over upstream dirs.
-      const supportedLocales = computeSupportedLocales(
-        appShellUiLocales,
-        targetLocales,
-      );
-      const allowedLocales =
-        supportedLocales.length > 0 ? new Set(supportedLocales) : undefined;
+      if (appShellUiLocales) {
+        // Compute supported locales first — if the app provides a
+        // supported-locales.json it acts as a filter over upstream dirs.
+        const supportedLocales = computeSupportedLocales(
+          appShellUiLocales,
+          targetLocales,
+        );
+        const allowedLocales =
+          supportedLocales.length > 0 ? new Set(supportedLocales) : undefined;
 
-      // Recursive merge: app-shell-ui files are merged into target,
-      // with existing (local) keys taking priority in JSON files.
-      // supported-locales.json is skipped during this step.
-      // Only locale dirs in the allowed set are merged (if filtering).
-      mergeDirs(appShellUiLocales, targetLocales, allowedLocales);
+        // Recursive merge: app-shell-ui files are merged into target,
+        // with existing (local) keys taking priority in JSON files.
+        // supported-locales.json is skipped during this step.
+        // Only locale dirs in the allowed set are merged (if filtering).
+        mergeDirs(appShellUiLocales, targetLocales, allowedLocales);
+      }
 
-      // Re-compute after merge so newly created dirs are included
+      // Generate supported-locales.json from the (possibly merged) output.
+      // When no upstream is involved, this is purely based on local dirs.
       const finalLocales = computeSupportedLocales(
         appShellUiLocales,
         targetLocales,

--- a/packages/app-shell-vite-plugin/src/vite-plugin.ts
+++ b/packages/app-shell-vite-plugin/src/vite-plugin.ts
@@ -316,6 +316,6 @@ export async function HvAppShellVitePlugin(
     generateEmptyShell && generateBashScript(externalImportMap, inlineConfig),
 
     // copy/merge app-shell-ui locales into dist (build) or serve via middleware (dev)
-    (buildEntryPoint || devMode) && copyAppShellLocales(),
+    copyAppShellLocales(buildEntryPoint),
   ];
 }


### PR DESCRIPTION
Two features included:
- feat: explicit supported-locales.json file filters translations [PPUC-512] -- needed to be able to limit the locales offered by a specific App Shell compilation, downstream
- feat: generate supported-locales.json for bundles [PPUC-512] -- compilations of type bundle also benefit from `supported-locales.json` generation

[PPUC-512]: https://hv-eng.atlassian.net/browse/PPUC-512?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PPUC-512]: https://hv-eng.atlassian.net/browse/PPUC-512?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ