### PR TITLE
chore: reduce rollup import usage

### DIFF
--- a/.config/vite.config.ts
+++ b/.config/vite.config.ts
@@ -2,7 +2,6 @@
 import { createRequire } from "node:module";
 import { resolve } from "node:path";
 import react from "@vitejs/plugin-react";
-import type { OutputOptions } from "rollup";
 import { defineConfig } from "vite";
 import dts from "vite-plugin-dts";
 
@@ -16,16 +15,6 @@ const external = [
   ...Object.keys(pkg.dependencies || {}),
   ...Object.keys(pkg.peerDependencies || {}),
 ].map((ext) => new RegExp(`^${ext.split("/")[0]}`));
-
-const esmOutput: OutputOptions = {
-  format: "esm",
-  preserveModules: true,
-  preserveModulesRoot: "src",
-  dir: "dist",
-  entryFileNames: "[name].js",
-  exports: "named",
-  interop: "auto",
-};
 
 export default defineConfig({
   plugins: [
@@ -42,10 +31,19 @@ export default defineConfig({
     lib: {
       name: pkg.name,
       entry: resolve("src/index.ts"),
+      formats: ["es"],
     },
     rollupOptions: {
-      output: [esmOutput],
       external,
+      output: {
+        format: "esm",
+        preserveModules: true,
+        preserveModulesRoot: "src",
+        dir: "dist",
+        entryFileNames: "[name].js",
+        exports: "named",
+        interop: "auto",
+      },
     },
   },
   test: {

--- a/.config/vite.config.ts
+++ b/.config/vite.config.ts
@@ -1,17 +1,15 @@
 /// <reference types="vitest/config" />
 import { createRequire } from "node:module";
-import { dirname, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
+import { resolve } from "node:path";
 import react from "@vitejs/plugin-react";
 import type { OutputOptions } from "rollup";
 import { defineConfig } from "vite";
 import dts from "vite-plugin-dts";
 
 const require = createRequire(import.meta.url);
-const __dirname = dirname(fileURLToPath(import.meta.url));
 
 // eslint-disable-next-line import/no-dynamic-require
-const pkg = require(resolve(process.cwd(), "package.json"));
+const pkg = require(resolve("package.json"));
 
 // dependencies that should not be bundled.
 const external = [
@@ -32,9 +30,8 @@ const esmOutput: OutputOptions = {
 export default defineConfig({
   plugins: [
     dts({
-      outDir: "dist",
       rollupTypes: true,
-      tsconfigPath: resolve(__dirname, "../tsconfig.build.json"),
+      tsconfigPath: resolve(import.meta.dirname, "../tsconfig.build.json"),
     }),
     react(),
   ],
@@ -44,7 +41,7 @@ export default defineConfig({
     emptyOutDir: true,
     lib: {
       name: pkg.name,
-      entry: resolve(process.cwd(), "src/index.ts"),
+      entry: resolve("src/index.ts"),
     },
     rollupOptions: {
       output: [esmOutput],
@@ -71,7 +68,7 @@ export default defineConfig({
         test: {
           name: { label: "dom", color: "yellow" },
           environment: "happy-dom",
-          setupFiles: resolve(__dirname, "test.setup.tsx"),
+          setupFiles: resolve(import.meta.dirname, "test.setup.tsx"),
           include: ["**/*.test.tsx"],
         },
       },

--- a/packages/app-shell-vite-plugin/src/vite-configuration-processor-plugin.ts
+++ b/packages/app-shell-vite-plugin/src/vite-configuration-processor-plugin.ts
@@ -1,7 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
-import type { NormalizedOutputOptions } from "rollup";
-import type { PluginOption, UserConfig } from "vite";
+import type { PluginOption } from "vite";
 import type { HvAppShellConfig } from "@hitachivantara/app-shell-shared";
 
 import { getAppModules, getBasePath } from "./config-utils.js";
@@ -35,7 +34,7 @@ export default function processConfiguration(
   return {
     name: "vite-plugin-appShell-configuration-processor",
 
-    config(config: UserConfig, { command }) {
+    config(config, { command }) {
       const projectRoot = root ?? config.root;
 
       let appModules: Record<string, string> = {};
@@ -82,7 +81,7 @@ export default function processConfiguration(
      *  - bundles replace with the final location (e.g. -> "bundle": "src/pages/Main" transformed to "bundle": "pages/Main.js",
      * @param options build options
      */
-    async generateBundle(options: NormalizedOutputOptions) {
+    async generateBundle(options) {
       if (generateEmptyShell || !buildEntryPoint) {
         return;
       }

--- a/packages/app-shell-vite-plugin/src/vite-crossorigin-fix-plugin.ts
+++ b/packages/app-shell-vite-plugin/src/vite-crossorigin-fix-plugin.ts
@@ -1,5 +1,4 @@
-import type { OutputBundle } from "rollup";
-import type { PluginOption } from "vite";
+import type { IndexHtmlTransformContext, PluginOption } from "vite";
 
 const replacer = (match: string) =>
   match.replace(
@@ -33,14 +32,14 @@ export function addUseCredentials(scriptSrc: string, html: string) {
 }
 
 function processScript(
-  bundle: OutputBundle,
+  bundle: IndexHtmlTransformContext["bundle"],
   scriptSrc: string,
   html: string,
   seen: Set<string> = new Set(),
 ) {
   seen.add(scriptSrc);
 
-  const script = bundle[scriptSrc];
+  const script = bundle?.[scriptSrc];
   if (!script || script.type !== "chunk") {
     return html;
   }

--- a/packages/app-shell-vite-plugin/src/vite-importmap-plugin.ts
+++ b/packages/app-shell-vite-plugin/src/vite-importmap-plugin.ts
@@ -1,7 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
 import virtual from "@rollup/plugin-virtual";
-import type { NormalizedOutputOptions } from "rollup";
 import type { PluginOption } from "vite";
 
 const ID_PREFIX = `/@id/`;
@@ -208,7 +207,7 @@ document.currentScript.after(im);
        *  - bundles replace with the final location (e.g. -> "bundle": "src/pages/Main" transformed to "bundle": "pages/Main.js",
        * @param options build options
        */
-      async generateBundle(options: NormalizedOutputOptions) {
+      async generateBundle(options) {
         if (!externalImportMap || placeholderEntryPoint) {
           return;
         }


### PR DESCRIPTION
- reduce `rollup`-specific imports (just types, no impact)
- migrate CJS `__dirname` to `import.meta.dirname`