### PR TITLE
feat(Navigation): review brand logo in Pentaho theme

### DIFF
--- a/packages/app-shell-ui/src/components/layout/Header/Header.tsx
+++ b/packages/app-shell-ui/src/components/layout/Header/Header.tsx
@@ -11,7 +11,6 @@ import {
   HvHeader,
   HvHeaderBrand,
   HvHeaderNavigation,
-  useTheme,
   type HvHeaderNavigationProps,
 } from "@hitachivantara/uikit-react-core";
 
@@ -30,7 +29,6 @@ export const Header = () => {
     i18n,
   });
   const { navigationMode, name, logo } = useHvAppShellModel();
-  const { activeTheme } = useTheme();
   const { navigate } = useHvNavigation();
 
   const {
@@ -61,7 +59,6 @@ export const Header = () => {
     }
   };
 
-  const isPentahoTheme = activeTheme?.name === "pentahoPlus";
   const appName = name ? tConfig(name) : "";
 
   return (
@@ -85,10 +82,7 @@ export const Header = () => {
         </HvButton>
       )}
 
-      <HvHeaderBrand
-        logo={isPentahoTheme ? undefined : <BrandLogo logo={logo} />}
-        name={appName}
-      />
+      <HvHeaderBrand logo={<BrandLogo logo={logo} />} name={appName} />
       {showNavigation && (
         <HvHeaderNavigation
           data={items}

--- a/packages/app-shell-ui/src/components/layout/VerticalNavigation/VerticalNavigation.tsx
+++ b/packages/app-shell-ui/src/components/layout/VerticalNavigation/VerticalNavigation.tsx
@@ -19,7 +19,6 @@ import { useLayoutContext } from "../../../providers/LayoutProvider";
 import { useNavigationContext } from "../../../providers/NavigationProvider";
 import type { NavigationMenuItem } from "../../../types";
 import { NavigationCollapse } from "./NavigationCollapse";
-import { NavigationHeader } from "./NavigationHeader";
 
 const classes = {
   root: css({
@@ -106,25 +105,21 @@ export const VerticalNavigation = () => {
         useIcons
         slider={isCompactMode}
       >
-        <div>
-          {isPentahoTheme && <NavigationHeader isOpen={open} />}
-
-          {(!isPentahoTheme || isCompactMode) && (
-            <HvVerticalNavigationHeader
-              title={t("title")}
-              onCollapseButtonClick={
-                !isCompactMode ? switchVerticalNavigationMode : undefined
-              }
-              collapseButtonProps={{
-                "aria-label": t(open ? "ariaLabelCollapse" : "ariaLabelExpand"),
-                "aria-expanded": open,
-              }}
-              backButtonProps={{
-                "aria-label": t("ariaLabelHeaderBackButton"),
-              }}
-            />
-          )}
-        </div>
+        {(!isPentahoTheme || isCompactMode) && (
+          <HvVerticalNavigationHeader
+            title={t("title")}
+            onCollapseButtonClick={
+              !isCompactMode ? switchVerticalNavigationMode : undefined
+            }
+            collapseButtonProps={{
+              "aria-label": t(open ? "ariaLabelCollapse" : "ariaLabelExpand"),
+              "aria-expanded": open,
+            }}
+            backButtonProps={{
+              "aria-label": t("ariaLabelHeaderBackButton"),
+            }}
+          />
+        )}
 
         <HvVerticalNavigationTree
           key={rootMenuItemId}

--- a/packages/core/src/themes/pentaho.ts
+++ b/packages/core/src/themes/pentaho.ts
@@ -732,8 +732,6 @@ export const pentaho = mergeTheme(pentahoBase, {
       classes: {
         separator: {
           backgroundColor: theme.colors.border,
-          margin: theme.spacing(0, "md"),
-          height: 32,
         },
       },
     } satisfies CSSClasses<HvHeaderBrandProps>,


### PR DESCRIPTION
- move Branding from VerticalNavigation to Header in Pentaho theme (same as NEXT)
- remove separator overrides