### PR TITLE
chore: remove HV Slack ci messages & docs links

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -23,24 +23,3 @@ jobs:
   build:
     name: Build
     uses: ./.github/workflows/build.yml
-
-  notify-fail:
-    name: Notify Fail
-    needs: [tests, build, visual-tests]
-    if: failure()
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Notify Failure
-        uses: slackapi/slack-github-action@v3.0.1
-        with:
-          method: chat.postMessage
-          token: ${{ secrets.SLACK_TOKEN }}
-          payload: |
-            channel: "ui-kit-internal"
-            attachments:
-              - mrkdwn_in:
-                  - text
-                color: "#C62828"
-                title: "${{ github.workflow }} finished: failure"
-                title_link: "${{ env.RUN_URL }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,9 +31,6 @@ jobs:
       RELEASE_TYPE: ${{ github.event.client_payload.type }}
       NPM_CONFIG_PROVENANCE: true
 
-    outputs:
-      SLACK_MESSAGE: ${{ steps.slackMessage.outputs.SLACK_MESSAGE }}
-
     permissions:
       contents: write
       id-token: write
@@ -93,11 +90,6 @@ jobs:
           npm i --no-save changelogithub@0.13
           npx changelogithub --from $CURRENT_VERSION --to $NEW_VERSION
 
-      - name: Set SLACK_MESSAGE
-        id: slackMessage
-        run: |
-          echo "SLACK_MESSAGE=$(.github/scripts/changelog.js $CURRENT_VERSION $NEW_VERSION)" >> $GITHUB_OUTPUT
-
   publish-documentation:
     name: Publish Documentation
     needs: [publish]
@@ -105,21 +97,3 @@ jobs:
     secrets: inherit
     with:
       publish-folder: ${{ github.ref_name }}
-
-  notify-release:
-    name: Notify release
-    runs-on: ubuntu-latest
-    needs: [publish]
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Send Slack message
-        uses: slackapi/slack-github-action@v1.27.0
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_TOKEN }}
-        with:
-          channel-id: "ui-kit"
-          payload: |
-            { "blocks": ${{ needs.publish.outputs.SLACK_MESSAGE }} }

--- a/apps/docs/src/components/Footer.tsx
+++ b/apps/docs/src/components/Footer.tsx
@@ -28,10 +28,6 @@ const footerLinks = [
         href: "https://github.com/pentaho/hv-uikit-react?tab=readme-ov-file#team-",
       },
       {
-        label: "Slack",
-        href: "https://hitachivantara-eng.slack.com/archives/CFY74GK6G",
-      },
-      {
         label: "GitHub",
         href: "https://github.com/pentaho/hv-uikit-react",
       },

--- a/apps/docs/src/content/docs/index.mdx
+++ b/apps/docs/src/content/docs/index.mdx
@@ -8,34 +8,27 @@ With a comprehensive suite of components and detailed usage guidelines, **UI Kit
 
 ## Why UI Kit
 
-- **Enhanced Productivity**  
+- **Enhanced Productivity**
   Quickly iterate with reusable, pre-built components tailored for production.
 
-- **Flexible Customization**  
+- **Flexible Customization**
   Leverage an extensive theming system for fine-grained control over layout and appearance.
 
-- **Seamless Multi-Theming**  
+- **Seamless Multi-Theming**
   Easily manage multiple themes across your application with minimal setup.
 
-- **Accessibility-Centric**  
+- **Accessibility-Centric**
   Built to meet accessibility standards and ensure inclusivity for all users.
 
 ## Contributing
 
 **UI Kit** is an open-source project, and community contributions are always welcome.
 
-- **Get Started**  
+- **Get Started**
   Read our [contribution guidelines](/docs/community) to learn how to contribute effectively.
 
-- **Join the Conversation**  
-  Share ideas and feedback to help improve the UI Kit for everyone.
-
-## Support
-
-We're here to support your journey with **UI Kit**.
-
-- **Chat with Us**: Join the discussion in [#ui-kit](https://hitachivantara-eng.slack.com/archives/GJ9AC2LMB)
-- **Report Issues**: Visit our [GitHub repository](https://github.com/pentaho/hv-uikit-react) to report bugs or suggest features.
+- **Join the Conversation**
+  Share ideas and [feedback](https://github.com/pentaho/hv-uikit-react/discussions) to help improve the UI Kit for everyone.
 
 ## License
 


### PR DESCRIPTION
remove Slack docs links & CI automated message, as the Slack workspace is changing