### PR TITLE
docs(nextra): fix css layer ordering

### DIFF
--- a/apps/docs/src/app/globals.css
+++ b/apps/docs/src/app/globals.css
@@ -1,5 +1,7 @@
 @unocss all;
 
+@layer base, theme, components, hv-uikit-baseline, utilities;
+
 html,
 body {
   height: auto;


### PR DESCRIPTION
`hv-uikit-baseline` layer was overriding `utilities`'s styles