### PR TITLE
build(icons): remove cpy-cli & tsx

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -121,7 +121,6 @@
         "@hitachivantara/app-shell-shared": "*",
         "@hitachivantara/uikit-react-core": "*",
         "@hitachivantara/uikit-react-icons": "*",
-        "@hv/templates": "*",
         "@mui/material": "^7.0.2",
         "@phosphor-icons/react": "^2.1.10",
         "@types/react-table": "^7.7.14",
@@ -14827,19 +14826,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/get-tsconfig": {
-      "version": "4.14.0",
-      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
-      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "resolve-pkg-maps": "^1.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
-      }
-    },
     "node_modules/git-raw-commits": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-4.0.0.tgz",
@@ -23251,16 +23237,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/resolve-pkg-maps": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
-      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
-      "devOptional": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
-      }
-    },
     "node_modules/resolve.exports": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-2.0.3.tgz",
@@ -25145,40 +25121,6 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
-    },
-    "node_modules/tsx": {
-      "version": "4.21.0",
-      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
-      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "esbuild": "~0.27.0",
-        "get-tsconfig": "^4.7.5"
-      },
-      "bin": {
-        "tsx": "dist/cli.mjs"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.3"
-      }
-    },
-    "node_modules/tsx/node_modules/fsevents": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
     },
     "node_modules/tuf-js": {
       "version": "4.1.0",
@@ -27110,7 +27052,6 @@
         "@types/recursive-readdir": "^2.2.4",
         "recursive-readdir": "^2.2.3",
         "svgo": "^3.1.0",
-        "tsx": "^4.6.2",
         "vite-plugin-static-copy": "^4.1.0"
       },
       "peerDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -121,6 +121,7 @@
         "@hitachivantara/app-shell-shared": "*",
         "@hitachivantara/uikit-react-core": "*",
         "@hitachivantara/uikit-react-icons": "*",
+        "@hv/templates": "*",
         "@mui/material": "^7.0.2",
         "@phosphor-icons/react": "^2.1.10",
         "@types/react-table": "^7.7.14",
@@ -27107,10 +27108,10 @@
         "@types/react": "^18.2.43",
         "@types/react-dom": "^18.2.17",
         "@types/recursive-readdir": "^2.2.4",
-        "cpy-cli": "^5.0.0",
         "recursive-readdir": "^2.2.3",
         "svgo": "^3.1.0",
