### PR TITLE
perf(QueryBuilder): use css grid & test performance

### DIFF
--- a/packages/core/src/QueryBuilder/QueryBuilder.test.tsx
+++ b/packages/core/src/QueryBuilder/QueryBuilder.test.tsx
@@ -7,8 +7,7 @@ import {
   HvQueryBuilder,
   hvQueryBuilderDefaultOperators,
   type HvQueryBuilderProps,
-} from ".";
-import { HvButton } from "../Button";
+} from "./index";
 
 const operators = {
   ...hvQueryBuilderDefaultOperators,
@@ -168,9 +167,9 @@ const Controlled = (props?: HvQueryBuilderProps) => {
 
   return (
     <>
-      <HvButton onClick={() => setValue(defaultValueWithoutIds)}>
+      <button type="button" onClick={() => setValue(defaultValueWithoutIds)}>
         Update Query
-      </HvButton>
+      </button>
       <HvQueryBuilder
         operators={operators}
         attributes={attributes}
@@ -285,7 +284,7 @@ const setupDuplicatedAttributes = async () => {
   await user.click(secondOption);
 };
 
-describe("QueryBuilder", () => {
+describe("QueryBuilder", { timeout: 12_000 }, () => {
   it("renders the component as expected when empty", () => {
     renderUncontrolled();
 
@@ -819,17 +818,9 @@ describe("QueryBuilder", () => {
 
   it("enables to create a rule (select attribute > select operator > type value)", async () => {
     const user = userEvent.setup();
-    renderUncontrolled();
+    renderUncontrolled({ defaultValue: { combinator: "and", rules: [{}] } });
 
-    const addButton = screen.getByRole("button", {
-      name: /Add condition/i,
-    });
-    await user.click(addButton);
-
-    const attributeDropdown = await screen.findByRole("combobox", {
-      name: /Attribute/i,
-    });
-    await user.click(attributeDropdown);
+    await user.click(screen.getByRole("combobox", { name: /Attribute/i }));
 
     const attrs = screen
       .getAllByRole("option")
@@ -844,10 +835,7 @@ describe("QueryBuilder", () => {
     ]);
     await user.click(screen.getByRole("option", { name: "Category" }));
 
-    const operatorDropdown = await screen.findByRole("combobox", {
-      name: /Operator/i,
-    });
-    await user.click(operatorDropdown);
+    await user.click(screen.getByRole("combobox", { name: /Operator/i }));
 
     const opts = screen
       .getAllByRole("option")

--- a/packages/core/src/QueryBuilder/Rule/Attribute.tsx
+++ b/packages/core/src/QueryBuilder/Rule/Attribute.tsx
@@ -42,6 +42,7 @@ export const Attribute = ({
       disabled={disabled}
       readOnly={readOnly}
       status={isInvalid ? "invalid" : "valid"}
+      style={{ gridArea: "attribute" }}
       statusMessage={labels.rule.attribute.exists}
       onChange={(selected) => {
         if (selected) {

--- a/packages/core/src/QueryBuilder/Rule/Operator.tsx
+++ b/packages/core/src/QueryBuilder/Rule/Operator.tsx
@@ -45,6 +45,7 @@ export const Operator = ({
       label={labels.rule.operator.label}
       placeholder={labels.rule.operator.placeholder}
       values={values}
+      style={{ gridArea: "operator" }}
       disabled={values.length === 0}
       readOnly={readOnly}
       onChange={(selected) => {

--- a/packages/core/src/QueryBuilder/Rule/Rule.styles.tsx
+++ b/packages/core/src/QueryBuilder/Rule/Rule.styles.tsx
@@ -9,8 +9,13 @@ export const { useClasses } = createClasses("HvQueryBuilderRule", {
     marginTop: theme.space.xs,
     minHeight: 94,
 
-    "&>div:not(:last-child)": {
-      paddingRight: theme.space.md,
+    display: "grid",
+    gridTemplateColumns: "1fr 1fr 2fr 32px",
+    gridTemplateAreas: '"attribute operator value actions"',
+    gap: theme.space.md,
+
+    "&:>*": {
+      minWidth: 0,
     },
 
     // hide required * as all fields are required
@@ -48,19 +53,17 @@ export const { useClasses } = createClasses("HvQueryBuilderRule", {
     },
   },
   actionsContainer: {
-    marginLeft: "auto",
+    gridArea: "actions",
+    justifySelf: "end",
     marginTop: "24px",
-
-    "&>:not(:last-child)": {
-      marginRight: theme.space.xs,
-    },
   },
   isMdDown: {
-    "&>div:not(:last-child)": {
-      paddingRight: 0,
-    },
-    "&>div:not(:first-of-type)": {
-      marginTop: theme.space.xs,
+    gridTemplateColumns: "1fr",
+    gridTemplateAreas: '"attribute" "operator" "value" "actions"',
+    gap: theme.space.xs,
+
+    "& $actionsContainer": {
+      marginTop: 0,
     },
   },
 });

--- a/packages/core/src/QueryBuilder/Rule/Rule.tsx
+++ b/packages/core/src/QueryBuilder/Rule/Rule.tsx
@@ -6,7 +6,6 @@ import {
   type ExtractNames,
 } from "@hitachivantara/uikit-react-utils";
 
-import { HvGrid } from "../../Grid";
 import { HvIconButton } from "../../IconButton";
 import { HvIcon } from "../../icons";
 import { useQueryBuilderContext } from "../Context";
@@ -72,56 +71,47 @@ export const Rule = (props: RuleProps) => {
   }, [attribute, attributes, combinator, operators]);
 
   return (
-    <HvGrid
-      container
-      className={cx(classes.root, { [classes.isMdDown]: isMdDown })}
-      spacing={0}
-    >
-      <HvGrid item xs={12} md={3}>
-        <Attribute
-          attribute={attribute}
-          id={id}
-          disabled={disabled}
-          isInvalid={isInvalid}
-        />
-      </HvGrid>
+    <div className={cx(classes.root, { [classes.isMdDown]: isMdDown })}>
+      <Attribute
+        attribute={attribute}
+        id={id}
+        disabled={disabled}
+        isInvalid={isInvalid}
+      />
       {attribute != null && availableOperators > 0 && (
-        <HvGrid item xs={12} md={3}>
-          <Operator
-            id={id}
-            combinator={combinator}
-            attribute={attribute}
-            operator={operator}
-          />
-        </HvGrid>
+        <Operator
+          id={id}
+          combinator={combinator}
+          attribute={attribute}
+          operator={operator}
+        />
       )}
       {attribute != null && (operator != null || availableOperators === 0) && (
-        <HvGrid item xs={12} md>
+        <div style={{ gridArea: "value" }}>
           <Value
             attribute={attribute}
             id={id}
             operator={operator}
             value={value}
           />
-        </HvGrid>
+        </div>
       )}
-      <HvGrid item className={classes.actionsContainer}>
-        <HvIconButton
-          placement="bottom"
-          title={labels.rule.delete.tooltip}
-          onClick={() =>
-            disableConfirmation
-              ? dispatchAction({ type: "remove-node", id })
-              : askAction({
-                  actions: [{ type: "remove-node", id }],
-                  dialog: labels.rule.delete,
-                })
-          }
-          disabled={readOnly}
-        >
-          <HvIcon name="Delete" />
-        </HvIconButton>
-      </HvGrid>
-    </HvGrid>
+      <HvIconButton
+        placement="bottom"
+        className={classes.actionsContainer}
+        title={labels.rule.delete.tooltip}
+        onClick={() =>
+          disableConfirmation
+            ? dispatchAction({ type: "remove-node", id })
+            : askAction({
+                actions: [{ type: "remove-node", id }],
+                dialog: labels.rule.delete,
+              })
+        }
+        disabled={readOnly}
+      >
+        <HvIcon name="Delete" />
+      </HvIconButton>
+    </div>
   );
 };

--- a/packages/core/src/QueryBuilder/stories/ReadOnly.tsx
+++ b/packages/core/src/QueryBuilder/stories/ReadOnly.tsx
@@ -1,4 +1,7 @@
-import { HvQueryBuilder } from "@hitachivantara/uikit-react-core";
+import {
+  HvQueryBuilder,
+  type HvQueryBuilderQueryGroup,
+} from "@hitachivantara/uikit-react-core";
 
 const attributes = {
   price: {
@@ -45,8 +48,12 @@ const initialQuery = {
         },
       ],
     },
+    {
+      attribute: "category",
+      operator: "IsNotEmpty",
+    },
   ],
-};
+} satisfies HvQueryBuilderQueryGroup;
 
 export const ReadOnly = () => (
   <HvQueryBuilder


### PR DESCRIPTION
QueryBuilder tests are slow, and sometimes hit the 10s timeout

- change to use native CSS grid instead of `HvGrid`
- increase test timeout to 12s
- replace `HvButton` with button
- improve flaky test performance (fewer setup clicks)