### PR TITLE
fix(Button): startIcon/endIcon padding alignment

### DIFF
--- a/packages/core/src/Button/Button.styles.ts
+++ b/packages/core/src/Button/Button.styles.ts
@@ -36,6 +36,14 @@ export const { staticClasses, useClasses } = createClasses("HvButton", {
     // remove icon container spacing
     "--icsize": "auto",
 
+    ":where(:has($startIcon))": {
+      paddingLeft: 8,
+    },
+    ":where(:has($endIcon))": {
+      paddingRight: 8,
+    },
+
+    // higher specificity, ensure icon doesn't shrink
     "& $startIcon, & $endIcon": {
       flexShrink: 0,
       lineHeight: 0,

--- a/packages/core/src/DropdownButton/DropdownButton.styles.tsx
+++ b/packages/core/src/DropdownButton/DropdownButton.styles.tsx
@@ -43,7 +43,5 @@ export const { staticClasses, useClasses } = createClasses("HvDropdownButton", {
     whiteSpace: "nowrap",
   },
   placeholder: {},
-  arrowContainer: {
-    marginRight: theme.spacing(-2),
-  },
+  arrowContainer: {},
 });

--- a/packages/core/src/DropdownButton/DropdownButton.tsx
+++ b/packages/core/src/DropdownButton/DropdownButton.tsx
@@ -47,7 +47,9 @@ export const HvDropdownButton = forwardRef<
 
   const { classes, cx } = useClasses(classesProp, false);
 
-  const endIcon = !icon && <HvIcon name="CaretDown" size="xs" rotate={open} />;
+  const endIcon = !icon && (
+    <HvIcon compact name="CaretDown" size="xs" rotate={open} />
+  );
 
   const children =
     childrenProp && typeof childrenProp === "string" ? (


### PR DESCRIPTION
When there's a `startIcon`/`endIcon`, `HvButton`'s padding should be smaller (`xs`)

<img width="350" height="157" alt="image" src="https://github.com/user-attachments/assets/3962d32e-03b8-454b-b428-c86f9f662456" />