-        "tsx": "^4.6.2"
+        "tsx": "^4.6.2",
+        "vite-plugin-static-copy": "^4.1.0"
       },
       "peerDependencies": {
         "@emotion/react": "^11.11.1",

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -26,7 +26,7 @@
   },
   "scripts": {
     "optimize": "svgo -r -f assets assets",
-    "convert": "tsx scripts/svgToReact.ts && tsx scripts/svgToSprite.ts",
+    "convert": "node scripts/svgToReact.ts && node scripts/svgToSprite.ts",
     "prebuild": "npm run clean && npm run convert",
     "build": "vite build",
     "clean": "npx rimraf dist sprites package",
@@ -50,7 +50,6 @@
     "@types/recursive-readdir": "^2.2.4",
     "recursive-readdir": "^2.2.3",
     "svgo": "^3.1.0",
-    "tsx": "^4.6.2",
     "vite-plugin-static-copy": "^4.1.0"
   },
   "files": [

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -29,7 +29,6 @@
     "convert": "tsx scripts/svgToReact.ts && tsx scripts/svgToSprite.ts",
     "prebuild": "npm run clean && npm run convert",
     "build": "vite build",
-    "postbuild": "npx cpy \"sprites\" \"dist\"",
     "clean": "npx rimraf dist sprites package",
     "prepare": "npm run convert",
     "prepublishOnly": "npm run build && npx clean-publish"
@@ -49,10 +48,10 @@
     "@types/react": "^18.2.43",
     "@types/react-dom": "^18.2.17",
     "@types/recursive-readdir": "^2.2.4",
-    "cpy-cli": "^5.0.0",
     "recursive-readdir": "^2.2.3",
     "svgo": "^3.1.0",
-    "tsx": "^4.6.2"
+    "tsx": "^4.6.2",
+    "vite-plugin-static-copy": "^4.1.0"
   },
   "files": [
     "dist"

--- a/packages/icons/scripts/svgToReact.ts
+++ b/packages/icons/scripts/svgToReact.ts
@@ -3,8 +3,8 @@ import fs from "node:fs/promises";
 import { parse, resolve } from "node:path";
 import { transform } from "@svgr/core";
 
-import { generateComponent } from "./generateComponent";
-import { extractColors, extractSize, replaceFill } from "./utils";
+import { generateComponent } from "./generateComponent.ts";
+import { extractColors, extractSize, replaceFill } from "./utils.ts";
 
 const transformToJsx = (fileData: string, iconName: string) => {
   const svgJsx = transform.sync(fileData, {

--- a/packages/icons/scripts/svgToSprite.ts
+++ b/packages/icons/scripts/svgToSprite.ts
@@ -3,8 +3,8 @@ import fs from "node:fs";
 import path from "node:path";
 import recursive from "recursive-readdir";
 
-import { generateSymbol } from "./generateSymbol";
-import { extractColors, replaceFill } from "./utils";
+import { generateSymbol } from "./generateSymbol.ts";
+import { extractColors, replaceFill } from "./utils.ts";
 
 // Resolve arguments
 const inputPath = "assets";

--- a/packages/icons/vite.config.ts
+++ b/packages/icons/vite.config.ts
@@ -1,3 +1,12 @@
+import { mergeConfig } from "vite";
+import { viteStaticCopy } from "vite-plugin-static-copy";
+
 import viteConfig from "../../.config/vite.config";
 
-export default viteConfig;
+export default mergeConfig(viteConfig, {
+  plugins: [
+    viteStaticCopy({
+      targets: [{ src: "sprites", dest: "./" }],
+    }),
+  ],
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,8 @@
 {
   "extends": "./tsconfig.build.json",
+  "compilerOptions": {
+    "allowImportingTsExtensions": true
+  },
   "include": [
     ".config/*.ts",
     "*.config.ts",


### PR DESCRIPTION
- replace `cpy-cli` with vite copy
- replace `tsx` with native `node`


<details>
<summary>Package size differences</summary>

```sh
➜  hv-uikit-react (master) ✗ npx howfat -r table cpy-cli
cpy-cli@7.0.0 (33 deps, 1.22mb, 303 files, ©MIT)
╭───────────────┬──────────────┬──────────┬───────┬───────────┬─────────┬───────────╮
│ Name          │ Dependencies │     Size │ Files │ Native    │ License │ Deprec    │
├───────────────┼──────────────┼──────────┼───────┼───────────┼─────────┼───────────┤
│ cpy@13.2.2    │           31 │  841.5kb │   288 │           │ MIT     │           │
├───────────────┼──────────────┼──────────┼───────┼───────────┼─────────┼───────────┤
│ globby@16.2.0 │           23 │ 680.65kb │   242 │           │ MIT     │           │
├───────────────┼──────────────┼──────────┼───────┼───────────┼─────────┼───────────┤
│ meow@14.1.0   │              │ 401.26kb │    11 │           │ MIT     │           │
╰───────────────┴──────────────┴──────────┴───────┴───────────┴─────────┴───────────╯
➜  hv-uikit-react (fix/stuff2) ✗ npx howfat -r table vite-plugin-static-copy
vite-plugin-static-copy@4.1.0 (21 deps, 857.72kb, 134 files, ©MIT)
╭───────────────────┬──────────────┬──────────┬───────┬───────────┬─────────┬───────────╮
│ Name              │ Dependencies │     Size │ Files │ Native    │ License │ Deprec    │
├───────────────────┼──────────────┼──────────┼───────┼───────────┼─────────┼───────────┤
│ chokidar@3.6.0    │           15 │  603.5kb │    93 │           │ MIT     │           │
├───────────────────┼──────────────┼──────────┼───────┼───────────┼─────────┼───────────┤
│ p-map@7.0.4       │              │  20.75kb │     5 │           │ MIT     │           │
├───────────────────┼──────────────┼──────────┼───────┼───────────┼─────────┼───────────┤
│ picocolors@1.1.1  │              │   6.22kb │     7 │           │ ISC     │           │
├───────────────────┼──────────────┼──────────┼───────┼───────────┼─────────┼───────────┤
│ tinyglobby@0.2.16 │            2 │ 179.08kb │    24 │           │ MIT     │           │
╰───────────────────┴──────────────┴──────────┴───────┴───────────┴─────────┴───────────╯
➜  hv-uikit-react (fix/stuff2) ✗ npx howfat -r table tsx
tsx@4.22.3 (3 deps, 10.85mb, 66 files, ©MIT)
╭────────────────┬──────────────┬──────────┬───────┬───────────┬─────────┬───────────╮
│ Name           │ Dependencies │     Size │ Files │ Native    │ License │ Deprec    │
├────────────────┼──────────────┼──────────┼───────┼───────────┼─────────┼───────────┤
│ esbuild@0.28.0 │            1 │  10.19mb │    10 │           │ MIT     │           │
├────────────────┼──────────────┼──────────┼───────┼───────────┼─────────┼───────────┤
│ fsevents@2.3.3 │              │ 169.16kb │     6 │           │ MIT     │           │
╰────────────────┴──────────────┴──────────┴───────┴───────────┴─────────┴───────────╯
```
</details>