### PR TITLE
fix(Badge): support inline position with other content

### DIFF
--- a/packages/core/src/Badge/Badge.stories.tsx
+++ b/packages/core/src/Badge/Badge.stories.tsx
@@ -44,9 +44,7 @@ export const Multiple: StoryObj<HvBadgeProps> = {
 
 export const WithIcon: StoryObj<HvBadgeProps> = {
   parameters: {
-    docs: {
-      description: { story: "Badge sample that uses a custom icon." },
-    },
+    docs: { description: { story: "Badge sample that uses a custom icon." } },
   },
   render: () => {
     return (
@@ -64,9 +62,7 @@ export const WithIcon: StoryObj<HvBadgeProps> = {
 
 export const WithText: StoryObj<HvBadgeProps> = {
   parameters: {
-    docs: {
-      description: { story: "Badge sample using only text." },
-    },
+    docs: { description: { story: "Badge sample using only text." } },
   },
   render: () => {
     return (
@@ -112,6 +108,10 @@ export const Test: StoryObj = {
       <HvBadge color="primary" label={8} icon={<Alert />} />
       <HvBadge color="textSubtle" showCount label={8} icon={<Alert />} />
       <HvBadge color="textSubtle" label={8} icon={<Alert />} />
+      <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
+        <HvTypography>Events</HvTypography>
+        <HvBadge label={10} showCount />
+      </div>
     </div>
   ),
 };

--- a/packages/core/src/Badge/Badge.styles.tsx
+++ b/packages/core/src/Badge/Badge.styles.tsx
@@ -31,6 +31,11 @@ export const { staticClasses, useClasses } = createClasses("HvBadge", {
     wordBreak: "keep-all",
     textAlign: "center",
 
+    "&$badgeIcon": {
+      top: "1px",
+      left: "calc(100% - 7px)",
+    },
+
     ":empty": {
       height: 8,
       width: 8,
@@ -41,6 +46,6 @@ export const { staticClasses, useClasses } = createClasses("HvBadge", {
   badgeHidden: {
     display: "none",
   },
-  badgeIcon: { top: "1px", left: "calc(100% - 7px)" },
+  badgeIcon: {},
   badgeOneDigit: { padding: 0, width: "16px" },
 });

--- a/packages/core/src/Badge/Badge.styles.tsx
+++ b/packages/core/src/Badge/Badge.styles.tsx
@@ -41,4 +41,9 @@ export const { staticClasses, useClasses } = createClasses("HvBadge", {
   },
   badgeIcon: { top: "1px", left: "calc(100% - 7px)" },
   badgeOneDigit: { padding: 0, width: "16px" },
+  badgeInline: {
+    position: "relative",
+    top: "auto",
+    left: "auto",
+  },
 });

--- a/packages/core/src/Badge/Badge.styles.tsx
+++ b/packages/core/src/Badge/Badge.styles.tsx
@@ -16,9 +16,11 @@ export const { staticClasses, useClasses } = createClasses("HvBadge", {
   },
   /** class applied to the badge */
   badge: {
-    position: "absolute",
-    top: 0,
-    left: "100%",
+    "&:not([data-badge-inline])": {
+      position: "absolute",
+      top: 0,
+      left: "100%",
+    },
     ...theme.typography.caption2,
     color: theme.colors.textDimmed,
     borderRadius: theme.radii.full,
@@ -41,9 +43,4 @@ export const { staticClasses, useClasses } = createClasses("HvBadge", {
   },
   badgeIcon: { top: "1px", left: "calc(100% - 7px)" },
   badgeOneDigit: { padding: 0, width: "16px" },
-  badgeInline: {
-    position: "relative",
-    top: "auto",
-    left: "auto",
-  },
 });

--- a/packages/core/src/Badge/Badge.tsx
+++ b/packages/core/src/Badge/Badge.tsx
@@ -55,6 +55,8 @@ export const HvBadge = forwardRef<
 
   const { classes, cx } = useClasses(classesProp);
 
+  const hasContent = !!(children || icon);
+
   const label = useMemo(() => {
     if (typeof labelProp !== "number") return labelProp;
 
@@ -78,6 +80,7 @@ export const HvBadge = forwardRef<
           [classes.badgeHidden]: label == null,
           [classes.badgeIcon]: icon,
           [classes.badgeOneDigit]: String(label).length === 1,
+          [classes.badgeInline]: !hasContent,
         })}
       >
         {label}

--- a/packages/core/src/Badge/Badge.tsx
+++ b/packages/core/src/Badge/Badge.tsx
@@ -76,11 +76,11 @@ export const HvBadge = forwardRef<
         style={mergeStyles(style, {
           "--bg-color": color && getColor(color),
         })}
+        data-badge-inline={!hasContent ? "" : undefined}
         className={cx(classes.badge, {
           [classes.badgeHidden]: label == null,
           [classes.badgeIcon]: icon,
           [classes.badgeOneDigit]: String(label).length === 1,
-          [classes.badgeInline]: !hasContent,
         })}
       >
         {label}


### PR DESCRIPTION
Fix misplacement of the badge when it doesn't have children allowing for correct positioning when placed inline with other content.

<img width="775" height="165" alt="image" src="https://github.com/user-attachments/assets/6a6c1330-a82c-4b1e-beeb-b7b52dc5d2a4" />
